### PR TITLE
A user can mark an occupied bed as closed

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -47,6 +47,13 @@ export default class BedspaceShowPage extends Page {
           cy.get('td')
             .eq(2)
             .contains(DateFormats.isoDateToUIDate(booking.arrival.expectedDepartureDate, { format: 'short' }))
+        } else if (booking.status === 'departed') {
+          cy.get('td')
+            .eq(1)
+            .contains(DateFormats.isoDateToUIDate(booking.arrival.arrivalDate, { format: 'short' }))
+          cy.get('td')
+            .eq(2)
+            .contains(DateFormats.isoDateToUIDate(booking.departure.dateTime, { format: 'short' }))
         }
 
         if (status === 'provisional') {
@@ -55,6 +62,8 @@ export default class BedspaceShowPage extends Page {
           cy.get('td').eq(3).contains('Confirmed')
         } else if (status === 'arrived') {
           cy.get('td').eq(3).contains('Active')
+        } else if (status === 'departed') {
+          cy.get('td').eq(3).contains('Closed')
         }
 
         cy.get('td').eq(4).contains('View')

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -21,6 +21,7 @@ export default class BookingArrivalNewPage extends Page {
 
     this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
     this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
+    this.shouldShowKeyAndValues('Notes', this.booking.confirmation.notes.split('\n'))
 
     this.shouldShowDateInputs('arrivalDate', this.booking.arrivalDate)
     this.shouldShowDateInputs('expectedDepartureDate', this.booking.departureDate)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -1,0 +1,46 @@
+import type { Booking, NewDeparture } from '@approved-premises/api'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+import Page from '../../page'
+
+export default class BookingDepartureNewPage extends Page {
+  constructor(private readonly booking: Booking) {
+    super('Mark booking as closed')
+  }
+
+  shouldShowBookingDetails(): void {
+    cy.get('.location-header').within(() => {
+      cy.get('p').should('contain', this.booking.person.crn)
+    })
+
+    this.shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.booking.arrival.arrivalDate))
+    this.shouldShowKeyAndValue(
+      'Expected departure date',
+      DateFormats.isoDateToUIDate(this.booking.arrival.expectedDepartureDate),
+    )
+    this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
+
+    this.shouldShowDateInputs('dateTime', this.booking.arrival.expectedDepartureDate)
+  }
+
+  completeForm(newDeparture: NewDeparture): void {
+    this.clearForm()
+
+    this.getLegend('What was the departure date?')
+    this.completeDateInputs('dateTime', newDeparture.dateTime)
+
+    this.getLabel('What was the departure reason?')
+    this.getSelectInputByIdAndSelectAnEntry('reasonId', newDeparture.reasonId)
+
+    this.getLabel('What was the move on category?')
+    this.getSelectInputByIdAndSelectAnEntry('moveOnCategoryId', newDeparture.moveOnCategoryId)
+
+    this.getLabel('Please provide any further details')
+    this.getTextInputByIdAndEnterDetails('notes', newDeparture.notes)
+
+    this.clickSubmit()
+  }
+
+  clearForm(): void {
+    this.clearDateInputs('dateTime')
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -1,10 +1,16 @@
 import type { Booking, NewDeparture } from '@approved-premises/api'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 import Page from '../../page'
 
 export default class BookingDepartureNewPage extends Page {
   constructor(private readonly booking: Booking) {
     super('Mark booking as closed')
+  }
+
+  static visit(premisesId: string, roomId: string, booking: Booking): BookingDepartureNewPage {
+    cy.visit(paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }))
+    return new BookingDepartureNewPage(booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -22,6 +22,10 @@ export default class BookingShowPage extends Page {
     cy.get('a').contains('Mark as active').click()
   }
 
+  clickMarkDepartedBookingButton(): void {
+    cy.get('a').contains('Mark as closed').click()
+  }
+
   shouldShowBookingDetails(): void {
     cy.get('.location-header').within(() => {
       cy.get('p').should('contain', this.booking.person.crn)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -41,6 +41,8 @@ export default class BookingShowPage extends Page {
         'Expected departure date',
         DateFormats.isoDateToUIDate(this.booking.arrival.expectedDepartureDate),
       )
+    } else if (status === 'departed') {
+      this.shouldShowKeyAndValue('Departure date', DateFormats.isoDateToUIDate(this.booking.departure.dateTime))
     }
 
     if (status === 'provisional') {
@@ -51,6 +53,11 @@ export default class BookingShowPage extends Page {
     } else if (status === 'arrived') {
       this.shouldShowKeyAndValue('Status', 'Active')
       this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
+    } else if (status === 'departed') {
+      this.shouldShowKeyAndValue('Status', 'Closed')
+      this.shouldShowKeyAndValue('Departure reason', this.booking.departure.reason.name)
+      this.shouldShowKeyAndValue('Move on category', this.booking.departure.moveOnCategory.name)
+      this.shouldShowKeyAndValues('Notes', this.booking.departure.notes.split('\n'))
     }
   }
 }

--- a/e2e/tests/booking.feature
+++ b/e2e/tests/booking.feature
@@ -34,3 +34,19 @@ Feature: Manage Temporary Accommodation - Booking
         And I confirm the booking
         And I attempt to mark the booking as arrived with required details missing
         Then I should see a list of the problems encountered marking the booking as arrived
+
+    Scenario: Marking a booking as departed
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I confirm the booking
+        And I mark the booking as arrived
+        And I mark the booking as departed
+        Then I should see the booking with the departed status
+
+    Scenario: Showing booking departure errors
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I confirm the booking
+        And I mark the booking as arrived
+        And I attempt to mark the booking as departed with required details missing
+        Then I should see a list of the problems encountered marking the booking as departed

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -1,0 +1,71 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+import Page from '../../../../cypress_shared/pages/page'
+import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import departureFactory from '../../../../server/testutils/factories/departure'
+import newDepartureFactory from '../../../../server/testutils/factories/newDeparture'
+
+Given('I mark the booking as departed', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.clickMarkDepartedBookingButton()
+
+    const departure = departureFactory.build()
+    const newDeparture = newDepartureFactory.build({
+      ...departure,
+      reasonId: departure.reason.id,
+      moveOnCategoryId: departure.moveOnCategory.id,
+    })
+
+    const bookingDeparturePage = Page.verifyOnPage(BookingDepartureNewPage, this.booking)
+    bookingDeparturePage.shouldShowBookingDetails()
+    bookingDeparturePage.completeForm(newDeparture)
+
+    const departedBooking = bookingFactory.build({
+      ...this.booking,
+      status: 'departed',
+      departure,
+    })
+
+    cy.wrap(departedBooking).as('booking')
+  })
+})
+
+Given('I attempt to mark the booking as departed with required details missing', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.clickMarkDepartedBookingButton()
+
+    const bookingDeparturePage = Page.verifyOnPage(
+      BookingDepartureNewPage,
+      this.premises.id,
+      this.room.id,
+      this.booking,
+    )
+    bookingDeparturePage.clearForm()
+    bookingDeparturePage.clickSubmit()
+  })
+})
+
+Then('I should see the booking with the departed status', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.shouldShowBanner('Booking marked as closed')
+    bookingShowPage.shouldShowBookingDetails()
+
+    bookingShowPage.clickBreadCrumbUp()
+
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    bedspaceShowPage.shouldShowBookingDetails(this.booking)
+  })
+})
+
+Then('I should see a list of the problems encountered marking the booking as departed', () => {
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BookingDepartureNewPage, this.premises.id, this.room.id, this.booking)
+
+    page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
+  })
+})

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -4,7 +4,7 @@ import type { Departure } from '@approved-premises/api'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
-import { departureReasons, moveOnCategories, destinationProviders } from '../../wiremock/referenceDataStubs'
+import { departureReasons, moveOnCategories } from '../../wiremock/referenceDataStubs'
 
 export default {
   stubDepartureGet: (args: { premisesId: string; bookingId: string; departure: Departure }): SuperAgentRequest =>
@@ -33,8 +33,8 @@ export default {
     }),
   stubDepartureErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`, 'POST')),
-  stubDepartureReferenceData: (): Promise<[Response, Response, Response]> =>
-    Promise.all([stubFor(departureReasons), stubFor(moveOnCategories), stubFor(destinationProviders)]),
+  stubDepartureReferenceData: (): Promise<[Response, Response]> =>
+    Promise.all([stubFor(departureReasons), stubFor(moveOnCategories)]),
   verifyDepartureCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -31,7 +31,7 @@ export default {
         jsonBody: args.departure,
       },
     }),
-  stubDepartureErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
+  stubDepartureCreateErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`, 'POST')),
   stubDepartureReferenceData: (): Promise<[Response, Response]> =>
     Promise.all([stubFor(departureReasons), stubFor(moveOnCategories)]),

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -1,0 +1,113 @@
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import newDepartureFactory from '../../../../server/testutils/factories/newDeparture'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import departureFactory from '../../../../server/testutils/factories/departure'
+import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
+
+context('Booking departure', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('allows me to mark a booking as departed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.arrived().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the booking departure page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureNewPage.visit(premises.id, room.id, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const departure = departureFactory.build()
+    const newDeparture = newDepartureFactory.build({
+      ...departure,
+      reasonId: departure.reason.id,
+      moveOnCategoryId: departure.moveOnCategory.id,
+    })
+
+    cy.task('stubDepartureCreate', { premisesId: premises.id, bookingId: booking.id, departure })
+
+    page.completeForm(newDeparture)
+
+    // Then the departure should have been created in the API
+    cy.task('verifyDepartureCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.dateTime).equal(newDeparture.dateTime)
+      expect(requestBody.reasonId).equal(newDeparture.reasonId)
+      expect(requestBody.moveOnCategoryId).equal(newDeparture.moveOnCategoryId)
+      expect(requestBody.notes).equal(newDeparture.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
+    bookingShowPage.shouldShowBanner('Booking marked as closed')
+  })
+
+  it('shows errors when the API returns an error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is an arrived booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.arrived().build()
+
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the booking departure page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureNewPage.visit(premises.id, room.id, booking)
+
+    // And I miss required fields
+    cy.task('stubDepartureCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['dateTime', 'reasonId', 'moveOnCategoryId'],
+    })
+    page.clearForm()
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
+  })
+
+  it('navigates back from the booking departure page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.arrived().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the booking departure page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureNewPage.visit(premises.id, room.id, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, booking)
+  })
+})

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -14,6 +14,30 @@ context('Booking departure', () => {
     cy.task('stubAuthUser')
   })
 
