### PR TITLE
Report for bookings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -130,3 +130,4 @@ integration_tests/screenshots/
 /e2e/screenshots
 /e2e/videos
 /e2e.env
+cypress/downloads/

--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -2,6 +2,7 @@ import { defineConfig } from 'cypress'
 import createBundler from '@bahmutov/cypress-esbuild-preprocessor'
 import { addCucumberPreprocessorPlugin } from '@badeball/cypress-cucumber-preprocessor'
 import createEsbuildPlugin from '@badeball/cypress-cucumber-preprocessor/esbuild'
+import NodeModulesPolyfillPlugin from '@esbuild-plugins/node-modules-polyfill'
 
 async function setupNodeEvents(
   on: Cypress.PluginEvents,
@@ -13,7 +14,7 @@ async function setupNodeEvents(
   on(
     'file:preprocessor',
     createBundler({
-      plugins: [createEsbuildPlugin(config)],
+      plugins: [NodeModulesPolyfillPlugin(), createEsbuildPlugin(config)],
     }),
   )
 

--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -14,6 +14,7 @@ import lostBed from './integration_tests/mockApis/lostBed'
 import person from './integration_tests/mockApis/person'
 import applications from './integration_tests/mockApis/applications'
 import room from './integration_tests/mockApis/room'
+import report from './integration_tests/mockApis/report'
 
 export default defineConfig({
   chromeWebSecurity: false,
@@ -44,6 +45,7 @@ export default defineConfig({
         ...person,
         ...applications,
         ...room,
+        ...report,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -104,4 +104,19 @@ export default abstract class Page extends Component {
   clickBreadCrumbUp(): void {
     cy.get('li.govuk-breadcrumbs__list-item:nth-last-child(2)').click()
   }
+
+  expectDownload() {
+    // This is a workaround for a Cypress bug to prevent it waiting
+    // indefinitely for a new page to load after clicking the download link
+    // See https://github.com/cypress-io/cypress/issues/14857
+    cy.window()
+      .document()
+      .then(doc => {
+        doc.addEventListener('click', () => {
+          setTimeout(() => {
+            doc.location?.reload()
+          }, Cypress.config('defaultCommandTimeout'))
+        })
+      })
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/dashboardPage.ts
+++ b/cypress_shared/pages/temporary-accommodation/dashboardPage.ts
@@ -13,4 +13,8 @@ export default class DashboardPage extends Page {
   clickPremisesLink(): void {
     cy.get('a').contains('Manage properties, bedspaces, and bookings').click()
   }
+
+  clickReportsLink(): void {
+    cy.get('a').contains('Download data').click()
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
@@ -1,0 +1,15 @@
+import type { ProbationRegion } from '@approved-premises/api'
+import Page from '../../page'
+
+export default class BookingReportNewPage extends Page {
+  constructor() {
+    super('Booking reports')
+  }
+
+  completeForm(probationRegion: ProbationRegion): void {
+    this.getLabel('Select a probation region')
+    this.getSelectInputByIdAndSelectAnEntry('probationRegionId', probationRegion.id)
+
+    this.clickSubmit()
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
@@ -1,9 +1,15 @@
 import type { ProbationRegion } from '@approved-premises/api'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 import Page from '../../page'
 
 export default class BookingReportNewPage extends Page {
   constructor() {
     super('Booking reports')
+  }
+
+  static visit(): BookingReportNewPage {
+    cy.visit(paths.reports.bookings.new({}))
+    return new BookingReportNewPage()
   }
 
   completeForm(probationRegion: ProbationRegion): void {

--- a/e2e/tests/report.feature
+++ b/e2e/tests/report.feature
@@ -1,0 +1,13 @@
+Feature: Manage Temporary Accommodation - Report
+    Background:
+        Given I am logged in
+
+    Scenario: Downloading a booking report for all probation regions
+        Given I'm downloading a booking report
+        And I select to download a report for all probation regions
+        Then I should download a booking report
+
+    Scenario: Downloading a booking report for a probation region
+        Given I'm downloading a booking report
+        And I select a probation region to download a report for
+        Then I should download a booking report

--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -1,0 +1,39 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+import path from 'path'
+import Page from '../../../../cypress_shared/pages/page'
+import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
+import BookingReportNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingReportNew'
+import referenceDataFactory from '../../../../server/testutils/factories/referenceData'
+import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
+
+Given("I'm downloading a booking report", () => {
+  const dashboardPage = Page.verifyOnPage(DashboardPage)
+  dashboardPage.clickReportsLink()
+})
+
+Given('I select to download a report for all probation regions', () => {
+  const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
+
+  bookingReportPage.expectDownload()
+  bookingReportPage.clickSubmit()
+
+  cy.wrap(bookingReportFilename()).as('filename')
+})
+
+Given('I select a probation region to download a report for', () => {
+  const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
+
+  const probationRegion = referenceDataFactory.probationRegion().build()
+  bookingReportPage.expectDownload()
+  bookingReportPage.completeForm(probationRegion)
+
+  cy.wrap(bookingReportForProbationRegionFilename(probationRegion)).as('filename')
+})
+
+Then('I should download a booking report', () => {
+  cy.then(function _() {
+    const filePath = path.join(Cypress.config('downloadsFolder'), this.filename)
+
+    cy.readFile(filePath).should('have.length.above', 0)
+  })
+})

--- a/integration_tests/mockApis/report.ts
+++ b/integration_tests/mockApis/report.ts
@@ -1,0 +1,70 @@
+import api from '../../server/paths/api'
+import { getMatchingRequests, stubFor } from '../../wiremock'
+import { probationRegions } from '../../wiremock/referenceDataStubs'
+
+export default {
+  stubBookingReport: (data: string) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: api.reports.bookings({}),
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+        body: data,
+      },
+    }),
+  stubBookingReportError: (data: string) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: api.reports.bookings({}),
+      },
+      response: {
+        status: 500,
+        body: data,
+      },
+    }),
+  stubBookingReportForRegion: (args: { data: string; probationRegionId: string }) =>
+    stubFor({
+      request: {
+        method: 'GET',
+        urlPath: api.reports.bookings({}),
+        queryParameters: {
+          probationRegionId: {
+            equalTo: args.probationRegionId,
+          },
+        },
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'text/plain',
+        },
+        body: args.data,
+      },
+    }),
+  verifyBookingReport: async () =>
+    (
+      await getMatchingRequests({
+        method: 'GET',
+        url: api.reports.bookings({}),
+      })
+    ).body.requests,
+  verifyBookingReportForRegion: async (probationRegionId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'GET',
+        urlPath: api.reports.bookings({}),
+        queryParameters: {
+          probationRegionId: {
+            equalTo: probationRegionId,
+          },
+        },
+      })
+    ).body.requests,
+  stubBookingReportReferenceData: () => stubFor(probationRegions),
+}

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -13,6 +13,24 @@ context('Report', () => {
     cy.task('stubAuthUser')
   })
 
+  it('should navigate to the booking report page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is reference data in the database
+    cy.task('stubBookingReportReferenceData')
+
+    // When I visit the dashboard page
+    const page = DashboardPage.visit()
+
+    // Add I click the reports link
+    cy.task('stubBookingReportReferenceData')
+    page.clickReportsLink()
+
+    // Then I navigate to the booking report page
+    Page.verifyOnPage(BookingReportNewPage)
+  })
+
   it('allows me to download a booking report for all regions', () => {
     // Given I am signed in
     cy.signIn()

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -1,0 +1,109 @@
+import path from 'path'
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingReportNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingReportNew'
+import referenceData from '../../../../server/testutils/factories/referenceData'
+import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
+
+context('Report', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    cy.task('stubSignIn')
+    cy.task('stubAuthUser')
+  })
+
+  it('allows me to download a booking report for all regions', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking report page
+    cy.task('stubBookingReportReferenceData')
+    const page = BookingReportNewPage.visit()
+
+    // And I submit the form without choosing a region out the form
+    cy.task('stubBookingReport', 'some-data')
+
+    page.expectDownload()
+    page.clickSubmit()
+
+    // Then a report should have been requested from the API
+    cy.task('verifyBookingReport').then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And the report should be downloded
+    const filePath = path.join(Cypress.config('downloadsFolder'), bookingReportFilename())
+
+    cy.readFile(filePath).then(file => {
+      expect(file).equals('some-data')
+    })
+  })
+
+  it('does not download a file when the API returns an error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking report page
+    cy.task('stubBookingReportReferenceData')
+    const page = BookingReportNewPage.visit()
+
+    // And I submit the form without choosing a region out the form
+    cy.task('stubBookingReportError', 'some-data')
+
+    page.expectDownload()
+    page.clickSubmit()
+
+    cy.get('h1').contains('Internal Server Error')
+  })
+
+  it('allows me to download a booking report for a region', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking report page
+    cy.task('stubBookingReportReferenceData')
+    const page = BookingReportNewPage.visit()
+
+    // And I fill out the form
+    const probationRegion = referenceData.probationRegion().build()
+
+    cy.task('stubBookingReportForRegion', { data: 'some-data', probationRegionId: probationRegion.id })
+    page.expectDownload()
+    page.completeForm(probationRegion)
+
+    // Then a report should have been requested from the API
+    cy.task('verifyBookingReportForRegion', probationRegion.id).then(requests => {
+      expect(requests).to.have.length(1)
+    })
+
+    // And the report should be downloded
+    const filePath = path.join(
+      Cypress.config('downloadsFolder'),
+      bookingReportForProbationRegionFilename(probationRegion),
+    )
+
+    cy.readFile(filePath).then(file => {
+      expect(file).equals('some-data')
+    })
+  })
+
+  it('navigates back from the booking report page to the dashboard page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const premises = premisesFactory.buildList(5)
+    cy.task('stubPremises', premises)
+
+    // When I visit the show premises page
+    cy.task('stubBookingReportReferenceData')
+    const page = BookingReportNewPage.visit()
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the dashboard page
+    Page.verifyOnPage(DashboardPage)
+  })
+})

