### PR TITLE
Fix report download timeout in E2E tests

### DIFF
--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -105,7 +105,7 @@ export default abstract class Page extends Component {
     cy.get('li.govuk-breadcrumbs__list-item:nth-last-child(2)').click()
   }
 
-  expectDownload() {
+  expectDownload(timeout?: number) {
     // This is a workaround for a Cypress bug to prevent it waiting
     // indefinitely for a new page to load after clicking the download link
     // See https://github.com/cypress-io/cypress/issues/14857
@@ -115,7 +115,7 @@ export default abstract class Page extends Component {
         doc.addEventListener('click', () => {
           setTimeout(() => {
             doc.location?.reload()
-          }, Cypress.config('defaultCommandTimeout'))
+          }, timeout || Cypress.config('defaultCommandTimeout'))
         })
       })
   }

--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -24,7 +24,7 @@ Given('I select a probation region to download a report for', () => {
   const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
 
   const probationRegion = referenceDataFactory.probationRegion().build()
-  bookingReportPage.expectDownload()
+  bookingReportPage.expectDownload(10000)
   bookingReportPage.completeForm(probationRegion)
 
   cy.wrap(bookingReportForProbationRegionFilename(probationRegion)).as('filename')
@@ -34,6 +34,6 @@ Then('I should download a booking report', () => {
   cy.then(function _() {
     const filePath = path.join(Cypress.config('downloadsFolder'), this.filename)
 
-    cy.readFile(filePath, { timeout: 10000 }).should('have.length.above', 0)
+    cy.readFile(filePath).should('have.length.above', 0)
   })
 })


### PR DESCRIPTION
In our E2E tests, we need to increase the time we wait for a download *before* refreshing the page and checking for the downloaded file