### PR TITLE
A user can view existing bookings on the bedspace information page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -2,6 +2,8 @@ import type { Room } from '@approved-premises/api'
 
 import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import { Booking } from '../../../../server/@types/shared'
+import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export default class BedspaceShowPage extends Page {
   constructor(private readonly room: Room) {
@@ -29,6 +31,23 @@ export default class BedspaceShowPage extends Page {
         .siblings('.govuk-summary-list__value')
         .should('contain', noteLine)
     })
+  }
+
+  shouldShowBookingDetails(booking: Booking): void {
+    cy.get('tr')
+      .contains(booking.person.crn)
+      .parent()
+      .within(() => {
+        cy.get('td').eq(0).contains(booking.person.crn)
+        cy.get('td')
+          .eq(1)
+          .contains(DateFormats.isoDateToUIDate(booking.arrivalDate, { format: 'short' }))
+        cy.get('td')
+          .eq(2)
+          .contains(DateFormats.isoDateToUIDate(booking.departureDate, { format: 'short' }))
+        cy.get('td').eq(3).contains('Provisional')
+        cy.get('td').eq(4).contains('View')
+      })
   }
 
   clickBedspaceEditLink(): void {

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -40,9 +40,11 @@ Given('I attempt to create a booking with required details missing', () => {
 })
 
 Then('I should see a confirmation for my new booking', () => {
-  cy.get('@room').then(room => {
-    const page = Page.verifyOnPage(BedspaceShowPage, room)
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BedspaceShowPage, this.room)
     page.shouldShowBanner('Booking created')
+
+    page.shouldShowBookingDetails(this.booking)
   })
 })
 

--- a/integration_tests/mockApis/room.ts
+++ b/integration_tests/mockApis/room.ts
@@ -3,6 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import paths from '../../server/paths/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
+import booking from './booking'
 
 export default {
   stubRoomsForPremisesId: (args: { premisesId: string; rooms: Array<Room> }) =>
@@ -20,19 +21,22 @@ export default {
       },
     }),
   stubSingleRoom: (args: { premisesId: string; room: Room }) =>