--- a/package-lock.json
+++ b/package-lock.json
@@ -48,6 +48,7 @@
       "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^15.0.0",
         "@bahmutov/cypress-esbuild-preprocessor": "^2.1.5",
+        "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
         "@faker-js/faker": "^7.5.0",
         "@golevelup/ts-jest": "^0.3.3",
         "@types/bunyan": "^1.8.8",
@@ -2409,6 +2410,19 @@
       "dev": true,
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/@esbuild-plugins/node-modules-polyfill": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.1.4.tgz",
+      "integrity": "sha512-uZbcXi0zbmKC/050p3gJnne5Qdzw8vkXIv+c2BW0Lsc1ji1SkrxbKPUy5Efr0blbTu1SL8w4eyfpnSdPg3G0Qg==",
+      "dev": true,
+      "dependencies": {
+        "escape-string-regexp": "^4.0.0",
+        "rollup-plugin-node-polyfills": "^0.2.1"
+      },
+      "peerDependencies": {
+        "esbuild": "*"
       }
     },
     "node_modules/@esbuild/android-arm": {
@@ -7406,6 +7420,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
+      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
+      "dev": true
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -10514,6 +10534,15 @@
         "yallist": "^3.0.2"
       }
     },
+    "node_modules/magic-string": {
+      "version": "0.25.9",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
+      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
+      "dev": true,
+      "dependencies": {
+        "sourcemap-codec": "^1.4.8"
+      }
+    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -12412,6 +12441,36 @@
         "node": ">=8.0"
       }
     },
