### PR TITLE
A user can mark a booking as cancelled

### DIFF
--- a/cypress_shared/components/bookingInfo.ts
+++ b/cypress_shared/components/bookingInfo.ts
@@ -11,7 +11,7 @@ export default class BookingInfoComponent extends Component {
   shouldShowBookingDetails(): void {
     const { status } = this.booking
 
-    if (status === 'provisional' || status === 'confirmed') {
+    if (status === 'provisional' || status === 'confirmed' || status === 'cancelled') {
       this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
       this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
     } else if (status === 'arrived') {
@@ -26,6 +26,10 @@ export default class BookingInfoComponent extends Component {
     } else if (status === 'confirmed') {
       this.shouldShowKeyAndValue('Status', 'Confirmed')
       this.shouldShowKeyAndValues('Notes', this.booking.confirmation.notes.split('\n'))
+    } else if (status === 'cancelled') {
+      this.shouldShowKeyAndValue('Status', 'Cancelled')
+      this.shouldShowKeyAndValue('Cancellation reason', this.booking.cancellation.reason.name)
+      this.shouldShowKeyAndValues('Notes', this.booking.cancellation.notes.split('\n'))
     } else if (status === 'arrived') {
       this.shouldShowKeyAndValue('Status', 'Active')
       this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))

--- a/cypress_shared/components/bookingInfo.ts
+++ b/cypress_shared/components/bookingInfo.ts
@@ -1,0 +1,43 @@
+import type { Booking } from '@approved-premises/api'
+
+import { DateFormats } from '../../server/utils/dateUtils'
+import Component from './component'
+
+export default class BookingInfoComponent extends Component {
+  constructor(private readonly booking: Booking) {
+    super()
+  }
+
+  shouldShowBookingDetails(): void {
+    const { status } = this.booking
+
+    if (status === 'provisional' || status === 'confirmed') {
+      this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
+      this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
+    } else if (status === 'arrived') {
+      this.shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
+      this.shouldShowKeyAndValue('Expected departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
+    } else if (status === 'departed') {
+      this.shouldShowKeyAndValue('Departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
+    }
+
+    if (status === 'provisional') {
+      this.shouldShowKeyAndValue('Status', 'Provisional')
+    } else if (status === 'confirmed') {
+      this.shouldShowKeyAndValue('Status', 'Confirmed')
+      this.shouldShowKeyAndValues('Notes', this.booking.confirmation.notes.split('\n'))
+    } else if (status === 'arrived') {
+      this.shouldShowKeyAndValue('Status', 'Active')
+      this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
+    } else if (status === 'departed') {
+      this.shouldShowKeyAndValue('Status', 'Closed')
+      this.shouldShowKeyAndValue('Departure reason', this.booking.departure.reason.name)
+      this.shouldShowKeyAndValue('Move on category', this.booking.departure.moveOnCategory.name)
+      this.shouldShowKeyAndValues('Notes', this.booking.departure.notes.split('\n'))
+    }
+
+    this.booking.extensions.forEach(extension => {
+      this.shouldShowKeyAndValues('Extension notes', extension.notes.split('\n'))
+    })
+  }
+}

--- a/cypress_shared/components/component.ts
+++ b/cypress_shared/components/component.ts
@@ -1,0 +1,18 @@
+export type PageElement = Cypress.Chainable<JQuery>
+
+export default abstract class Component {
+  shouldShowKeyAndValue(key: string, value: string): void {
+    cy.get('.govuk-summary-list__key').contains(key).siblings('.govuk-summary-list__value').should('contain', value)
+  }
+
+  shouldShowKeyAndValues(key: string, values: string[]): void {
+    cy.get('.govuk-summary-list__key')
+      .contains(key)
+      .siblings('.govuk-summary-list__value')
+      .within(elements => {
+        values.forEach(value => {
+          cy.wrap(elements).should('contain', value)
+        })
+      })
+  }
+}

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -27,10 +27,10 @@ export default abstract class Page {
 
   headerUserName = (): PageElement => cy.get('[data-qa=header-user-name]')
 
-  shouldShowErrorMessagesForFields(fields: Array<string>): void {
+  shouldShowErrorMessagesForFields(fields: Array<string>, context = 'generic'): void {
     fields.forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups[field]?.empty)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field]?.empty)
+      cy.get('.govuk-error-summary').should('contain', errorLookups[context][field]?.empty)
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[context][field]?.empty)
     })
   }
 

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,14 +1,17 @@
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
+import Component from '../components/component'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
-export default abstract class Page {
+export default abstract class Page extends Component {
   static verifyOnPage<T>(constructor: new (...args: unknown[]) => T, ...args: unknown[]): T {
     return new constructor(...args)
   }
 
   constructor(private readonly title: string) {
+    super()
+
     this.checkOnPage()
   }
 
@@ -36,21 +39,6 @@ export default abstract class Page {
 
   shouldShowBanner(copy: string): void {
     cy.get('.govuk-notification-banner').contains(copy)
-  }
-
-  shouldShowKeyAndValue(key: string, value: string): void {
-    cy.get('.govuk-summary-list__key').contains(key).siblings('.govuk-summary-list__value').should('contain', value)
-  }
-
-  shouldShowKeyAndValues(key: string, values: string[]): void {
-    cy.get('.govuk-summary-list__key')
-      .contains(key)
-      .siblings('.govuk-summary-list__value')
-      .within(elements => {
-        values.forEach(value => {
-          cy.wrap(elements).should('contain', value)
-        })
-      })
   }
 
   shouldShowDateInputs(prefix: string, date: string): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -1,12 +1,16 @@
 import type { Booking, NewArrival } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
-import { DateFormats } from '../../../../server/utils/dateUtils'
 import Page from '../../page'
 import errorLookups from '../../../../server/i18n/en/errors.json'
+import BookingInfoComponent from '../../../components/bookingInfo'
 
 export default class BookingArrivalNewPage extends Page {
+  private readonly bookingInfoComponent: BookingInfoComponent
+
   constructor(private readonly booking: Booking) {
     super('Mark booking as active')
+
+    this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
   static visit(premisesId: string, roomId: string, booking: Booking): BookingArrivalNewPage {
@@ -19,9 +23,7 @@ export default class BookingArrivalNewPage extends Page {
       cy.get('p').should('contain', this.booking.person.crn)
     })
 
-    this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-    this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    this.shouldShowKeyAndValues('Notes', this.booking.confirmation.notes.split('\n'))
+    this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('arrivalDate', this.booking.arrivalDate)
     this.shouldShowDateInputs('expectedDepartureDate', this.booking.departureDate)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -29,8 +29,8 @@ export default class BookingArrivalNewPage extends Page {
 
   shouldShowDateConflictErrorMessages(): void {
     ;['arrivalDate', 'expectedDepartureDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field].conflict)
+      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
     })
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
@@ -1,4 +1,5 @@
 import type { Booking, NewCancellation } from '@approved-premises/api'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import Page from '../../page'
 
@@ -9,6 +10,11 @@ export default class BookingCancellationNewPage extends Page {
     super('Cancel booking')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)
+  }
+
+  static visit(premisesId: string, roomId: string, booking: Booking): BookingCancellationNewPage {
+    cy.visit(paths.bookings.cancellations.new({ premisesId, roomId, bookingId: booking.id }))
+    return new BookingCancellationNewPage(booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
@@ -1,0 +1,42 @@
+import type { Booking, NewCancellation } from '@approved-premises/api'
+import BookingInfoComponent from '../../../components/bookingInfo'
+import Page from '../../page'
+
+export default class BookingCancellationNewPage extends Page {
+  private readonly bookingInfoComponent: BookingInfoComponent
+
+  constructor(private readonly booking: Booking) {
+    super('Cancel booking')
+
+    this.bookingInfoComponent = new BookingInfoComponent(booking)
+  }
+
+  shouldShowBookingDetails(): void {
+    cy.get('.location-header').within(() => {
+      cy.get('p').should('contain', this.booking.person.crn)
+    })
+
+    this.bookingInfoComponent.shouldShowBookingDetails()
+
+    this.shouldShowDateInputs('date', this.booking.departureDate)
+  }
+
+  completeForm(newCancellation: NewCancellation): void {
+    this.clearForm()
+
+    this.getLegend('When was this booking cancelled?')
+    this.completeDateInputs('date', newCancellation.date)
+
+    this.getLabel('What was the reason for cancellation?')
+    this.getSelectInputByIdAndSelectAnEntry('reason', newCancellation.reason)
+
+    this.getLabel('Please provide any further details')
+    this.getTextInputByIdAndEnterDetails('notes', newCancellation.notes)
+
+    this.clickSubmit()
+  }
+
+  clearForm(): void {
+    this.clearDateInputs('date')
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
@@ -1,11 +1,15 @@
 import type { Booking, NewConfirmation } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
-import { DateFormats } from '../../../../server/utils/dateUtils'
+import BookingInfoComponent from '../../../components/bookingInfo'
 import Page from '../../page'
 
 export default class BookingConfirmationNewPage extends Page {
+  private readonly bookingInfoComponent: BookingInfoComponent
+
   constructor(private readonly booking: Booking) {
     super('Mark booking as confirmed')
+
+    this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
   static visit(premisesId: string, roomId: string, booking: Booking): BookingConfirmationNewPage {
@@ -18,8 +22,7 @@ export default class BookingConfirmationNewPage extends Page {
       cy.get('p').should('contain', this.booking.person.crn)
     })
 
-    this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-    this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
+    this.bookingInfoComponent.shouldShowBookingDetails()
   }
 
   completeForm(newConfirmation: NewConfirmation): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -1,11 +1,15 @@
 import type { Booking, NewDeparture } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
-import { DateFormats } from '../../../../server/utils/dateUtils'
+import BookingInfoComponent from '../../../components/bookingInfo'
 import Page from '../../page'
 
 export default class BookingDepartureNewPage extends Page {
+  private readonly bookingInfoComponent: BookingInfoComponent
+
   constructor(private readonly booking: Booking) {
     super('Mark booking as closed')
+
+    this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
   static visit(premisesId: string, roomId: string, booking: Booking): BookingDepartureNewPage {
@@ -18,9 +22,7 @@ export default class BookingDepartureNewPage extends Page {
       cy.get('p').should('contain', this.booking.person.crn)
     })
 
-    this.shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-    this.shouldShowKeyAndValue('Expected departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
+    this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('dateTime', this.booking.departureDate)
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
@@ -5,8 +5,8 @@ import errorLookups from '../../../../server/i18n/en/errors.json'
 export default abstract class BookingEditablePage extends Page {
   shouldShowDateConflictErrorMessages(): void {
     ;['arrivalDate', 'departureDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field].conflict)
+      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
     })
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -1,12 +1,16 @@
 import type { Booking, NewExtension } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
-import { DateFormats } from '../../../../server/utils/dateUtils'
 import Page from '../../page'
 import errorLookups from '../../../../server/i18n/en/errors.json'
+import BookingInfoComponent from '../../../components/bookingInfo'
 
 export default class BookingExtensionNewPage extends Page {
+  private readonly bookingInfoComponent: BookingInfoComponent
+
   constructor(private readonly booking: Booking) {
     super('Extend or shorten booking')
+
+    this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
   static visit(premisesId: string, roomId: string, booking: Booking): BookingExtensionNewPage {
@@ -19,9 +23,7 @@ export default class BookingExtensionNewPage extends Page {
       cy.get('p').should('contain', this.booking.person.crn)
     })
 
-    this.shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-    this.shouldShowKeyAndValue('Expected departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
+    this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('newDepartureDate', this.booking.departureDate)
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -28,8 +28,8 @@ export default class BookingExtensionNewPage extends Page {
 
   shouldShowDateConflictErrorMessages(): void {
     ;['newDepartureDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups[field].conflict)
+      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
     })
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -2,11 +2,15 @@ import type { Premises, Room, Booking } from '@approved-premises/api'
 
 import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
-import { DateFormats } from '../../../../server/utils/dateUtils'
+import BookingInfoComponent from '../../../components/bookingInfo'
 
 export default class BookingShowPage extends Page {
+  private readonly bookingInfoComponent: BookingInfoComponent
+
   constructor(private readonly premises: Premises, private readonly room: Room, private readonly booking: Booking) {
     super('View a booking')
+
+    this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
   static visit(premises: Premises, room: Room, booking: Booking): BookingShowPage {
@@ -50,35 +54,6 @@ export default class BookingShowPage extends Page {
       cy.get('p').should('contain', this.premises.postcode)
     })
 
-    const { status } = this.booking
-
-    if (status === 'provisional' || status === 'confirmed') {
-      this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-      this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    } else if (status === 'arrived') {
-      this.shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-      this.shouldShowKeyAndValue('Expected departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    } else if (status === 'departed') {
-      this.shouldShowKeyAndValue('Departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    }
-
-    if (status === 'provisional') {
-      this.shouldShowKeyAndValue('Status', 'Provisional')
-    } else if (status === 'confirmed') {
-      this.shouldShowKeyAndValue('Status', 'Confirmed')
-      this.shouldShowKeyAndValues('Notes', this.booking.confirmation.notes.split('\n'))
-    } else if (status === 'arrived') {
-      this.shouldShowKeyAndValue('Status', 'Active')
-      this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
-    } else if (status === 'departed') {
-      this.shouldShowKeyAndValue('Status', 'Closed')
-      this.shouldShowKeyAndValue('Departure reason', this.booking.departure.reason.name)
-      this.shouldShowKeyAndValue('Move on category', this.booking.departure.moveOnCategory.name)
-      this.shouldShowKeyAndValues('Notes', this.booking.departure.notes.split('\n'))
-    }
-
-    this.booking.extensions.forEach(extension => {
-      this.shouldShowKeyAndValues('Extension notes', extension.notes.split('\n'))
-    })
+    this.bookingInfoComponent.shouldShowBookingDetails()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -46,6 +46,13 @@ export default class BookingShowPage extends Page {
     })
   }
 
+  clickCancelBookingButton(): void {
+    cy.get('.moj-identity-bar').within(() => {
+      cy.get('button').contains('Actions').click()
+      cy.get('a').contains('Cancel booking').click()
+    })
+  }
+
   shouldShowBookingDetails(): void {
     cy.get('.location-header').within(() => {
       cy.get('p').should('contain', this.booking.person.crn)

--- a/e2e/tests/booking.feature
+++ b/e2e/tests/booking.feature
@@ -15,11 +15,30 @@ Feature: Manage Temporary Accommodation - Booking
         And I attempt to create a booking with required details missing
         Then I should see a list of the problems encountered creating the booking
 
+    Scenario: Cancelling a pending booking
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I cancel the booking
+        Then I should see a confirmation for cancellation
+
+    Scenario: Showing booking cancellation errors
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I attempt to cancel the booking with required details missing
+        Then I should see a list of the problems encountered cancelling the booking
+
     Scenario: Confirming a booking
         Given I'm creating a booking
         And I create a booking with all necessary details
         And I confirm the booking
         Then I should see the booking with the confirmed status
+
+    Scenario: Cancelling a confirmed booking
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I confirm the booking
+        And I cancel the booking
+        Then I should see a confirmation for cancellation
 
     Scenario: Marking a booking as arrived
         Given I'm creating a booking

--- a/e2e/tests/stepDefinitions/manage/cancellation.ts
+++ b/e2e/tests/stepDefinitions/manage/cancellation.ts
@@ -1,0 +1,65 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+import Page from '../../../../cypress_shared/pages/page'
+import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import BookingCancellationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import cancellationFactory from '../../../../server/testutils/factories/cancellation'
+import newCancellationFactory from '../../../../server/testutils/factories/newCancellation'
+
+Given('I cancel the booking', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.clickCancelBookingButton()
+
+    const cancellation = cancellationFactory.build()
+    const newCancellation = newCancellationFactory.build({
+      ...cancellation,
+      reason: cancellation.reason.id,
+    })
+
+    const bookingCancellationPage = Page.verifyOnPage(BookingCancellationNewPage, this.booking)
+    bookingCancellationPage.shouldShowBookingDetails()
+    bookingCancellationPage.completeForm(newCancellation)
+
+    const cancelledBooking = bookingFactory.build({
+      ...this.booking,
+      status: 'cancelled',
+      cancellation,
+    })
+
+    cy.wrap(cancelledBooking).as('booking')
+  })
+})
+
+Given('I attempt to cancel the booking with required details missing', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.clickCancelBookingButton()
+
+    const bookingCancellationPage = Page.verifyOnPage(BookingCancellationNewPage, this.booking)
+    bookingCancellationPage.clearForm()
+    bookingCancellationPage.clickSubmit()
+  })
+})
+
+Then('I should see the booking with the cancelled status', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.shouldShowBanner('Booking cancelled')
+    bookingShowPage.shouldShowBookingDetails()
+
+    bookingShowPage.clickBreadCrumbUp()
+
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    bedspaceShowPage.shouldShowBookingDetails(this.booking)
+  })
+})
+
+Then('I should see a list of the problems encountered marking the booking as departed', () => {
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BookingCancellationNewPage, this.booking)
+
+    page.shouldShowErrorMessagesForFields(['date'])
+  })
+})

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -45,12 +45,7 @@ Given('I attempt to mark the booking as departed with required details missing',
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
     bookingShowPage.clickMarkDepartedBookingButton()
 
-    const bookingDeparturePage = Page.verifyOnPage(
-      BookingDepartureNewPage,
-      this.premises.id,
-      this.room.id,
-      this.booking,
-    )
+    const bookingDeparturePage = Page.verifyOnPage(BookingDepartureNewPage, this.booking)
     bookingDeparturePage.clearForm()
     bookingDeparturePage.clickSubmit()
   })
@@ -71,7 +66,7 @@ Then('I should see the booking with the departed status', () => {
 
 Then('I should see a list of the problems encountered marking the booking as departed', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingDepartureNewPage, this.premises.id, this.room.id, this.booking)
+    const page = Page.verifyOnPage(BookingDepartureNewPage, this.booking)
 
     page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
   })

--- a/integration_tests/mockApis/cancellation.ts
+++ b/integration_tests/mockApis/cancellation.ts
@@ -3,6 +3,7 @@ import type { Cancellation } from '@approved-premises/api'
 
 import { stubFor, getMatchingRequests } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
+import { cancellationReasons } from '../../wiremock/referenceDataStubs'
 
 export default {
   stubCancellationCreate: (args: {
@@ -35,7 +36,7 @@ export default {
         jsonBody: args.cancellation,
       },
     }),
-  stubCancellationErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
+  stubCancellationCreateErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/cancellations`, 'POST')),
   verifyCancellationCreate: async (args: { premisesId: string; bookingId: string; cancellation: Cancellation }) =>
     (
@@ -44,4 +45,5 @@ export default {
         url: `/premises/${args.premisesId}/bookings/${args.bookingId}/cancellations`,
       })
     ).body.requests,
+  stubCancellationReferenceData: () => stubFor(cancellationReasons),
 }

--- a/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
@@ -1,0 +1,111 @@
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import BookingCancellationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew'
+import cancellationFactory from '../../../../server/testutils/factories/cancellation'
+import newCancellationFactory from '../../../../server/testutils/factories/newCancellation'
+
+context('Booking cancellation', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('allows me to mark a booking as cancelled', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.provisional().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the booking cancellation page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationNewPage.visit(premises.id, room.id, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const cancellation = cancellationFactory.build()
+    const newCancellation = newCancellationFactory.build({
+      ...cancellation,
+      reason: cancellation.reason.id,
+    })
+
+    cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
+
+    page.completeForm(newCancellation)
+
+    // Then the cancellation should have been created in the API
+    cy.task('verifyCancellationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.date).equal(newCancellation.date)
+      expect(requestBody.reason).equal(newCancellation.reason)
+      expect(requestBody.notes).equal(newCancellation.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
+    bookingShowPage.shouldShowBanner('Booking cancelled')
+  })
+
+  it('shows errors when the API returns an error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a provisional booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.provisional().build()
+
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the booking cancellation page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationNewPage.visit(premises.id, room.id, booking)
+
+    // And I miss required fields
+    cy.task('stubCancellationCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['date'],
+    })
+    page.clearForm()
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['date'], 'bookingCancellation')
+  })
+
+  it('navigates back from the booking cancellation page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.provisional().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the booking cancellation page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationNewPage.visit(premises.id, room.id, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, booking)
+  })
+})

--- a/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
@@ -14,6 +14,30 @@ context('Booking cancellation', () => {
     cy.task('stubAuthUser')
   })
 
+  it('navigates to the booking cancellation page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+    const booking = bookingFactory.provisional().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, room, booking)
+
+    // Add I click the cancel booking action
+    cy.task('stubCancellationReferenceData')
+    bookingShow.clickCancelBookingButton()
+
+    // Then I navigate to the booking cancellation page
+    Page.verifyOnPage(BookingCancellationNewPage, premises.id, room.id, booking)
+  })
+
   it('allows me to mark a booking as cancelled', () => {
     // Given I am signed in
     cy.signIn()

--- a/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
@@ -126,7 +126,13 @@ describe('CancellationsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, '', 'bookingCancellation')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.bookings.cancellations.new({ premisesId, roomId, bookingId }),
+        'bookingCancellation',
+      )
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
@@ -1,0 +1,132 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import paths from '../../../paths/temporary-accommodation/manage'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import bookingFactory from '../../../testutils/factories/booking'
+import { BookingService, CancellationService } from '../../../services'
+import { DateFormats } from '../../../utils/dateUtils'
+import { CancellationsController } from '.'
+import cancellationFactory from '../../../testutils/factories/cancellation'
+import newCancellationFactory from '../../../testutils/factories/newCancellation'
+
+jest.mock('../../../utils/validation')
+
+describe('CancellationsController', () => {
+  const token = 'SOME_TOKEN'
+  const premisesId = 'premisesId'
+  const roomId = 'roomId'
+  const bookingId = 'bookingId'
+
+  let request: DeepMocked<Request>
+
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const bookingService = createMock<BookingService>({})
+  const cancellationService = createMock<CancellationService>({})
+
+  const cancellationsController = new CancellationsController(bookingService, cancellationService)
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token } })
+  })
+
+  describe('new', () => {
+    it('renders the form prepopulated with the current departure date', async () => {
+      const booking = bookingFactory.build()
+
+      request.params = {
+        premisesId,
+        roomId,
+        bookingId: booking.id,
+      }
+
+      bookingService.getBookingDetails.mockResolvedValue({ booking, summaryList: { rows: [] } })
+      cancellationService.getReferenceData.mockResolvedValue({ cancellationReasons: [] })
+
+      const requestHandler = cancellationsController.new()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.getBookingDetails).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(cancellationService.getReferenceData).toHaveBeenCalledWith(token)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/cancellations/new', {
+        booking,
+        summaryList: { rows: [] },
+        roomId,
+        premisesId,
+        allCancellationReasons: [],
+        errors: {},
+        ...DateFormats.convertIsoToDateAndTimeInputs(booking.departureDate, 'date'),
+        errorSummary: [],
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('creates a cancellation and redirects to the show booking page', async () => {
+      const requestHandler = cancellationsController.create()
+
+      const cancellation = cancellationFactory.build()
+      const newCancellation = newCancellationFactory.build({
+        ...cancellation,
+        reason: cancellation.reason.id,
+      })
+
+      request.params = {
+        premisesId,
+        roomId,
+        bookingId,
+      }
+      request.body = {
+        ...newCancellation,
+        ...DateFormats.convertIsoToDateAndTimeInputs(newCancellation.date, 'date'),
+      }
+
+      cancellationService.createCancellation.mockResolvedValue(cancellation)
+
+      await requestHandler(request, response, next)
+
+      expect(cancellationService.createCancellation).toHaveBeenCalledWith(
+        token,
+        premisesId,
+        bookingId,
+        expect.objectContaining(newCancellation),
+      )
+
+      expect(request.flash).toHaveBeenCalledWith('success', 'Booking cancelled')
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId }))
+    })
+
+    it('renders with errors if the API returns an error', async () => {
+      const requestHandler = cancellationsController.create()
+
+      const cancellation = cancellationFactory.build()
+      const newCancellation = newCancellationFactory.build({
+        ...cancellation,
+        reason: cancellation.reason.id,
+      })
+
+      request.params = {
+        premisesId,
+        roomId,
+        bookingId,
+      }
+      request.body = {
+        ...newCancellation,
+        ...DateFormats.convertIsoToDateAndTimeInputs(newCancellation.date, 'date'),
+      }
+
+      const err = new Error()
+      cancellationService.createCancellation.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, '', 'bookingCancellation')
+    })
+  })
+})

--- a/server/controllers/temporary-accommodation/manage/cancellationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationsController.ts
@@ -52,7 +52,13 @@ export default class CanellationsController {
         req.flash('success', 'Booking cancelled')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
       } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, '', 'bookingCancellation')
+        catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          paths.bookings.cancellations.new({ premisesId, roomId, bookingId }),
+          'bookingCancellation',
+        )
       }
     }
   }

--- a/server/controllers/temporary-accommodation/manage/cancellationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationsController.ts
@@ -1,0 +1,59 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import type { NewCancellation } from '@approved-premises/api'
+import paths from '../../../paths/temporary-accommodation/manage'
+import { BookingService, CancellationService } from '../../../services'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { DateFormats } from '../../../utils/dateUtils'
+
+export default class CanellationsController {
+  constructor(
+    private readonly bookingsService: BookingService,
+    private readonly cancellationService: CancellationService,
+  ) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
+      const { premisesId, roomId, bookingId } = req.params
+
+      const { token } = req.user
+
+      const { booking, summaryList } = await this.bookingsService.getBookingDetails(token, premisesId, bookingId)
+      const { cancellationReasons: allCancellationReasons } = await this.cancellationService.getReferenceData(token)
+
+      return res.render('temporary-accommodation/cancellations/new', {
+        booking,
+        summaryList,
+        roomId,
+        premisesId,
+        allCancellationReasons,
+        errors,
+        errorSummary: requestErrorSummary,
+        ...DateFormats.convertIsoToDateAndTimeInputs(booking.departureDate, 'date'),
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, roomId, bookingId } = req.params
+      const { token } = req.user
+
+      const newCancellation: NewCancellation = {
+        ...req.body,
+        ...DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'date'),
+      }
+
+      try {
+        await this.cancellationService.createCancellation(token, premisesId, bookingId, newCancellation)
+
+        req.flash('success', 'Booking cancelled')
+        res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, '', 'bookingCancellation')
+      }
+    }
+  }
+}

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -8,6 +8,7 @@ import ConfirmationsController from './confirmationsController'
 import ArrivalsController from './arrivalsController'
 import DeparturesController from './departuresController'
 import ExtensionsController from './extensionsController'
+import CancellationsController from './cancellationsController'
 
 export const controllers = (services: Services) => {
   const premisesController = new PremisesController(services.premisesService, services.bedspaceService)
@@ -23,12 +24,10 @@ export const controllers = (services: Services) => {
   )
 
   const confirmationsController = new ConfirmationsController(services.bookingService, services.confirmationService)
-
   const arrivalsController = new ArrivalsController(services.bookingService, services.arrivalService)
-
   const departuresController = new DeparturesController(services.bookingService, services.departureService)
-
   const extensionsController = new ExtensionsController(services.bookingService, services.extensionService)
+  const cancellationsController = new CancellationsController(services.bookingService, services.cancellationService)
 
   return {
     premisesController,
@@ -38,7 +37,16 @@ export const controllers = (services: Services) => {
     arrivalsController,
     departuresController,
     extensionsController,
+    cancellationsController,
   }
 }
 
-export { PremisesController, BedspacesController, BookingsController, ConfirmationsController, ArrivalsController }
+export {
+  PremisesController,
+  BedspacesController,
+  BookingsController,
+  ConfirmationsController,
+  ArrivalsController,
+  ExtensionsController,
+  CancellationsController,
+}

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -1,83 +1,85 @@
 {
-  "crn": {
-    "empty": "You must enter a CRN",
-    "doesNotExist": "This CRN does not exist",
-    "userPermission": "You do not have permission to access this CRN"
-  },
-  "data": {
-    "invalid": "This data does not conform to the newest application schema"
-  },
-  "submittedAt": {
-    "isInFuture": "The submitted at date must be in the past"
-  },
-  "name": {
-    "empty": "You must enter a name"
-  },
-  "arrivalDate": {
-    "empty": "You must enter a start date",
-    "invalid": "The start date is an invalid date",
-    "conflict": "An existing booking overlaps with these dates"
-  },
-  "date": {
-    "empty": "You must enter a valid departure date",
-    "invalid": "The departure date is an invalid date"
-  },
-  "reasonId": {
-    "empty": "You must choose a departure reason",
-    "doesNotExist": "This reason does not exist"
-  },
-  "departureDate": {
-    "empty": "You must enter an end date",
-    "invalid": "The end date is an invalid date",
-    "beforeBookingArrivalDate": "The end date cannot be before the start date",
-    "conflict": "An existing booking overlaps with these dates"
-  },
-  "expectedDepartureDate": {
-    "empty": "You must enter an expected departure date",
-    "invalid": "The expected departure date is an invalid date",
-    "beforeBookingArrivalDate": "The departure date cannot be before the arrival date",
-    "conflict": "An existing booking overlaps with these dates"
-  },
-  "keyWorkerStaffId": {
-    "empty": "You must choose a keyworker"
-  },
-  "dateTime": {
-    "empty": "You must enter a departure date and time",
-    "invalid": "The departure date and time is an invalid date and time",
-    "beforeBookingArrivalDate": "The departure date and time must be after the booking's arrival date"
-  },
-  "destinationProviderId": {
-    "doesNotExist": "The destination provider does not exist"
-  },
-  "moveOnCategoryId": { "empty": "You must choose a move on category" },
-  "destinationProvider": { "empty": "You must enter a destination provider" },
-  "newDepartureDate": {
-    "empty": "You must enter a new departure date",
-    "invalid": "The departure date is an invalid date",
-    "beforeBookingArrivalDate": "The new departure date must be after the arrival date",
-    "conflict": "An existing booking overlaps with this date"
-  },
-  "startDate": { "empty": "You must enter a start date", "invalid": "The start date is an invalid date" },
-  "endDate": {
-    "empty": "You must enter a end date",
-    "invalid": "The end date is an invalid date",
-    "beforeStartDate": "The end date must be before the start date"
-  },
-  "numberOfBeds": { "empty": "You must enter the number of beds lost" },
-  "referenceNumber": { "empty": "You must enter a reference number" },
-  "addressLine1": {
-    "empty": "You must enter an address"
-  },
-  "postcode": {
-    "empty": "You must enter a postcode"
-  },
-  "localAuthorityAreaId": {
-    "empty": "You must choose a local authority"
-  },
-  "probationRegionId": {
-    "empty": "You must choose a probation region"
-  },
-  "status": {
-    "empty": "You must choose a status"
+  "generic": {
+    "crn": {
+      "empty": "You must enter a CRN",
+      "doesNotExist": "This CRN does not exist",
+      "userPermission": "You do not have permission to access this CRN"
+    },
+    "data": {
+      "invalid": "This data does not conform to the newest application schema"
+    },
+    "submittedAt": {
+      "isInFuture": "The submitted at date must be in the past"
+    },
+    "name": {
+      "empty": "You must enter a name"
+    },
+    "arrivalDate": {
+      "empty": "You must enter a start date",
+      "invalid": "The start date is an invalid date",
+      "conflict": "An existing booking overlaps with these dates"
+    },
+    "date": {
+      "empty": "You must enter a valid departure date",
+      "invalid": "The departure date is an invalid date"
+    },
+    "reasonId": {
+      "empty": "You must choose a departure reason",
+      "doesNotExist": "This reason does not exist"
+    },
+    "departureDate": {
+      "empty": "You must enter an end date",
+      "invalid": "The end date is an invalid date",
+      "beforeBookingArrivalDate": "The end date cannot be before the start date",
+      "conflict": "An existing booking overlaps with these dates"
+    },
+    "expectedDepartureDate": {
+      "empty": "You must enter an expected departure date",
+      "invalid": "The expected departure date is an invalid date",
+      "beforeBookingArrivalDate": "The departure date cannot be before the arrival date",
+      "conflict": "An existing booking overlaps with these dates"
+    },
+    "keyWorkerStaffId": {
+      "empty": "You must choose a keyworker"
+    },
+    "dateTime": {
+      "empty": "You must enter a departure date and time",
+      "invalid": "The departure date and time is an invalid date and time",
+      "beforeBookingArrivalDate": "The departure date and time must be after the booking's arrival date"
+    },
+    "destinationProviderId": {
+      "doesNotExist": "The destination provider does not exist"
+    },
+    "moveOnCategoryId": { "empty": "You must choose a move on category" },
+    "destinationProvider": { "empty": "You must enter a destination provider" },
+    "newDepartureDate": {
+      "empty": "You must enter a new departure date",
+      "invalid": "The departure date is an invalid date",
+      "beforeBookingArrivalDate": "The new departure date must be after the arrival date",
+      "conflict": "An existing booking overlaps with this date"
+    },
+    "startDate": { "empty": "You must enter a start date", "invalid": "The start date is an invalid date" },
+    "endDate": {
+      "empty": "You must enter a end date",
+      "invalid": "The end date is an invalid date",
+      "beforeStartDate": "The end date must be before the start date"
+    },
+    "numberOfBeds": { "empty": "You must enter the number of beds lost" },
+    "referenceNumber": { "empty": "You must enter a reference number" },
+    "addressLine1": {
+      "empty": "You must enter an address"
+    },
+    "postcode": {
+      "empty": "You must enter a postcode"
+    },
+    "localAuthorityAreaId": {
+      "empty": "You must choose a local authority"
+    },
+    "probationRegionId": {
+      "empty": "You must choose a probation region"
+    },
+    "status": {
+      "empty": "You must choose a status"
+    } 
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -81,5 +81,15 @@
     "status": {
       "empty": "You must choose a status"
     } 
+  },
+  "bookingCancellation": {
+    "date": {
+      "empty": "You must enter a valid cancellation date",
+      "invalid": "The cancellation date is an invalid date",
+      "beforeBookingArrivalDate": "The cancellation date must be after the arrival date"
+    },
+    "reason": {
+      "empty": "You must choose a cancellation reason"
+    }
   }
 }

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -13,6 +13,7 @@ const confirmationsPath = singleBookingPath.path('confirm')
 const arrivalsPath = singleBookingPath.path('mark-as-active')
 const departuresPath = singleBookingPath.path('mark-as-closed')
 const extensionsPath = singleBookingPath.path('extend')
+const cancellationsPath = singleBookingPath.path('cancellations')
 
 const paths = {
   premises: {
@@ -49,6 +50,10 @@ const paths = {
     extensions: {
       new: extensionsPath.path('new'),
       create: extensionsPath,
+    },
+    cancellations: {
+      new: cancellationsPath.path('new'),
+      create: cancellationsPath,
     },
   },
 }

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -18,6 +18,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     arrivalsController,
     departuresController,
     extensionsController,
+    cancellationsController,
   } = controllers.temporaryAccommodation
 
   get(paths.premises.index.pattern, premisesController.index())
@@ -48,6 +49,9 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.bookings.extensions.new.pattern, extensionsController.new())
   post(paths.bookings.extensions.create.pattern, extensionsController.create())
+
+  get(paths.bookings.cancellations.new.pattern, cancellationsController.new())
+  post(paths.bookings.cancellations.create.pattern, cancellationsController.create())
 
   return router
 }

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -340,6 +340,71 @@ describe('BookingService', () => {
       expect(formatLines).toHaveBeenCalledWith(booking.confirmation.notes)
     })
 
+    it('returns a booking and a summary list of details for a cancelled booking', async () => {
+      const booking = bookingFactory.cancelled().build({
+        arrivalDate: '2022-03-21',
+        departureDate: '2023-01-07',
+      })
+
+      ;(formatStatus as jest.MockedFunction<typeof formatStatus>).mockReturnValue(statusHtml)
+      ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+      bookingClient.find.mockResolvedValue(booking)
+
+      const result = await service.getBookingDetails(token, premisesId, booking.id)
+
+      expect(result).toEqual({
+        booking,
+        summaryList: {
+          rows: [
+            {
+              key: {
+                text: 'Status',
+              },
+              value: {
+                html: statusHtml,
+              },
+            },
+            {
+              key: {
+                text: 'Start date',
+              },
+              value: {
+                text: '21 March 2022',
+              },
+            },
+            {
+              key: {
+                text: 'End date',
+              },
+              value: {
+                text: '7 January 2023',
+              },
+            },
+            {
+              key: {
+                text: 'Cancellation reason',
+              },
+              value: {
+                text: booking.cancellation.reason.name,
+              },
+            },
+            {
+              key: {
+                text: 'Notes',
+              },
+              value: {
+                html: booking.cancellation.notes,
+              },
+            },
+          ],
+        },
+      })
+
+      expect(formatStatus).toHaveBeenCalledWith('cancelled')
+      expect(formatLines).toHaveBeenCalledWith(booking.cancellation.notes)
+    })
+
     it('returns a booking and a summary list of details for an arrived booking', async () => {
       const booking = bookingFactory.arrived().build({
         arrivalDate: '2022-03-21',

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -89,7 +89,7 @@ export default class BookingService {
       },
     ] as SummaryList['rows']
 
-    if (status === 'provisional' || status === 'confirmed') {
+    if (status === 'provisional' || status === 'confirmed' || status === 'cancelled') {
       rows.push({
         key: this.textValue('Start date'),
         value: this.textValue(DateFormats.isoDateToUIDate(arrivalDate)),
@@ -122,6 +122,17 @@ export default class BookingService {
         key: this.textValue('Notes'),
         value: this.htmlValue(formatLines(booking.confirmation.notes)),
       })
+    } else if (status === 'cancelled') {
+      rows.push(
+        {
+          key: this.textValue('Cancellation reason'),
+          value: this.textValue(booking.cancellation.reason.name),
+        },
+        {
+          key: this.textValue('Notes'),
+          value: this.htmlValue(formatLines(booking.cancellation.notes)),
+        },
+      )
     } else if (status === 'arrived') {
       rows.push({
         key: this.textValue('Notes'),

--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -41,15 +41,15 @@ describe('CancellationService', () => {
     })
   })
 
-  describe('getCancellationReasons', () => {
+  describe('getReferenceData', () => {
     it('should return the cancellation reasons', async () => {
       const cancellationReasons = referenceDataFactory.buildList(2)
 
       referenceDataClient.getReferenceData.mockResolvedValue(cancellationReasons)
 
-      const result = await service.getCancellationReasons(token)
+      const result = await service.getReferenceData(token)
 
-      expect(result).toEqual(cancellationReasons)
+      expect(result).toEqual({ cancellationReasons })
 
       expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('cancellation-reasons')

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -2,6 +2,10 @@ import type { ReferenceData } from '@approved-premises/ui'
 import type { Cancellation, NewCancellation } from '@approved-premises/api'
 import type { BookingClient, RestClientBuilder, ReferenceDataClient } from '../data'
 
+export type CancellationReferenceData = {
+  cancellationReasons: Array<ReferenceData>
+}
+
 export default class CancellationService {
   constructor(
     private readonly bookingClientFactory: RestClientBuilder<BookingClient>,
@@ -34,11 +38,11 @@ export default class CancellationService {
     return booking
   }
 
-  async getCancellationReasons(token: string): Promise<Array<ReferenceData>> {
+  async getReferenceData(token: string): Promise<CancellationReferenceData> {
     const referenceDataClient = this.referenceDataClientFactory(token)
 
-    const reasons = await referenceDataClient.getReferenceData('cancellation-reasons')
+    const cancellationReasons = await referenceDataClient.getReferenceData('cancellation-reasons')
 
-    return reasons as Array<ReferenceData>
+    return { cancellationReasons }
   }
 }

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -6,6 +6,7 @@ import type { Booking } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 import arrivalFactory from './arrival'
 import confirmationFactory from './confirmation'
+import cancellationFactory from './cancellation'
 import departureFactory from './departure'
 import personFactory from './person'
 
@@ -44,6 +45,14 @@ class BookingFactory extends Factory<Booking> {
       status: 'departed',
     })
   }
+
+  cancelled() {
+    return this.params({
+      arrivalDate: past(),
+      departureDate: past(),
+      status: 'cancelled',
+    })
+  }
 }
 
 export default BookingFactory.define(() => ({
@@ -58,6 +67,7 @@ export default BookingFactory.define(() => ({
   arrival: arrivalFactory.build(),
   departure: departureFactory.build(),
   confirmation: confirmationFactory.build(),
+  cancellation: cancellationFactory.build(),
   extensions: [],
   serviceName: 'temporary-accommodation' as const,
 }))

--- a/server/testutils/factories/newCancellation.ts
+++ b/server/testutils/factories/newCancellation.ts
@@ -5,16 +5,10 @@ import type { NewCancellation } from '@approved-premises/api'
 import referenceDataFactory from './referenceData'
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<NewCancellation>(() => {
-  const date = faker.date.soon()
-  return {
-    id: faker.datatype.uuid(),
-    date: DateFormats.formatApiDate(faker.date.soon()),
-    'date-day': date.getDate().toString(),
-    'date-month': date.getMonth().toString(),
-    'date-year': date.getFullYear().toString(),
-    bookingId: faker.datatype.uuid(),
-    reason: referenceDataFactory.cancellationReasons().build().id,
-    notes: faker.lorem.sentence(),
-  }
-})
+export default Factory.define<NewCancellation>(() => ({
+  id: faker.datatype.uuid(),
+  date: DateFormats.formatApiDate(faker.date.soon()),
+  bookingId: faker.datatype.uuid(),
+  reason: referenceDataFactory.cancellationReasons().build().id,
+  notes: faker.lorem.sentence(),
+}))

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -18,6 +18,11 @@ describe('bookingUtils', () => {
               classes: '',
               href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId: booking.id }),
             },
+            {
+              text: 'Cancel booking',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.cancellations.new({ premisesId, roomId, bookingId: booking.id }),
+            },
           ],
         },
       ])
@@ -33,6 +38,11 @@ describe('bookingUtils', () => {
               text: 'Mark as active',
               classes: '',
               href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId: booking.id }),
+            },
+            {
+              text: 'Cancel booking',
+              classes: 'govuk-button--secondary',
+              href: paths.bookings.cancellations.new({ premisesId, roomId, bookingId: booking.id }),
             },
           ],
         },
@@ -62,6 +72,12 @@ describe('bookingUtils', () => {
 
     it('returns null for adeparted booking', () => {
       const booking = bookingFactory.departed().build()
+
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual(null)
+    })
+
+    it('returns null for a cancelled booking', () => {
+      const booking = bookingFactory.cancelled().build()
 
       expect(bookingActions('premisesId', 'roomId', booking)).toEqual(null)
     })

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -60,14 +60,10 @@ describe('bookingUtils', () => {
       ])
     })
 
-    it('returns an empty list of action items for a departed booking', () => {
+    it('returns null for adeparted booking', () => {
       const booking = bookingFactory.departed().build()
 
-      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
-        {
-          items: [],
-        },
-      ])
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual(null)
     })
   })
 

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -5,18 +5,30 @@ import paths from '../paths/temporary-accommodation/manage'
 export function bookingActions(premisesId: string, roomId: string, booking: Booking): Array<IdentityBarMenu> {
   const items = []
 
+  const cancelAction = {
+    text: 'Cancel booking',
+    classes: 'govuk-button--secondary',
+    href: paths.bookings.cancellations.new({ premisesId, roomId, bookingId: booking.id }),
+  }
+
   if (booking.status === 'provisional') {
-    items.push({
-      text: 'Mark as confirmed',
-      classes: '',
-      href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId: booking.id }),
-    })
+    items.push(
+      {
+        text: 'Mark as confirmed',
+        classes: '',
+        href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId: booking.id }),
+      },
+      cancelAction,
+    )
   } else if (booking.status === 'confirmed') {
-    items.push({
-      text: 'Mark as active',
-      classes: '',
-      href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId: booking.id }),
-    })
+    items.push(
+      {
+        text: 'Mark as active',
+        classes: '',
+        href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId: booking.id }),
+      },
+      cancelAction,
+    )
   } else if (booking.status === 'arrived') {
     items.push(
       {
@@ -59,6 +71,11 @@ export const allStatuses: Array<{ name: string; id: Booking['status']; tagClass:
     name: 'Closed',
     id: 'departed',
     tagClass: 'govuk-tag--red',
+  },
+  {
+    name: 'Cancelled',
+    id: 'cancelled',
+    tagClass: 'govuk-tag--orange',
   },
 ]
 

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -32,6 +32,10 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
     )
   }
 
+  if (items.length === 0) {
+    return null
+  }
+
   return [{ items }]
 }
 

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -32,7 +32,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form>
+      <form action="{{ paths.bookings.cancellations.create({ premisesId: premisesId, roomId: roomId, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ taDateInput(

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -1,0 +1,81 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../components/ta-textarea/macro.njk" import taTextarea %}
+{% from "../components/ta-date-input/macro.njk" import taDateInput %}
+{% from "../components/ta-select/macro.njk" import taSelect %}
+{% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Cancel booking" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.bookings.show({ premisesId: premisesId, roomId: roomId, bookingId: booking.id })
+  }) }}
+
+  {% include "../../_messages.njk" %}
+
+  <h1>Cancel booking</h1>
+
+  {{ showErrorSummary(errorSummary) }}
+
+  <div class="location-header">
+    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
+  </div>
+
+  {{ bookingInfo(summaryList) }}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ taDateInput(
+          {
+            fieldset: {
+              legend: {
+                text: "When was this booking cancelled?",
+                classes: "govuk-fieldset__legend--m"
+              }
+            },
+            fieldName: "date",
+            items: dateFieldValues('date', errors)
+          },
+          fetchContext()
+        ) }}
+
+        {{ taSelect(
+          {
+            label: {
+                text: "What was the reason for cancellation?",
+                classes: "govuk-label--m"
+            },
+            items: convertObjectsToSelectOptions(allCancellationReasons, "Select a cancellation reason", "name", "id", "reason"),
+            fieldName: "reason"
+          },
+          fetchContext()
+        ) }}
+
+        {{ taTextarea(
+          {
+            label: {
+              text: "Please provide any further details"
+            },
+            fieldName: "notes"
+          },
+          fetchContext()
+        ) }}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -156,6 +156,7 @@ premises.forEach(item => {
     bedspaceBookingFactory.confirmed().buildList(rand()),
     bedspaceBookingFactory.arrived().buildList(rand()),
     bedspaceBookingFactory.departed().buildList(rand()),
+    bedspaceBookingFactory.cancelled().buildList(rand()),
   ].flat()
 
   stubs.push({

--- a/wiremock/stubs/cancellation-reasons.json
+++ b/wiremock/stubs/cancellation-reasons.json
@@ -1,18 +1,26 @@
 [
   {
-    "id": "78b9c1a4-1d60-11ed-861d-0242ac120002",
-    "name": "Recall"
+    "id": "3d57413f-ca94-424a-b026-bf9e99ed28fe",
+    "name": "Alternative suitable accommodation provided by LHA"
   },
   {
-    "id": "51b44b8c-f7f3-415d-90c3-61bb7fb96286",
-    "name": "Death"
+    "id": "f023aab7-4bd8-42a3-9f80-7aab3d4f40b8",
+    "name": "Alternative suitable accommodation provided (Other)"
   },
   {
-    "id": "9ddc9bfc-72fa-4a25-88c0-cc0ff8c6c00e",
-    "name": "Request from probabtion practictioner"
+    "id": "edd09efb-ef83-42da-a15c-750afd057eb3",
+    "name": "Person on probation rejected placement (Out of area)"
   },
   {
-    "id": "7f3eb6cd-b3fc-4a8d-b9ce-5959918ffbe8",
-    "name": "Non-arrival"
+    "id": "7c54c8f5-14df-4836-af9c-c66a6021a375",
+    "name": "Person on probation failed to arrive"
+  },
+  {
+    "id": "8afe2dc8-f024-4ab1-a98d-0e321e317b19",
+    "name": "Withdrawn by referrer"
+  },
+  {
+    "id": "d2a0d037-53db-4bb2-b9f7-afa07948a3f5",
+    "name": "Administrative error"
   }
 ]


### PR DESCRIPTION
# Changes in this PR

* A user can cancel a provisional or confirmed booking

Since this PR adds another screen showing a booking summary, we do some refactoring to reduce the duplication within our E2E tests. We also allow `catchValidationErrorOrPropogate` to take an error context, to allow us to have context-specific errors for generically named fields

## Screenshots of UI changes

### Before
![localhost_3000_properties_a3982fd5-cd14-413d-871e-51efbd796ab3_bedspaces_c2f36666-a65d-43f9-93a8-371a438428f5_bookings_67f2408d-26e3-46b3-862e-0a9839b68be1](https://user-images.githubusercontent.com/94137563/206741496-084faf54-68ca-4e87-9e51-7c47a056bbdc.png)

### After

![localhost_3000_properties_a3982fd5-cd14-413d-871e-51efbd796ab3_bedspaces_044f083b-4781-47c3-a097-611bc8565d4e_bookings_f5b2bf0e-27d7-4115-85bf-6f8bbb07c50f](https://user-images.githubusercontent.com/94137563/206741037-852fa819-0934-4f7f-8560-ad3464886f85.png)

![localhost_3000_properties_a3982fd5-cd14-413d-871e-51efbd796ab3_bedspaces_044f083b-4781-47c3-a097-611bc8565d4e_bookings_f5b2bf0e-27d7-4115-85bf-6f8bbb07c50f_cancellations_new](https://user-images.githubusercontent.com/94137563/206741043-5e8d86ac-37c5-4fba-9084-3167bfa0d213.png)

![localhost_3000_properties_a3982fd5-cd14-413d-871e-51efbd796ab3_bedspaces_044f083b-4781-47c3-a097-611bc8565d4e_bookings_0552ae7b-3413-410b-8c96-a155095e7b4f (1)](https://user-images.githubusercontent.com/94137563/206741052-73a4a175-c4bb-43dd-87a3-038d21cf9edb.png)