+  it('navigates to the booking departure page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.arrived().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, room, booking)
+
+    // Add I click the marked departed booking action
+    cy.task('stubDepartureReferenceData')
+    bookingShow.clickMarkDepartedBookingButton()
+
+    // Then I navigate to the booking departure page
+    Page.verifyOnPage(BookingDepartureNewPage, premises.id, room.id, booking)
+  })
+
   it('allows me to mark a booking as departed', () => {
     // Given I am signed in
     cy.signIn()

--- a/server/@types/shared/models/NewPremises.ts
+++ b/server/@types/shared/models/NewPremises.ts
@@ -10,6 +10,7 @@ export type NewPremises = {
     postcode: string;
     notes?: string;
     localAuthorityAreaId: string;
+    probationRegionId: string;
     characteristicIds: Array<string>;
     status: PropertyStatus;
 };

--- a/server/@types/shared/models/UpdatePremises.ts
+++ b/server/@types/shared/models/UpdatePremises.ts
@@ -9,6 +9,7 @@ export type UpdatePremises = {
     postcode: string;
     notes?: string;
     localAuthorityAreaId: string;
+    probationRegionId: string;
     characteristicIds: Array<string>;
     status: PropertyStatus;
 };

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -1,0 +1,131 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import paths from '../../../paths/temporary-accommodation/manage'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import bookingFactory from '../../../testutils/factories/booking'
+import { BookingService, DepartureService } from '../../../services'
+import departureFactory from '../../../testutils/factories/departure'
+import newDepartureFactory from '../../../testutils/factories/newDeparture'
+import { DateFormats } from '../../../utils/dateUtils'
+import DeparturesController from './departuresController'
+
+jest.mock('../../../utils/validation')
+
+describe('DeparturesController', () => {
+  const token = 'SOME_TOKEN'
+  const premisesId = 'premisesId'
+  const roomId = 'roomId'
+  const bookingId = 'bookingId'
+
+  let request: DeepMocked<Request>
+
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const bookingService = createMock<BookingService>({})
+  const departureService = createMock<DepartureService>({})
+
+  const departuresController = new DeparturesController(bookingService, departureService)
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token } })
+  })
+
+  describe('new', () => {
+    it('renders the form prepopulated with the current departure dates', async () => {
+      const booking = bookingFactory.build()
+
+      request.params = {
+        premisesId,
+        roomId,
+        bookingId: booking.id,
+      }
+
+      bookingService.getBookingDetails.mockResolvedValue({ booking, summaryList: { rows: [] } })
+      departureService.getReferenceData.mockResolvedValue({ departureReasons: [], moveOnCategories: [] })
+
+      const requestHandler = departuresController.new()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.getBookingDetails).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(departureService.getReferenceData).toHaveBeenCalledWith(token)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/departures/new', {
+        booking,
+        summaryList: { rows: [] },
+        roomId,
+        premisesId,
+        allDepartureReasons: [],
+        allMoveOnCategories: [],
+        errors: {},
+        ...DateFormats.convertIsoToDateAndTimeInputs(booking.arrival.expectedDepartureDate, 'dateTime'),
+        errorSummary: [],
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('creates a departure and redirects to the show booking page', async () => {
+      const requestHandler = departuresController.create()
+
+      const departure = departureFactory.build()
+      const newDeparture = newDepartureFactory.build({
+        ...departure,
+      })
+
+      request.params = {
+        premisesId,
+        roomId,
+        bookingId,
+      }
+      request.body = {
+        ...newDeparture,
+        ...DateFormats.convertIsoToDateAndTimeInputs(newDeparture.dateTime, 'dateTime'),
+      }
+
+      departureService.createDeparture.mockResolvedValue(departure)
+
+      await requestHandler(request, response, next)
+
+      expect(departureService.createDeparture).toHaveBeenCalledWith(
+        token,
+        premisesId,
+        bookingId,
+        expect.objectContaining(newDeparture),
+      )
+
+      expect(request.flash).toHaveBeenCalledWith('success', 'Booking marked as closed')
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId }))
+    })
+
+    it('renders with errors if the API returns an error', async () => {
+      const requestHandler = departuresController.create()
+
+      const departure = departureFactory.build()
+      const newDeparture = newDepartureFactory.build({
+        ...departure,
+      })
+
+      request.params = {
+        premisesId,
+        roomId,
+        bookingId,
+      }
+      request.body = {
+        ...newDeparture,
+        ...DateFormats.convertIsoToDateAndTimeInputs(newDeparture.dateTime, 'dateTime'),
+      }
+
+      const err = new Error()
+      departureService.createDeparture.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, '')
+    })
+  })
+})

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -125,7 +125,12 @@ describe('DeparturesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, '')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.bookings.departures.new({ premisesId, roomId, bookingId }),
+      )
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -1,0 +1,58 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import type { NewDeparture } from '@approved-premises/api'
+import paths from '../../../paths/temporary-accommodation/manage'
+import { BookingService, DepartureService } from '../../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { DateFormats } from '../../../utils/dateUtils'
+
+export default class DeparturesController {
+  constructor(private readonly bookingsService: BookingService, private readonly departureService: DepartureService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
+      const { premisesId, roomId, bookingId } = req.params
+
+      const { token } = req.user
+
+      const { booking, summaryList } = await this.bookingsService.getBookingDetails(token, premisesId, bookingId)
+      const { departureReasons: allDepartureReasons, moveOnCategories: allMoveOnCategories } =
+        await this.departureService.getReferenceData(token)
+
+      return res.render('temporary-accommodation/departures/new', {
+        booking,
+        summaryList,
+        roomId,
+        premisesId,
+        allDepartureReasons,
+        allMoveOnCategories,
+        errors,
+        errorSummary: requestErrorSummary,
+        ...DateFormats.convertIsoToDateAndTimeInputs(booking.arrival.expectedDepartureDate, 'dateTime'),
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, roomId, bookingId } = req.params
+      const { token } = req.user
+
+      const newDeparture: NewDeparture = {
+        ...req.body,
+        ...DateFormats.convertDateAndTimeInputsToIsoString({ ...req.body }, 'dateTime', { representation: 'complete' }),
+      }
+
+      try {
+        await this.departureService.createDeparture(token, premisesId, bookingId, newDeparture)
+
+        req.flash('success', 'Booking marked as closed')
+        res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, '')
+      }
+    }
+  }
+}

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -51,7 +51,7 @@ export default class DeparturesController {
         req.flash('success', 'Booking marked as closed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
       } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, '')