+    "node_modules/rollup-plugin-inject": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
+      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
+      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1",
+        "magic-string": "^0.25.3",
+        "rollup-pluginutils": "^2.8.1"
+      }
+    },
+    "node_modules/rollup-plugin-node-polyfills": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
+      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
+      "dev": true,
+      "dependencies": {
+        "rollup-plugin-inject": "^3.0.0"
+      }
+    },
+    "node_modules/rollup-pluginutils": {
+      "version": "2.8.2",
+      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
+      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
+      "dev": true,
+      "dependencies": {
+        "estree-walker": "^0.6.1"
+      }
+    },
     "node_modules/run-parallel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
@@ -12846,6 +12905,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/sourcemap-codec": {
+      "version": "1.4.8",
+      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
+      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
+      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
+      "dev": true
     },
     "node_modules/spawn-command": {
       "version": "0.0.2-1",

--- a/package.json
+++ b/package.json
@@ -152,6 +152,7 @@
     "uuid": "^9.0.0"
   },
   "devDependencies": {
+    "@esbuild-plugins/node-modules-polyfill": "^0.1.4",
     "@badeball/cypress-cucumber-preprocessor": "^15.0.0",
     "@bahmutov/cypress-esbuild-preprocessor": "^2.1.5",
     "@faker-js/faker": "^7.5.0",

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
@@ -1,0 +1,90 @@
+import type { Request, Response, NextFunction } from 'express'
+import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { BookingReportsController } from '.'
+import BookingReportService from '../../../services/bookingReportService'
+
+jest.mock('../../../utils/validation')
+
+describe('BookingReportsController', () => {
+  const token = 'SOME_TOKEN'
+
+  let request: DeepMocked<Request>
+
+  const response: DeepMocked<Response> = createMock<Response>({})
+  const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
+
+  const bookingReportService = createMock<BookingReportService>({})
+
+  const bookingReportsController = new BookingReportsController(bookingReportService)
+
+  beforeEach(() => {
+    request = createMock<Request>({ user: { token } })
+  })
+
+  describe('new', () => {
+    it('renders the form', async () => {
+      bookingReportService.getReferenceData.mockResolvedValue({ probationRegions: [] })
+
+      const requestHandler = bookingReportsController.new()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      await requestHandler(request, response, next)
+
+      expect(bookingReportService.getReferenceData).toHaveBeenCalledWith(token)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/reports/bookings/new', {
+        allProbationRegions: [],
+        errors: {},
+        errorSummary: [],
+      })
+    })
+  })
+
+  describe('create', () => {
+    it('when the probationRegionId is empty, creates a booking report and pipes it into the express response', async () => {
+      const requestHandler = bookingReportsController.create()
+
+      request.body = {
+        probationRegionId: '',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(bookingReportService.pipeBookings).toHaveBeenCalledWith(token, response)
+    })
+
+    it('when the probationRegionId is not empty, creates a booking report for the probation region and pipes it into the express response', async () => {
+      const requestHandler = bookingReportsController.create()
+
+      request.body = {
+        probationRegionId: 'probation-region',
+      }
+
+      await requestHandler(request, response, next)
+
+      expect(bookingReportService.pipeBookingsForProbationRegion).toHaveBeenCalledWith(
+        token,
+        response,
+        'probation-region',
+      )
+    })
+
+    it('renders with errors if the API returns an error', async () => {
+      const requestHandler = bookingReportsController.create()
+
+      request.body = {
+        probationRegionId: '',
+      }
+
+      const err = new Error()
+      bookingReportService.pipeBookings.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, '')
+    })
+  })
+})

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
+import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { BookingReportsController } from '.'
 import BookingReportService from '../../../services/bookingReportService'
