### PR TITLE
Fix report download timeout

### DIFF
--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -14,7 +14,7 @@ Given("I'm downloading a booking report", () => {
 Given('I select to download a report for all probation regions', () => {
   const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
 
-  bookingReportPage.expectDownload()
+  bookingReportPage.expectDownload(10000)
   bookingReportPage.clickSubmit()
 
   cy.wrap(bookingReportFilename()).as('filename')


### PR DESCRIPTION
Previously, we were only setting a timeout for the "specific region" report E2E test, causing a test failure