### PR TITLE
Remove redundant dependency lines in CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -125,8 +125,6 @@ workflows:
               only:
                 - main
           requires:
-            - helm_lint
-            - build_docker
             - request-test-approval
 
       - request-preprod-approval:


### PR DESCRIPTION
# Changes in this PR

The requirement for `helm_lint` and `build_docker` was effectively duplicated.

The third job to run is called `deploy_dev` which must always run. This job depends on the first two jobs: `helm_lint` and `build_docker`.

Therefore we can assume that any job thereafter that depends on `deploy_dev` can inherit this instead.

Though functionally it shouldn't change anything the circleci deployment pipeline graph will be simpler as a result.

## Screenshots of UI changes

![Screenshot 2023-01-11 at 16 37 38](https://user-images.githubusercontent.com/912473/211864483-87e468f2-9d64-4b00-b5d1-3c2423550742.png)