@@ -84,7 +85,12 @@ describe('BookingReportsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, '')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.reports.bookings.new({}),
+      )
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
@@ -1,5 +1,6 @@
 import type { Request, Response, RequestHandler } from 'express'
 
+import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BookingReportService from '../../../services/bookingReportService'
 
@@ -35,7 +36,7 @@ export default class BookingReportsController {
           await this.bookingReportService.pipeBookings(token, res)
         }
       } catch (err) {
-        catchValidationErrorOrPropogate(req, res, err, '')
+        catchValidationErrorOrPropogate(req, res, err, paths.reports.bookings.new({}))
       }
     }
   }

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
@@ -1,0 +1,42 @@
+import type { Request, Response, RequestHandler } from 'express'
+
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import BookingReportService from '../../../services/bookingReportService'
+
+export default class BookingReportsController {
+  constructor(private readonly bookingReportService: BookingReportService) {}
+
+  new(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
+
+      const { token } = req.user
+
+      const { probationRegions: allProbationRegions } = await this.bookingReportService.getReferenceData(token)
+
+      return res.render('temporary-accommodation/reports/bookings/new', {
+        allProbationRegions,
+        errors,
+        errorSummary: requestErrorSummary,
+        ...userInput,
+      })
+    }
+  }
+
+  create(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      try {
+        const { probationRegionId } = req.body
+        const { token } = req.user
+
+        if (probationRegionId?.length) {
+          await this.bookingReportService.pipeBookingsForProbationRegion(token, res, probationRegionId)
+        } else {
+          await this.bookingReportService.pipeBookings(token, res)
+        }
+      } catch (err) {
+        catchValidationErrorOrPropogate(req, res, err, '')
+      }
+    }
+  }
+}

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -9,6 +9,7 @@ import ArrivalsController from './arrivalsController'
 import DeparturesController from './departuresController'
 import ExtensionsController from './extensionsController'
 import CancellationsController from './cancellationsController'
