### PR TITLE
A user can see information about a booking

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -67,4 +67,13 @@ export default class BedspaceShowPage extends Page {
       cy.get('a').contains('Void bedspace').click()
     })
   }
+
+  clickBookingLink(booking: Booking): void {
+    cy.get('tr')
+      .contains(booking.person.crn)
+      .parent()
+      .within(() => {
+        cy.get('a').contains('View').click()
+      })
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -1,11 +1,17 @@
 import type { Premises, Room, Booking } from '@approved-premises/api'
 
 import Page from '../../page'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export default class BookingShowPage extends Page {
   constructor(private readonly premises: Premises, private readonly room: Room, private readonly booking: Booking) {
     super('View a booking')
+  }
+
+  static visit(premises: Premises, room: Room, booking: Booking): BookingShowPage {
+    cy.visit(paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
+    return new BookingShowPage(premises, room, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -1,0 +1,30 @@
+import type { Premises, Room, Booking } from '@approved-premises/api'
+
+import Page from '../../page'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+
+export default class BookingShowPage extends Page {
+  constructor(private readonly premises: Premises, private readonly room: Room, private readonly booking: Booking) {
+    super('View a booking')
+  }
+
+  shouldShowBookingDetails(): void {
+    cy.get('.property-identity').within(() => {
+      cy.get('p').should('contain', this.room.name)
+      cy.get('p').should('contain', this.premises.addressLine1)
+      cy.get('p').should('contain', this.premises.postcode)
+    })
+
+    cy.get('h2').should('contain', this.booking.person.crn)
+
+    cy.get('.govuk-summary-list__key')
+      .contains('Start date')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
+
+    cy.get('.govuk-summary-list__key')
+      .contains('End date')
+      .siblings('.govuk-summary-list__value')
+      .should('contain', DateFormats.isoDateToUIDate(this.booking.departureDate))
+  }
+}

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -2,6 +2,7 @@ import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import Page from '../../../../cypress_shared/pages/page'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
 import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import bookingFactory from '../../../../server/testutils/factories/booking'
 import newBookingFactory from '../../../../server/testutils/factories/newBooking'
 import personFactory from '../../../../server/testutils/factories/person'
@@ -41,10 +42,14 @@ Given('I attempt to create a booking with required details missing', () => {
 
 Then('I should see a confirmation for my new booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BedspaceShowPage, this.room)
-    page.shouldShowBanner('Booking created')
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.shouldShowBanner('Booking created')
+    bookingShowPage.shouldShowBookingDetails()
 
-    page.shouldShowBookingDetails(this.booking)
+    bookingShowPage.clickBreadCrumbUp()
+
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })
 

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -36,6 +36,36 @@ context('Booking', () => {
     Page.verifyOnPage(BookingNewPage)
   })
 
+  it('navigates to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and bookings in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({
+          id: room.beds[0].id,
+        }),
+      })
+      .buildList(5)
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubBooking', { premisesId: premises.id, booking: bookings[0] })
+
+    // When I visit the show bedspace page
+    const bedspaceShowPage = BedspaceShowPage.visit(premises.id, room)
+
+    // Add I click the booking link
+    bedspaceShowPage.clickBookingLink(bookings[0])
+
+    // Then I navigate to the booking page
+    Page.verifyOnPage(BookingShowPage, premises, room, bookings[0])
+  })
+
   it('allows me to create a booking', () => {
     // Given I am signed in
     cy.signIn()

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -61,6 +61,7 @@ context('Booking', () => {
     })
 
     cy.task('stubBookingCreate', { premisesId: premises.id, booking })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
 
     page.completeForm(newBooking)
 
@@ -76,9 +77,9 @@ context('Booking', () => {
       expect(requestBody.departureDate).equal(newBooking.departureDate)
     })
 
-    // And I should be redirected to the show bedspace page
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, room)
-    bedspaceShowPage.shouldShowBanner('Booking created')
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
+    bookingShowPage.shouldShowBanner('Booking created')
   })
 
   it('shows a suggested end date for the booking', () => {

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -97,7 +97,7 @@ describe('BookingsController', () => {
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking created')
-      expect(response.redirect).toHaveBeenCalledWith(paths.premises.bedspaces.show({ premisesId, roomId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId: booking.id }))
     })
 
     it('renders with errors if the API returns an error', async () => {

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -174,4 +174,43 @@ describe('BookingsController', () => {
       )
     })
   })
+
+  describe('show', () => {
+    it('renders the template for viewing a booking', async () => {
+      const premises = premisesFactory.build()
+      const room = roomFactory.build()
+      const booking = bookingFactory.build()
+
+      premisesService.getPremises.mockResolvedValue(premises)
+      bedspaceService.getRoom.mockResolvedValue(room)
+      bookingService.getBookingDetails.mockResolvedValue({
+        booking,
+        summaryList: {
+          rows: [],
+        },
+      })
+
+      request.params = {
+        premisesId: premises.id,
+        roomId: room.id,
+        bookingId: booking.id,
+      }
+
+      const requestHandler = bookingsController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/show', {
+        premises,
+        room,
+        booking,
+        summaryList: {
+          rows: [],
+        },
+      })
+
+      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premises.id, room.id)
+      expect(bookingService.getBookingDetails).toHaveBeenCalledWith(token, premises.id, booking.id)
+    })
+  })
 })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -49,10 +49,10 @@ export default class BookingsController {
       }
 
       try {
-        await this.bookingsService.createForBedspace(token, premisesId, room, newBooking)
+        const booking = await this.bookingsService.createForBedspace(token, premisesId, room, newBooking)
 
         req.flash('success', 'Booking created')
-        res.redirect(paths.premises.bedspaces.show({ premisesId, roomId }))
+        res.redirect(paths.bookings.show({ premisesId, roomId, bookingId: booking.id }))
       } catch (err) {
         if (err.status === 409) {
           insertGenericError(err, 'arrivalDate', 'conflict')

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -63,4 +63,23 @@ export default class BookingsController {
       }
     }
   }
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, roomId, bookingId } = req.params
+      const { token } = req.user
+
+      const premises = await this.premisesService.getPremises(token, premisesId)
+      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+
+      const { booking, summaryList } = await this.bookingsService.getBookingDetails(token, premisesId, bookingId)
+
+      return res.render('temporary-accommodation/bookings/show', {
+        premises,
+        room,
+        booking,
+        summaryList,
+      })
+    }
+  }
 }

