### PR TITLE
Change default service to Temporary Accommodation

### DIFF
--- a/integration_tests/support/commands.ts
+++ b/integration_tests/support/commands.ts
@@ -1,5 +1,5 @@
 Cypress.Commands.add('signIn', (options = { failOnStatusCode: true }) => {
-  cy.task('stubPremises', { premises: [], service: 'approved-premises' })
+  cy.task('stubPremises', { premises: [], service: 'temporary-accommodation' })
   cy.request('/')
   return cy.task('getSignInUrl').then((url: string) => cy.visit(url, options))
 })

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -1,4 +1,4 @@
-import { PremisesListPage } from '../../cypress_shared/pages/manage'
+import PremisesListPage from '../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
 import AuthSignInPage from '../../cypress_shared/pages/authSignIn'
 import Page from '../../cypress_shared/pages/page'
 import AuthManageDetailsPage from '../../cypress_shared/pages/authManageDetails'

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -57,7 +57,7 @@ const getService = (req: Request): Service => {
     }
   }
 
-  return 'approved-premises'
+  return 'temporary-accommodation'
 }
 
 export { getTaskStatus, taskLink, getCompleteSectionCount, getService }


### PR DESCRIPTION
As we are now in a TA-specific repository, we change the default service to Temporary Accommodation

This requires some minor changes to our integration tests, as the default page we now hit following login will the the TA premise listing, not the AP premises listing