### PR TITLE
Fix deploys to test by setting staging CircleCI context

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -117,7 +117,9 @@ workflows:
           name: deploy_test
           env: 'test'
           jira_update: true
-          context: hmpps-common-vars
+          context:
+            - hmpps-common-vars
+            - hmpps-temporary-accommodation-ui-stage
           filters:
             branches:
               only:


### PR DESCRIPTION
# Context

Without this the deployment will use the default projects variables rather than those provisioning via a circleci context. Right now, deploying test attempts to deploy to dev and breaks it.

![Screenshot 2022-12-23 at 11 01 26](https://user-images.githubusercontent.com/912473/209324814-5e8596a2-418e-4b8b-9d8c-6ccc6b9bfb8c.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