--- a/server/form-pages/apply/basic-information/oralHearing.test.ts
+++ b/server/form-pages/apply/basic-information/oralHearing.test.ts
@@ -123,7 +123,7 @@ describe('OralHearing', () => {
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        'Oral Hearing Date': 'Friday 11 November 2022',
+        'Oral Hearing Date': '11 November 2022',
       })
     })
   })

--- a/server/form-pages/apply/basic-information/placementDate.test.ts
+++ b/server/form-pages/apply/basic-information/placementDate.test.ts
@@ -118,7 +118,7 @@ describe('PlacementDate', () => {
 
       expect(page.response()).toEqual({
         [page.title]: 'No',
-        'Placement Start Date': 'Friday 11 November 2022',
+        'Placement Start Date': '11 November 2022',
       })
     })
   })

--- a/server/form-pages/apply/basic-information/releaseDate.test.ts
+++ b/server/form-pages/apply/basic-information/releaseDate.test.ts
@@ -139,7 +139,7 @@ describe('ReleaseDate', () => {
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        'Release Date': 'Friday 11 November 2022',
+        'Release Date': '11 November 2022',
       })
     })
   })

--- a/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
+++ b/server/form-pages/apply/type-of-ap/pipeReferral.test.ts
@@ -126,7 +126,7 @@ describe('PipeReferral', () => {
 
       expect(page.response()).toEqual({
         [page.title]: 'Yes',
-        "When was John Wayne's last consultation or formulation?": 'Friday 11 November 2022',
+        "When was John Wayne's last consultation or formulation?": '11 November 2022',
       })
     })
   })

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -4,9 +4,10 @@ const premisesPath = temporaryAccommodationPath.path('properties')
 const singlePremisesPath = premisesPath.path(':premisesId')
 
 const bedspacesPath = singlePremisesPath.path('bedspaces')
-const singleBedspacePath = singlePremisesPath.path('bedspaces').path(':roomId')
+const singleBedspacePath = bedspacesPath.path(':roomId')
 
 const bookingsPath = singleBedspacePath.path('bookings')
