### PR TITLE
Enable E2E tests

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,8 +64,8 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e --\
-              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},offender_name=${OFFENDER_NAME_<< parameters.environment >>},keyworker_name=${KEYWORKER_NAME_<< parameters.environment >>},lost_bed_reason_id=${LOST_BED_REASON_ID_<< parameters.environment >>}"  \
-              --config baseUrl=https://approved-premises-<< parameters.environment >>.hmpps.service.justice.gov.uk
+              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>}"  \
+              --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots
           destination: screenshots
@@ -96,15 +96,15 @@ workflows:
           requires:
             - helm_lint
             - build_docker
-      # - e2e_environment_test:
-      #     environment: 'dev'
-      #     context: hmpps-common-vars
-      #     filters:
-      #       branches:
-      #         only:
-      #           - main
-      #     requires:
-      #       - deploy_dev
+      - e2e_environment_test:
+          environment: 'dev'
+          context: hmpps-common-vars
+          filters:
+            branches:
+              only:
+                - main
+          requires:
+            - deploy_dev
 
   #      - request-preprod-approval:
   #          type: approval


### PR DESCRIPTION
Now we have a new dev environment, let's try turning the e2e tests on so they run as part of the release pipeline.

We started by testing this change worked on this feature branch so we could observe it works and could access the correct sign in credentials:

https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui/122/workflows/5cdab797-e285-49b9-887c-bc7ad3673b5f/jobs/185

![Screenshot 2022-11-11 at 10 47 24](https://user-images.githubusercontent.com/912473/201325547-8b9aeeb5-5236-4a84-a056-d015e7c62ca5.png)