+import BookingReportsController from './bookingReportsController'
 
 export const controllers = (services: Services) => {
   const premisesController = new PremisesController(services.premisesService, services.bedspaceService)
@@ -29,6 +30,8 @@ export const controllers = (services: Services) => {
   const extensionsController = new ExtensionsController(services.bookingService, services.extensionService)
   const cancellationsController = new CancellationsController(services.bookingService, services.cancellationService)
 
+  const bookingReportsController = new BookingReportsController(services.bookingReportService)
+
   return {
     premisesController,
     bedspacesController,
@@ -38,6 +41,7 @@ export const controllers = (services: Services) => {
     departuresController,
     extensionsController,
     cancellationsController,
+    bookingReportsController,
   }
 }
 
@@ -49,4 +53,5 @@ export {
   ArrivalsController,
   ExtensionsController,
   CancellationsController,
+  BookingReportsController,
 }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -21,6 +21,7 @@ import TokenStore from './tokenStore'
 import LostBedClient from './lostBedClient'
 import ApplicationClient from './applicationClient'
 import RoomClient from './roomClient'
+import ReportClient from './reportClient'
 
 type RestClientBuilder<T> = (token: string) => T
 
@@ -34,6 +35,7 @@ export const dataAccess = () => ({
   personClient: ((token: string) => new PersonClient(token)) as RestClientBuilder<PersonClient>,
   applicationClientBuilder: ((token: string) => new ApplicationClient(token)) as RestClientBuilder<ApplicationClient>,
   roomClientBuilder: ((token: string) => new RoomClient(token)) as RestClientBuilder<RoomClient>,
+  reportClientBuilder: ((token: string) => new ReportClient(token)) as RestClientBuilder<ReportClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>
@@ -47,4 +49,5 @@ export {
   LostBedClient,
   PersonClient,
   ApplicationClient,
+  ReportClient,
 }

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -1,0 +1,96 @@
+import nock from 'nock'
+
+import { createMock } from '@golevelup/ts-jest'
+import { Response } from 'express'
+import config from '../config'
+import paths from '../paths/api'
+import ReportClient from './reportClient'
+import probationRegionFactory from '../testutils/factories/probationRegion'
+
+describe('ReportClient', () => {
+  let fakeApprovedPremisesApi: nock.Scope
+  let reportClient: ReportClient
+
+  const token = 'token-1'
+
+  beforeEach(() => {
+    config.apis.approvedPremises.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    reportClient = new ReportClient(token)
+  })
+
+  afterEach(() => {
+    if (!nock.isDone()) {
+      nock.cleanAll()
+      throw new Error('Not all nock interceptors were used!')
+    }
+    nock.abortPendingRequests()
+    nock.cleanAll()
+  })
+
+  describe('bookings', () => {
+    it('pipes all bookings to an express response', async () => {
+      const data = 'some-data'
+
+      fakeApprovedPremisesApi
+        .get(paths.reports.bookings({}))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, data, { 'content-type': 'some-content-type' })
+
+      const response = createMock<Response>()
+
+      await reportClient.bookings(response, 'some-filename')
+
+      expect(response.write).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
+      expect(response.set).toHaveBeenCalledWith({
+        'Content-Type': 'some-content-type',
+        'Content-Disposition': `attachment; filename="some-filename"`,
+      })
+    })
+  })
+
+  describe('bookings', () => {
+    it('pipes all bookings to an express response', async () => {
+      const data = 'some-data'
+
+      fakeApprovedPremisesApi
+        .get(paths.reports.bookings({}))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .reply(200, data, { 'content-type': 'some-content-type' })
+
+      const response = createMock<Response>()
+
+      await reportClient.bookings(response, 'some-filename')
+
+      expect(response.write).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
+      expect(response.set).toHaveBeenCalledWith({
+        'Content-Type': 'some-content-type',
+        'Content-Disposition': `attachment; filename="some-filename"`,
+      })
+    })
+  })
+
+  describe('bookingsForProbationRegion', () => {
+    it('pipes bookings for a probation region to an express response', async () => {
+      const probationRegion = probationRegionFactory.build()
+
+      const data = 'some-data'
+
+      fakeApprovedPremisesApi
+        .get(paths.reports.bookings({}))
+        .matchHeader('authorization', `Bearer ${token}`)
+        .query({ probationRegionId: probationRegion.id })
+        .reply(200, data, { 'content-type': 'some-content-type' })
+
+      const response = createMock<Response>()
+
+      await reportClient.bookingsForProbationRegion(response, 'some-filename', probationRegion.id)
+
+      expect(response.write).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
+      expect(response.set).toHaveBeenCalledWith({
+        'Content-Type': 'some-content-type',
+        'Content-Disposition': `attachment; filename="some-filename"`,
+      })
+    })
+  })
+})

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -1,0 +1,20 @@
+import { Response } from 'express'
+import RestClient from './restClient'
+import config, { ApiConfig } from '../config'
+import paths from '../paths/api'
+
+export default class ReportClient {
+  restClient: RestClient
+
+  constructor(token: string) {
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
+  }
+
+  async bookings(response: Response, filename: string): Promise<void> {
+    await this.restClient.pipe(response, filename, { path: paths.reports.bookings({}) })
+  }
+
+  async bookingsForProbationRegion(response: Response, filename: string, probationRegionId: string): Promise<void> {
+    await this.restClient.pipe(response, filename, { path: paths.reports.bookings({}) }, { probationRegionId })
+  }
+}

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -31,6 +31,8 @@ const singleApplicationPath = applicationsPath.path(':id')
 const peoplePath = path('/people')
 const personPath = peoplePath.path(':crn')
 
+const reportsPath = path('/reports')
+
 const applyPaths = {
   applications: {
     show: singleApplicationPath,
@@ -71,5 +73,8 @@ export default {
       show: personPath.path('risks'),
     },
     search: peoplePath.path('search'),
+  },
+  reports: {
+    bookings: reportsPath.path('bookings'),
   },
 }

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -15,6 +15,8 @@ const departuresPath = singleBookingPath.path('mark-as-closed')
 const extensionsPath = singleBookingPath.path('extend')
 const cancellationsPath = singleBookingPath.path('cancellations')
 
+const reportsPath = temporaryAccommodationPath.path('reports')
+
 const paths = {
   premises: {
     index: premisesPath,
@@ -55,6 +57,12 @@ const paths = {
     cancellations: {
       new: cancellationsPath.path('new'),
       create: cancellationsPath,
+    },
+  },
+  reports: {
+    bookings: {
+      new: reportsPath.path('bookings'),
+      create: reportsPath.path('bookings'),
     },
   },
 }

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -19,6 +19,7 @@ export default function routes(controllers: Controllers, router: Router): Router
     departuresController,
     extensionsController,
     cancellationsController,
+    bookingReportsController,
   } = controllers.temporaryAccommodation
 
   get(paths.premises.index.pattern, premisesController.index())
@@ -53,6 +54,9 @@ export default function routes(controllers: Controllers, router: Router): Router
 
   get(paths.bookings.cancellations.new.pattern, cancellationsController.new())
   post(paths.bookings.cancellations.create.pattern, cancellationsController.create())
+
+  get(paths.reports.bookings.new.pattern, bookingReportsController.new())
+  post(paths.reports.bookings.create.pattern, bookingReportsController.create())
 
   return router
 }

--- a/server/services/bookingReportService.test.ts
+++ b/server/services/bookingReportService.test.ts
@@ -1,0 +1,78 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Response } from 'express'
+import ReferenceDataClient from '../data/referenceDataClient'
+import BookingReportService from './bookingReportService'
+import { ReportClient } from '../data'
+import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../utils/reportUtils'
+import probationRegionFactory from '../testutils/factories/probationRegion'
+
+jest.mock('../data/reportClient.ts')
+jest.mock('../data/referenceDataClient.ts')
+jest.mock('../utils/reportUtils')
+
+describe('BookingReportService', () => {
+  const reportClient = new ReportClient(null) as jest.Mocked<ReportClient>
+  const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+
+  const ReportClientFactory = jest.fn()
+  const ReferenceDataClientFactory = jest.fn()
+
+  const token = 'SOME_TOKEN'
+
+  const service = new BookingReportService(ReportClientFactory, ReferenceDataClientFactory)
+
+  beforeEach(() => {
+    jest.resetAllMocks()
+    ReportClientFactory.mockReturnValue(reportClient)
+    ReferenceDataClientFactory.mockReturnValue(referenceDataClient)
+  })
+
+  describe('pipeBookings', () => {
+    it('pipes all bookings to an express response, for download as a file', async () => {
+      const response = createMock<Response>()
+      ;(bookingReportFilename as jest.MockedFunction<typeof bookingReportFilename>).mockReturnValue('some-filename')
+
+      await service.pipeBookings(token, response)
+
+      expect(ReportClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingReportFilename).toHaveBeenCalled()
+      expect(reportClient.bookings).toHaveBeenCalledWith(response, 'some-filename')
+    })
+  })
+
+  describe('pipeBookingsForProbationRegion', () => {
+    it('pipes all bookings to an express response, for download as a file', async () => {
+      const probationRegions = probationRegionFactory.buildList(5)
+      referenceDataClient.getReferenceData.mockResolvedValue(probationRegions)
+      const response = createMock<Response>()
+      ;(
+        bookingReportForProbationRegionFilename as jest.MockedFunction<typeof bookingReportForProbationRegionFilename>
+      ).mockReturnValue('some-filename')
+
+      await service.pipeBookingsForProbationRegion(token, response, probationRegions[0].id)
+
+      expect(ReportClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingReportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0])
+      expect(reportClient.bookingsForProbationRegion).toHaveBeenCalledWith(
+        response,
+        'some-filename',
+        probationRegions[0].id,
+      )
+    })
+  })
+
+  describe('getReferenceData', () => {
+    it('should return the probation regions', async () => {
+      const probationRegions = probationRegionFactory.buildList(5)
+
+      referenceDataClient.getReferenceData.mockResolvedValue(probationRegions)
+
+      const result = await service.getReferenceData(token)
+
+      expect(result).toEqual({ probationRegions })
+
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('probation-regions')
+    })
+  })
+})

