### PR TITLE
A user can view a single bedspace

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -11,4 +11,5 @@ $path: "/assets/images/"
 @import './local'
 
 @import './pages/temporary-accommodation/index'
-@import './pages/temporary-accommodation/premises/show'
+@import './pages/temporary-accommodation/show'
+@import './pages/temporary-accommodation/bedspaces/show'

--- a/assets/sass/pages/temporary-accommodation/bedspaces/show.scss
+++ b/assets/sass/pages/temporary-accommodation/bedspaces/show.scss
@@ -1,0 +1,5 @@
+.temporary-accommodation-bedspaces-show {
+    .property-identity {
+        margin-bottom: 2em;
+    }
+}

--- a/assets/sass/pages/temporary-accommodation/show.scss
+++ b/assets/sass/pages/temporary-accommodation/show.scss
@@ -1,4 +1,4 @@
-.temporary-accommodation-premises-show {
+.temporary-accommodation-premises-show, .temporary-accommodation-bedspaces-show {
   .details {
     ul {
       padding-inline-start: 0px;
@@ -19,7 +19,7 @@
       margin: 0;
     }
     &__title {
-      h2 {
+      h1, h2 {
         display: inline;
         margin: 0;
         padding: 0;
@@ -46,7 +46,7 @@
     &__title {
       display: inline-block;
       font-size: 1.1875rem;
-      h3, h4 {
+      h2, h3, h4 {
         display: inline;
         margin: 0;
         padding: 0;

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -1,10 +1,16 @@
 import type { Room } from '@approved-premises/api'
 
 import Page from '../../page'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 
 export default class BedspaceShowPage extends Page {
   constructor(private readonly room: Room) {
     super('View a bedspace')
+  }
+
+  static visit(premisesId: string, room: Room): BedspaceShowPage {
+    cy.visit(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))
+    return new BedspaceShowPage(room)
   }
 
   shouldShowBedspaceDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -1,0 +1,45 @@
+import type { Room } from '@approved-premises/api'
+
+import Page from '../../page'
+
+export default class BedspaceShowPage extends Page {
+  constructor(private readonly room: Room) {
+    super('View a bedspace')
+  }
+
+  shouldShowBedspaceDetails(): void {
+    cy.get('h2').should('contain', this.room.name)
+
+    this.room.characteristics.forEach(characteristic => {
+      cy.get('.govuk-summary-list__key')
+        .contains('Attributes')
+        .siblings('.govuk-summary-list__value')
+        .should('contain', characteristic.name)
+    })
+
+    this.room.notes.split('\n').forEach(noteLine => {
+      cy.get('.govuk-summary-list__key')
+        .contains('Notes')
+        .siblings('.govuk-summary-list__value')
+        .should('contain', noteLine)
+    })
+  }
+
+  clickBedspaceEditLink(): void {
+    cy.get('a').contains('Edit').click()
+  }
+
+  clickBookBedspaceLink(): void {
+    cy.get('.moj-identity-bar').within(() => {
+      cy.get('button').contains('Actions').click()
+      cy.get('a').contains('Book bedspace').click()
+    })
+  }
+
+  clickVoidBedspaceLink(): void {
+    cy.get('.moj-identity-bar').within(() => {
+      cy.get('button').contains('Actions').click()
+      cy.get('a').contains('Void bedspace').click()
+    })
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -80,12 +80,12 @@ export default class PremisesShowPage extends Page {
     })
   }
 
-  clickBedpaceEditLink(room: Room): void {
+  clickBedpaceViewLink(room: Room): void {
     cy.get('h4')
       .contains(room.name)
       .parents('[data-cy-bedspace]')
       .within(() => {
-        cy.get('a').contains('Edit').click()
+        cy.get('a').contains('View').click()
       })
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -5,7 +5,7 @@ import paths from '../../../../server/paths/temporary-accommodation/manage'
 
 export default class PremisesShowPage extends Page {
   constructor(private readonly premises: Premises) {
-    super('Manage a property')
+    super('View a property')
   }
 
   static visit(premises: Premises): PremisesShowPage {

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -57,14 +57,20 @@ Given("I'm editing the bedspace", () => {
   cy.then(function _() {
     premisesListPage.clickPremisesViewLink(this.premises)
 
-    const premisesShowPage = PremisesShowPage.verifyOnPage(PremisesShowPage, this.premises)
-    premisesShowPage.clickBedpaceEditLink(this.room)
+    const premisesShowPage = Page.verifyOnPage(PremisesShowPage, this.premises)
+    premisesShowPage.clickBedpaceViewLink(this.room)
+
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    bedspaceShowPage.clickBedspaceEditLink()
+
+    const bedspaceEditPage = Page.verifyOnPage(BedspaceEditPage, this.room)
+    bedspaceEditPage.shouldShowBedspaceDetails()
   })
 })
 
 Given('I edit the bedspace details', () => {
   cy.get('@room').then(room => {
-    const page = BedspaceEditPage.verifyOnPage(BedspaceEditPage, room)
+    const page = Page.verifyOnPage(BedspaceEditPage, room)
 
     page.getCharacteristicIdByLabel('Park nearby', 'parkNearbyCharacteristicId')
     page.getCharacteristicIdByLabel('Floor level access', 'floorLevelAccessCharacteristicId')

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -7,6 +7,8 @@ import BedspaceNewPage from '../../../../cypress_shared/pages/temporary-accommod
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 import PremisesListPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
 import BedspaceEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit'
+import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import Page from '../../../../cypress_shared/pages/page'
 
 Given("I'm creating a bedspace", () => {
   cy.get('@premises').then(premises => {
@@ -97,19 +99,19 @@ Given('I edit the bedspace details', () => {
 })
 
 Then('I should see a confirmation for my new bedspace', () => {
-  cy.then(function _() {
-    const page = PremisesShowPage.verifyOnPage(PremisesShowPage, this.premises)
+  cy.get('@room').then(room => {
+    const page = Page.verifyOnPage(BedspaceShowPage, room)
     page.shouldShowBanner('Bedspace created')
 
-    page.shouldShowRoomDetails(this.room)
+    page.shouldShowBedspaceDetails()
   })
 })
 
 Then('I should see a confirmation for my updated bedspace', () => {
-  cy.then(function _() {
-    const page = PremisesShowPage.verifyOnPage(PremisesShowPage, this.premises)
+  cy.get('@room').then(room => {
+    const page = Page.verifyOnPage(BedspaceShowPage, room)
     page.shouldShowBanner('Bedspace updated')
 
-    page.shouldShowRoomDetails(this.room)
+    page.shouldShowBedspaceDetails()
   })
 })

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -12,13 +12,13 @@ import Page from '../../../../cypress_shared/pages/page'
 
 Given("I'm creating a bedspace", () => {
   cy.get('@premises').then(premises => {
-    const page = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    const page = Page.verifyOnPage(PremisesShowPage, premises)
     page.clickAddBedspaceLink()
   })
 })
 
 Given('I create a bedspace with all necessary details', () => {
-  const page = BedspaceNewPage.verifyOnPage(BedspaceNewPage)
+  const page = Page.verifyOnPage(BedspaceNewPage)
 
   page.getCharacteristicIdByLabel('Not suitable for arson offenders', 'arsonCharacteristicId')
   page.getCharacteristicIdByLabel('School nearby', 'schooNearbyCharacteristicId')

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -8,6 +8,7 @@ import PremisesNewPage from '../../../../cypress_shared/pages/temporary-accommod
 import PremisesListPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 import PremisesEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesEdit'
+import Page from '../../../../cypress_shared/pages/page'
 
 Given("I'm creating a premises", () => {
   const page = PremisesListPage.visit()
@@ -24,7 +25,7 @@ Given("I'm viewing an existing premises", () => {
 })
 
 Given('I create a premises with all necessary details', () => {
-  const page = PremisesNewPage.verifyOnPage(PremisesNewPage)
+  const page = Page.verifyOnPage(PremisesNewPage)
 
   page.getLocalAuthorityAreaIdByLabel('North Lanarkshire', 'localAuthorityAreaId')
 
@@ -66,7 +67,7 @@ Given('I create a premises with all necessary details', () => {
 })
 
 Given('I attempt to create a premises with required details missing', () => {
-  const page = PremisesNewPage.verifyOnPage(PremisesNewPage)
+  const page = Page.verifyOnPage(PremisesNewPage)
   page.clickSubmit()
 })
 
@@ -75,14 +76,17 @@ Given("I'm editing the premises", () => {
 
   cy.get('@premises').then(premises => {
     listPage.clickPremisesViewLink(premises)
-    const showPage = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    const showPage = Page.verifyOnPage(PremisesShowPage, premises)
     showPage.clickPremisesEditLink()
+
+    const editPage = Page.verifyOnPage(PremisesEditPage, premises)
+    editPage.shouldShowPremisesDetails()
   })
 })
 
 Given('I edit the premises details', () => {
   cy.get('@premises').then(premises => {
-    const page = PremisesEditPage.verifyOnPage(PremisesEditPage, premises)
+    const page = Page.verifyOnPage(PremisesEditPage, premises)
 
     page.getLocalAuthorityAreaIdByLabel('North Lanarkshire', 'localAuthorityAreaId')
 
@@ -126,7 +130,7 @@ Given('I edit the premises details', () => {
 
 Given('I attempt to edit the premise to remove required details', () => {
   cy.get('@premises').then(premises => {
-    const page = PremisesEditPage.verifyOnPage(PremisesEditPage, premises)
+    const page = Page.verifyOnPage(PremisesEditPage, premises)
 
     page.clearForm()
     page.clickSubmit()
@@ -135,7 +139,7 @@ Given('I attempt to edit the premise to remove required details', () => {
 
 Then('I should see a confirmation for my new premises', () => {
   cy.get('@premises').then(premises => {
-    const page = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    const page = Page.verifyOnPage(PremisesShowPage, premises)
     page.shouldShowBanner('Property created')
 
     page.shouldShowPremisesDetails()
@@ -143,13 +147,13 @@ Then('I should see a confirmation for my new premises', () => {
 })
 
 Then('I should see a list of the problems encountered creating the premises', () => {
-  const page = PremisesNewPage.verifyOnPage(PremisesNewPage)
+  const page = Page.verifyOnPage(PremisesNewPage)
   page.shouldShowErrorMessagesForFields(['name', 'addressLine1', 'postcode', 'localAuthorityAreaId'])
 })
 
 Then('I should see a confirmation for my updated premises', () => {
   cy.get('@premises').then(premises => {
-    const page = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+    const page = Page.verifyOnPage(PremisesShowPage, premises)
     page.shouldShowBanner('Property updated')
 
     page.shouldShowPremisesDetails()
@@ -158,7 +162,7 @@ Then('I should see a confirmation for my updated premises', () => {
 
 Then('I should see a list of the problems encountered updating the premises', () => {
   cy.get('@premises').then(premises => {
-    const page = PremisesEditPage.verifyOnPage(PremisesEditPage, premises)
+    const page = Page.verifyOnPage(PremisesEditPage, premises)
     page.shouldShowErrorMessagesForFields(['addressLine1', 'postcode', 'localAuthorityAreaId'])
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -2,11 +2,11 @@ import premisesFactory from '../../../../server/testutils/factories/premises'
 import newRoomFactory from '../../../../server/testutils/factories/newRoom'
 import roomFactory from '../../../../server/testutils/factories/room'
 import updateRoomFactory from '../../../../server/testutils/factories/updateRoom'
-import PremisesNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesNew'
 import Page from '../../../../cypress_shared/pages/page'
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 import BedspaceNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceNew'
 import BedspaceEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit'
+import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
 
 context('Bedspace', () => {
   beforeEach(() => {
@@ -87,6 +87,7 @@ context('Bedspace', () => {
       notes: room.notes,
     })
     cy.task('stubRoomCreate', { premisesId: premises.id, room })
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     page.completeForm(newRoom)
 
@@ -100,9 +101,9 @@ context('Bedspace', () => {
       expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(newRoom.notes)
     })
 
-    // And I should be redirected to the show premises page
-    const premisesNewPage = PremisesNewPage.verifyOnPage(PremisesShowPage, premises)
-    premisesNewPage.shouldShowBanner('Bedspace created')
+    // And I should be redirected to the show bedspace page
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, room)
+    bedspaceShowPage.shouldShowBanner('Bedspace created')
   })
 
   it('shows errors when the API returns an error', () => {
@@ -180,9 +181,9 @@ context('Bedspace', () => {
       expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(updatePremises.notes)
     })
 
-    // And I should be redirected to the show premises page
-    const premisesShowPage = PremisesShowPage.verifyOnPage(PremisesShowPage, premisesId, room)
-    premisesShowPage.shouldShowBanner('Bedspace updated')
+    // And I should be redirected to the show bedspace page
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, room)
+    bedspaceShowPage.shouldShowBanner('Bedspace updated')
   })
 
   it('should navigate back from the edit room page to the premises show page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -59,11 +59,42 @@ context('Bedspace', () => {
     // When I visit the show premises page
     const premisesShowPage = PremisesShowPage.visit(premises)
 
-    // Add I click an edit bedspace link
-    premisesShowPage.clickBedpaceEditLink(rooms[0])
+    // Add I click a view bedspace link
+    premisesShowPage.clickBedpaceViewLink(rooms[0])
+
+    // And I click the edit bedspace link
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, rooms[0])
+    bedspaceShowPage.clickBedspaceEditLink()
 
     // Then I navigate to the edit bedspace page
     Page.verifyOnPage(BedspaceEditPage, rooms[0])
+  })
+
+  it('should navigate to the show bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are local authorities in the database
+    cy.task('stubLocalAuthoritiesReferenceData')
+
+    // And there are characteristics in the database
+    cy.task('stubCharacteristicsReferenceData')
+
+    // And there is a premises with rooms in the database
+    const premises = premisesFactory.build()
+    const rooms = roomFactory.buildList(5)
+
+    cy.task('stubPremisesWithRooms', { premises, rooms })
+    cy.task('stubSingleRoom', { premisesId: premises.id, room: rooms[0] })
+
+    // When I visit the show premises page
+    const premisesShowPage = PremisesShowPage.visit(premises)
+
+    // Add I click a view bedspace link
+    premisesShowPage.clickBedpaceViewLink(rooms[0])
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BedspaceShowPage, rooms[0])
   })
 
   it('allows me to create a bedspace', () => {
@@ -125,7 +156,7 @@ context('Bedspace', () => {
     page.shouldShowErrorMessagesForFields(['name'])
   })
 
-  it('should navigate back from the new bedspace page to the show premises page', () => {
+  it('navigates back from the new bedspace page to the show premises page', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -186,7 +217,7 @@ context('Bedspace', () => {
     bedspaceShowPage.shouldShowBanner('Bedspace updated')
   })
 
-  it('should navigate back from the edit room page to the premises show page', () => {
+  it('navigates back from the edit bedspace page to the show bedspace page', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -208,8 +239,8 @@ context('Bedspace', () => {
     // And I click the previous bread crumb
     page.clickBreadCrumbUp()
 
-    // Then I navigate to the premises show page
-    Page.verifyOnPage(PremisesShowPage, premises)
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BedspaceShowPage, premises)
   })
 
   it('shows a single bedspace', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -210,4 +210,43 @@ context('Bedspace', () => {
     // Then I navigate to the premises show page
     Page.verifyOnPage(PremisesShowPage, premises)
   })
+
+  it('shows a single bedspace', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a room in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+
+    // When I visit the show bedspace page
+    const page = BedspaceShowPage.visit(premises.id, room)
+
+    // Then I should see the bedspace details
+    page.shouldShowBedspaceDetails()
+  })
+
+  it('navigates back from the show bedspace page to the show premises page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises with rooms in the database
+    const premises = premisesFactory.build()
+    const rooms = roomFactory.buildList(5)
+
+    cy.task('stubPremisesWithRooms', { premises, rooms })
+    cy.task('stubSingleRoom', { premisesId: premises.id, room: rooms[0] })
+
+    // When I visit the show bedspace page
+    const page = BedspaceShowPage.visit(premises.id, rooms[0])
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the show premises page
+    Page.verifyOnPage(PremisesShowPage, premises)
+  })
 })

--- a/script/local_e2e
+++ b/script/local_e2e
@@ -11,7 +11,7 @@ if ! [ "$(command -v ap-tools)" ];then
     exit
 fi
 
-ap-tools server start --local-ui
+ap-tools server start --local-ui --local-api
 
 set -a
 

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -58,7 +58,7 @@ describe('BedspacesController', () => {
   })
 
   describe('create', () => {
-    it('creates a premises and redirects to the show premises page', async () => {
+    it('creates a bedspace and redirects to the show bedspace page', async () => {
       const requestHandler = bedspacesController.create()
 
       const room = roomFactory.build()
@@ -82,7 +82,7 @@ describe('BedspacesController', () => {
       })
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Bedspace created')
-      expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))
     })
 
     it('renders with errors if the API returns an error', async () => {
@@ -179,7 +179,7 @@ describe('BedspacesController', () => {
   })
 
   describe('update', () => {
-    it('updates a bedspace and redirects to the show premises page', async () => {
+    it('updates a bedspace and redirects to the show bedspace page', async () => {
       const requestHandler = bedspacesController.update()
 
       const room = roomFactory.build()
@@ -201,7 +201,7 @@ describe('BedspacesController', () => {
       })
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Bedspace updated')
-      expect(response.redirect).toHaveBeenCalledWith(paths.premises.show({ premisesId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))
     })
 
     it('renders with errors if the API returns an error', async () => {

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -5,10 +5,12 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BedspaceService from '../../../services/bedspaceService'
 import BedspacesController from './bedspacesController'
+import premisesFactory from '../../../testutils/factories/premises'
 import roomFactory from '../../../testutils/factories/room'
 import characteristicFactory from '../../../testutils/factories/characteristic'
 import updateRoomFactory from '../../../testutils/factories/updateRoom'
-import { ErrorsAndUserInput } from '../../../@types/ui'
+import { ErrorsAndUserInput, SummaryListItem } from '../../../@types/ui'
+import { PremisesService } from '../../../services'
 
 jest.mock('../../../utils/validation')
 
@@ -21,8 +23,9 @@ describe('BedspacesController', () => {
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
+  const premisesService = createMock<PremisesService>({})
   const bedspaceService = createMock<BedspaceService>({})
-  const bedspacesController = new BedspacesController(bedspaceService)
+  const bedspacesController = new BedspacesController(premisesService, bedspaceService)
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
@@ -226,6 +229,31 @@ describe('BedspacesController', () => {
         err,
         paths.premises.bedspaces.edit({ premisesId, roomId: room.id }),
       )
+    })
+  })
+
+  describe('show', () => {
+    it('returns the bedspace details to the template', async () => {
+      const premises = premisesFactory.build()
+      const room = roomFactory.build()
+
+      premisesService.getPremises.mockResolvedValue(premises)
+
+      const bedspaceDetails = { room, summaryList: { rows: [] as Array<SummaryListItem> } }
+      bedspaceService.getSingleBedspaceDetails.mockResolvedValue(bedspaceDetails)
+
+      request.params = { premisesId: premises.id, roomId: room.id }
+
+      const requestHandler = bedspacesController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/show', {
+        premises,
+        bedspace: bedspaceDetails,
+      })
+
+      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
+      expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(token, premises.id, room.id)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -37,10 +37,10 @@ export default class BedspacesController {
       }
 
       try {
-        await this.bedspaceService.createRoom(req.user.token, premisesId, newRoom)
+        const room = await this.bedspaceService.createRoom(req.user.token, premisesId, newRoom)
 
         req.flash('success', 'Bedspace created')
-        res.redirect(paths.premises.show({ premisesId }))
+        res.redirect(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.premises.bedspaces.new({ premisesId }))
       }
@@ -84,7 +84,7 @@ export default class BedspacesController {
         await this.bedspaceService.updateRoom(token, premisesId, roomId, updateRoom)
 
         req.flash('success', 'Bedspace updated')
-        res.redirect(paths.premises.show({ premisesId }))
+        res.redirect(paths.premises.bedspaces.show({ premisesId, roomId }))
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.premises.bedspaces.edit({ premisesId, roomId }))
       }

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -4,9 +4,10 @@ import type { NewRoom, UpdateRoom } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BedspaceService from '../../../services/bedspaceService'
+import { PremisesService } from '../../../services'
 
 export default class BedspacesController {
-  constructor(private readonly bedspaceService: BedspaceService) {}
+  constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -87,6 +88,21 @@ export default class BedspacesController {
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.premises.bedspaces.edit({ premisesId, roomId }))
       }
+    }
+  }
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { token } = req.user
+      const { premisesId, roomId } = req.params
+
+      const premises = await this.premisesService.getPremises(token, premisesId)
+      const bedspaceDetails = await this.bedspaceService.getSingleBedspaceDetails(token, premisesId, roomId)
+
+      return res.render('temporary-accommodation/bedspaces/show', {
+        premises,
+        bedspace: bedspaceDetails,
+      })
     }
   }
 }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -10,7 +10,7 @@ export const controllers = (services: Services) => {
     services.bedspaceService,
     services.localAuthorityService,
   )
-  const bedspacesController = new BedspacesController(services.bedspaceService)
+  const bedspacesController = new BedspacesController(services.premisesService, services.bedspaceService)
 
   return {
     premisesController,

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -280,7 +280,7 @@ describe('PremisesController', () => {
       premisesService.getTemporaryAccommodationPremisesDetails.mockResolvedValue(details)
 
       const bedspaceDetails = rooms.map(room => ({ room, summaryList: { rows: [] as Array<SummaryListItem> } }))
-      bedspaceService.getRoomDetails.mockResolvedValue(bedspaceDetails)
+      bedspaceService.getBedspaceDetails.mockResolvedValue(bedspaceDetails)
 
       request.params.premisesId = premises.id
 
@@ -293,7 +293,7 @@ describe('PremisesController', () => {
       })
 
       expect(premisesService.getTemporaryAccommodationPremisesDetails).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getRoomDetails).toHaveBeenCalledWith(token, premises.id)
+      expect(bedspaceService.getBedspaceDetails).toHaveBeenCalledWith(token, premises.id)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -111,7 +111,7 @@ export default class PremisesController {
 
       const details = await this.premisesService.getTemporaryAccommodationPremisesDetails(token, premisesId)
 
-      const bedspaceDetails = await this.bedspaceService.getRoomDetails(token, premisesId)
+      const bedspaceDetails = await this.bedspaceService.getBedspaceDetails(token, premisesId)
 
       return res.render('temporary-accommodation/premises/show', {
         ...details,

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -17,8 +17,9 @@ const paths = {
     bedspaces: {
       new: bedspacesPath.path('new'),
       create: bedspacesPath,
-      edit: singleBedspacePath,
+      edit: singleBedspacePath.path('edit'),
       update: singleBedspacePath,
+      show: singleBedspacePath,
     },
   },
 }

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -23,6 +23,7 @@ export default function routes(controllers: Controllers, router: Router): Router
   post(paths.premises.bedspaces.create.pattern, bedspacesController.create())
   get(paths.premises.bedspaces.edit.pattern, bedspacesController.edit())
   put(paths.premises.bedspaces.update.pattern, bedspacesController.update())
+  get(paths.premises.bedspaces.show.pattern, bedspacesController.show())
 
   return router
 }

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -30,7 +30,7 @@ describe('BedspaceService', () => {
     referenceDataClientFactory.mockReturnValue(referenceDataClient)
   })
 
-  describe('getRoomDetails', () => {
+  describe('getBedspaceDetails', () => {
     it('returns a list of rooms and a summary list for each room, for the given premises ID', async () => {
       const room1 = roomFactory.build({
         name: 'XYX',
@@ -53,7 +53,7 @@ describe('BedspaceService', () => {
         text: 'Some attributes',
       }))
 
-      const result = await service.getRoomDetails(token, premisesId)
+      const result = await service.getBedspaceDetails(token, premisesId)
 
       expect(result).toEqual([
         {

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -11,7 +11,10 @@ export default class BedspaceService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getRoomDetails(token: string, premisesId: string): Promise<Array<{ room: Room; summaryList: SummaryList }>> {
+  async getBedspaceDetails(
+    token: string,
+    premisesId: string,
+  ): Promise<Array<{ room: Room; summaryList: SummaryList }>> {
     const roomClient = this.roomClientFactory(token)
     const rooms = await roomClient.all(premisesId)
 

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -26,6 +26,20 @@ export default class BedspaceService {
       }))
   }
 
+  async getSingleBedspaceDetails(
+    token: string,
+    premisesId: string,
+    roomId: string,
+  ): Promise<{ room: Room; summaryList: SummaryList }> {
+    const roomClient = this.roomClientFactory(token)
+    const room = await roomClient.find(premisesId, roomId)
+
+    return {
+      room,
+      summaryList: this.summaryListForRoom(room),
+    }
+  }
+
   async getUpdateRoom(token: string, premisesId: string, roomId: string): Promise<UpdateRoom> {
     const roomClient = this.roomClientFactory(token)
     const room = await roomClient.find(premisesId, roomId)

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -297,6 +297,20 @@ describe('PremisesService', () => {
     })
   })
 
+  describe('getPremises', () => {
+    it('returns the premises for the given premises ID', async () => {
+      const premises = premisesFactory.build()
+      premisesClient.find.mockResolvedValue(premises)
+
+      const result = await service.getPremises(token, premises.id)
+
+      expect(result).toEqual(premises)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
+    })
+  })
+
   describe('getApprovedPremisesPremisesDetails', () => {
     it('returns a title and a summary list for a given Premises ID', async () => {
       const premises = approvedPremisesFactory.build({

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -334,8 +334,6 @@ describe('PremisesService', () => {
         },
       })
 
-      expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
-
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
     })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -80,6 +80,13 @@ export default class PremisesService {
       })
   }
 
+  async getPremises(token: string, id: string): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(token)
+    const premises = await premisesClient.find(id)
+
+    return premises
+  }
+
   async getApprovedPremisesPremisesDetails(
     token: string,
     id: string,

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -11,7 +11,7 @@
 
   {{ breadCrumb('Edit a bedspace', [
     {title: 'List of properties', href: paths.premises.index()},
-    {title: 'Manage a property', href: paths.premises.show({ premisesId: premisesId })}
+    {title: 'View a property', href: paths.premises.show({ premisesId: premisesId })}
   ]) }}
 
   {% include "../../_messages.njk" %}

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -10,7 +10,8 @@
 
   {{ breadCrumb('Edit a bedspace', [
     {title: 'List of properties', href: paths.premises.index()},
-    {title: 'View a property', href: paths.premises.show({ premisesId: premisesId })}
+    {title: 'View a property', href: paths.premises.show({ premisesId: premisesId })},
+    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premisesId, roomId: id })}
   ]) }}
 
   {% include "../../_messages.njk" %}

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -1,4 +1,3 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -10,7 +10,7 @@
 
   {{ breadCrumb('Add a bedspace', [
     {title: 'List of properties', href: paths.premises.index()},
-    {title: 'Manage a property', href: paths.premises.show({ premisesId: premisesId })}
+    {title: 'View a property', href: paths.premises.show({ premisesId: premisesId })}
   ]) }}
 
   {% include "../../_messages.njk" %}

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -1,0 +1,68 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - View a bedspace" %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set bodyClasses = "temporary-accommodation-bedspaces-show" %}
+
+{% block content %}
+
+  {{ breadCrumb('View a bedspace', [
+    {title: 'List of properties', href: paths.premises.index()},
+    {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })}
+  ]) }}
+
+  {% include "../../_messages.njk" %}
+
+  {{ mojIdentityBar({
+    title: {
+      html: '<h1>View a bedspace</h1>'
+    },
+    menus: [{
+      items: [{
+        text: "Book bedspace",
+        classes: 'govuk-button--secondary',
+        href: '#'
+      }, {
+        text: 'Void bedspace',
+        classes: 'govuk-button--secondary',
+        href: '#'
+      }]
+    }]
+  }) }}
+
+  <div class="property-identity">
+    <h2 class="govuk-label govuk-label--m">Property reference</h2>
+    <p class="govuk-body">{{ premises.name }}</p>
+
+    <h2 class="govuk-label govuk-label--m">Property address</h2>
+    <p class="govuk-body">{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
+  </div>
+
+  <div class="edit-bar">
+    <div class="edit-bar__container">
+      <div class="edit-bar__title">
+        <h2 class="govuk-label govuk-label--m">{{ bedspace.room.name }}</h2>
+      </div>
+      <div class="edit-bar__action">
+        <a href="{{ paths.premises.bedspaces.edit({ premisesId: premises.id, roomId: bedspace.room.id }) }}">Edit</a>
+      </div>
+    </div>
+  </div>
+
+  {{ govukSummaryList({
+    rows: bedspace.summaryList.rows,
+    classes: 'govuk-summary-list--no-border details'
+  }) }}
+
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
+{% endblock %}

--- a/server/views/temporary-accommodation/premises/edit.njk
+++ b/server/views/temporary-accommodation/premises/edit.njk
@@ -11,7 +11,7 @@
 
   {{ breadCrumb('Edit a property', [
     {title: 'List of properties', href: paths.premises.index()},
-    {title: 'Manage a property', href: paths.premises.show({ premisesId: id })}
+    {title: 'View a property', href: paths.premises.show({ premisesId: id })}
   ]) }}
 
   {% include "../../_messages.njk" %}

--- a/server/views/temporary-accommodation/premises/edit.njk
+++ b/server/views/temporary-accommodation/premises/edit.njk
@@ -1,4 +1,3 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -1,4 +1,3 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -1,4 +1,3 @@
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -6,19 +6,19 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Manage a property" %}
+{% set pageTitle = applicationName + " - View a property" %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set bodyClasses = "temporary-accommodation-premises-show" %}
 
 {% block content %}
 
-  {{ breadCrumb('Manage a property', [
+  {{ breadCrumb('View a property', [
     {title: 'List of properties', href: paths.premises.index()}
   ]) }}
 
   {% include "../../_messages.njk" %}
 
-  <h1>Manage a property</h1>
+  <h1>View a property</h1>
 
   {{ mojIdentityBar({
     title: {

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -64,7 +64,7 @@
             <h4>{{ bedspace.room.name }}</h4>
           </div>
           <div class="edit-bar__action">
-            <a href="{{ paths.premises.bedspaces.edit({ premisesId: premises.id, roomId: bedspace.room.id }) }}">Edit</a>
+            <a href="{{ paths.premises.bedspaces.show({ premisesId: premises.id, roomId: bedspace.room.id }) }}">View</a>
           </div>
         </div>
       </div>

--- a/wiremock/roomStub.ts
+++ b/wiremock/roomStub.ts
@@ -15,7 +15,7 @@ rooms.push({
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
     },
-    jsonBody: JSON.stringify(roomFactory.build()),
+    jsonBody: roomFactory.build(),
   },
 })
 


### PR DESCRIPTION
# Changes in this PR

- A user can view a page showing the details of a single bedspace, rather than only seeing them in a list on the property page
- Editing a bedspace is now reached via this new page

## Screenshots of UI changes

### Before


![localhost_3000_properties_0d0b2e17-c2ae-4ea1-b64d-c642e2c130a5 (1)](https://user-images.githubusercontent.com/94137563/201342184-871f1420-ddb2-45fd-b533-0cbd8c2a327f.png)

### After
![localhost_3000_properties_0d0b2e17-c2ae-4ea1-b64d-c642e2c130a5](https://user-images.githubusercontent.com/94137563/201342225-5b8d26a2-8e1c-4c45-ae51-cf6727cdde17.png)


![localhost_3000_properties_0d0b2e17-c2ae-4ea1-b64d-c642e2c130a5_bedspaces_8f0ee60d-482a-4086-a4d7-d85ce53e6b93](https://user-images.githubusercontent.com/94137563/201342196-238e8beb-0ac2-407c-9c8c-21ca40ac2078.png)