+        catchValidationErrorOrPropogate(req, res, err, paths.bookings.departures.new({ premisesId, roomId, bookingId }))
       }
     }
   }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -6,6 +6,7 @@ import BedspacesController from './bedspacesController'
 import BookingsController from './bookingsController'
 import ConfirmationsController from './confirmationsController'
 import ArrivalsController from './arrivalsController'
+import DeparturesController from './departuresController'
 
 export const controllers = (services: Services) => {
   const premisesController = new PremisesController(
@@ -28,12 +29,15 @@ export const controllers = (services: Services) => {
 
   const arrivalsController = new ArrivalsController(services.bookingService, services.arrivalService)
 
+  const departuresController = new DeparturesController(services.bookingService, services.departureService)
+
   return {
     premisesController,
     bedspacesController,
     bookingsController,
     confirmationsController,
     arrivalsController,
+    departuresController,
   }
 }
 

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -22,8 +22,8 @@
     "empty": "You must enter a valid departure date",
     "invalid": "The departure date is an invalid date"
   },
-  "reason": {
-    "empty": "You must choose a valid reason",
+  "reasonId": {
+    "empty": "You must choose a departure reason",
     "doesNotExist": "This reason does not exist"
   },
   "departureDate": {
@@ -49,7 +49,7 @@
   "destinationProviderId": {
     "doesNotExist": "The destination provider does not exist"
   },
-  "moveOnCategory": { "empty": "You must enter a move on category" },
+  "moveOnCategoryId": { "empty": "You must choose a move on category" },
   "destinationProvider": { "empty": "You must enter a destination provider" },
   "newDepartureDate": {
     "empty": "You must enter a new departure date",

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -9,8 +9,9 @@ const singleBedspacePath = bedspacesPath.path(':roomId')
 const bookingsPath = singleBedspacePath.path('bookings')
 const singleBookingPath = bookingsPath.path(':bookingId')
 
-const confirmationsPath = singleBookingPath.path('confirmations')
-const arrivalsPath = singleBookingPath.path('activations')
+const confirmationsPath = singleBookingPath.path('confirm')
+const arrivalsPath = singleBookingPath.path('mark-as-active')
+const departuresPath = singleBookingPath.path('mark-as-closed')
 
 const paths = {
   premises: {
@@ -39,6 +40,10 @@ const paths = {
     arrivals: {
       new: arrivalsPath.path('new'),
       create: arrivalsPath,
+    },
+    departures: {
+      new: departuresPath.path('new'),
+      create: departuresPath,
     },
   },
 }

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -10,8 +10,14 @@ import actions from '../utils'
 export default function routes(controllers: Controllers, router: Router): Router {
   const { get, post, put } = actions(router)
 
-  const { premisesController, bedspacesController, bookingsController, confirmationsController, arrivalsController } =
-    controllers.temporaryAccommodation
+  const {
+    premisesController,
+    bedspacesController,
+    bookingsController,
+    confirmationsController,
+    arrivalsController,
+    departuresController,
+  } = controllers.temporaryAccommodation
 
   get(paths.premises.index.pattern, premisesController.index())
   get(paths.premises.new.pattern, premisesController.new())
@@ -35,6 +41,9 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.bookings.arrivals.new.pattern, arrivalsController.new())
   post(paths.bookings.arrivals.create.pattern, arrivalsController.create())
+
+  get(paths.bookings.departures.new.pattern, departuresController.new())
+  post(paths.bookings.departures.create.pattern, departuresController.create())
 
   return router
 }

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -65,14 +65,12 @@ describe('DepartureService', () => {
     it('should return the reference data needed to create departures', async () => {
       const departureReasons = referenceDataFactory.buildList(2)
       const moveOnCategories = referenceDataFactory.buildList(3)
-      const destinationProviders = referenceDataFactory.buildList(4)
 
       referenceDataClient.getReferenceData.mockImplementation(category => {
         return Promise.resolve(
           {
             'departure-reasons': departureReasons,
             'move-on-categories': moveOnCategories,
-            'destination-providers': destinationProviders,
           }[category],
         )
       })
@@ -82,14 +80,12 @@ describe('DepartureService', () => {
       expect(result).toEqual({
         departureReasons,
         moveOnCategories,
-        destinationProviders,
       })
 
       expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
 
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('departure-reasons')
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('move-on-categories')
-      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('destination-providers')
     })
   })
 })

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -6,7 +6,6 @@ import { DateFormats } from '../utils/dateUtils'
 export type DepartureReferenceData = {
   departureReasons: Array<ReferenceData>
   moveOnCategories: Array<ReferenceData>
-  destinationProviders: Array<ReferenceData>
 }
 
 export default class DepartureService {
@@ -39,16 +38,14 @@ export default class DepartureService {
   async getReferenceData(token: string): Promise<DepartureReferenceData> {
     const referenceDataClient = this.referenceDataClientFactory(token)
 
-    const [departureReasons, moveOnCategories, destinationProviders] = await Promise.all([
+    const [departureReasons, moveOnCategories] = await Promise.all([
       referenceDataClient.getReferenceData('departure-reasons'),
       referenceDataClient.getReferenceData('move-on-categories'),
-      referenceDataClient.getReferenceData('destination-providers'),
     ])
 
     return {
       departureReasons,
       moveOnCategories,
-      destinationProviders,
     }
   }
 }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -218,11 +218,13 @@ describe('PremisesService', () => {
       premisesClient.find.mockResolvedValue(premises)
 
       const result = await service.getUpdatePremises(token, premises.id)
-      expect(result).toEqual({
-        ...premises,
-        localAuthorityAreaId: 'local-authority',
-        characteristicIds: ['characteristic-a', 'characteristic-b'],
-      })
+      expect(result).toEqual(
+        expect.objectContaining({
+          ...premises,
+          localAuthorityAreaId: 'local-authority',
+          characteristicIds: ['characteristic-a', 'characteristic-b'],
+        }),
+      )
 
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
     })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -106,6 +106,7 @@ export default class PremisesService {
       ...premises,
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
+      probationRegionId: premises.probationRegion.id,
     }
   }
 

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -36,6 +36,14 @@ class BookingFactory extends Factory<Booking> {
       status: 'arrived',
     })
   }
+
+  departed() {
+    return this.params({
+      arrivalDate: past(),
+      departureDate: past(),
+      status: 'departed',
+    })
+  }
 }
 
 export default BookingFactory.define(() => ({

--- a/server/testutils/factories/departure.ts
+++ b/server/testutils/factories/departure.ts
@@ -7,7 +7,7 @@ import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Departure>(() => ({
   id: faker.datatype.uuid(),
-  dateTime: DateFormats.formatApiDateTime(faker.date.soon()),
+  dateTime: DateFormats.formatApiDateAsDateTime(faker.date.soon()),
   bookingId: faker.datatype.uuid(),
   reason: referenceDataFactory.departureReasons().build(),
   notes: faker.lorem.sentence(),

--- a/server/testutils/factories/newDeparture.ts
+++ b/server/testutils/factories/newDeparture.ts
@@ -9,7 +9,7 @@ import { DateFormats } from '../../utils/dateUtils'
 export default Factory.define<NewDeparture>(() => {
   const date = faker.date.soon()
   return {
-    dateTime: DateFormats.formatApiDateTime(date),
+    dateTime: DateFormats.formatApiDateAsDateTime(date),
     'dateTime-day': date.getDate().toString(),
     'dateTime-month': date.getMonth().toString(),
     'dateTime-year': date.getFullYear().toString(),

--- a/server/testutils/factories/newDeparture.ts
+++ b/server/testutils/factories/newDeparture.ts
@@ -10,9 +10,6 @@ export default Factory.define<NewDeparture>(() => {
   const date = faker.date.soon()
   return {
     dateTime: DateFormats.formatApiDateAsDateTime(date),
-    'dateTime-day': date.getDate().toString(),
-    'dateTime-month': date.getMonth().toString(),
-    'dateTime-year': date.getFullYear().toString(),
     reasonId: referenceDataFactory.departureReasons().build().id,
     notes: faker.lorem.sentence(),
     moveOnCategoryId: referenceDataFactory.moveOnCategories().build().id,

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -12,6 +12,7 @@ export default Factory.define<NewPremises>(() => ({
   characteristicIds: unique([referenceDataFactory.characteristic('premises').build()]).map(
     characteristic => characteristic.id,
   ),
+  probationRegionId: faker.datatype.uuid(),
   status: faker.helpers.arrayElement(['pending', 'active', 'archived']),
   notes: faker.lorem.lines(),
 }))

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -11,6 +11,7 @@ export default Factory.define<UpdatePremises>(() => ({
   characteristicIds: unique([referenceDataFactory.characteristic('premises').build()]).map(
     characteristic => characteristic.id,
   ),
+  probationRegionId: faker.datatype.uuid(),
   status: faker.helpers.arrayElement(['pending', 'active', 'archived']),
   notes: faker.lorem.lines(),
 }))

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -39,8 +39,24 @@ describe('bookingUtils', () => {
       ])
     })
 
-    it('returns an empty list of action items for an arrived booking', () => {
+    it('returns a mark as closed action for an arrived booking', () => {
       const booking = bookingFactory.arrived().build()
+
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+        {
+          items: [
+            {
+              text: 'Mark as closed',
+              classes: '',
+              href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
+            },
+          ],
+        },
+      ])
+    })
+
+    it('returns an empty list of action items for a departed booking', () => {
+      const booking = bookingFactory.departed().build()
 
       expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
         {

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -17,6 +17,12 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
       classes: '',
       href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId: booking.id }),
     })
+  } else if (booking.status === 'arrived') {
+    items.push({
+      text: 'Mark as closed',
+      classes: '',
+      href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
+    })
   }
 
   return [{ items }]

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -2,6 +2,18 @@ import type { ObjectWithDateParts } from '@approved-premises/ui'
 import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates, dateIsBlank } from './dateUtils'
 
 describe('DateFormats', () => {
+  describe('formatApiDate', () => {
+    it('converts a date object to a ISO8601 date string', () => {
+      expect(DateFormats.formatApiDate(new Date(2022, 4, 11))).toEqual('2022-05-11')
+    })
+  })
+
+  describe('formatApiDateAsDateTime', () => {
+    it('converts a date object to a ISO8601 date string, with the time as midnight', () => {
+      expect(DateFormats.formatApiDateAsDateTime(new Date(2022, 4, 11))).toEqual('2022-05-11T00:00:00.000Z')
+    })
+  })
+
   describe('convertIsoToDateObj', () => {
     it('converts a ISO8601 date string', () => {
       const date = '2022-11-11T00:00:00.000Z'

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -98,6 +98,31 @@ describe('DateFormats', () => {
       expect(result.date).toEqual('2022-01-01T12:35:00.000Z')
     })
 
+    it('returns the date with a time if passed one and the representation is specified as complete', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2022',
+        'date-month': '1',
+        'date-day': '1',
+        'date-time': '12:35',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date', { representation: 'complete' })
+
+      expect(result.date).toEqual('2022-01-01T12:35:00.000Z')
+    })
+
+    it('returns the date with the time set to midnight if not passed a time and the representation is specified as complete', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '2022',
+        'date-month': '1',
+        'date-day': '1',
+      }
+
+      const result = DateFormats.convertDateAndTimeInputsToIsoString(obj, 'date', { representation: 'complete' })
+
+      expect(result.date).toEqual('2022-01-01T00:00:00.000Z')
+    })
+
     it('returns an empty string when given empty strings as input', () => {
       const obj: ObjectWithDateParts<'date'> = {
         'date-year': '',

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -24,6 +24,14 @@ export class DateFormats {
 
   /**
    * @param date JS Date object.
+   * @returns the date in the format '2019-09-18T00:00:00.000Z'.
+   */
+  static formatApiDateAsDateTime(date: Date) {
+    return `${formatISO(date, { representation: 'date' })}T00:00:00.000Z`
+  }
+
+  /**
+   * @param date JS Date object.
    * @returns the date in the to be shown in the UI: "20 December 2012".
    */
   static dateObjtoUIDate(date: Date, options: { format: 'short' | 'long' } = { format: 'long' }) {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -16,14 +16,6 @@ export class DateFormats {
 
   /**
    * @param date JS Date object.
-   * @returns the date in the format '2019-09-18T19:00:52Z'.
-   */
-  static formatApiDateTime(date: Date) {
-    return formatISO(date)
-  }
-
-  /**
-   * @param date JS Date object.
    * @returns the date in the format '2019-09-18T00:00:00.000Z'.
    */
   static formatApiDateAsDateTime(date: Date) {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -65,7 +65,7 @@ export class DateFormats {
    * @param key the key that prefixes each item in the dateInputObj, also the name of the property which the date object will be returned in the return value.
    * @returns an ISO8601 date string.
    */
-  static convertDateAndTimeInputsToIsoString<K extends string | number>(dateInputObj: ObjectWithDateParts<K>, key: K) {
+  static convertDateAndTimeInputsToIsoString<K extends string | number>(dateInputObj: ObjectWithDateParts<K>, key: K, options: { representation: 'auto' | 'complete' } = { representation: 'auto' }) {
     const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
     const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
     const year = dateInputObj[`${key}-year`]
@@ -75,6 +75,8 @@ export class DateFormats {
     if (day && month && year) {
       if (time) {
         o[key] = `${year}-${month}-${day}T${time}:00.000Z`
+      } else if (options.representation === 'complete') {
+        o[key] = `${year}-${month}-${day}T00:00:00.000Z`
       } else {
         o[key] = `${year}-${month}-${day}`
       }

--- a/server/views/temporary-accommodation/components/ta-select/macro.njk
+++ b/server/views/temporary-accommodation/components/ta-select/macro.njk
@@ -1,0 +1,12 @@
+{% from "govuk/components/select/macro.njk" import govukSelect %}
+
+{% macro taSelect(params, context) %}
+  {{
+    govukSelect(
+      mergeObjects(
+        params,
+        { id: params.fieldName, name: params.fieldName, errorMessage: context.errors[params.fieldName] }
+      )
+    )
+  }}
+{% endmacro %}

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -1,0 +1,93 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../components/ta-textarea/macro.njk" import taTextarea %}
+{% from "../components/ta-date-input/macro.njk" import taDateInput %}
+{% from "../components/ta-select/macro.njk" import taSelect %}
+{% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Mark booking as closed" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.bookings.show({ premisesId: premisesId, roomId: roomId, bookingId: booking.id })
+  }) }}
+
+  {% include "../../_messages.njk" %}
+
+  <h1>Mark booking as closed</h1>
+
+  {{ showErrorSummary(errorSummary) }}
+
+  <div class="location-header">
+    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
+  </div>
+
+  {{ bookingInfo(summaryList) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ taDateInput(
+          {
+            fieldset: {
+              legend: {
+                text: "What was the departure date?",
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            fieldName: "dateTime",
+            items: dateFieldValues('dateTime', errors)
+          },
+          fetchContext()
+        ) }}
+
+        {{ taSelect(
+          {
+            label: {
+                text: "What was the departure reason?",
+                classes: "govuk-label--m"
+            },
+            items: convertObjectsToSelectOptions(allDepartureReasons, "Select a departure reason", "name", "id", "reasonId"),
+            fieldName: "reasonId"
+          },
+          fetchContext()
+        ) }}
+
+        {{ taSelect(
+          {
+            label: {
+                text: "What was the move on category?",
+                classes: "govuk-label--m"
+            },
+            items: convertObjectsToSelectOptions(allMoveOnCategories, "Select a move on category", "name", "id", "moveOnCategoryId"),
+            fieldName: "moveOnCategoryId"
+          },
+          fetchContext()
+        ) }}
+
+        {{ taTextarea(
+          {
+            label: {
+              text: "Please provide any further details"
+            },
+            fieldName: "notes"
+          },
+          fetchContext()
+        ) }}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -32,7 +32,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form>
+      <form action="{{ paths.bookings.departures.create({ premisesId: premisesId, roomId: roomId, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ taDateInput(

--- a/wiremock/departuresStubs.ts
+++ b/wiremock/departuresStubs.ts
@@ -34,7 +34,7 @@ departureStubs.push(
   },
 )
 
-const requiredFields = getCombinations(['dateTime', 'destinationProvider', 'moveOnCategory', 'reason'])
+const requiredFields = getCombinations(['dateTime', 'moveOnCategoryId', 'reasonId'])
 
 requiredFields.forEach((fields: Array<string>) => {
   departureStubs.push(errorStub(fields, `/premises/${guidRegex}/bookings/${guidRegex}/departures`, 'POST'))

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -142,6 +142,7 @@ premises.forEach(item => {
     bedspaceBookingFactory.provisional().buildList(rand()),
     bedspaceBookingFactory.confirmed().buildList(rand()),
     bedspaceBookingFactory.arrived().buildList(rand()),
+    bedspaceBookingFactory.departed().buildList(rand()),
   ].flat()
 
   stubs.push({

--- a/wiremock/stubs/departure-reasons.json
+++ b/wiremock/stubs/departure-reasons.json
@@ -1,98 +1,21 @@
 [
-  {
-    "id": "f996644b-a561-4525-9fdb-f69fbe451a98",
-    "name": "Admitted to Hospital",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "e718e14d-8f8d-41a3-b8f1-25d23955af8f",
-    "name": "Arrested, remanded in custody, or sentenced",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "c56567a8-dbcd-414a-9427-3ea443ad4dc0",
-    "name": "Bed Withdrawn",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "7801b1a0-ca4c-4287-8b5b-203b1c3fa4f7",
-    "name": "Breach / recall (abscond)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "905ed7ef-e45d-4f50-91ca-a21ccf9c5af6",
-    "name": "Breach / recall (behaviour / increasing risk)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "0bef1bf3-12a2-49b9-9cd2-83fb9af0e71e",
-    "name": "Breach / recall (curfew)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "e15aef5f-9153-4dc6-a4dd-1f569acf8d5d",
-    "name": "Breach / recall (house rules)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "bc6eef37-a261-4408-98ef-428925ff6df4",
-    "name": "Breach / recall (licence or bail condition)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "6900ffe4-07ff-4da5-bbef-89099c710620",
-    "name": "Breach / recall (other)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "70860b69-088d-47e5-a1bd-f19012c99a93",
-    "name": "Breach / recall (positive drugs test)",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "aade20d8-cd39-404c-b2e6-988ec0c67c03",
-    "name": "Died",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "28fd41c6-6a25-44ff-aacd-e7ce8748ec6d",
-    "name": "End of ROTL",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "bab1a71d-52c6-4262-b3fa-4c535559c1c6",
-    "name": "Left of own volition",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "6071eeb1-69fa-4509-a1b9-1e06b2bee382",
-    "name": "Order / licence expired",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "5cd283b3-8969-49a4-92db-b44e8bf50cdc",
-    "name": "Other",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "b77865aa-2f16-4821-80ff-6f1d72c93d61",
-    "name": "Planned move-on",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-   }
+  { "id": "5bb2a91b-a33a-425e-8503-2ba69d7cabe7", "name": "Admitted to Hospital", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "e718e14d-8f8d-41a3-b8f1-25d23955af8f", "name": "Arrested, remanded in custody, or sentenced", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "c56567a8-dbcd-414a-9427-3ea443ad4dc0", "name": "Bed Withdrawn", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "7801b1a0-ca4c-4287-8b5b-203b1c3fa4f7", "name": "Breach / recall (abscond)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "9a68687d-944b-4960-9de2-7645635910f3", "name": "Bed Withdrawn", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "c81c42fe-f7af-4d16-b67d-93f0b4cbd338", "name": "Breach / recall (abscond)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "f5b57d36-1b3c-4777-93a2-72ff59cf7674", "name": "Breach / recall (behaviour / increasing risk)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "0bef1bf3-12a2-49b9-9cd2-83fb9af0e71e", "name": "Breach / recall (curfew)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "e15aef5f-9153-4dc6-a4dd-1f569acf8d5d", "name": "Breach / recall (house rules)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "b80cbd68-c223-40af-b82b-5f7cee6f6fd7", "name": "Breach / recall (curfew)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "ff751e28-f957-4941-8049-5b44c6da878e", "name": "Breach / recall (house rules)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "d6e3f1db-01a7-4ce4-b7cb-f1ff5454d62e", "name": "Breach / recall (licence or bail condition)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "d86b6e2e-0b95-459a-a85a-065729149f0a", "name": "Breach / recall (other)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "761cfbe1-c102-4fe9-b943-bf131d550c90", "name": "Breach / recall (positive drugs test)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "69eac20f-c3b9-4ea3-87fd-814c3f1fd117", "name": "Died", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "6589f8fb-d377-4bc4-ace9-d3a2ce02f97b", "name": "Left of own volition", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "60d030db-ce2d-4f1a-b24f-42ce15d268f7", "name": "Other", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "f4d00e1c-8bfd-40e9-8241-a7d0f744e737", "name": "Planned move-on", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "ae93ec2c-157a-49fd-a4c9-b67f1a9457d8", "name": "Further custodial sentence imposed", "isActive": true, "serviceScope": "temporary-accommodation" }
 ]

--- a/wiremock/stubs/move-on-categories.json
+++ b/wiremock/stubs/move-on-categories.json
@@ -1,74 +1,15 @@
 [
-  {
-    "id": "5c862d3f-e037-4991-ac1b-bb5466609ae7",
-    "name": "B & B / Temp / Short-Term Housing",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "6ea92218-dc6a-46eb-b166-e8d5b9321322",
-    "name": "Custody",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "08130ae9-effb-4797-9897-fb628661f822",
-    "name": "Deported/ Detention Centre/IRC",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "5832ac40-813f-4ffb-af93-3a0df648b08f",
-    "name": "Housing Association - Rented",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "da94bce8-4372-49dd-b6cc-cab19a6245b0",
-    "name": "Living with Family/ Partner/ Other",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "994dc7d6-494b-4540-81c0-e64dbda1e208",
-    "name": "Local Authority - Rented",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "5b413993-1a70-4b93-adeb-1af32d63458e",
-    "name": "No Fixed Abode",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "c12f7498-a3d9-4e0c-a66f-f2d4cf61a3d3",
-    "name": "Not Applicable",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "e1863cc4-dbc8-4c02-8ff7-08c0c9952ba1",
-    "name": "Owner Occupied",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "c6d3c3e3-d05b-4828-b393-9cfddc5daa6b",
-    "name": "Private Rented",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "8f35e009-cdf8-4a70-9ca4-97d99609893e",
-    "name": "Supported Housing",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-  },
-  {
-    "id": "29c0c4e8-6899-4471-832b-883cea522128",
-    "name": "Transferred to different AP",
-    "isActive": true,
-    "serviceScope": "temporary-accommodation"
-   }
+  { "id": "8f35e009-cdf8-4a70-9ca4-97d99609893e", "name": "Supported Housing", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "d8e04fa1-9757-4681-bfab-6c61913c8463", "name": "Approved Premises", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "247ae3f4-7958-4c59-97ed-272a39ad411c", "name": "Friends/Family (settled)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "2236cd7e-32c5-4784-a461-8f0aead1d386", "name": "Householder (Owner - freehold or leasehold)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "d3b9f02e-c3a5-475b-a5dd-124c058900d9", "name": "Long Term Residential Healthcare", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "587dc0dc-9073-4992-9d58-5576753050e9", "name": "Rental accommodation - private rental", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "12c739fa-7bb1-416d-bbf2-71362578a7f3", "name": "Rental accommodation - social rental", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "3de4665a-c848-4797-ba80-502cacc6f7d7", "name": "Friends/Family (transient)", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "a90a77a3-5662-4fa8-85ab-07d0c085052f", "name": "Homeless - Shelter/Emergency Hostel/Campsite", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "33244330-87e9-4cc6-9940-f78586585436", "name": "Homeless - Rough Sleeping", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "15fb0af2-3406-49c9-81ed-5e42bddf9fc2", "name": "Homeless - Squat", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "91158ed5-467e-4ee8-90d9-4f17a5dac82f", "name": "Transient/short term accommodation", "isActive": true, "serviceScope": "temporary-accommodation" },
+  { "id": "9e18dc4d-297b-4a9c-86cc-31238d339b3a", "name": "AfEO Funded", "isActive": true }
 ]


### PR DESCRIPTION
# Changes in this PR

Similar to the previous two state transitions, this adds our last "happy path" booking state transition, and updates our booking display to handle "closed" bookings

This PR follows a similar sequence of API synchronisation, tidying, building up helper functions, then adding and using the new page/controller

## Screenshots of UI changes

### Before
![localhost_3000_properties_54b86577-b31c-4432-ac96-ce938270d55f_bedspaces_156276d9-f8aa-4cdc-a575-11db9e23b428_bookings_006af608-b74b-42cc-9336-e6173cc5c88e (1)](https://user-images.githubusercontent.com/94137563/205270490-34ec3eb6-7933-4c1a-9765-97efe88d0b31.png)


### After
![localhost_3000_properties_54b86577-b31c-4432-ac96-ce938270d55f_bedspaces_156276d9-f8aa-4cdc-a575-11db9e23b428_bookings_006af608-b74b-42cc-9336-e6173cc5c88e](https://user-images.githubusercontent.com/94137563/205270359-9903fe23-35d8-4eeb-a469-c1dee77d31e5.png)

![localhost_3000_properties_54b86577-b31c-4432-ac96-ce938270d55f_bedspaces_156276d9-f8aa-4cdc-a575-11db9e23b428_bookings_006af608-b74b-42cc-9336-e6173cc5c88e_mark-as-closed_new](https://user-images.githubusercontent.com/94137563/205270726-bfd66f2b-bf07-4d7d-ba38-6f89b03b3b55.png)

![localhost_3000_properties_54b86577-b31c-4432-ac96-ce938270d55f_bedspaces_156276d9-f8aa-4cdc-a575-11db9e23b428_bookings_ea93da8f-327b-42a2-9281-16cda6ce8e09](https://user-images.githubusercontent.com/94137563/205270377-d5463f8c-d5ed-44dc-83ad-e8f61c761049.png)
