### PR TITLE
Remove `cas` prefix from domains

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -6,14 +6,14 @@ generic-service:
 
   ingress:
     hosts:
-      - cas-temporary-accommodation-dev.hmpps.service.justice.gov.uk
+      - temporary-accommodation-dev.hmpps.service.justice.gov.uk
     contextColour: green
     tlsSecretName: hmpps-temporary-accommodation-dev-cert
 
   env:
     ENVIRONMENT: dev
-    APPROVED_PREMISES_API_URL: 'https://cas-approved-premises-api-dev.hmpps.service.justice.gov.uk'
-    INGRESS_URL: 'https://cas-temporary-accommodation-dev.hmpps.service.justice.gov.uk'
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-dev.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://temporary-accommodation-dev.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
 


### PR DESCRIPTION
`cas` was added to all services added to the new community-accommodation-dev namespace as a means to help us migrate from approved-premises-dev. We couldn't have two namespaces using the same host.

This change is made possible by the certificate change made in the Cloud Platform https://github.com/ministryofjustice/cloud-platform-environments/pull/9190/files