+const singleBookingPath = bookingsPath.path(':bookingId')
 
 const paths = {
   premises: {
@@ -27,6 +28,7 @@ const paths = {
   bookings: {
     new: bookingsPath.path('new'),
     create: bookingsPath,
+    show: singleBookingPath,
   },
 }
 

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -27,6 +27,7 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.bookings.new.pattern, bookingsController.new())
   post(paths.bookings.create.pattern, bookingsController.create())
+  get(paths.bookings.show.pattern, bookingsController.show())
 
   return router
 }

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -180,6 +180,43 @@ describe('BookingService', () => {
     })
   })
 
+  describe('getBookingDetails', () => {
+    it('returns a booking and a summary list of details for the booking', async () => {
+      const booking = bookingFactory.build({
+        arrivalDate: '2022-03-21',
+        departureDate: '2023-01-07',
+      })
+
+      bookingClient.find.mockResolvedValue(booking)
+
+      const result = await service.getBookingDetails(token, premisesId, booking.id)
+
+      expect(result).toEqual({
+        booking,
+        summaryList: {
+          rows: [
+            {
+              key: {
+                text: 'Start date',
+              },
+              value: {
+                text: '21 March 2022',
+              },
+            },
+            {
+              key: {
+                text: 'End date',
+              },
+              value: {
+                text: '7 January 2023',
+              },
+            },
+          ],
+        },
+      })
+    })
+  })
+
   describe('listOfBookingsForPremisesId', () => {
     it('should return table rows of bookings', async () => {
       const bookings = bookingFactory.buildList(3)

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -5,7 +5,8 @@ import newBookingFactory from '../testutils/factories/newBooking'
 import bookingExtensionFactory from '../testutils/factories/bookingExtension'
 import bookingFactory from '../testutils/factories/booking'
 
-import paths from '../paths/manage'
+import apPaths from '../paths/manage'
+import taPaths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from '../utils/dateUtils'
 import roomFactory from '../testutils/factories/room'
 import bedFactory from '../testutils/factories/bed'
@@ -136,7 +137,13 @@ describe('BookingService', () => {
             html: `<strong class="govuk-tag">Provisional</strong>`,
           },
           {
-            html: `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking1.person.crn}</span></a>`,
+            html: `<a href="${taPaths.bookings.show({
+              premisesId,
+              roomId: room.id,
+              bookingId: booking1.id,
+            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+              booking1.person.crn
+            }</span></a>`,
           },
         ],
         [
@@ -153,7 +160,13 @@ describe('BookingService', () => {
             html: `<strong class="govuk-tag">Provisional</strong>`,
           },
           {
-            html: `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking2.person.crn}</span></a>`,
+            html: `<a href="${taPaths.bookings.show({
+              premisesId,
+              roomId: room.id,
+              bookingId: booking2.id,
+            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+              booking2.person.crn
+            }</span></a>`,
           },
         ],
         [
@@ -170,7 +183,13 @@ describe('BookingService', () => {
             html: `<strong class="govuk-tag">Provisional</strong>`,
           },
           {
-            html: `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking3.person.crn}</span></a>`,
+            html: `<a href="${taPaths.bookings.show({
+              premisesId,
+              roomId: room.id,
+              bookingId: booking3.id,
+            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+              booking3.person.crn
+            }</span></a>`,
           },
         ],
       ])
@@ -312,13 +331,13 @@ describe('BookingService', () => {
       expect(results[0][0]).toEqual({ text: bookings[0].person.crn })
       expect(results[0][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking1Date) })
       expect(results[0][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[0].id })),
+        html: expect.stringMatching(apPaths.bookings.show({ premisesId, bookingId: bookings[0].id })),
       })
 
       expect(results[1][0]).toEqual({ text: bookings[1].person.crn })
       expect(results[1][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking2Date) })
       expect(results[1][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[1].id })),
+        html: expect.stringMatching(apPaths.bookings.show({ premisesId, bookingId: bookings[1].id })),
       })
     })
 
@@ -336,13 +355,13 @@ describe('BookingService', () => {
       expect(results[0][0]).toEqual({ text: bookings[0].person.crn })
       expect(results[0][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking1Date) })
       expect(results[0][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[0].id })),
