### PR TITLE
App can deploy into the new CAS namespace

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -84,18 +84,18 @@ workflows:
             branches:
               only:
                 - main
-      # - hmpps/deploy_env:
-      #     name: deploy_dev
-      #     env: 'dev'
-      #     jira_update: true
-      #     context: hmpps-common-vars
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      #     requires:
-      #       - helm_lint
-      #       - build_docker
+      - hmpps/deploy_env:
+          name: deploy_dev
+          env: 'dev'
+          jira_update: true
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - helm_lint
+            - build_docker
       # - e2e_environment_test:
       #     environment: 'dev'
       #     context: hmpps-common-vars

--- a/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
@@ -13,7 +13,7 @@ generic-service:
     enabled: true
     hosts:
       - app-hostname.local # override per environment
-    tlsSecretName: approved-premises-ui-cert # override per environment
+    tlsSecretName: temporary-accommodation-ui-cert # override per environment
 
   livenessProbe:
     httpGet:
@@ -42,7 +42,7 @@ generic-service:
   #     [name of environment variable as seen by app]: [key of kubernetes secret to load]
 
   namespace_secrets:
-    approved-premises-ui:
+    hmpps-temporary-accommodation-ui:
       APPINSIGHTS_INSTRUMENTATIONKEY: 'APPINSIGHTS_INSTRUMENTATIONKEY'
       API_CLIENT_ID: 'API_CLIENT_ID'
       API_CLIENT_SECRET: 'API_CLIENT_SECRET'

--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,14 +6,14 @@ generic-service:
 
   ingress:
     hosts:
-      - approved-premises-dev.hmpps.service.justice.gov.uk
+      - cas-temporary-accommodation-dev.hmpps.service.justice.gov.uk
     contextColour: green
-    tlsSecretName: hmpps-approved-premises-dev-cert
+    tlsSecretName: hmpps-temporary-accommodation-dev-cert
 
   env:
     ENVIRONMENT: dev
-    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'
-    INGRESS_URL: 'https://approved-premises-dev.hmpps.service.justice.gov.uk'
+    APPROVED_PREMISES_API_URL: 'https://cas-approved-premises-api-dev.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://cas-temporary-accommodation-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
 


### PR DESCRIPTION
The new community-accommodation-dev namespace is being defined here [1]. This change updates the existing Approved Premises configuration that we copied across and gets temporary-accommodation ready to launch into the new namespace.

Whilst the API service is referenced, it is not deployed into this new namespace yet so some cooridination will be needed.

We found that this line `tlsSecretName: temporary-accommodation-ui-cert # override per environment` includes a value that we can't trace. We think it's a default that if it were used would cause issues, however in values-dev.yml this key is being set to `hmpps-temporary-accommodation-dev-cert` which is known. We aren't sure if we can remove the former without causing an issue so we leave it the same as AP for now.

[1] https://github.com/ministryofjustice/cloud-platform-environments/pull/9081

