### PR TITLE
Increase timeout when downloading report in E2E test

### DIFF
--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -34,6 +34,6 @@ Then('I should download a booking report', () => {
   cy.then(function _() {
     const filePath = path.join(Cypress.config('downloadsFolder'), this.filename)
 
-    cy.readFile(filePath).should('have.length.above', 0)
+    cy.readFile(filePath, { timeout: 10000 }).should('have.length.above', 0)
   })
 })


### PR DESCRIPTION
The API call behind this seems to sometimes take longer than the default 4 seconds, so we increase the timeout to fix an intermittent test failure