+        html: expect.stringMatching(apPaths.bookings.show({ premisesId, bookingId: bookings[0].id })),
       })
 
       expect(results[1][0]).toEqual({ text: bookings[1].person.crn })
       expect(results[1][1]).toEqual({ text: DateFormats.dateObjtoUIDate(booking2Date) })
       expect(results[1][2]).toEqual({
-        html: expect.stringMatching(paths.bookings.show({ premisesId, bookingId: bookings[1].id })),
+        html: expect.stringMatching(apPaths.bookings.show({ premisesId, bookingId: bookings[1].id })),
       })
     })
   })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -12,7 +12,8 @@ import type { TableRow, GroupedListofBookings, SummaryList } from '@approved-pre
 
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
-import paths from '../paths/manage'
+import apPaths from '../paths/manage'
+import taPaths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from '../utils/dateUtils'
 
 export default class BookingService {
@@ -68,7 +69,11 @@ export default class BookingService {
           this.textValue(DateFormats.isoDateToUIDate(booking.departureDate, { format: 'short' })),
           this.htmlValue('<strong class="govuk-tag">Provisional</strong>'),
           this.htmlValue(
-            `<a href="#">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking.person.crn}</span></a>`,
+            `<a href="${taPaths.bookings.show({
+              premisesId,
+              roomId: room.id,
+              bookingId: booking.id,
+            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${booking.person.crn}</span></a>`,
           ),
         ]
       })
@@ -143,7 +148,7 @@ export default class BookingService {
         text: DateFormats.isoDateToUIDate(type === 'arrival' ? booking.arrivalDate : booking.departureDate),
       },
       {
-        html: `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
+        html: `<a href="${apPaths.bookings.show({ premisesId, bookingId: booking.id })}">
           Manage
           <span class="govuk-visually-hidden">
             booking for ${booking.person.crn}
@@ -171,7 +176,7 @@ export default class BookingService {
         text: DateFormats.isoDateToUIDate(booking.departureDate),
       },
       {
-        html: `<a href="${paths.bookings.show({ premisesId, bookingId: booking.id })}">
+        html: `<a href="${apPaths.bookings.show({ premisesId, bookingId: booking.id })}">
         Manage
         <span class="govuk-visually-hidden">
           booking for ${booking.person.crn}

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -8,7 +8,7 @@ import type {
   Room,
   NewTemporaryAccommodationBooking,
 } from '@approved-premises/api'
-import type { TableRow, GroupedListofBookings } from '@approved-premises/ui'
+import type { TableRow, GroupedListofBookings, SummaryList } from '@approved-premises/ui'
 
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
@@ -72,6 +72,31 @@ export default class BookingService {
           ),
         ]
       })