--- a/server/services/bookingReportService.ts
+++ b/server/services/bookingReportService.ts
@@ -1,0 +1,44 @@
+import type { ProbationRegion } from '@approved-premises/api'
+import { Response } from 'express'
+import type { RestClientBuilder, ReferenceDataClient } from '../data'
+import ReportClient from '../data/reportClient'
+import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../utils/reportUtils'
+
+export type BookingReportReferenceData = {
+  probationRegions: Array<ProbationRegion>
+}
+
+export default class BookingReportService {
+  constructor(
+    private readonly reportClientFactory: RestClientBuilder<ReportClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
+
+  async pipeBookings(token: string, response: Response): Promise<void> {
+    const reportClient = this.reportClientFactory(token)
+
+    const filename = bookingReportFilename()
+
+    await reportClient.bookings(response, filename)
+  }
+
+  async pipeBookingsForProbationRegion(token: string, response: Response, probationRegionId: string): Promise<void> {
+    const reportClient = this.reportClientFactory(token)
+
+    const probationRegion = (await this.getReferenceData(token)).probationRegions.find(
+      region => region.id === probationRegionId,
+    )
+
+    const filename = bookingReportForProbationRegionFilename(probationRegion)
+
+    await reportClient.bookingsForProbationRegion(response, filename, probationRegionId)
+  }
+
+  async getReferenceData(token: string): Promise<BookingReportReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(token)
+
+    const probationRegions = await referenceDataClient.getReferenceData('probation-regions')
+
+    return { probationRegions }
+  }
+}

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -15,6 +15,7 @@ import ApplicationService from './applicationService'
 import BedspaceService from './bedspaceService'
 import ConfirmationService from './confirmationService'
 import ExtensionService from './extensionService'
