### PR TITLE
Remove unnecessary escaping from premises show page

### DIFF
--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -21,7 +21,7 @@
 
   {{ mojPageHeaderActions({
     heading: {
-      text: (premises.addressLine1 | e) + ', ' + (premises.postcode | e),
+      text: premises.addressLine1 + ', ' + premises.postcode,
       classes: 'govuk-heading-m',
       level: 2
     },


### PR DESCRIPTION
# Changes in this PR

In a previous commit we moved from constructing the heading HTML "by hand" to using the mojPageHeaderActions component, but did not remove the now unnecessary escaping, leading to double-escaping in some cases. Here we fix this bug


## Screenshots of UI changes

### Before
![localhost_3000_properties_0709378b-3961-480a-bb79-a6caeb8ec4a0 (1)](https://user-images.githubusercontent.com/94137563/214555218-861185ca-ce89-4e52-bac2-67f8949a4e8f.png)

### After
![localhost_3000_properties_0709378b-3961-480a-bb79-a6caeb8ec4a0](https://user-images.githubusercontent.com/94137563/214555226-d406c631-bedf-414e-88ee-c25c8d04f60e.png)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
