### PR TITLE
Pass request into RestClient

### DIFF
--- a/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
@@ -9,16 +9,16 @@ import newArrivalFactory from '../../../testutils/factories/newArrival'
 import ArrivalsController from './arrivalsController'
 import { DateFormats } from '../../../utils/dateUtils'
 import arrivalFactory from '../../../testutils/factories/arrival'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('ArrivalsController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -29,7 +29,7 @@ describe('ArrivalsController', () => {
   const arrivalsController = new ArrivalsController(bookingService, arrivalService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -49,7 +49,7 @@ describe('ArrivalsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/arrivals/new', {
         booking,
@@ -88,7 +88,7 @@ describe('ArrivalsController', () => {
       await requestHandler(request, response, next)
 
       expect(arrivalService.createArrival).toHaveBeenCalledWith(
-        token,
+        request,
         premisesId,
         bookingId,
         expect.objectContaining(newArrival),

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -14,9 +14,7 @@ export default class ArrivalsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
-
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
 
       return res.render('temporary-accommodation/arrivals/new', {
         booking,
@@ -34,7 +32,6 @@ export default class ArrivalsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
       const newArrival: NewArrival = {
         ...req.body,
@@ -43,7 +40,7 @@ export default class ArrivalsController {
       }
 
       try {
-        await this.arrivalService.createArrival(token, premisesId, bookingId, newArrival)
+        await this.arrivalService.createArrival(req, premisesId, bookingId, newArrival)
 
         req.flash('success', 'Booking marked as active')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import paths from '../../../paths/temporary-accommodation/manage'
@@ -11,18 +11,18 @@ import updateRoomFactory from '../../../testutils/factories/updateRoom'
 import { ErrorsAndUserInput, SummaryListItem, TableRow } from '../../../@types/ui'
 import { PremisesService, BookingService } from '../../../services'
 import referenceDataFactory from '../../../testutils/factories/referenceData'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('BedspacesController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
 
   const referenceData = {
     characteristics: referenceDataFactory.characteristic('room').buildList(5),
   }
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -33,7 +33,7 @@ describe('BedspacesController', () => {
   const bedspacesController = new BedspacesController(premisesService, bedspaceService, bookingService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -49,7 +49,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(request)
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/new', {
         premisesId,
         allCharacteristics: referenceData.characteristics,
@@ -78,7 +78,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.createRoom).toHaveBeenCalledWith(token, premisesId, {
+      expect(bedspaceService.createRoom).toHaveBeenCalledWith(request, premisesId, {
         name: room.name,
         characteristicIds: [],
         notes: room.notes,
@@ -134,8 +134,8 @@ describe('BedspacesController', () => {
       request.params = { premisesId, roomId: room.id }
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(token, premisesId, room.id)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(request)
+      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(request, premisesId, room.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/edit', {
         allCharacteristics: referenceData.characteristics,
@@ -164,8 +164,8 @@ describe('BedspacesController', () => {
       request.params = { premisesId, roomId: room.id }
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(token, premisesId, room.id)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(request)
+      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(request, premisesId, room.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/edit', {
         allCharacteristics: referenceData.characteristics,
@@ -195,7 +195,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.updateRoom).toHaveBeenCalledWith(token, premisesId, room.id, {
+      expect(bedspaceService.updateRoom).toHaveBeenCalledWith(request, premisesId, room.id, {
         name: room.name,
         notes: room.notes,
         characteristicIds: [],
@@ -257,9 +257,9 @@ describe('BedspacesController', () => {
         bookingTableRows,
       })
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(token, premises.id, room.id)
-      expect(bookingService.getTableRowsForBedspace).toHaveBeenCalledWith(token, premises.id, room.id)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(request, premises.id)
+      expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(request, premises.id, room.id)
+      expect(bookingService.getTableRowsForBedspace).toHaveBeenCalledWith(request, premises.id, room.id)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -18,7 +18,7 @@ export default class BedspacesController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId } = req.params
 
-      const { characteristics: allCharacteristics } = await this.bedspaceService.getReferenceData(req.user.token)
+      const { characteristics: allCharacteristics } = await this.bedspaceService.getReferenceData(req)
 
       return res.render('temporary-accommodation/bedspaces/new', {
         premisesId,
@@ -41,7 +41,7 @@ export default class BedspacesController {
       }
 
       try {
-        const room = await this.bedspaceService.createRoom(req.user.token, premisesId, newRoom)
+        const room = await this.bedspaceService.createRoom(req, premisesId, newRoom)
 
         req.flash('success', 'Bedspace created')
         res.redirect(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))
@@ -56,11 +56,10 @@ export default class BedspacesController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const { premisesId, roomId } = req.params
-      const { token } = req.user
 
-      const { characteristics: allCharacteristics } = await this.bedspaceService.getReferenceData(token)
+      const { characteristics: allCharacteristics } = await this.bedspaceService.getReferenceData(req)
 
-      const updateRoom = await this.bedspaceService.getUpdateRoom(token, premisesId, roomId)
+      const updateRoom = await this.bedspaceService.getUpdateRoom(req, premisesId, roomId)
 
       return res.render('temporary-accommodation/bedspaces/edit', {
         allCharacteristics,
@@ -77,7 +76,6 @@ export default class BedspacesController {
   update(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId } = req.params
-      const { token } = req.user
 
       const updateRoom: UpdateRoom = {
         characteristicIds: [],
@@ -85,7 +83,7 @@ export default class BedspacesController {
       }
 
       try {
-        await this.bedspaceService.updateRoom(token, premisesId, roomId, updateRoom)
+        await this.bedspaceService.updateRoom(req, premisesId, roomId, updateRoom)
 
         req.flash('success', 'Bedspace updated')
         res.redirect(paths.premises.bedspaces.show({ premisesId, roomId }))
@@ -97,14 +95,13 @@ export default class BedspacesController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { token } = req.user
       const { premisesId, roomId } = req.params
 
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspaceService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(req, premisesId)
+      const room = await this.bedspaceService.getRoom(req, premisesId, roomId)
 
-      const bedspaceDetails = await this.bedspaceService.getSingleBedspaceDetails(token, premisesId, roomId)
-      const bookingTableRows = await this.bookingService.getTableRowsForBedspace(token, premisesId, room)
+      const bedspaceDetails = await this.bedspaceService.getSingleBedspaceDetails(req, premisesId, roomId)
+      const bookingTableRows = await this.bookingService.getTableRowsForBedspace(req, premisesId, room)
 
       return res.render('temporary-accommodation/bedspaces/show', {
         premises,

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
@@ -1,16 +1,15 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { BookingReportsController } from '.'
 import BookingReportService from '../../../services/bookingReportService'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('BookingReportsController', () => {
-  const token = 'SOME_TOKEN'
-
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -20,7 +19,7 @@ describe('BookingReportsController', () => {
   const bookingReportsController = new BookingReportsController(bookingReportService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -32,7 +31,7 @@ describe('BookingReportsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingReportService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bookingReportService.getReferenceData).toHaveBeenCalledWith(request)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/reports/bookings/new', {
         allProbationRegions: [],
@@ -52,7 +51,7 @@ describe('BookingReportsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingReportService.pipeBookings).toHaveBeenCalledWith(token, response)
+      expect(bookingReportService.pipeBookings).toHaveBeenCalledWith(request, response)
     })
 
     it('when the probationRegionId is not empty, creates a booking report for the probation region and pipes it into the express response', async () => {
@@ -65,7 +64,7 @@ describe('BookingReportsController', () => {
       await requestHandler(request, response, next)
 
       expect(bookingReportService.pipeBookingsForProbationRegion).toHaveBeenCalledWith(
-        token,
+        request,
         response,
         'probation-region',
       )

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
@@ -11,9 +11,7 @@ export default class BookingReportsController {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const { token } = req.user
-
-      const { probationRegions: allProbationRegions } = await this.bookingReportService.getReferenceData(token)
+      const { probationRegions: allProbationRegions } = await this.bookingReportService.getReferenceData(req)
 
       return res.render('temporary-accommodation/reports/bookings/new', {
         allProbationRegions,
@@ -28,12 +26,11 @@ export default class BookingReportsController {
     return async (req: Request, res: Response) => {
       try {
         const { probationRegionId } = req.body
-        const { token } = req.user
 
         if (probationRegionId?.length) {
-          await this.bookingReportService.pipeBookingsForProbationRegion(token, res, probationRegionId)
+          await this.bookingReportService.pipeBookingsForProbationRegion(req, res, probationRegionId)
         } else {
-          await this.bookingReportService.pipeBookings(token, res)
+          await this.bookingReportService.pipeBookings(req, res)
         }
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.reports.bookings.new({}))

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
@@ -11,16 +11,16 @@ import { PremisesService, BookingService } from '../../../services'
 import BookingsController from './bookingsController'
 import { DateFormats } from '../../../utils/dateUtils'
 import { bookingActions, deriveBookingHistory } from '../../../utils/bookingUtils'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/bookingUtils')
 
 describe('BookingsController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const roomId = 'roomId'
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -32,7 +32,7 @@ describe('BookingsController', () => {
   const bookingsController = new BookingsController(premisesService, bedspaceService, bookingService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -53,8 +53,8 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premisesId)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premisesId, roomId)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(request, premisesId)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(request, premisesId, roomId)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/new', {
         premises,
@@ -92,7 +92,7 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(bookingService.createForBedspace).toHaveBeenCalledWith(
-        token,
+        request,
         premisesId,
         room,
         expect.objectContaining(newBooking),
@@ -204,9 +204,9 @@ describe('BookingsController', () => {
         actions: [],
       })
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premises.id, room.id)
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premises.id, booking.id)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(request, premises.id)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(request, premises.id, room.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premises.id, booking.id)
     })
   })
 
@@ -247,9 +247,9 @@ describe('BookingsController', () => {
         ],
       })
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premises.id, room.id)
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premises.id, booking.id)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(request, premises.id)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(request, premises.id, room.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premises.id, booking.id)
       expect(deriveBookingHistory).toHaveBeenCalledWith(booking)
     })
   })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -20,10 +20,8 @@ export default class BookingsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId } = req.params
 
-      const { token } = req.user
-
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(req, premisesId)
+      const room = await this.bedspacesService.getRoom(req, premisesId, roomId)
 
       return res.render('temporary-accommodation/bookings/new', {
         premises,
@@ -38,9 +36,8 @@ export default class BookingsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId } = req.params
-      const { token } = req.user
 
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const room = await this.bedspacesService.getRoom(req, premisesId, roomId)
 
       const newBooking: NewBooking = {
         service: 'temporary-accommodation',
@@ -50,7 +47,7 @@ export default class BookingsController {
       }
 
       try {
-        const booking = await this.bookingsService.createForBedspace(token, premisesId, room, newBooking)
+        const booking = await this.bookingsService.createForBedspace(req, premisesId, room, newBooking)
 
         req.flash('success', 'Booking created')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId: booking.id }))
@@ -68,12 +65,11 @@ export default class BookingsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(req, premisesId)
+      const room = await this.bedspacesService.getRoom(req, premisesId, roomId)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
 
       return res.render('temporary-accommodation/bookings/show', {
         premises,
@@ -87,12 +83,11 @@ export default class BookingsController {
   history(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(req, premisesId)
+      const room = await this.bedspacesService.getRoom(req, premisesId, roomId)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
 
       return res.render('temporary-accommodation/bookings/history', {
         premises,

--- a/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -8,16 +8,16 @@ import { DateFormats } from '../../../utils/dateUtils'
 import { CancellationsController } from '.'
 import cancellationFactory from '../../../testutils/factories/cancellation'
 import newCancellationFactory from '../../../testutils/factories/newCancellation'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('CancellationsController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -28,7 +28,7 @@ describe('CancellationsController', () => {
   const cancellationsController = new CancellationsController(bookingService, cancellationService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -49,8 +49,8 @@ describe('CancellationsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
-      expect(cancellationService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premisesId, booking.id)
+      expect(cancellationService.getReferenceData).toHaveBeenCalledWith(request)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/cancellations/new', {
         booking,
@@ -89,7 +89,7 @@ describe('CancellationsController', () => {
       await requestHandler(request, response, next)
 
       expect(cancellationService.createCancellation).toHaveBeenCalledWith(
-        token,
+        request,
         premisesId,
         bookingId,
         expect.objectContaining(newCancellation),

--- a/server/controllers/temporary-accommodation/manage/cancellationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationsController.ts
@@ -17,10 +17,8 @@ export default class CanellationsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
-
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
-      const { cancellationReasons: allCancellationReasons } = await this.cancellationService.getReferenceData(token)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
+      const { cancellationReasons: allCancellationReasons } = await this.cancellationService.getReferenceData(req)
 
       return res.render('temporary-accommodation/cancellations/new', {
         booking,
@@ -38,7 +36,6 @@ export default class CanellationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
       const newCancellation: NewCancellation = {
         ...req.body,
@@ -46,7 +43,7 @@ export default class CanellationsController {
       }
 
       try {
-        await this.cancellationService.createCancellation(token, premisesId, bookingId, newCancellation)
+        await this.cancellationService.createCancellation(req, premisesId, bookingId, newCancellation)
 
         req.flash('success', 'Booking cancelled')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/confirmationsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/confirmationsController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -8,16 +8,16 @@ import ConfirmationsController from './confirmationsController'
 import ConfirmationService from '../../../services/confirmationService'
 import confirmationFactory from '../../../testutils/factories/confirmation'
 import newConfirmationFactory from '../../../testutils/factories/newConfirmation'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('ConfirmationsController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -28,7 +28,7 @@ describe('ConfirmationsController', () => {
   const confirmationsController = new ConfirmationsController(bookingService, confirmationService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -48,7 +48,7 @@ describe('ConfirmationsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/confirmations/new', {
         booking,
@@ -82,7 +82,12 @@ describe('ConfirmationsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(confirmationService.createConfirmation).toHaveBeenCalledWith(token, premisesId, bookingId, newConfirmation)
+      expect(confirmationService.createConfirmation).toHaveBeenCalledWith(
+        request,
+        premisesId,
+        bookingId,
+        newConfirmation,
+      )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking confirmed')
       expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/confirmationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/confirmationsController.ts
@@ -17,9 +17,7 @@ export default class ConfirmationsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
-
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
 
       return res.render('temporary-accommodation/confirmations/new', {
         booking,
@@ -35,14 +33,13 @@ export default class ConfirmationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
       const newConfirmation: NewConfirmation = {
         ...req.body,
       }
 
       try {
-        await this.confirmationService.createConfirmation(token, premisesId, bookingId, newConfirmation)
+        await this.confirmationService.createConfirmation(req, premisesId, bookingId, newConfirmation)
 
         req.flash('success', 'Booking confirmed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -8,16 +8,16 @@ import departureFactory from '../../../testutils/factories/departure'
 import newDepartureFactory from '../../../testutils/factories/newDeparture'
 import { DateFormats } from '../../../utils/dateUtils'
 import DeparturesController from './departuresController'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('DeparturesController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -28,7 +28,7 @@ describe('DeparturesController', () => {
   const departuresController = new DeparturesController(bookingService, departureService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -49,8 +49,8 @@ describe('DeparturesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
-      expect(departureService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premisesId, booking.id)
+      expect(departureService.getReferenceData).toHaveBeenCalledWith(request)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/departures/new', {
         booking,
@@ -89,7 +89,7 @@ describe('DeparturesController', () => {
       await requestHandler(request, response, next)
 
       expect(departureService.createDeparture).toHaveBeenCalledWith(
-        token,
+        request,
         premisesId,
         bookingId,
         expect.objectContaining(newDeparture),

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -14,11 +14,9 @@ export default class DeparturesController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
-
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
       const { departureReasons: allDepartureReasons, moveOnCategories: allMoveOnCategories } =
-        await this.departureService.getReferenceData(token)
+        await this.departureService.getReferenceData(req)
 
       return res.render('temporary-accommodation/departures/new', {
         booking,
@@ -37,7 +35,6 @@ export default class DeparturesController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
       const newDeparture: NewDeparture = {
         ...req.body,
@@ -45,7 +42,7 @@ export default class DeparturesController {
       }
 
       try {
-        await this.departureService.createDeparture(token, premisesId, bookingId, newDeparture)
+        await this.departureService.createDeparture(req, premisesId, bookingId, newDeparture)
 
         req.flash('success', 'Booking marked as closed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/extensionsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/extensionsController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
@@ -11,17 +11,17 @@ import ExtensionsController from './extensionsController'
 import extensionFactory from '../../../testutils/factories/extension'
 import newExtensionFactory from '../../../testutils/factories/newExtension'
 import { getLatestExtension } from '../../../utils/bookingUtils'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/bookingUtils')
 
 describe('ExtensionsController', () => {
-  const token = 'SOME_TOKEN'
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -32,7 +32,7 @@ describe('ExtensionsController', () => {
   const extensionsController = new ExtensionsController(bookingService, extensionService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('new', () => {
@@ -54,7 +54,7 @@ describe('ExtensionsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/extensions/new', {
         booking,
@@ -87,7 +87,7 @@ describe('ExtensionsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(request, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/extensions/new', {
         booking,
@@ -125,7 +125,7 @@ describe('ExtensionsController', () => {
       await requestHandler(request, response, next)
 
       expect(extensionService.createExtension).toHaveBeenCalledWith(
-        token,
+        request,
         premisesId,
         bookingId,
         expect.objectContaining(newExtension),

--- a/server/controllers/temporary-accommodation/manage/extensionsController.ts
+++ b/server/controllers/temporary-accommodation/manage/extensionsController.ts
@@ -15,9 +15,7 @@ export default class ExtensionsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
-
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(req, premisesId, bookingId)
 
       return res.render('temporary-accommodation/extensions/new', {
         booking,
@@ -35,7 +33,6 @@ export default class ExtensionsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
 
       const newExtension: NewExtension = {
         ...req.body,
@@ -43,7 +40,7 @@ export default class ExtensionsController {
       }
 
       try {
-        await this.extensionService.createExtension(token, premisesId, bookingId, newExtension)
+        await this.extensionService.createExtension(req, premisesId, bookingId, newExtension)
 
         req.flash('success', 'Booking departure date changed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -1,4 +1,4 @@
-import type { Request, Response, NextFunction } from 'express'
+import type { Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 
 import type { ErrorsAndUserInput, SummaryListItem } from '@approved-premises/ui'
@@ -13,12 +13,11 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../
 import BedspaceService from '../../../services/bedspaceService'
 import { allStatuses } from '../../../utils/premisesUtils'
 import referenceDataFactory from '../../../testutils/factories/referenceData'
+import { createMockRequest, MockRequest } from '../../../testutils/createMockRequest'
 
 jest.mock('../../../utils/validation')
 
 describe('PremisesController', () => {
-  const token = 'SOME_TOKEN'
-
   const referenceData = {
     localAuthorities: referenceDataFactory.localAuthority().buildList(5),
     characteristics: referenceDataFactory.characteristic('premises').buildList(5),
@@ -26,7 +25,7 @@ describe('PremisesController', () => {
     pdus: referenceDataFactory.pdu().buildList(5),
   }
 
-  let request: DeepMocked<Request>
+  let request: MockRequest
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -36,7 +35,7 @@ describe('PremisesController', () => {
   const premisesController = new PremisesController(premisesService, bedspaceService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMockRequest()
   })
 
   describe('index', () => {
@@ -48,7 +47,7 @@ describe('PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/index', { tableRows: [] })
 
-      expect(premisesService.tableRows).toHaveBeenCalledWith(token)
+      expect(premisesService.tableRows).toHaveBeenCalledWith(request)
     })
   })
 
@@ -61,7 +60,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(request)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/new', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -85,7 +84,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(request)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/new', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -118,7 +117,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.create).toHaveBeenCalledWith(token, {
+      expect(premisesService.create).toHaveBeenCalledWith(request, {
         ...newPremises,
         characteristicIds: [],
       })
@@ -165,8 +164,8 @@ describe('PremisesController', () => {
       request.params.premisesId = premises.id
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(token, premises.id)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(request)
+      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(request, premises.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/edit', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -198,8 +197,8 @@ describe('PremisesController', () => {
       request.params.premisesId = premises.id
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(token, premises.id)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(request)
+      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(request, premises.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/edit', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -234,7 +233,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.update).toHaveBeenCalledWith(token, premises.id, {
+      expect(premisesService.update).toHaveBeenCalledWith(request, premises.id, {
         ...newPremises,
         characteristicIds: [],
       })
@@ -292,8 +291,8 @@ describe('PremisesController', () => {
         bedspaces: bedspaceDetails,
       })
 
-      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getBedspaceDetails).toHaveBeenCalledWith(token, premises.id)
+      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(request, premises.id)
+      expect(bedspaceService.getBedspaceDetails).toHaveBeenCalledWith(request, premises.id)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -12,7 +12,7 @@ export default class PremisesController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const tableRows = await this.premisesService.tableRows(req.user.token)
+      const tableRows = await this.premisesService.tableRows(req)
       return res.render('temporary-accommodation/premises/index', { tableRows })
     }
   }
@@ -21,14 +21,12 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const { token } = req.user
-
       const {
         localAuthorities: allLocalAuthorities,
         characteristics: allCharacteristics,
         probationRegions: allProbationRegions,
         pdus: allPdus,
-      } = await this.premisesService.getReferenceData(token)
+      } = await this.premisesService.getReferenceData(req)
 
       return res.render('temporary-accommodation/premises/new', {
         allLocalAuthorities,
@@ -52,7 +50,7 @@ export default class PremisesController {
       }
 
       try {
-        const { id: premisesId } = await this.premisesService.create(req.user.token, newPremises)
+        const { id: premisesId } = await this.premisesService.create(req, newPremises)
 
         req.flash('success', 'Property created')
         res.redirect(paths.premises.show({ premisesId }))
@@ -67,16 +65,15 @@ export default class PremisesController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const { premisesId } = req.params
-      const { token } = req.user
 
       const {
         localAuthorities: allLocalAuthorities,
         characteristics: allCharacteristics,
         probationRegions: allProbationRegions,
         pdus: allPdus,
-      } = await this.premisesService.getReferenceData(token)
+      } = await this.premisesService.getReferenceData(req)
 
-      const updatePremises = await this.premisesService.getUpdatePremises(token, premisesId)
+      const updatePremises = await this.premisesService.getUpdatePremises(req, premisesId)
 
       return res.render('temporary-accommodation/premises/edit', {
         allLocalAuthorities,
@@ -96,7 +93,6 @@ export default class PremisesController {
   update(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId } = req.params
-      const { token } = req.user
 
       const updatePremises: UpdatePremises = {
         characteristicIds: [],
@@ -104,7 +100,7 @@ export default class PremisesController {
       }
 
       try {
-        await this.premisesService.update(token, premisesId, updatePremises)
+        await this.premisesService.update(req, premisesId, updatePremises)
 
         req.flash('success', 'Property updated')
         res.redirect(paths.premises.show({ premisesId }))
@@ -116,12 +112,11 @@ export default class PremisesController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { token } = req.user
       const { premisesId } = req.params
 
-      const details = await this.premisesService.getPremisesDetails(token, premisesId)
+      const details = await this.premisesService.getPremisesDetails(req, premisesId)
 
-      const bedspaceDetails = await this.bedspaceService.getBedspaceDetails(token, premisesId)
+      const bedspaceDetails = await this.bedspaceService.getBedspaceDetails(req, premisesId)
 
       return res.render('temporary-accommodation/premises/show', {
         ...details,

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -5,17 +5,18 @@ import config from '../config'
 import applicationSummaryFactory from '../testutils/factories/applicationSummary'
 import applicationFactory from '../testutils/factories/application'
 import paths from '../paths/api'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('ApplicationClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let applicationClient: ApplicationClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    applicationClient = new ApplicationClient(token)
+    applicationClient = new ApplicationClient(request)
   })
 
   afterEach(() => {
@@ -33,7 +34,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .post(paths.applications.new.pattern)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, application)
 
       const result = await applicationClient.create(application.person.crn)
@@ -49,7 +50,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.applications.show({ id: application.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, application)
 
       const result = await applicationClient.find(application.id)
@@ -65,7 +66,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .put(paths.applications.update({ id: application.id }), JSON.stringify({ data: application.data }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, application)
 
       const result = await applicationClient.update(application)
@@ -81,7 +82,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.applications.index.pattern)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, previousApplications)
 
       const result = await applicationClient.all()

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,4 +1,5 @@
 import type { Application } from '@approved-premises/api'
+import { Request } from 'express'
 import { ApplicationSummary } from '../testutils/factories/applicationSummary'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
@@ -7,8 +8,8 @@ import paths from '../paths/api'
 export default class ApplicationClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async find(applicationId: string): Promise<Application> {

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -15,17 +15,18 @@ import newArrivalFactory from '../testutils/factories/newArrival'
 import config from '../config'
 import confirmationFactory from '../testutils/factories/confirmation'
 import newConfirmationFactory from '../testutils/factories/newConfirmation'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('BookingClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let bookingClient: BookingClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    bookingClient = new BookingClient(token)
+    bookingClient = new BookingClient(request)
   })
 
   afterEach(() => {
@@ -48,7 +49,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/some-uuid/bookings`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, booking)
 
       const result = await bookingClient.create('some-uuid', payload)
@@ -64,7 +65,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, booking)
 
       const result = await bookingClient.find('premisesId', 'bookingId')
@@ -80,7 +81,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/some-uuid/bookings`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, bookings)
 
       const result = await bookingClient.allBookingsForPremisesId('some-uuid')
@@ -103,7 +104,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/${booking.id}/extensions`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, booking)
 
       const result = await bookingClient.extendBooking('premisesId', booking.id, payload)
@@ -122,7 +123,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/confirmations`, payload)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, confirmation)
 
       const result = await bookingClient.markAsConfirmed('premisesId', 'bookingId', payload)
@@ -143,7 +144,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/arrivals`, payload)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, arrival)
 
       const result = await bookingClient.markAsArrived('premisesId', 'bookingId', payload)
@@ -164,7 +165,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/cancellations`, newCancellation)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, cancellation)
 
       const result = await bookingClient.cancel('premisesId', 'bookingId', newCancellation)
@@ -180,7 +181,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId/cancellations/${cancellation.id}`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, cancellation)
 
       const result = await bookingClient.findCancellation('premisesId', 'bookingId', cancellation.id)
@@ -196,7 +197,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/departures`, departure)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, departure)
 
       const result = await bookingClient.markDeparture('premisesId', 'bookingId', departure)
@@ -212,7 +213,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId/departures/${departure.id}`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, departure)
 
       const result = await bookingClient.findDeparture('premisesId', 'bookingId', departure.id)
@@ -233,7 +234,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/non-arrivals`, payload)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, nonArrival)
 
       const result = await bookingClient.markNonArrival('premisesId', 'bookingId', payload)

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -14,14 +14,15 @@ import type {
   Confirmation,
   NewNonarrival,
 } from '@approved-premises/api'
+import { Request } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 
 export default class BookingClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async create(premisesId: string, data: NewBooking): Promise<Booking> {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -1,6 +1,7 @@
 import nock from 'nock'
 
 import config from '../config'
+import { createMockRequest } from '../testutils/createMockRequest'
 import HmppsAuthClient from './hmppsAuthClient'
 import TokenStore from './tokenStore'
 
@@ -10,6 +11,7 @@ const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
 
 const username = 'Bob'
 const token = { access_token: 'token-1', expires_in: 300 }
+const request = createMockRequest()
 
 describe('hmppsAuthClient', () => {
   let fakeHmppsAuthApi: nock.Scope
@@ -31,10 +33,10 @@ describe('hmppsAuthClient', () => {
 
       fakeHmppsAuthApi
         .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, response)
 
-      const output = await hmppsAuthClient.getUser(token.access_token)
+      const output = await hmppsAuthClient.getUser(request)
       expect(output).toEqual(response)
     })
   })
@@ -43,10 +45,10 @@ describe('hmppsAuthClient', () => {
     it('should return data from api', async () => {
       fakeHmppsAuthApi
         .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
 
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
+      const output = await hmppsAuthClient.getUserRoles(request)
       expect(output).toEqual(['role1', 'role2'])
     })
   })

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -1,6 +1,7 @@
 import superagent from 'superagent'
 import { URLSearchParams } from 'url'
 
+import { Request } from 'express'
 import type TokenStore from './tokenStore'
 import logger from '../../logger'
 import config from '../config'
@@ -43,17 +44,17 @@ export interface UserRole {
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
 
-  private static restClient(token: string): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
+  private static restClient(req: Request): RestClient {
+    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, req)
   }
 
-  getUser(token: string): Promise<User> {
+  getUser(req: Request): Promise<User> {
     logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
+    return HmppsAuthClient.restClient(req).get({ path: '/api/user/me' }) as Promise<User>
   }
 
-  getUserRoles(token: string): Promise<string[]> {
-    return HmppsAuthClient.restClient(token)
+  getUserRoles(req: Request): Promise<string[]> {
+    return HmppsAuthClient.restClient(req)
       .get({ path: '/api/user/me/roles' })
       .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
   }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -5,6 +5,7 @@
  */
 /* istanbul ignore file */
 
+import { Request } from 'express'
 import { initialiseAppInsights, buildAppInsightsClient } from '../utils/azureAppInsights'
 import BookingClient from './bookingClient'
 
@@ -23,19 +24,19 @@ import ApplicationClient from './applicationClient'
 import RoomClient from './roomClient'
 import ReportClient from './reportClient'
 
-type RestClientBuilder<T> = (token: string) => T
+type RestClientBuilder<T> = (req: Request) => T
 
 export const dataAccess = () => ({
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient({ legacyMode: false }))),
-  premisesClientBuilder: ((token: string) => new PremisesClient(token)) as RestClientBuilder<PremisesClient>,
-  bookingClientBuilder: ((token: string) => new BookingClient(token)) as RestClientBuilder<BookingClient>,
-  referenceDataClientBuilder: ((token: string) =>
-    new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,
-  lostBedClientBuilder: ((token: string) => new LostBedClient(token)) as RestClientBuilder<LostBedClient>,
-  personClient: ((token: string) => new PersonClient(token)) as RestClientBuilder<PersonClient>,
-  applicationClientBuilder: ((token: string) => new ApplicationClient(token)) as RestClientBuilder<ApplicationClient>,
-  roomClientBuilder: ((token: string) => new RoomClient(token)) as RestClientBuilder<RoomClient>,
-  reportClientBuilder: ((token: string) => new ReportClient(token)) as RestClientBuilder<ReportClient>,
+  premisesClientBuilder: ((req: Request) => new PremisesClient(req)) as RestClientBuilder<PremisesClient>,
+  bookingClientBuilder: ((req: Request) => new BookingClient(req)) as RestClientBuilder<BookingClient>,
+  referenceDataClientBuilder: ((req: Request) =>
+    new ReferenceDataClient(req)) as RestClientBuilder<ReferenceDataClient>,
+  lostBedClientBuilder: ((req: Request) => new LostBedClient(req)) as RestClientBuilder<LostBedClient>,
+  personClient: ((req: Request) => new PersonClient(req)) as RestClientBuilder<PersonClient>,
+  applicationClientBuilder: ((req: Request) => new ApplicationClient(req)) as RestClientBuilder<ApplicationClient>,
+  roomClientBuilder: ((req: Request) => new RoomClient(req)) as RestClientBuilder<RoomClient>,
+  reportClientBuilder: ((req: Request) => new ReportClient(req)) as RestClientBuilder<ReportClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/lostBedClient.test.ts
+++ b/server/data/lostBedClient.test.ts
@@ -4,17 +4,18 @@ import LostBedClient from './lostBedClient'
 import config from '../config'
 import lostBedFactory from '../testutils/factories/lostBed'
 import newLostBedFactory from '../testutils/factories/newLostBed'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('LostBedClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let lostBedClient: LostBedClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    lostBedClient = new LostBedClient(token)
+    lostBedClient = new LostBedClient(request)
   })
 
   afterEach(() => {
@@ -33,7 +34,7 @@ describe('LostBedClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/lost-beds`, newLostBed)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, lostBed)
 
       const result = await lostBedClient.create('premisesId', newLostBed)

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -1,4 +1,5 @@
 import type { LostBed, NewLostBed } from '@approved-premises/api'
+import { Request } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -6,8 +7,8 @@ import paths from '../paths/api'
 export default class LostBedClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async create(premisesId: string, lostBed: NewLostBed): Promise<LostBed> {

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -4,17 +4,18 @@ import PersonClient from './personClient'
 import config from '../config'
 import riskFactory from '../testutils/factories/risks'
 import personFactory from '../testutils/factories/person'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let personClient: PersonClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    personClient = new PersonClient(token)
+    personClient = new PersonClient(request)
   })
 
   afterEach(() => {
@@ -32,7 +33,7 @@ describe('PersonClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/people/search?crn=crn`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, person)
 
       const result = await personClient.search('crn')
@@ -49,7 +50,7 @@ describe('PersonClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/people/${crn}/risks`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, person)
 
       const result = await personClient.risks(crn)

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,4 +1,5 @@
 import type { Person, PersonRisks } from '@approved-premises/api'
+import { Request } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -6,8 +7,8 @@ import paths from '../paths/api'
 export default class PersonClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async search(crn: string): Promise<Person> {

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -8,17 +8,18 @@ import config from '../config'
 import paths from '../paths/api'
 import dateCapacityFactory from '../testutils/factories/dateCapacity'
 import staffMemberFactory from '../testutils/factories/staffMember'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('PremisesClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let premisesClient: PremisesClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    premisesClient = new PremisesClient(token)
+    premisesClient = new PremisesClient(request)
   })
 
   afterEach(() => {
@@ -36,7 +37,7 @@ describe('PremisesClient', () => {
     it('should get all premises for the given service', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.index({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, premises)
 
       const output = await premisesClient.all()
@@ -50,7 +51,7 @@ describe('PremisesClient', () => {
     it('should get a single premises', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.show({ premisesId: premises.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, premises)
 
       const output = await premisesClient.find(premises.id)
@@ -65,7 +66,7 @@ describe('PremisesClient', () => {
     it('should get the capacity of a premises for a given date', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.capacity({ premisesId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, premisesCapacityItem)
 
       const output = await premisesClient.capacity(premisesId)
@@ -80,7 +81,7 @@ describe('PremisesClient', () => {
     it('should return a list of staff members', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.staffMembers.index({ premisesId: premises.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, staffMembers)
 
       const output = await premisesClient.getStaffMembers(premises.id)
@@ -98,7 +99,7 @@ describe('PremisesClient', () => {
 
       fakeApprovedPremisesApi
         .post(paths.premises.create({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(201, premises)
 
       const output = await premisesClient.create(payload)
@@ -116,7 +117,7 @@ describe('PremisesClient', () => {
 
       fakeApprovedPremisesApi
         .put(paths.premises.update({ premisesId: premises.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, premises)
 
       const output = await premisesClient.update(premises.id, payload)

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -5,6 +5,7 @@ import type {
   StaffMember,
   UpdatePremises,
 } from '@approved-premises/api'
+import { Request } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -12,8 +13,8 @@ import paths from '../paths/api'
 export default class PremisesClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async all(): Promise<Array<Premises>> {

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -3,17 +3,18 @@ import nock from 'nock'
 import ReferenceDataClient from './referenceDataClient'
 import referenceDataFactory from '../testutils/factories/referenceData'
 import config from '../config'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('PremisesClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let referenceDataClient: ReferenceDataClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    referenceDataClient = new ReferenceDataClient(token)
+    referenceDataClient = new ReferenceDataClient(request)
   })
 
   afterEach(() => {
@@ -31,7 +32,7 @@ describe('PremisesClient', () => {
     it('should return an array of reference data', async () => {
       fakeApprovedPremisesApi
         .get('/reference-data/some-reference-data')
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, referenceData)
 
       const output = await referenceDataClient.getReferenceData('some-reference-data')

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -1,12 +1,13 @@
 import type { ReferenceData } from '@approved-premises/ui'
+import { Request } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 
 export default class ReferenceDataClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async getReferenceData<T = ReferenceData>(objectType: string): Promise<Array<T>> {

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -6,17 +6,18 @@ import config from '../config'
 import paths from '../paths/api'
 import ReportClient from './reportClient'
 import probationRegionFactory from '../testutils/factories/probationRegion'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('ReportClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let reportClient: ReportClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    reportClient = new ReportClient(token)
+    reportClient = new ReportClient(request)
   })
 
   afterEach(() => {
@@ -34,7 +35,7 @@ describe('ReportClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
@@ -55,7 +56,7 @@ describe('ReportClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
@@ -78,7 +79,7 @@ describe('ReportClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .query({ probationRegionId: probationRegion.id })
         .reply(200, data, { 'content-type': 'some-content-type' })
 

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -1,4 +1,4 @@
-import { Response } from 'express'
+import { Request, Response } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -6,8 +6,8 @@ import paths from '../paths/api'
 export default class ReportClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async bookings(response: Response, filename: string): Promise<void> {

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -3,13 +3,14 @@ import { Response } from 'express'
 import nock from 'nock'
 
 import type { ApiConfig } from '../config'
+import { createMockRequest } from '../testutils/createMockRequest'
 import RestClient from './restClient'
 
 describe('restClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let restClient: RestClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
 
   beforeEach(() => {
     const apiConfig: ApiConfig = {
@@ -24,11 +25,11 @@ describe('restClient', () => {
 
     fakeApprovedPremisesApi = nock(apiConfig.url, {
       reqheaders: {
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${request.user.token}`,
         'X-SERVICE-NAME': 'approved-premises',
       },
     })
-    restClient = new RestClient('premisesClient', apiConfig, token)
+    restClient = new RestClient('premisesClient', apiConfig, request)
   })
 
   afterEach(() => {
@@ -62,11 +63,11 @@ describe('restClient', () => {
 
       fakeApprovedPremisesApi = nock(apiConfig.url, {
         reqheaders: {
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${request.user.token}`,
         },
         badheaders: ['X-SERVICE-NAME'],
       })
-      restClient = new RestClient('premisesClient', apiConfig, token)
+      restClient = new RestClient('premisesClient', apiConfig, request)
 
       fakeApprovedPremisesApi.get(`/some/path`).reply(200, { some: 'data' })
 

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -4,7 +4,7 @@ import superagent from 'superagent'
 import Agent, { HttpsAgent } from 'agentkeepalive'
 import { Readable } from 'stream'
 
-import { Response } from 'express'
+import { Request, Response } from 'express'
 import logger from '../../logger'
 import sanitiseError from '../sanitisedError'
 import { ApiConfig } from '../config'
@@ -40,9 +40,12 @@ export default class RestClient {
 
   defaultHeaders: Record<string, string>
 
-  constructor(private readonly name: string, private readonly config: ApiConfig, private readonly token: string) {
+  private readonly token: string
+
+  constructor(private readonly name: string, private readonly config: ApiConfig, req: Request) {
     this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new Agent(config.agent)
     this.defaultHeaders = config.serviceName ? { 'X-SERVICE-NAME': config.serviceName } : {}
+    this.token = req.user.token
   }
 
   private apiUrl() {

--- a/server/data/roomClient.test.ts
+++ b/server/data/roomClient.test.ts
@@ -6,18 +6,19 @@ import roomFactory from '../testutils/factories/room'
 import newRoomFactory from '../testutils/factories/newRoom'
 import updateRoomFactory from '../testutils/factories/updateRoom'
 import RoomClient from './roomClient'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 describe('Room Client', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let roomClient: RoomClient
 
-  const token = 'token-1'
+  const request = createMockRequest()
   const premisesId = 'premisesId'
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    roomClient = new RoomClient(token)
+    roomClient = new RoomClient(request)
   })
 
   afterEach(() => {
@@ -35,7 +36,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .get(paths.premises.rooms.index({ premisesId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, rooms)
 
       const output = await roomClient.all(premisesId)
@@ -49,7 +50,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .get(paths.premises.rooms.show({ premisesId, roomId: room.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, room)
 
       const output = await roomClient.find(premisesId, room.id)
@@ -68,7 +69,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .post(paths.premises.rooms.create({ premisesId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, room)
 
       const output = await roomClient.create(premisesId, payload)
@@ -85,7 +86,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .put(paths.premises.rooms.update({ premisesId, roomId: room.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${request.user.token}`)
         .reply(200, room)
 
       const output = await roomClient.update(premisesId, room.id, payload)

--- a/server/data/roomClient.ts
+++ b/server/data/roomClient.ts
@@ -1,4 +1,5 @@
 import type { Room, NewRoom } from '@approved-premises/api'
+import { Request } from 'express'
 import RestClient from './restClient'
 import config, { ApiConfig } from '../config'
 import api from '../paths/api'
@@ -7,8 +8,8 @@ import { UpdateRoom } from '../@types/shared/models/UpdateRoom'
 export default class RoomClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('bedspaceClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(req: Request) {
+    this.restClient = new RestClient('bedspaceClient', config.apis.approvedPremises as ApiConfig, req)
   }
 
   async all(premisesId: string): Promise<Array<Room>> {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -6,7 +6,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
   return async (req, res, next) => {
     try {
       if (res.locals.user) {
-        const user = res.locals.user && (await userService.getUser(res.locals.user.token))
+        const user = res.locals.user && (await userService.getUser(req))
         if (user) {
           res.locals.user = { ...user, ...res.locals.user }
         } else {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -12,6 +12,7 @@ import { pages } from '../form-pages/apply'
 import paths from '../paths/apply'
 import applicationFactory from '../testutils/factories/application'
 import { DateFormats } from '../utils/dateUtils'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 const FirstPage = jest.fn()
 const SecondPage = jest.fn()
@@ -62,11 +63,11 @@ describe('ApplicationService', () => {
       })
 
       const applicationSummaries = [applicationSummaryA, applicationSummaryB]
-      const token = 'SOME_TOKEN'
+      const request = createMockRequest()
 
       applicationClient.all.mockResolvedValue(applicationSummaries)
 
-      const result = await service.tableRows(token)
+      const result = await service.tableRows(request)
 
       expect(result).toEqual([
         [
@@ -109,7 +110,7 @@ describe('ApplicationService', () => {
         ],
       ])
 
-      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClientFactory).toHaveBeenCalledWith(request)
       expect(applicationClient.all).toHaveBeenCalled()
     })
   })
@@ -117,15 +118,15 @@ describe('ApplicationService', () => {
   describe('createApplication', () => {
     it('calls the create method and returns an application', async () => {
       const application = applicationFactory.build()
-      const token = 'SOME_TOKEN'
+      const request = createMockRequest()
 
       applicationClient.create.mockResolvedValue(application)
 
-      const result = await service.createApplication(token, application.person.crn)
+      const result = await service.createApplication(request, application.person.crn)
 
       expect(result).toEqual(application)
 
-      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClientFactory).toHaveBeenCalledWith(request)
       expect(applicationClient.create).toHaveBeenCalledWith(application.person.crn)
     })
   })
@@ -133,21 +134,21 @@ describe('ApplicationService', () => {
   describe('findApplication', () => {
     it('calls the find method and returns an application', async () => {
       const application = applicationFactory.build()
-      const token = 'SOME_TOKEN'
+      const request = createMockRequest()
 
       applicationClient.find.mockResolvedValue(application)
 
-      const result = await service.findApplication(token, application.id)
+      const result = await service.findApplication(request, application.id)
 
       expect(result).toEqual(application)
 
-      expect(applicationClientFactory).toHaveBeenCalledWith(token)
+      expect(applicationClientFactory).toHaveBeenCalledWith(request)
       expect(applicationClient.find).toHaveBeenCalledWith(application.id)
     })
   })
 
   describe('getCurrentPage', () => {
-    let request: DeepMocked<Request>
+    let request: Request
     const dataServices = createMock<DataServices>({}) as DataServices
     const application = applicationFactory.build()
 
@@ -273,7 +274,7 @@ describe('ApplicationService', () => {
       it('saves data to the api', async () => {
         await service.save(page, request)
 
-        expect(applicationClientFactory).toHaveBeenCalledWith(token)
+        expect(applicationClientFactory).toHaveBeenCalledWith(request)
         expect(applicationClient.update).toHaveBeenCalledWith(application)
       })
 

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -16,16 +16,16 @@ type ApplicationResponse = Record<string, Array<PageResponse>>
 export default class ApplicationService {
   constructor(private readonly applicationClientFactory: RestClientBuilder<ApplicationClient>) {}
 
-  async createApplication(token: string, crn: string): Promise<Application> {
-    const applicationClient = this.applicationClientFactory(token)
+  async createApplication(req: Request, crn: string): Promise<Application> {
+    const applicationClient = this.applicationClientFactory(req)
 
     const application = await applicationClient.create(crn)
 
     return application
   }
 
-  async findApplication(token: string, id: string): Promise<Application> {
-    const applicationClient = this.applicationClientFactory(token)
+  async findApplication(req: Request, id: string): Promise<Application> {
+    const applicationClient = this.applicationClientFactory(req)
 
     const application = await applicationClient.find(id)
 
@@ -120,7 +120,7 @@ export default class ApplicationService {
     if (application && application.id === request.params.id) {
       return application
     }
-    return this.findApplication(request.user.token, request.params.id)
+    return this.findApplication(request, request.params.id)
   }
 
   private async saveToSession(application: Application, page: TasklistPage, request: Request) {
@@ -129,7 +129,7 @@ export default class ApplicationService {
   }
 
   private async saveToApi(application: Application, request: Request) {
-    const client = this.applicationClientFactory(request.user.token)
+    const client = this.applicationClientFactory(request)
 
     await client.update(application)
   }
@@ -148,8 +148,8 @@ export default class ApplicationService {
     return application.data?.[request.params.task]?.[request.params.page] || {}
   }
 
-  async tableRows(token: string): Promise<(TextItem | HtmlItem)[][]> {
-    const applicationClient = this.applicationClientFactory(token)
+  async tableRows(req: Request): Promise<(TextItem | HtmlItem)[][]> {
+    const applicationClient = this.applicationClientFactory(req)
 
     const applicationSummaries = await applicationClient.all()
 

--- a/server/services/arrivalService.test.ts
+++ b/server/services/arrivalService.test.ts
@@ -2,6 +2,7 @@ import ArrivalService from './arrivalService'
 import BookingClient from '../data/bookingClient'
 import arrivalFactory from '../testutils/factories/arrival'
 import newArrivalFactory from '../testutils/factories/newArrival'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -21,14 +22,14 @@ describe('ArrivalService', () => {
       const arrival = arrivalFactory.build()
       const payload = newArrivalFactory.build()
 
-      const token = 'SOME_TOKEN'
+      const request = createMockRequest()
 
       bookingClient.markAsArrived.mockResolvedValue(arrival)
 
-      const postedArrival = await service.createArrival(token, 'premisesID', 'bookingId', payload)
+      const postedArrival = await service.createArrival(request, 'premisesID', 'bookingId', payload)
       expect(postedArrival).toEqual(arrival)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.markAsArrived).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
     })
   })

--- a/server/services/arrivalService.ts
+++ b/server/services/arrivalService.ts
@@ -1,11 +1,12 @@
 import type { Arrival, NewArrival } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, BookingClient } from '../data'
 
 export default class ArrivalService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async createArrival(token: string, premisesId: string, bookingId: string, arrival: NewArrival): Promise<Arrival> {
-    const bookingClient = this.bookingClientFactory(token)
+  async createArrival(req: Request, premisesId: string, bookingId: string, arrival: NewArrival): Promise<Arrival> {
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedArrival = await bookingClient.markAsArrived(premisesId, bookingId, arrival)
 

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -6,6 +6,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import characteristicFactory from '../testutils/factories/characteristic'
 import { formatLines } from '../utils/viewUtils'
 import { formatCharacteristics, filterCharacteristics } from '../utils/characteristicUtils'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/roomClient')
 jest.mock('../data/referenceDataClient')
@@ -21,7 +22,7 @@ describe('BedspaceService', () => {
 
   const service = new BedspaceService(roomClientFactory, referenceDataClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
   const premisesId = 'premisesId'
 
   beforeEach(() => {
@@ -35,11 +36,11 @@ describe('BedspaceService', () => {
       const room = roomFactory.build()
       roomClient.find.mockResolvedValue(room)
 
-      const result = await service.getRoom(token, premisesId, room.id)
+      const result = await service.getRoom(request, premisesId, room.id)
 
       expect(result).toEqual(room)
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(request)
       expect(roomClient.find).toHaveBeenCalledWith(premisesId, room.id)
     })
   })
@@ -67,7 +68,7 @@ describe('BedspaceService', () => {
         text: 'Some attributes',
       }))
 
-      const result = await service.getBedspaceDetails(token, premisesId)
+      const result = await service.getBedspaceDetails(request, premisesId)
 
       expect(result).toEqual([
         {
@@ -102,7 +103,7 @@ describe('BedspaceService', () => {
         },
       ])
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(request)
       expect(roomClient.all).toHaveBeenCalledWith(premisesId)
 
       expect(formatLines).toHaveBeenCalledWith('Some more notes')
@@ -140,7 +141,7 @@ describe('BedspaceService', () => {
         text: 'Some attributes',
       }))
 
-      const result = await service.getSingleBedspaceDetails(token, premisesId, room.id)
+      const result = await service.getSingleBedspaceDetails(request, premisesId, room.id)
 
       expect(result).toEqual({
         room,
@@ -158,7 +159,7 @@ describe('BedspaceService', () => {
         },
       })
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(request)
       expect(roomClient.find).toHaveBeenCalledWith(premisesId, room.id)
 
       expect(formatLines).toHaveBeenCalledWith('Some notes')
@@ -191,7 +192,7 @@ describe('BedspaceService', () => {
 
       roomClient.find.mockResolvedValue(room)
 
-      const result = await service.getUpdateRoom(token, premisesId, room.id)
+      const result = await service.getUpdateRoom(request, premisesId, room.id)
       expect(result).toEqual({
         ...room,
         characteristicIds: ['characteristic-a', 'characteristic-b'],
@@ -209,10 +210,10 @@ describe('BedspaceService', () => {
       })
       roomClient.create.mockResolvedValue(room)
 
-      const postedRoom = await service.createRoom(token, premisesId, newRoom)
+      const postedRoom = await service.createRoom(request, premisesId, newRoom)
       expect(postedRoom).toEqual(room)
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(request)
       expect(roomClient.create).toHaveBeenCalledWith(premisesId, newRoom)
     })
   })
@@ -225,10 +226,10 @@ describe('BedspaceService', () => {
       })
       roomClient.update.mockResolvedValue(room)
 
-      const updatedRoom = await service.updateRoom(token, premisesId, room.id, newRoom)
+      const updatedRoom = await service.updateRoom(request, premisesId, room.id, newRoom)
       expect(updatedRoom).toEqual(room)
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(request)
       expect(roomClient.update).toHaveBeenCalledWith(premisesId, room.id, newRoom)
     })
   })
@@ -252,7 +253,7 @@ describe('BedspaceService', () => {
         roomCharacteristic1,
       ])
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(request)
       expect(result).toEqual({ characteristics: [roomCharacteristic1, roomCharacteristic2, genericCharacteristic] })
 
       expect(filterCharacteristics).toHaveBeenCalledWith(

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -1,4 +1,5 @@
 import type { Characteristic, Room, NewRoom, UpdateRoom } from '@approved-premises/api'
+import { Request } from 'express'
 import { SummaryList } from '../@types/ui'
 import { ReferenceDataClient, RestClientBuilder } from '../data'
 import RoomClient from '../data/roomClient'
@@ -15,18 +16,15 @@ export default class BedspaceService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getRoom(token: string, premisesId: string, roomId: string): Promise<Room> {
-    const roomClient = this.roomClientFactory(token)
+  async getRoom(req: Request, premisesId: string, roomId: string): Promise<Room> {
+    const roomClient = this.roomClientFactory(req)
     const room = await roomClient.find(premisesId, roomId)
 
     return room
   }
 
-  async getBedspaceDetails(
-    token: string,
-    premisesId: string,
-  ): Promise<Array<{ room: Room; summaryList: SummaryList }>> {
-    const roomClient = this.roomClientFactory(token)
+  async getBedspaceDetails(req: Request, premisesId: string): Promise<Array<{ room: Room; summaryList: SummaryList }>> {
+    const roomClient = this.roomClientFactory(req)
     const rooms = await roomClient.all(premisesId)
 
     return rooms
@@ -38,11 +36,11 @@ export default class BedspaceService {
   }
 
   async getSingleBedspaceDetails(
-    token: string,
+    req: Request,
     premisesId: string,
     roomId: string,
   ): Promise<{ room: Room; summaryList: SummaryList }> {
-    const roomClient = this.roomClientFactory(token)
+    const roomClient = this.roomClientFactory(req)
     const room = await roomClient.find(premisesId, roomId)
 
     return {
@@ -51,8 +49,8 @@ export default class BedspaceService {
     }
   }
 
-  async getUpdateRoom(token: string, premisesId: string, roomId: string): Promise<UpdateRoom> {
-    const roomClient = this.roomClientFactory(token)
+  async getUpdateRoom(req: Request, premisesId: string, roomId: string): Promise<UpdateRoom> {
+    const roomClient = this.roomClientFactory(req)
     const room = await roomClient.find(premisesId, roomId)
 
     return {
@@ -61,22 +59,22 @@ export default class BedspaceService {
     }
   }
 
-  async createRoom(token: string, premisesId: string, newRoom: NewRoom): Promise<Room> {
-    const roomClient = this.roomClientFactory(token)
+  async createRoom(req: Request, premisesId: string, newRoom: NewRoom): Promise<Room> {
+    const roomClient = this.roomClientFactory(req)
     const room = await roomClient.create(premisesId, newRoom)
 
     return room
   }
 
-  async updateRoom(token: string, premisesId: string, roomId: string, updateRoom: UpdateRoom): Promise<Room> {
-    const roomClient = this.roomClientFactory(token)
+  async updateRoom(req: Request, premisesId: string, roomId: string, updateRoom: UpdateRoom): Promise<Room> {
+    const roomClient = this.roomClientFactory(req)
     const room = await roomClient.update(premisesId, roomId, updateRoom)
 
     return room
   }
 
-  async getReferenceData(token: string): Promise<BedspaceReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(req: Request): Promise<BedspaceReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(req)
 
     const characteristics = filterCharacteristics(
       await referenceDataClient.getReferenceData<Characteristic>('characteristics'),

--- a/server/services/bookingReportService.test.ts
+++ b/server/services/bookingReportService.test.ts
@@ -5,6 +5,7 @@ import BookingReportService from './bookingReportService'
 import { ReportClient } from '../data'
 import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../utils/reportUtils'
 import probationRegionFactory from '../testutils/factories/probationRegion'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/reportClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -17,7 +18,7 @@ describe('BookingReportService', () => {
   const ReportClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
 
   const service = new BookingReportService(ReportClientFactory, ReferenceDataClientFactory)
 
@@ -32,9 +33,9 @@ describe('BookingReportService', () => {
       const response = createMock<Response>()
       ;(bookingReportFilename as jest.MockedFunction<typeof bookingReportFilename>).mockReturnValue('some-filename')
 
-      await service.pipeBookings(token, response)
+      await service.pipeBookings(request, response)
 
-      expect(ReportClientFactory).toHaveBeenCalledWith(token)
+      expect(ReportClientFactory).toHaveBeenCalledWith(request)
       expect(bookingReportFilename).toHaveBeenCalled()
       expect(reportClient.bookings).toHaveBeenCalledWith(response, 'some-filename')
     })
@@ -49,9 +50,9 @@ describe('BookingReportService', () => {
         bookingReportForProbationRegionFilename as jest.MockedFunction<typeof bookingReportForProbationRegionFilename>
       ).mockReturnValue('some-filename')
 
-      await service.pipeBookingsForProbationRegion(token, response, probationRegions[0].id)
+      await service.pipeBookingsForProbationRegion(request, response, probationRegions[0].id)
 
-      expect(ReportClientFactory).toHaveBeenCalledWith(token)
+      expect(ReportClientFactory).toHaveBeenCalledWith(request)
       expect(bookingReportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0])
       expect(reportClient.bookingsForProbationRegion).toHaveBeenCalledWith(
         response,
@@ -67,11 +68,11 @@ describe('BookingReportService', () => {
 
       referenceDataClient.getReferenceData.mockResolvedValue(probationRegions)
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(request)
 
       expect(result).toEqual({ probationRegions })
 
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(request)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('probation-regions')
     })
   })

--- a/server/services/bookingReportService.ts
+++ b/server/services/bookingReportService.ts
@@ -1,5 +1,5 @@
 import type { ProbationRegion } from '@approved-premises/api'
-import { Response } from 'express'
+import { Request, Response } from 'express'
 import type { RestClientBuilder, ReferenceDataClient } from '../data'
 import ReportClient from '../data/reportClient'
 import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../utils/reportUtils'
@@ -14,18 +14,18 @@ export default class BookingReportService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async pipeBookings(token: string, response: Response): Promise<void> {
-    const reportClient = this.reportClientFactory(token)
+  async pipeBookings(req: Request, response: Response): Promise<void> {
+    const reportClient = this.reportClientFactory(req)
 
     const filename = bookingReportFilename()
 
     await reportClient.bookings(response, filename)
   }
 
-  async pipeBookingsForProbationRegion(token: string, response: Response, probationRegionId: string): Promise<void> {
-    const reportClient = this.reportClientFactory(token)
+  async pipeBookingsForProbationRegion(req: Request, response: Response, probationRegionId: string): Promise<void> {
+    const reportClient = this.reportClientFactory(req)
 
-    const probationRegion = (await this.getReferenceData(token)).probationRegions.find(
+    const probationRegion = (await this.getReferenceData(req)).probationRegions.find(
       region => region.id === probationRegionId,
     )
 
@@ -34,8 +34,8 @@ export default class BookingReportService {
     await reportClient.bookingsForProbationRegion(response, filename, probationRegionId)
   }
 
-  async getReferenceData(token: string): Promise<BookingReportReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(req: Request): Promise<BookingReportReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(req)
 
     const probationRegions = await referenceDataClient.getReferenceData('probation-regions')
 

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -9,6 +9,7 @@ import { DateFormats } from '../utils/dateUtils'
 import roomFactory from '../testutils/factories/room'
 import bedFactory from '../testutils/factories/bed'
 import { formatStatus } from '../utils/bookingUtils'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/bookingClient')
 jest.mock('../data/referenceDataClient')
@@ -20,7 +21,7 @@ describe('BookingService', () => {
   const bookingClientFactory = jest.fn()
 
   const service = new BookingService(bookingClientFactory)
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
 
   const premisesId = 'premiseId'
   const bedId = 'bedId'
@@ -38,10 +39,10 @@ describe('BookingService', () => {
       const newBooking = newBookingFactory.build()
       bookingClient.create.mockResolvedValue(booking)
 
-      const postedBooking = await service.create(token, premisesId, newBooking)
+      const postedBooking = await service.create(request, premisesId, newBooking)
       expect(postedBooking).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.create).toHaveBeenCalledWith(premisesId, newBooking)
     })
   })
@@ -60,10 +61,10 @@ describe('BookingService', () => {
         ],
       })
 
-      const postedBooking = await service.createForBedspace(token, premisesId, room, newBooking)
+      const postedBooking = await service.createForBedspace(request, premisesId, room, newBooking)
       expect(postedBooking).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.create).toHaveBeenCalledWith(premisesId, {
         serviceName: 'temporary-accommodation',
         bedId,
@@ -84,10 +85,10 @@ describe('BookingService', () => {
 
       bookingClient.find.mockResolvedValue(booking)
 
-      const retrievedBooking = await service.find(token, premisesId, booking.id)
+      const retrievedBooking = await service.find(request, premisesId, booking.id)
       expect(retrievedBooking).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
     })
   })
@@ -128,7 +129,7 @@ describe('BookingService', () => {
         ],
       })
 
-      const rows = await service.getTableRowsForBedspace(token, premisesId, room)
+      const rows = await service.getTableRowsForBedspace(request, premisesId, room)
 
       expect(rows).toEqual([
         [
@@ -225,7 +226,7 @@ describe('BookingService', () => {
         ],
       ])
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
 
       expect(formatStatus).toHaveBeenCalledTimes(4)
@@ -237,11 +238,11 @@ describe('BookingService', () => {
       const booking = bookingFactory.build()
       bookingClient.find.mockResolvedValue(booking)
 
-      const result = await service.getBooking(token, premisesId, booking.id)
+      const result = await service.getBooking(request, premisesId, booking.id)
 
       expect(result).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
     })
   })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,6 +1,7 @@
 import type { Booking, NewBooking, Room, NewTemporaryAccommodationBooking } from '@approved-premises/api'
 import type { TableRow } from '@approved-premises/ui'
 
+import { Request } from 'express'
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import paths from '../paths/temporary-accommodation/manage'
@@ -12,16 +13,16 @@ export default class BookingService {
 
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async create(token: string, premisesId: string, booking: NewBooking): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async create(req: Request, premisesId: string, booking: NewBooking): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedBooking = await bookingClient.create(premisesId, booking)
 
     return confirmedBooking
   }
 
-  async createForBedspace(token: string, premisesId: string, room: Room, booking: NewBooking): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async createForBedspace(req: Request, premisesId: string, room: Room, booking: NewBooking): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedBooking = await bookingClient.create(premisesId, {
       serviceName: 'temporary-accommodation',
@@ -32,16 +33,16 @@ export default class BookingService {
     return confirmedBooking
   }
 
-  async find(token: string, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async find(req: Request, premisesId: string, bookingId: string): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(req)
 
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking
   }
 
-  async getTableRowsForBedspace(token: string, premisesId: string, room: Room): Promise<Array<TableRow>> {
-    const bookingClient = this.bookingClientFactory(token)
+  async getTableRowsForBedspace(req: Request, premisesId: string, room: Room): Promise<Array<TableRow>> {
+    const bookingClient = this.bookingClientFactory(req)
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
     const bedId = room.beds[0].id
@@ -71,8 +72,8 @@ export default class BookingService {
       })
   }
 
-  async getBooking(token: string, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async getBooking(req: Request, premisesId: string, bookingId: string): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(req)
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking

--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -5,6 +5,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import newCancellationFactory from '../testutils/factories/newCancellation'
 import cancellationFactory from '../testutils/factories/cancellation'
 import referenceDataFactory from '../testutils/factories/referenceData'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -16,7 +17,7 @@ describe('CancellationService', () => {
   const BookingClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
 
   const service = new CancellationService(BookingClientFactory, ReferenceDataClientFactory)
 
@@ -33,10 +34,10 @@ describe('CancellationService', () => {
 
       bookingClient.cancel.mockResolvedValue(cancellation)
 
-      const postedDeparture = await service.createCancellation(token, 'premisesId', 'bookingId', newCancellation)
+      const postedDeparture = await service.createCancellation(request, 'premisesId', 'bookingId', newCancellation)
       expect(postedDeparture).toEqual(cancellation)
 
-      expect(BookingClientFactory).toHaveBeenCalledWith(token)
+      expect(BookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.cancel).toHaveBeenCalledWith('premisesId', 'bookingId', newCancellation)
     })
   })
@@ -47,11 +48,11 @@ describe('CancellationService', () => {
 
       referenceDataClient.getReferenceData.mockResolvedValue(cancellationReasons)
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(request)
 
       expect(result).toEqual({ cancellationReasons })
 
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(request)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('cancellation-reasons')
     })
   })
@@ -61,11 +62,11 @@ describe('CancellationService', () => {
       const cancellation = cancellationFactory.build()
       bookingClient.findCancellation.mockResolvedValue(cancellation)
 
-      const requestedDeparture = await service.getCancellation(token, 'premisesId', 'bookingId', cancellation.id)
+      const requestedDeparture = await service.getCancellation(request, 'premisesId', 'bookingId', cancellation.id)
 
       expect(requestedDeparture).toEqual(cancellation)
 
-      expect(BookingClientFactory).toHaveBeenCalledWith(token)
+      expect(BookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.findCancellation).toHaveBeenCalledWith('premisesId', 'bookingId', cancellation.id)
     })
   })

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -1,5 +1,6 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import type { Cancellation, NewCancellation } from '@approved-premises/api'
+import { Request } from 'express'
 import type { BookingClient, RestClientBuilder, ReferenceDataClient } from '../data'
 
 export type CancellationReferenceData = {
@@ -13,12 +14,12 @@ export default class CancellationService {
   ) {}
 
   async createCancellation(
-    token: string,
+    req: Request,
     premisesId: string,
     bookingId: string,
     cancellation: NewCancellation,
   ): Promise<Cancellation> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedCancellation = await bookingClient.cancel(premisesId, bookingId, cancellation)
 
@@ -26,20 +27,20 @@ export default class CancellationService {
   }
 
   async getCancellation(
-    token: string,
+    req: Request,
     premisesId: string,
     bookingId: string,
     cancellationId: string,
   ): Promise<Cancellation> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(req)
 
     const booking = await bookingClient.findCancellation(premisesId, bookingId, cancellationId)
 
     return booking
   }
 
-  async getReferenceData(token: string): Promise<CancellationReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(req: Request): Promise<CancellationReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(req)
 
     const cancellationReasons = await referenceDataClient.getReferenceData('cancellation-reasons')
 

--- a/server/services/confirmationService.test.ts
+++ b/server/services/confirmationService.test.ts
@@ -2,6 +2,7 @@ import BookingClient from '../data/bookingClient'
 import ConfirmationService from './confirmationService'
 import newConfirmationFactory from '../testutils/factories/newConfirmation'
 import confirmationFactory from '../testutils/factories/confirmation'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -10,7 +11,7 @@ describe('ConfirmationService', () => {
 
   const BookingClientFactory = jest.fn()
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
   const premisesId = 'premisesId'
   const bookingId = 'bookingId'
 
@@ -28,10 +29,10 @@ describe('ConfirmationService', () => {
 
       bookingClient.markAsConfirmed.mockResolvedValue(confirmation)
 
-      const returnedConfirmation = await service.createConfirmation(token, premisesId, bookingId, newConfirmation)
+      const returnedConfirmation = await service.createConfirmation(request, premisesId, bookingId, newConfirmation)
       expect(returnedConfirmation).toEqual(confirmation)
 
-      expect(BookingClientFactory).toHaveBeenCalledWith(token)
+      expect(BookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.markAsConfirmed).toHaveBeenCalledWith(premisesId, bookingId, newConfirmation)
     })
   })

--- a/server/services/confirmationService.ts
+++ b/server/services/confirmationService.ts
@@ -1,16 +1,17 @@
 import type { Confirmation, NewConfirmation } from '@approved-premises/api'
+import { Request } from 'express'
 import type { BookingClient, RestClientBuilder } from '../data'
 
 export default class ConfirmationService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async createConfirmation(
-    token: string,
+    req: Request,
     premisesId: string,
     bookingId: string,
     confirmation: NewConfirmation,
   ): Promise<Confirmation> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(req)
 
     return bookingClient.markAsConfirmed(premisesId, bookingId, confirmation)
   }

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -8,6 +8,7 @@ import departureFactory from '../testutils/factories/departure'
 import referenceDataFactory from '../testutils/factories/referenceData'
 import newDepartureFactory from '../testutils/factories/newDeparture'
 import { DateFormats } from '../utils/dateUtils'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -16,7 +17,7 @@ describe('DepartureService', () => {
   const bookingClient = new BookingClient(null) as jest.Mocked<BookingClient>
   const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
 
   const DepartureClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
@@ -36,10 +37,10 @@ describe('DepartureService', () => {
 
       bookingClient.markDeparture.mockResolvedValue(departure)
 
-      const postedDeparture = await service.createDeparture(token, 'premisesId', 'bookingId', newDeparture)
+      const postedDeparture = await service.createDeparture(request, 'premisesId', 'bookingId', newDeparture)
       expect(postedDeparture).toEqual(departure)
 
-      expect(DepartureClientFactory).toHaveBeenCalledWith(token)
+      expect(DepartureClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.markDeparture).toHaveBeenCalledWith('premisesId', 'bookingId', newDeparture)
     })
   })
@@ -49,14 +50,14 @@ describe('DepartureService', () => {
       const departure: Departure = departureFactory.build()
       bookingClient.findDeparture.mockResolvedValue(departure)
 
-      const requestedDeparture = await service.getDeparture(token, 'premisesId', 'bookingId', departure.id)
+      const requestedDeparture = await service.getDeparture(request, 'premisesId', 'bookingId', departure.id)
 
       expect(requestedDeparture).toEqual({
         ...departure,
         dateTime: DateFormats.isoDateToUIDate(departure.dateTime),
       })
 
-      expect(DepartureClientFactory).toHaveBeenCalledWith(token)
+      expect(DepartureClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.findDeparture).toHaveBeenCalledWith('premisesId', 'bookingId', departure.id)
     })
   })
@@ -75,14 +76,14 @@ describe('DepartureService', () => {
         )
       })
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(request)
 
       expect(result).toEqual({
         departureReasons,
         moveOnCategories,
       })
 
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(request)
 
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('departure-reasons')
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('move-on-categories')

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -1,5 +1,6 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import type { Departure, NewDeparture } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, BookingClient, ReferenceDataClient } from '../data'
 import { DateFormats } from '../utils/dateUtils'
 
@@ -15,28 +16,28 @@ export default class DepartureService {
   ) {}
 
   async createDeparture(
-    token: string,
+    req: Request,
     premisesId: string,
     bookingId: string,
     departure: NewDeparture,
   ): Promise<Departure> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedDeparture = await bookingClient.markDeparture(premisesId, bookingId, departure)
 
     return confirmedDeparture
   }
 
-  async getDeparture(token: string, premisesId: string, bookingId: string, departureId: string): Promise<Departure> {
-    const departureClient = this.bookingClientFactory(token)
+  async getDeparture(req: Request, premisesId: string, bookingId: string, departureId: string): Promise<Departure> {
+    const departureClient = this.bookingClientFactory(req)
 
     const departure = await departureClient.findDeparture(premisesId, bookingId, departureId)
 
     return { ...departure, dateTime: DateFormats.isoDateToUIDate(departure.dateTime) }
   }
 
-  async getReferenceData(token: string): Promise<DepartureReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(req: Request): Promise<DepartureReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(req)
 
     const [departureReasons, moveOnCategories] = await Promise.all([
       referenceDataClient.getReferenceData('departure-reasons'),

--- a/server/services/extensionService.test.ts
+++ b/server/services/extensionService.test.ts
@@ -1,4 +1,5 @@
 import BookingClient from '../data/bookingClient'
+import { createMockRequest } from '../testutils/createMockRequest'
 import extensionFactory from '../testutils/factories/extension'
 import newExtensionFactory from '../testutils/factories/newExtension'
 import ExtensionService from './extensionService'
@@ -6,7 +7,7 @@ import ExtensionService from './extensionService'
 jest.mock('../data/bookingClient.ts')
 
 describe('ExtensionService', () => {
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
   const premiseId = 'premisesId'
   const bookingId = 'bookingId'
 
@@ -27,10 +28,10 @@ describe('ExtensionService', () => {
 
       bookingClient.extendBooking.mockResolvedValue(extension)
 
-      const postedExtension = await service.createExtension(token, premiseId, bookingId, payload)
+      const postedExtension = await service.createExtension(request, premiseId, bookingId, payload)
       expect(postedExtension).toEqual(extension)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.extendBooking).toHaveBeenCalledWith(premiseId, bookingId, payload)
     })
   })

--- a/server/services/extensionService.ts
+++ b/server/services/extensionService.ts
@@ -1,16 +1,17 @@
 import type { Extension, NewExtension } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, BookingClient } from '../data'
 
 export default class ExtensionService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async createExtension(
-    token: string,
+    req: Request,
     premisesId: string,
     bookingId: string,
     extension: NewExtension,
   ): Promise<Extension> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedExtension = await bookingClient.extendBooking(premisesId, bookingId, extension)
 

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -7,6 +7,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import lostBedFactory from '../testutils/factories/lostBed'
 import newLostBedFactory from '../testutils/factories/newLostBed'
 import referenceDataFactory from '../testutils/factories/referenceData'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/lostBedClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -31,13 +32,13 @@ describe('LostBedService', () => {
       const lostBed: LostBed = lostBedFactory.build()
       const newLostBed: NewLostBed = newLostBedFactory.build()
 
-      const token = 'SOME_TOKEN'
+      const request = createMockRequest()
       lostBedClient.create.mockResolvedValue(lostBed)
 
-      const postedLostBed = await service.createLostBed(token, 'premisesID', newLostBed)
+      const postedLostBed = await service.createLostBed(request, 'premisesID', newLostBed)
 
       expect(postedLostBed).toEqual(lostBed)
-      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(request)
       expect(lostBedClient.create).toHaveBeenCalledWith('premisesID', newLostBed)
     })
   })
@@ -45,7 +46,7 @@ describe('LostBedService', () => {
   describe('getReferenceData', () => {
     it('should return the lost bed reasons data needed', async () => {
       const lostBedReasons = referenceDataFactory.buildList(2)
-      const token = 'SOME_TOKEN'
+      const request = createMockRequest()
 
       referenceDataClient.getReferenceData.mockImplementation(category => {
         return Promise.resolve(
@@ -55,10 +56,10 @@ describe('LostBedService', () => {
         )
       })
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(request)
 
       expect(result).toEqual(lostBedReasons)
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(request)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('lost-bed-reasons')
     })
   })

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -1,5 +1,6 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import type { LostBed, NewLostBed } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, LostBedClient, ReferenceDataClient } from '../data'
 
 export type LostBedReferenceData = Array<ReferenceData>
@@ -9,16 +10,16 @@ export default class LostBedService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async createLostBed(token: string, premisesId: string, lostBed: NewLostBed): Promise<LostBed> {
-    const lostBedClient = this.lostBedClientFactory(token)
+  async createLostBed(req: Request, premisesId: string, lostBed: NewLostBed): Promise<LostBed> {
+    const lostBedClient = this.lostBedClientFactory(req)
 
     const confirmedLostBed = await lostBedClient.create(premisesId, lostBed)
 
     return confirmedLostBed
   }
 
-  async getReferenceData(token: string): Promise<LostBedReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(req: Request): Promise<LostBedReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(req)
 
     const reasons = await referenceDataClient.getReferenceData('lost-bed-reasons')
 

--- a/server/services/nonArrivalService.test.ts
+++ b/server/services/nonArrivalService.test.ts
@@ -3,6 +3,7 @@ import type { Nonarrival } from '@approved-premises/api'
 import NonarrivalService from './nonArrivalService'
 import BookingClient from '../data/bookingClient'
 import NonArrivalFactory from '../testutils/factories/nonArrival'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -12,7 +13,7 @@ describe('NonarrivalService', () => {
 
   const service = new NonarrivalService(bookingClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -28,11 +29,11 @@ describe('NonarrivalService', () => {
       }
       bookingClient.markNonArrival.mockResolvedValue(nonArrival)
 
-      const postedNonArrival = await service.createNonArrival(token, 'premisesID', 'bookingId', newNonArrival)
+      const postedNonArrival = await service.createNonArrival(request, 'premisesID', 'bookingId', newNonArrival)
 
       expect(postedNonArrival).toEqual(nonArrival)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(request)
       expect(bookingClient.markNonArrival).toHaveBeenCalledWith('premisesID', 'bookingId', newNonArrival)
     })
   })

--- a/server/services/nonArrivalService.ts
+++ b/server/services/nonArrivalService.ts
@@ -1,16 +1,17 @@
 import type { NewNonarrival, Nonarrival } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, BookingClient } from '../data'
 
 export default class NonarrivalService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async createNonArrival(
-    token: string,
+    req: Request,
     premisesId: string,
     bookingId: string,
     nonArrival: NewNonarrival,
   ): Promise<Nonarrival> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(req)
 
     const confirmedNonArrival = await bookingClient.markNonArrival(premisesId, bookingId, nonArrival)
 

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -5,6 +5,7 @@ import PersonClient from '../data/personClient'
 import PersonFactory from '../testutils/factories/person'
 import risksFactory from '../testutils/factories/risks'
 import { mapApiPersonRisksForUi } from '../utils/utils'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/personClient.ts')
 
@@ -14,7 +15,7 @@ describe('PersonService', () => {
 
   const service = new PersonService(personClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -26,11 +27,11 @@ describe('PersonService', () => {
       const person: Person = PersonFactory.build()
       personClient.search.mockResolvedValue(person)
 
-      const postedPerson = await service.findByCrn(token, 'crn')
+      const postedPerson = await service.findByCrn(request, 'crn')
 
       expect(postedPerson).toEqual(person)
 
-      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClientFactory).toHaveBeenCalledWith(request)
       expect(personClient.search).toHaveBeenCalledWith('crn')
     })
   })
@@ -41,11 +42,11 @@ describe('PersonService', () => {
       const uiRisks = mapApiPersonRisksForUi(apiRisks)
       personClient.risks.mockResolvedValue(apiRisks)
 
-      const postedPerson = await service.getPersonRisks(token, 'crn')
+      const postedPerson = await service.getPersonRisks(request, 'crn')
 
       expect(postedPerson).toEqual(uiRisks)
 
-      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClientFactory).toHaveBeenCalledWith(request)
       expect(personClient.risks).toHaveBeenCalledWith('crn')
     })
   })

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -1,5 +1,6 @@
 import type { PersonRisksUI } from '@approved-premises/ui'
 import type { Person } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, PersonClient } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
@@ -7,15 +8,15 @@ import { mapApiPersonRisksForUi } from '../utils/utils'
 export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
 
-  async findByCrn(token: string, crn: string): Promise<Person> {
-    const personClient = this.personClientFactory(token)
+  async findByCrn(req: Request, crn: string): Promise<Person> {
+    const personClient = this.personClientFactory(req)
 
     const person = await personClient.search(crn)
     return person
   }
 
-  async getPersonRisks(token: string, crn: string): Promise<PersonRisksUI> {
-    const personClient = this.personClientFactory(token)
+  async getPersonRisks(req: Request, crn: string): Promise<PersonRisksUI> {
+    const personClient = this.personClientFactory(req)
 
     const risks = await personClient.risks(crn)
 

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -15,6 +15,7 @@ import { formatCharacteristics, filterCharacteristics } from '../utils/character
 import probationRegionFactory from '../testutils/factories/probationRegion'
 import pduFactory from '../testutils/factories/pdu'
 import pduJson from '../data/pdus.json'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/premisesClient')
 jest.mock('../data/referenceDataClient')
@@ -34,7 +35,7 @@ describe('PremisesService', () => {
 
   const service = new PremisesService(premisesClientFactory, referenceDataClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const request = createMockRequest()
   const premisesId = 'premisesId'
 
   beforeEach(() => {
@@ -48,11 +49,11 @@ describe('PremisesService', () => {
       const staffMembers = staffMemberFactory.buildList(5)
       premisesClient.getStaffMembers.mockResolvedValue(staffMembers)
 
-      const result = await service.getStaffMembers(token, premisesId)
+      const result = await service.getStaffMembers(request, premisesId)
 
       expect(result).toEqual(staffMembers)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.getStaffMembers).toHaveBeenCalledWith(premisesId)
     })
   })
@@ -94,7 +95,7 @@ describe('PremisesService', () => {
         premisesCharacteristic1,
       ])
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(request)
       expect(result).toEqual({
         localAuthorities: [localAuthority1, localAuthority2, localAuthority3],
         characteristics: [premisesCharacteristic1, premisesCharacteristic2, genericCharacteristic],
@@ -123,7 +124,7 @@ describe('PremisesService', () => {
       const premises = [premises4, premises1, premises3, premises2]
       premisesClient.all.mockResolvedValue(premises)
 
-      const rows = await service.tableRows(token)
+      const rows = await service.tableRows(request)
 
       expect(rows).toEqual([
         [
@@ -192,7 +193,7 @@ describe('PremisesService', () => {
         ],
       ])
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.all).toHaveBeenCalled()
     })
   })
@@ -204,7 +205,7 @@ describe('PremisesService', () => {
       const premisesC = premisesFactory.build({ name: 'c' })
       premisesClient.all.mockResolvedValue([premisesC, premisesB, premisesA])
 
-      const result = await service.getPremisesSelectList(token)
+      const result = await service.getPremisesSelectList(request)
 
       expect(result).toEqual([
         { text: premisesA.name, value: premisesA.id },
@@ -212,7 +213,7 @@ describe('PremisesService', () => {
         { text: premisesC.name, value: premisesC.id },
       ])
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.all).toHaveBeenCalled()
     })
   })
@@ -242,7 +243,7 @@ describe('PremisesService', () => {
 
       premisesClient.find.mockResolvedValue(premises)
 
-      const result = await service.getUpdatePremises(token, premises.id)
+      const result = await service.getUpdatePremises(request, premises.id)
       expect(result).toEqual({
         ...premises,
         localAuthorityAreaId: 'local-authority',
@@ -259,11 +260,11 @@ describe('PremisesService', () => {
       const premises = premisesFactory.build()
       premisesClient.find.mockResolvedValue(premises)
 
-      const result = await service.getPremises(token, premises.id)
+      const result = await service.getPremises(request, premises.id)
 
       expect(result).toEqual(premises)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
     })
   })
@@ -302,7 +303,7 @@ describe('PremisesService', () => {
       }))
       ;(formatStatus as jest.MockedFn<typeof formatStatus>).mockReturnValue('Online')
 
-      const result = await service.getPremisesDetails(token, premises.id)
+      const result = await service.getPremisesDetails(request, premises.id)
 
       expect(result).toEqual({
         premises,
@@ -340,7 +341,7 @@ describe('PremisesService', () => {
         },
       })
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
 
       expect(escape).toHaveBeenCalledWith('10 Example Street')
@@ -361,7 +362,7 @@ describe('PremisesService', () => {
       premisesClient.capacity.mockResolvedValue([])
       ;(getDateRangesWithNegativeBeds as jest.Mock).mockReturnValue([])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(request, premisesId)
 
       expect(result).toBe('')
     })
@@ -375,7 +376,7 @@ describe('PremisesService', () => {
       ])
       ;(getDateRangesWithNegativeBeds as jest.Mock).mockReturnValue([])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(request, premisesId)
 
       expect(result).toBe('')
     })
@@ -390,7 +391,7 @@ describe('PremisesService', () => {
       premisesClient.capacity.mockResolvedValue(capacityStub)
       ;(getDateRangesWithNegativeBeds as jest.Mock).mockReturnValue([{ start: capacityStub[0].date }])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(request, premisesId)
 
       expect(result).toEqual([
         '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on 1 January 2022</h4>',
@@ -416,7 +417,7 @@ describe('PremisesService', () => {
         },
       ])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(request, premisesId)
 
       expect(result).toEqual([
         '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period 1 January 2022 to 1 February 2022</h4>',
@@ -443,7 +444,7 @@ describe('PremisesService', () => {
         },
       ])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(request, premisesId)
 
       expect(result).toEqual([
         `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>
@@ -468,7 +469,7 @@ describe('PremisesService', () => {
           end: capacityStub[3].date,
         },
       ])
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(request, premisesId)
 
       expect(result).toEqual([
         `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>
@@ -486,10 +487,10 @@ describe('PremisesService', () => {
       })
       premisesClient.create.mockResolvedValue(premises)
 
-      const createdPremises = await service.create(token, newPremises)
+      const createdPremises = await service.create(request, newPremises)
       expect(createdPremises).toEqual(premises)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.create).toHaveBeenCalledWith(newPremises)
     })
   })
@@ -503,10 +504,10 @@ describe('PremisesService', () => {
       })
       premisesClient.update.mockResolvedValue(premises)
 
-      const updatedPremises = await service.update(token, premises.id, newPremises)
+      const updatedPremises = await service.update(request, premises.id, newPremises)
       expect(updatedPremises).toEqual(premises)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(request)
       expect(premisesClient.update).toHaveBeenCalledWith(premises.id, newPremises)
     })
   })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -7,6 +7,7 @@ import type {
   LocalAuthorityArea,
   TemporaryAccommodationPremises as Premises,
 } from '@approved-premises/api'
+import { Request } from 'express'
 import type { RestClientBuilder, PremisesClient, ReferenceDataClient } from '../data'
 import pduJson from '../data/pdus.json'
 import paths from '../paths/temporary-accommodation/manage'
@@ -29,16 +30,16 @@ export default class PremisesService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getStaffMembers(token: string, premisesId: string): Promise<Array<StaffMember>> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getStaffMembers(req: Request, premisesId: string): Promise<Array<StaffMember>> {
+    const premisesClient = this.premisesClientFactory(req)
 
     const staffMembers = await premisesClient.getStaffMembers(premisesId)
 
     return staffMembers
   }
 
-  async getReferenceData(token: string): Promise<PremisesReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(req: Request): Promise<PremisesReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(req)
 
     const localAuthorities = (
       (await referenceDataClient.getReferenceData('local-authority-areas')) as Array<LocalAuthorityArea>
@@ -58,8 +59,8 @@ export default class PremisesService {
     return { localAuthorities, characteristics, probationRegions, pdus }
   }
 
-  async tableRows(token: string): Promise<Array<TableRow>> {
-    const premisesClient = this.premisesClientFactory(token)
+  async tableRows(req: Request): Promise<Array<TableRow>> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.all()
 
     return premises
@@ -79,15 +80,15 @@ export default class PremisesService {
       })
   }
 
-  async getPremises(token: string, id: string): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getPremises(req: Request, id: string): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.find(id)
 
     return premises
   }
 
-  async getPremisesDetails(token: string, id: string): Promise<{ premises: Premises; summaryList: SummaryList }> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getPremisesDetails(req: Request, id: string): Promise<{ premises: Premises; summaryList: SummaryList }> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.find(id)
 
     const summaryList = await this.summaryListForPremises(premises)
@@ -95,8 +96,8 @@ export default class PremisesService {
     return { premises, summaryList }
   }
 
-  async getOvercapacityMessage(token: string, premisesId: string): Promise<string[] | string> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getOvercapacityMessage(req: Request, premisesId: string): Promise<string[] | string> {
+    const premisesClient = this.premisesClientFactory(req)
     const premisesDateCapacities = await premisesClient.capacity(premisesId)
 
     const overcapacityDateRanges = getDateRangesWithNegativeBeds(premisesDateCapacities)
@@ -106,8 +107,8 @@ export default class PremisesService {
     return overcapacityMessage ? [overcapacityMessage] : ''
   }
 
-  async getPremisesSelectList(token: string): Promise<Array<{ text: string; value: string }>> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getPremisesSelectList(req: Request): Promise<Array<{ text: string; value: string }>> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.all()
 
     return premises
@@ -125,8 +126,8 @@ export default class PremisesService {
       })
   }
 
-  async getUpdatePremises(token: string, id: string): Promise<UpdatePremises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getUpdatePremises(req: Request, id: string): Promise<UpdatePremises> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.find(id)
 
     return {
@@ -138,15 +139,15 @@ export default class PremisesService {
     }
   }
 
-  async create(token: string, newPremises: NewPremises): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async create(req: Request, newPremises: NewPremises): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.create(newPremises)
 
     return premises
   }
 
-  async update(token: string, id: string, updatePremises: UpdatePremises): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async update(req: Request, id: string, updatePremises: UpdatePremises): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(req)
     const premises = await premisesClient.update(id, updatePremises)
 
     return premises

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,9 +1,10 @@
 import UserService from './userService'
 import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
+import { createMockRequest } from '../testutils/createMockRequest'
 
 jest.mock('../data/hmppsAuthClient')
 
-const token = 'some token'
+const request = createMockRequest()
 
 describe('User service', () => {
   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
@@ -17,14 +18,14 @@ describe('User service', () => {
     it('Retrieves and formats user name', async () => {
       hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
-      const result = await userService.getUser(token)
+      const result = await userService.getUser(request)
 
       expect(result.displayName).toEqual('John Smith')
     })
     it('Propagates error', async () => {
       hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
 
-      await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
+      await expect(userService.getUser(request)).rejects.toEqual(new Error('some error'))
     })
   })
 })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,3 +1,4 @@
+import { Request } from 'express'
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
 
@@ -9,8 +10,8 @@ interface UserDetails {
 export default class UserService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  async getUser(token: string): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getUser(token)
+  async getUser(req: Request): Promise<UserDetails> {
+    const user = await this.hmppsAuthClient.getUser(req)
     return { ...user, displayName: convertToTitleCase(user.name) }
   }
 }

--- a/server/testutils/createMockRequest.ts
+++ b/server/testutils/createMockRequest.ts
@@ -1,0 +1,12 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Request } from 'express'
+
+export type MockRequest = Omit<Request, 'flash'> & { flash: jest.MockedFunction<Request['flash']> }
+
+export function createMockRequest() {
+  return {
+    user: { token: 'some-token' },
+    flash: jest.fn() as jest.MockedFunction<Request['flash']>,
+    params: createMock(),
+  } as MockRequest
+}


### PR DESCRIPTION
This is a refactoring PR as part of our work to limit users to properties of their own region. Our intent is to store the user region in the session, which we will then pass back to the API on each call, within an `X-USER-REGION` header. To do this, we either need to pass an additional argument into our `RestClient` alongside the `token`, or we pass the request object into the `RestClient`, and let the `RestClient` extract both the token from `req.user` and later the user region `req.session`.

Though a scary number of files have changed, the only "real" change is to `restClient.ts`, and everything else simply flows from there, so we pass `req` through our controllers, services, and clients, rather than `token`