+import BookingReportService from './bookingReportService'
 
 export const services = () => {
   const {
@@ -26,6 +27,7 @@ export const services = () => {
     personClient,
     applicationClientBuilder,
     roomClientBuilder,
+    reportClientBuilder,
   } = dataAccess()
 
   const userService = new UserService(hmppsAuthClient)
@@ -41,6 +43,7 @@ export const services = () => {
   const bedspaceService = new BedspaceService(roomClientBuilder, referenceDataClientBuilder)
   const confirmationService = new ConfirmationService(bookingClientBuilder)
   const extensionService = new ExtensionService(bookingClientBuilder)
+  const bookingReportService = new BookingReportService(reportClientBuilder, referenceDataClientBuilder)
 
   return {
     userService,
@@ -56,6 +59,7 @@ export const services = () => {
     bedspaceService,
     confirmationService,
     extensionService,
+    bookingReportService,
   }
 }
 

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -1,0 +1,27 @@
+import probationRegionFactory from '../testutils/factories/probationRegion'
+import { bookingReportFilename, bookingReportForProbationRegionFilename } from './reportUtils'
+
+describe('reportUtils', () => {
+  describe('bookingReportFilename', () => {
+    it('returns a filename with the current date', () => {
+      jest.useFakeTimers().setSystemTime(new Date(2023, 2, 14))
+
+      const result = bookingReportFilename()
+
+      expect(result).toEqual('bookings-14-mar-23.xlsx')
+    })
+  })
+
+  describe('bookingReportForProbationRegionFilename', () => {
+    it('returns a filename with the current date', () => {
+      const probationRegion = probationRegionFactory.build({
+        name: 'Kent, Surrey & Sussex',
+      })
+      jest.useFakeTimers().setSystemTime(new Date(2023, 2, 14))
+
+      const result = bookingReportForProbationRegionFilename(probationRegion)
+
+      expect(result).toEqual('bookings-kent-surrey-sussex-14-mar-23.xlsx')
+    })
+  })
+})

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -1,0 +1,30 @@
+import { ProbationRegion } from '@approved-premises/api'
+import { DateFormats } from './dateUtils'
+
+const permittedFilenameCharacters = 'abcdefghijklmnopqrstuvwxyz01234567890 '
+
+export const bookingReportFilename = () => {
+  const date = DateFormats.dateObjtoUIDate(new Date(), { format: 'short' })
+
+  const concatenatedName = `bookings ${date}`
+
+  return `${filterFilename(concatenatedName)}.xlsx`
+}
+
+export const bookingReportForProbationRegionFilename = (probationRegion: ProbationRegion) => {
+  const date = DateFormats.dateObjtoUIDate(new Date(), { format: 'short' })
+  const regionName = probationRegion.name
+
+  const concatenatedName = `bookings ${regionName} ${date}`
+
+  return `${filterFilename(concatenatedName)}.xlsx`
+}
+
+const filterFilename = (filename: string): string => {
+  return filename
+    .toLocaleLowerCase()
+    .split('')
+    .filter(character => permittedFilenameCharacters.includes(character))
+    .join('')
+    .replace(/([ ])+/g, '-')
+}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -19,6 +19,15 @@
         <p class="govuk-body">Add new properties, bedspaces, and bookings, and update attributes</p>
         </div>
     </div>
+
+    <div class="card">
+      <div class="card-body">
+        <h3 class="govuk-heading-s">
+          <a class="govuk-link"  href="{{ paths.reports.bookings.new({}) }}">Download data</a>
+        </h3>
+        <p class="govuk-body">Download data on properties, bedspaces, and bookings</p>
+        </div>
+    </div>
   </div>
 
 {% endblock %}

--- a/server/views/temporary-accommodation/reports/bookings/new.njk
+++ b/server/views/temporary-accommodation/reports/bookings/new.njk
@@ -1,0 +1,45 @@
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% extends "../../../partials/layout.njk" %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../../components/ta-select/macro.njk" import taSelect %}
+
+{% set pageTitle = applicationName + " - Booking reports" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ breadCrumb('Booking reports', []) }}
+
+  {% include "../../../_messages.njk" %}
+  
+  <h1>Booking reports</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form>
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ showErrorSummary(errorSummary) }}
+
+        {{ taSelect(
+          {
+            label: {
+                text: "Select a probation region",
+                classes: "govuk-label--m"
+            },
+            items: convertObjectsToSelectOptions(allProbationRegions, "All", "name", "id", "probationRegionId"),
+            fieldName: "probationRegionId"
+          },
+          fetchContext()
+        ) }}
+
+        {{ govukButton({
+          text: "Download report"
+        }) }}
+      
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/temporary-accommodation/reports/bookings/new.njk
+++ b/server/views/temporary-accommodation/reports/bookings/new.njk
@@ -17,7 +17,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form>
+      <form action="{{ paths.reports.bookings.create() }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}

