### PR TITLE
Property references are mandatory

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
@@ -35,7 +35,7 @@ export default class PremisesNewPage extends Page {
   }
 
   completeForm(newPremises: NewPremises): void {
-    this.getLabel('Property name (optional)')
+    this.getLabel('Property name')
     this.getTextInputByIdAndEnterDetails('name', newPremises.name)
 
     this.getLabel('Address line 1')

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -84,5 +84,5 @@ Then('I should see a confirmation for my new premises', () => {
 
 Then('I should see a list of the problems encountered creating the premises', () => {
   const page = PremisesNewPage.verifyOnPage(PremisesNewPage)
-  page.shouldShowErrorMessagesForFields(['addressLine1', 'postcode', 'localAuthorityAreaId'])
+  page.shouldShowErrorMessagesForFields(['name', 'addressLine1', 'postcode', 'localAuthorityAreaId'])
 })

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -134,11 +134,11 @@ context('Premises', () => {
     const page = PremisesNewPage.visit()
 
     // And I miss required fields
-    cy.task('stubPremisesCreateErrors', ['addressLine1', 'postcode', 'localAuthorityAreaId'])
+    cy.task('stubPremisesCreateErrors', ['name', 'addressLine1', 'postcode', 'localAuthorityAreaId'])
     page.clickSubmit()
 
     // Then I should see error messages relating to those fields
-    page.shouldShowErrorMessagesForFields(['addressLine1', 'postcode', 'localAuthorityAreaId'])
+    page.shouldShowErrorMessagesForFields(['name', 'addressLine1', 'postcode', 'localAuthorityAreaId'])
   })
 
   it('should navigate back from the new premises page to the premises list page', () => {

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -31,7 +31,7 @@
 
         {{ govukInput({
           label: {
-            text: "Property name (optional)",
+            text: "Property name",
             classes: "govuk-label--m"
           },
           hint: {

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -46,7 +46,7 @@ stubs.push({
   },
 })
 
-const requiredFields = getCombinations(['addressLine1', 'postcode', 'localAuthorityAreaId'])
+const requiredFields = getCombinations(['name', 'addressLine1', 'postcode', 'localAuthorityAreaId'])
 
 requiredFields.forEach((fields: Array<string>) => {
   stubs.push(errorStub(fields, `/premises`))


### PR DESCRIPTION
# Changes in this PR

* A user must now enter a name when creating a property

## Screenshots of UI changes

### Before
![localhost_3000_properties_new (1)](https://user-images.githubusercontent.com/94137563/199956086-9dbeef13-155b-4720-844c-0e7cda5aec0e.png)

### After
![localhost_3000_properties_new](https://user-images.githubusercontent.com/94137563/199956098-ce14171b-889c-4e1b-9ca1-5adb105829e1.png)
![localhost_3000_properties_new (2)](https://user-images.githubusercontent.com/94137563/199956103-76858b88-19af-464a-a982-f2fcb88f9f5d.png)