+  }
+
+  async getBookingDetails(
+    token: string,
+    premisesId: string,
+    bookingId: string,
+  ): Promise<{ booking: Booking; summaryList: SummaryList }> {
+    const bookingClient = this.bookingClientFactory(token)
+    const booking = await bookingClient.find(premisesId, bookingId)
+
+    return {
+      booking,
+      summaryList: {
+        rows: [
+          {
+            key: this.textValue('Start date'),
+            value: this.textValue(DateFormats.isoDateToUIDate(booking.arrivalDate)),
+          },
+          {
+            key: this.textValue('End date'),
+            value: this.textValue(DateFormats.isoDateToUIDate(booking.departureDate)),
+          },
+        ],
+      },
+    }
   }
 
   async listOfBookingsForPremisesId(token: string, premisesId: string): Promise<Array<TableRow>> {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -471,7 +471,7 @@ describe('PremisesService', () => {
       const result = await service.getOvercapacityMessage(token, premisesId)
 
       expect(result).toEqual([
-        '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on Saturday 1 January 2022</h4>',
+        '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on 1 January 2022</h4>',
       ])
     })
 
@@ -497,7 +497,7 @@ describe('PremisesService', () => {
       const result = await service.getOvercapacityMessage(token, premisesId)
 
       expect(result).toEqual([
-        '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period Saturday 1 January 2022 to Tuesday 1 February 2022</h4>',
+        '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period 1 January 2022 to 1 February 2022</h4>',
       ])
     })
 
@@ -525,7 +525,7 @@ describe('PremisesService', () => {
 
       expect(result).toEqual([
         `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>
-        <ul class="govuk-list govuk-list--bullet"><li>Sunday 1 January 2023 to Wednesday 1 February 2023</li><li>Thursday 2 March 2023 to Sunday 2 April 2023</li></ul>`,
+        <ul class="govuk-list govuk-list--bullet"><li>1 January 2023 to 1 February 2023</li><li>2 March 2023 to 2 April 2023</li></ul>`,
       ])
     })
 
@@ -550,7 +550,7 @@ describe('PremisesService', () => {
 
       expect(result).toEqual([
         `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>
-        <ul class="govuk-list govuk-list--bullet"><li>Sunday 1 January 2023</li><li>Thursday 2 March 2023 to Sunday 2 April 2023</li></ul>`,
+        <ul class="govuk-list govuk-list--bullet"><li>1 January 2023</li><li>2 March 2023 to 2 April 2023</li></ul>`,
       ])
     })
   })

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -26,7 +26,7 @@ describe('DateFormats', () => {
     it('converts a ISO8601 date string to a GOV.UK formatted date', () => {
       const date = '2022-11-11T00:00:00.000Z'
 
-      expect(DateFormats.isoDateToUIDate(date)).toEqual('Friday 11 November 2022')
+      expect(DateFormats.isoDateToUIDate(date)).toEqual('11 November 2022')
     })
 
     it('converts a ISO8601 date string to a short format date', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -24,11 +24,11 @@ export class DateFormats {
 
   /**
    * @param date JS Date object.
-   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   * @returns the date in the to be shown in the UI: "20 December 2012".
    */
   static dateObjtoUIDate(date: Date, options: { format: 'short' | 'long' } = { format: 'long' }) {
     if (options.format === 'long') {
-      return format(date, 'cccc d MMMM y')
+      return format(date, 'd MMMM y')
     } else {
       return format(date, 'd MMM yy')
     }
@@ -52,7 +52,7 @@ export class DateFormats {
 
   /**
    * @param isoDate an ISO date string.
-   * @returns the date in the to be shown in the UI: "Thursday, 20 December 2012".
+   * @returns the date in the to be shown in the UI: "20 December 2012".
    */
   static isoDateToUIDate(isoDate: string, options: { format: 'short' | 'long' } = { format: 'long' }) {
     return DateFormats.dateObjtoUIDate(DateFormats.convertIsoToDateObj(isoDate), options)

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -1,0 +1,48 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - View a booking" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ breadCrumb('View a booking', [
+    {title: 'List of properties', href: paths.premises.index()},
+    {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
+    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+  ]) }}
+
+  {% include "../../_messages.njk" %}
+
+  <h1>View a booking</h1>
+
+  <div class="property-identity">
+    <h2 class="govuk-label govuk-label--m">Bedspace reference</h2>
+    <p class="govuk-body">{{ room.name }}</p>
+
+    <h2 class="govuk-label govuk-label--m">Property address</h2>
+    <p class="govuk-body">{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
+  </div>
+
+  <div class="edit-bar">
+    <div class="edit-bar__container">
+      <div class="edit-bar__title">
+        <h2 class="govuk-label govuk-label--m">CRN: {{ booking.person.crn }}</h2>
+      </div>
+      <div class="edit-bar__action">
+        <a href="#">Edit</a>
+      </div>
+    </div>
+  </div>
+
+  {{ govukSummaryList({
+    rows: summaryList.rows,
+    classes: 'govuk-summary-list--no-border details'
+  }) }}
+
+{% endblock %}


### PR DESCRIPTION
# Changes in this PR

- A user can now click the "view" link in the table of bookings on a bedspace page, and see a page of information about that booking

## Screenshots of UI changes

![localhost_3000_properties_3d9f4ad2-97f8-464d-ab79-e197e0f9e0aa_bedspaces_5cf4ec04-49ef-420f-beb5-b492a3246552_bookings_d8890a41-10bc-4e20-b7f5-25a1bb5554be](https://user-images.githubusercontent.com/94137563/203105280-e7ae4ac3-9ea4-4abc-99c6-665e7df12324.png)