--- a/wiremock/reportStubs.ts
+++ b/wiremock/reportStubs.ts
@@ -1,0 +1,19 @@
+import paths from '../server/paths/api'
+
+const reportStubs: Array<Record<string, unknown>> = []
+
+reportStubs.push({
+  request: {
+    method: 'GET',
+    urlPath: paths.reports.bookings({}),
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'text/csv',
+    },
+    body: '"Column 1","Column 2"\n"Entry 1A","Entry 1B"\n"Entry 2A","Entry 2B"',
+  },
+})
+
+export default reportStubs

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -26,6 +26,7 @@ import staffMemberFactory from '../server/testutils/factories/staffMember'
 import { errorStub, getCombinations } from './utils'
 import path from '../server/paths/api'
 import confirmationStubs from './confirmationStubs'
+import reportStubs from './reportStubs'
 
 const stubs = []
 
@@ -202,6 +203,7 @@ stubs.push(
   ...personStubs,
   ...applicationStubs,
   ...roomStubs,
+  ...reportStubs,
   ...Object.values(referenceDataStubs),
 )
 


### PR DESCRIPTION
# Changes in this PR

* Adds a page for downloading booking reports

Most of the intelligence for this lives on the API side, with the UI simply forwarding the report into a file download for the user. The largest technical work in this PR is modifying our rest client to allow this kind of forwarding

## Screenshots of UI changes

### Before
![localhost_3000_ (1)](https://user-images.githubusercontent.com/94137563/208717019-75b8ea12-b85b-43c9-9654-cf4cddd47fee.png)

### After
![localhost_3000_ (2)](https://user-images.githubusercontent.com/94137563/208717027-9a7e17b5-d723-455c-ad89-ea23910eaa61.png)
![localhost_3000_reports_bookings](https://user-images.githubusercontent.com/94137563/208717037-e4d5702c-dbf8-4437-bd12-20f38bc0faed.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
