### PR TITLE
Remove unnecessary config option when running local E2E tests

### DIFF
--- a/script/local_e2e
+++ b/script/local_e2e
@@ -20,4 +20,4 @@ set -a
 
 set +a
 
-npx cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000","e2e":{"experimentalSessionAndOrigin": true}}'
+npx cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000"}'


### PR DESCRIPTION
experimentalSessionAndOrigin support is no longer experimental and supported by default in Cypress 12