### PR TITLE
Chore/document release process

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,3 +11,35 @@
 ### Before
 
 ### After
+
+# Release checklist
+
+As part of our continuous deployment strategy we must ensure that this work is
+ready to be released at any point. Before merging to `main` we must first
+confirm:
+
+## Pre merge checklist
+
+- [ ] Have all changes to any dependencies been deployed to both `preprod` and
+    `production` in a backwards compatible way? (This includes our API,
+    infrastructure, third-party integrations and any secrets or environment variables)
+- [ ] Has a required data migration been included in this change or been done in
+    advance?
+
+## Post merge checklist
+
+Once we've merged we now need to release this through to production before
+considering it done.
+
+[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
+and work through the following steps:
+
+- [ ] Has the product manager asked to provide approval for this feature?
+  - [ ] Has the product manager approved?
+- [ ] Manually approve release to preprod
+- [ ] Verify change released to preprod
+- [ ] Manually approve release to prod
+- [ ] Verify change released to production
+
+Should a release fail at any step, you as the author should now lead the work to
+fix it as soon as possible.

--- a/README.md
+++ b/README.md
@@ -70,3 +70,7 @@ script/local_e2e
 ```
 
 Note: This requires `ap-tools` to be installed (<https://github.com/ministryofjustice/hmpps-approved-premises-tools>)
+
+## Release process
+
+Our release process aligns with the other CAS teams and as such [lives in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process)

--- a/README.md
+++ b/README.md
@@ -73,4 +73,6 @@ Note: This requires `ap-tools` to be installed (<https://github.com/ministryofju
 
 ## Release process
 
-Our release process aligns with the other CAS teams and as such [lives in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process)
+Our release process aligns with the other CAS teams and as such [lives in
+Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process).
+The steps are also available in the [PULL_REQUEST_TEMPLATE](/.github/PULL_REQUEST_TEMPLATE.md#release-checklist).

--- a/doc/architecture/decisions/0006-release-with-continuous-deployment.md
+++ b/doc/architecture/decisions/0006-release-with-continuous-deployment.md
@@ -1,0 +1,34 @@
+# 6. release-with-continuous-deployment
+
+Date: 2022-12-15
+
+## Status
+
+Accepted
+
+## Context
+
+The context around this decision goes beyond this single repository and affects
+the whole CAS team, as such we've written [the context in Confluence](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process).
+
+## Decision
+
+The CAS team will use the continuous deployment methodology to release our work
+to our three environments.
+
+## Consequences
+
+- redefining our definition of done to include the release all the way to live
+  will add overhead to each individual piece of work
+- as the author will be responsible for releasing into live before moving on to
+  other features, they will be best placed to quickly recover from failure
+- as we'll always be in a deployable state we should be able to quickly push
+  through hot fixes with low risk
+- we will avoid big bang releases that are riskier and can be harder and slower
+  to fix
+- we want to extend our pull request templates to prompt us to follow the new
+  deployment steps
+- we will follow the convention found in MoJ which should make it more familiar
+  when we exit and hand the project back to MoJ
+- all CAS services will head in the same direction that will make it easier to
+  for us to work across the set of codebases


### PR DESCRIPTION
As discussed with the team at the office day. The draft process has now had a bit of time to sit and is not published with one amendment: Product review should start as opt-in during the planning stage to not overly hold up delivery. 

Once we're happy here I'll propose similar changes to AP UI and the API.