-    stubFor({
-      request: {
-        method: 'GET',
-        urlPath: paths.premises.rooms.show({ premisesId: args.premisesId, roomId: args.room.id }),
-      },
-      response: {
-        status: 200,
-        headers: {
-          'Content-Type': 'application/json;charset=UTF-8',
+    Promise.all([
+      stubFor({
+        request: {
+          method: 'GET',
+          urlPath: paths.premises.rooms.show({ premisesId: args.premisesId, roomId: args.room.id }),
         },
-        jsonBody: args.room,
-      },
-    }),
+        response: {
+          status: 200,
+          headers: {
+            'Content-Type': 'application/json;charset=UTF-8',
+          },
+          jsonBody: args.room,
+        },
+      }),
+      booking.stubBookingsForPremisesId({ premisesId: args.premisesId, bookings: [] }),
+    ]),
   stubRoomCreate: (args: { premisesId: string; room: Room }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -2,6 +2,8 @@ import premisesFactory from '../../../../server/testutils/factories/premises'
 import newRoomFactory from '../../../../server/testutils/factories/newRoom'
 import roomFactory from '../../../../server/testutils/factories/room'
 import updateRoomFactory from '../../../../server/testutils/factories/updateRoom'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import bedFactory from '../../../../server/testutils/factories/bed'
 import Page from '../../../../cypress_shared/pages/page'
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 import BedspaceNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceNew'
@@ -247,18 +249,31 @@ context('Bedspace', () => {
     // Given I am signed in
     cy.signIn()
 
-    // And there is a premises and a room in the database
+    // And there is a premises, a room, and bookings in the database
     const premises = premisesFactory.build()
     const room = roomFactory.build()
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({
+          id: room.beds[0].id,
+        }),
+      })
+      .buildList(5)
 
     cy.task('stubSinglePremises', premises)
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
 
     // When I visit the show bedspace page
     const page = BedspaceShowPage.visit(premises.id, room)
 
     // Then I should see the bedspace details
     page.shouldShowBedspaceDetails()
+
+    // And I should see the booking details
+    bookings.forEach(booking => {
+      page.shouldShowBookingDetails(booking)
+    })
   })
 
   it('navigates back from the show bedspace page to the show premises page', () => {

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -9,8 +9,8 @@ import premisesFactory from '../../../testutils/factories/premises'
 import roomFactory from '../../../testutils/factories/room'
 import characteristicFactory from '../../../testutils/factories/characteristic'
 import updateRoomFactory from '../../../testutils/factories/updateRoom'
-import { ErrorsAndUserInput, SummaryListItem } from '../../../@types/ui'
-import { PremisesService } from '../../../services'
+import { ErrorsAndUserInput, SummaryListItem, TableRow } from '../../../@types/ui'
+import { PremisesService, BookingService } from '../../../services'
 
 jest.mock('../../../utils/validation')
 
@@ -25,7 +25,8 @@ describe('BedspacesController', () => {
 
   const premisesService = createMock<PremisesService>({})
   const bedspaceService = createMock<BedspaceService>({})
-  const bedspacesController = new BedspacesController(premisesService, bedspaceService)
+  const bookingService = createMock<BookingService>({})
+  const bedspacesController = new BedspacesController(premisesService, bedspaceService, bookingService)
 
   beforeEach(() => {
     request = createMock<Request>({ user: { token } })
@@ -242,6 +243,9 @@ describe('BedspacesController', () => {
       const bedspaceDetails = { room, summaryList: { rows: [] as Array<SummaryListItem> } }
       bedspaceService.getSingleBedspaceDetails.mockResolvedValue(bedspaceDetails)
 
+      const bookingTableRows: Array<TableRow> = []
+      bookingService.getTableRowsForBedspace.mockResolvedValue([])
+
       request.params = { premisesId: premises.id, roomId: room.id }
 
       const requestHandler = bedspacesController.show()
@@ -250,10 +254,12 @@ describe('BedspacesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/show', {
         premises,
         bedspace: bedspaceDetails,
+        bookingTableRows,
       })
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
       expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(token, premises.id, room.id)
+      expect(bookingService.getTableRowsForBedspace).toHaveBeenCalledWith(token, premises.id, room.id)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -4,10 +4,14 @@ import type { NewRoom, UpdateRoom } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BedspaceService from '../../../services/bedspaceService'
-import { PremisesService } from '../../../services'
+import { PremisesService, BookingService } from '../../../services'
 
 export default class BedspacesController {
-  constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
+  constructor(
+    private readonly premisesService: PremisesService,
+    private readonly bedspaceService: BedspaceService,
+    private readonly bookingService: BookingService,
+  ) {}
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
@@ -97,11 +101,15 @@ export default class BedspacesController {
       const { premisesId, roomId } = req.params
 
       const premises = await this.premisesService.getPremises(token, premisesId)
+      const room = await this.bedspaceService.getRoom(token, premisesId, roomId)
+
       const bedspaceDetails = await this.bedspaceService.getSingleBedspaceDetails(token, premisesId, roomId)
+      const bookingTableRows = await this.bookingService.getTableRowsForBedspace(token, premisesId, room)
 
       return res.render('temporary-accommodation/bedspaces/show', {
         premises,
         bedspace: bedspaceDetails,
+        bookingTableRows,
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -11,7 +11,11 @@ export const controllers = (services: Services) => {
     services.bedspaceService,
     services.localAuthorityService,
   )
-  const bedspacesController = new BedspacesController(services.premisesService, services.bedspaceService)
+  const bedspacesController = new BedspacesController(
+    services.premisesService,
+    services.bedspaceService,
+    services.bookingService,
+  )
   const bookingsController = new BookingsController(
     services.premisesService,
     services.bedspaceService,

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -89,6 +89,97 @@ describe('BookingService', () => {
     })
   })
 
+  describe('getTableRowsForBedspace', () => {
+    it('returns a sorted table view of the bookings for the given room', async () => {
+      const booking1 = bookingFactory.build({
+        bed: bedFactory.build({ id: bedId }),
+        arrivalDate: '2023-07-01',
+      })
+      const booking2 = bookingFactory.build({
+        bed: bedFactory.build({ id: bedId }),
+        arrivalDate: '2022-11-14',
+      })
+      const booking3 = bookingFactory.build({
+        bed: bedFactory.build({ id: bedId }),
+        arrivalDate: '2022-04-19',
+      })
+
+      const otherBedBooking = bookingFactory.build({
+        bed: bedFactory.build({ id: 'other-bed-id' }),
+      })
+
+      const bookings = [booking2, booking1, booking3, otherBedBooking]
+      bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)
+
+      const room = roomFactory.build({
+        beds: [
+          bedFactory.build({
+            id: bedId,
+          }),
+        ],
+      })
+
+      const rows = await service.getTableRowsForBedspace(token, premisesId, room)
+
+      expect(rows).toEqual([
+        [
+          {
+            text: booking1.person.crn,
+          },
+          {
+            text: '1 Jul 23',
+          },
+          {
+            text: DateFormats.isoDateToUIDate(booking1.departureDate, { format: 'short' }),
+          },
+          {
+            html: `<strong class="govuk-tag">Provisional</strong>`,
+          },
+          {
+            html: `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking1.person.crn}</span></a>`,
+          },
+        ],
+        [
+          {
+            text: booking2.person.crn,
+          },
+          {
+            text: '14 Nov 22',
+          },
+          {
+            text: DateFormats.isoDateToUIDate(booking2.departureDate, { format: 'short' }),
+          },
+          {
+            html: `<strong class="govuk-tag">Provisional</strong>`,
+          },
+          {
+            html: `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking2.person.crn}</span></a>`,
+          },
+        ],
+        [
+          {
+            text: booking3.person.crn,
+          },
+          {
+            text: '19 Apr 22',
+          },
+          {
+            text: DateFormats.isoDateToUIDate(booking3.departureDate, { format: 'short' }),
+          },
+          {
+            html: `<strong class="govuk-tag">Provisional</strong>`,
+          },
+          {
+            html: `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking3.person.crn}</span></a>`,
+          },
+        ],
+      ])
+
+      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
+    })
+  })
+
   describe('listOfBookingsForPremisesId', () => {
     it('should return table rows of bookings', async () => {
       const bookings = bookingFactory.buildList(3)

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
@@ -58,6 +59,30 @@
     rows: bedspace.summaryList.rows,
     classes: 'govuk-summary-list--no-border details'
   }) }}
+
+  <h2>Bookings</h2>
+
+  {{ govukTable({
+    captionClasses: "govuk-table__caption--m",
+    head: [
+      {
+        text: "CRN"
+      },
+      {
+        text: "Start date"
+      },
+      {
+        text: "End date"
+      },
+      {
+        text: "Status"
+      },
+      {
+        html: '<span class="govuk-visually-hidden">Actions</span>'
+      }
+    ],
+    rows: bookingTableRows
+  }) }} 
 
 {% endblock %}
 

--- a/wiremock/roomStub.ts
+++ b/wiremock/roomStub.ts
@@ -1,6 +1,7 @@
 import { guidRegex } from './index'
 import roomFactory from '../server/testutils/factories/room'
 import { errorStub, getCombinations } from './utils'
+import bed from '../server/testutils/factories/bed'
 
 const rooms: Array<Record<string, unknown>> = []
 
@@ -51,7 +52,13 @@ rooms.push({
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
     },
-    jsonBody: roomFactory.build(),
+    jsonBody: roomFactory.build({
+      beds: [
+        bed.build({
+          id: 'bedId',
+        }),
+      ],
+    }),
   },
 })
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -6,6 +6,7 @@ import { bulkStub } from './index'
 
 import premisesJson from './stubs/premises.json'
 import bookingFactory from '../server/testutils/factories/booking'
+import bedFactory from '../server/testutils/factories/bed'
 import premisesFactory from '../server/testutils/factories/premises'
 
 import bookingStubs from './bookingStubs'
@@ -128,16 +129,22 @@ premises.forEach(item => {
     },
   })
 
-  const rand = () => Math.floor(Math.random() * 10)
+  const rand = () => Math.floor(1 + Math.random() * 2)
+
+  const bedspaceBookingFactory = bookingFactory.params({
+    bed: bedFactory.build({
+      id: 'bedId',
+    }),
+  })
 
   const bookings = [
-    bookingFactory.arrivingToday().buildList(rand()),
-    bookingFactory.arrivedToday().buildList(rand()),
-    bookingFactory.departingToday().buildList(rand()),
-    bookingFactory.departedToday().buildList(rand()),
-    bookingFactory.arrivingSoon().buildList(rand()),
-    bookingFactory.cancelledWithFutureArrivalDate().buildList(rand()),
-    bookingFactory.departingSoon().buildList(rand()),
+    bedspaceBookingFactory.arrivingToday().buildList(rand()),
+    bedspaceBookingFactory.arrivedToday().buildList(rand()),
+    bedspaceBookingFactory.departingToday().buildList(rand()),
+    bedspaceBookingFactory.departedToday().buildList(rand()),
+    bedspaceBookingFactory.arrivingSoon().buildList(rand()),
+    bedspaceBookingFactory.cancelledWithFutureArrivalDate().buildList(rand()),
+    bedspaceBookingFactory.departingSoon().buildList(rand()),
   ].flat()
 
   stubs.push({


### PR DESCRIPTION
# Changes in this PR

- The bedspace page now contains a table of bookings for that bedpsace

## Screenshots of UI changes

### Before
![localhost_3000_properties_3d9f4ad2-97f8-464d-ab79-e197e0f9e0aa_bedspaces_14a1d03f-9296-409d-9fb2-598af2d2f7af (1)](https://user-images.githubusercontent.com/94137563/203104462-27bf0869-249e-4570-bbaf-6964deaa3ec0.png)

### After
![localhost_3000_properties_3d9f4ad2-97f8-464d-ab79-e197e0f9e0aa_bedspaces_14a1d03f-9296-409d-9fb2-598af2d2f7af](https://user-images.githubusercontent.com/94137563/203104369-b7eee811-8c30-43da-be6b-fc5751154571.png)
