### PR TITLE
Add environment variables for preprod

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -105,21 +105,20 @@ workflows:
                 - main
           requires:
             - deploy_dev
+      - request-preprod-approval:
+          type: approval
+          requires:
+            - deploy_dev
+            - e2e_environment_test
+      - hmpps/deploy_env:
+          name: deploy_preprod
+          env: 'preprod'
+          context:
+            - hmpps-common-vars
+            - temporary-accommodation-ui-preprod
+          requires:
+            - request-preprod-approval
 
-  #      - request-preprod-approval:
-  #          type: approval
-  #          requires:
-  #            - deploy_dev
-  #      - hmpps/deploy_env:
-  #          name: deploy_preprod
-  #          env: "preprod"
-  #          jira_update: true
-  #          jira_env_type: staging
-  #          context:
-  #            - hmpps-common-vars
-  #            - approved-premises-ui-preprod
-  #          requires:
-  #            - request-preprod-approval
   #      - request-prod-approval:
   #          type: approval
   #          requires:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -1,0 +1,21 @@
+---
+# Per environment values which override defaults in approved-premises-ui/values.yaml
+
+generic-service:
+  ingress:
+    hosts:
+      - temporary-accommodation-preprod.hmpps.service.justice.gov.uk
+    contextColour: green
+    tlsSecretName: hmpps-temporary-accommodation-preprod-cert
+
+  env:
+    ENVIRONMENT: preprod
+    APPROVED_PREMISES_API_URL: 'https://approved-premises-api-preprod.hmpps.service.justice.gov.uk'
+    INGRESS_URL: 'https://temporary-accommodation-preprod.hmpps.service.justice.gov.uk'
+    HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
+    TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
+
+  allowlist: null
+
+generic-prometheus-alerts:
+  alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
The values for the preprod hostnames were pulled from the certificates made for each respective service over in the https://github.com/ministryofjustice/cloud-platform-environments repo.