### PR TITLE
Use username rather than UUID in audit events

### DIFF
--- a/server/middleware/auditMiddleware.test.ts
+++ b/server/middleware/auditMiddleware.test.ts
@@ -7,7 +7,7 @@ import { auditMiddleware } from './auditMiddleware'
 
 jest.mock('../../logger')
 
-const userUuid = 'some-user-uuid'
+const username = 'some-username'
 const requestParams = { param1: 'value-1', param2: 'value-2' }
 const auditEvent = 'SOME_AUDIT_EVENT'
 
@@ -24,7 +24,7 @@ describe('auditMiddleware', () => {
 
   it('returns an audited request handler, that forwards call on to the given request handler', async () => {
     const handler = jest.fn()
-    const response = createMock<Response>({ locals: { user: { uuid: userUuid } } })
+    const response = createMock<Response>({ locals: { user: { username } } })
     const request = createMock<Request>()
     const next = jest.fn()
 
@@ -51,12 +51,12 @@ describe('auditMiddleware', () => {
 
     expect(handler).not.toHaveBeenCalled()
     expect(response.redirect).toHaveBeenCalledWith('/authError')
-    expect(logger.error).toHaveBeenCalledWith('User without a UUID is attempt to access an audited path')
+    expect(logger.error).toHaveBeenCalledWith('User without a username is attempt to access an audited path')
   })
 
   it('returns an audited request handler, that sends an audit message that includes the request parameters', async () => {
     const handler = jest.fn()
-    const response = createMock<Response>({ locals: { user: { uuid: userUuid } } })
+    const response = createMock<Response>({ locals: { user: { username } } })
     const request = createMock<Request>({ params: requestParams })
     const next = jest.fn()
 
@@ -67,12 +67,12 @@ describe('auditMiddleware', () => {
     await auditedhandler(request, response, next)
 
     expect(handler).toHaveBeenCalled()
-    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, userUuid, requestParams)
+    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, username, requestParams)
   })
 
   it('returns an audited request handler, that sends an audit message that includes selected request body parameters', async () => {
     const handler = jest.fn()
-    const response = createMock<Response>({ locals: { user: { uuid: userUuid } } })
+    const response = createMock<Response>({ locals: { user: { username } } })
     const request = createMock<Request>({
       params: requestParams,
       body: { bodyParam1: 'body-value-1', bodyParam2: 'body-value-2', bodyParam3: 'body-value-3' },
@@ -89,7 +89,7 @@ describe('auditMiddleware', () => {
     await auditedhandler(request, response, next)
 
     expect(handler).toHaveBeenCalled()
-    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, userUuid, {
+    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, username, {
       ...requestParams,
       bodyParam1: 'body-value-1',
       bodyParam2: 'body-value-2',
@@ -98,7 +98,7 @@ describe('auditMiddleware', () => {
 
   it('ignores empty request body parameters', async () => {
     const handler = jest.fn()
-    const response = createMock<Response>({ locals: { user: { uuid: userUuid } } })
+    const response = createMock<Response>({ locals: { user: { username } } })
     const request = createMock<Request>({
       params: requestParams,
       body: { bodyParam1: 'body-value-1', bodyParam2: '' },
@@ -115,7 +115,7 @@ describe('auditMiddleware', () => {
     await auditedhandler(request, response, next)
 
     expect(handler).toHaveBeenCalled()
-    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, userUuid, {
+    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, username, {
       ...requestParams,
       bodyParam1: 'body-value-1',
     })
@@ -126,7 +126,7 @@ describe('auditMiddleware', () => {
 
     const handler = jest.fn()
     const response = createMock<Response>({
-      locals: { user: { uuid: userUuid } },
+      locals: { user: { username } },
       get: field => {
         return field === 'Location' ? somePath({ premisesId: 'some-premises', roomId: 'some-room' }) : undefined
       },
@@ -143,7 +143,7 @@ describe('auditMiddleware', () => {
     await auditedhandler(request, response, next)
 
     expect(handler).toHaveBeenCalled()
-    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, userUuid, {
+    expect(auditService.sendAuditMessage).toHaveBeenCalledWith(auditEvent, username, {
       premisesId: 'some-premises',
       roomId: 'some-room',
     })
@@ -156,7 +156,7 @@ describe('auditMiddleware', () => {
 
     const handler = jest.fn()
     const response = createMock<Response>({
-      locals: { user: { uuid: userUuid } },
+      locals: { user: { username } },
       get: field => {
         return field === 'Location' ? matchingPath1({ premisesId: 'some-premises' }) : undefined
       },
@@ -177,7 +177,7 @@ describe('auditMiddleware', () => {
     await auditedhandler(request, response, next)
 
     expect(handler).toHaveBeenCalled()
-    expect(auditService.sendAuditMessage).toHaveBeenCalledWith('MATCHING_PATH_1_AUDIT_EVENT', userUuid, {
+    expect(auditService.sendAuditMessage).toHaveBeenCalledWith('MATCHING_PATH_1_AUDIT_EVENT', username, {
       premisesId: 'some-premises',
     })
   })

--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -48,10 +48,10 @@ const wrapHandler =
     let redirectAuditEvent: string
     let redirectParams: Record<string, string>
 
-    const userUuid = res?.locals?.user?.uuid
+    const userUuid = res?.locals?.user?.username
 
     if (!userUuid) {
-      logger.error('User without a UUID is attempt to access an audited path')
+      logger.error('User without a username is attempt to access an audited path')
       res.redirect('/authError')
       return
     }

--- a/server/services/auditService.ts
+++ b/server/services/auditService.ts
@@ -25,12 +25,12 @@ export default class AuditService {
     this.logErrors = config.logErrors
   }
 
-  async sendAuditMessage(action: string, userUuid: string, details: Record<string, string>) {
+  async sendAuditMessage(action: string, username: string, details: Record<string, string>) {
     const jsonDetails = JSON.stringify(details)
 
     const jsonMessage = JSON.stringify({
       what: action,
-      who: userUuid,
+      who: username,
       when: new Date(),
       service: this.serviceName,
       details: jsonDetails,


### PR DESCRIPTION
Following discussions with the audit team, we send the username rather than the UUID in audit events
