### PR TITLE
Remove the null allowlist for preprod

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -15,7 +15,5 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
 
-  allowlist: null
-
 generic-prometheus-alerts:
   alertSeverity: digital-prison-service-dev


### PR DESCRIPTION
Even though we’re not mastering data in preprod yet, we are accessing preprod services, so should be using the master allowlist in the main `hmpps-temporary—accommodation-ui/values.yaml` file