### PR TITLE
Pass call config into RestClient

### DIFF
--- a/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
@@ -9,16 +9,19 @@ import newArrivalFactory from '../../../testutils/factories/newArrival'
 import ArrivalsController from './arrivalsController'
 import { DateFormats } from '../../../utils/dateUtils'
 import arrivalFactory from '../../../testutils/factories/arrival'
+import { CallConfig } from '../../../data/restClient'
+import extractCallConfig from '../../../utils/restUtils'
 
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/restUtils')
 
 describe('ArrivalsController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -29,7 +32,8 @@ describe('ArrivalsController', () => {
   const arrivalsController = new ArrivalsController(bookingService, arrivalService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('new', () => {
@@ -49,7 +53,7 @@ describe('ArrivalsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/arrivals/new', {
         booking,
@@ -88,7 +92,7 @@ describe('ArrivalsController', () => {
       await requestHandler(request, response, next)
 
       expect(arrivalService.createArrival).toHaveBeenCalledWith(
-        token,
+        callConfig,
         premisesId,
         bookingId,
         expect.objectContaining(newArrival),

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -5,6 +5,7 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { ArrivalService, BookingService } from '../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class ArrivalsController {
   constructor(private readonly bookingsService: BookingService, private readonly arrivalService: ArrivalService) {}
@@ -14,9 +15,9 @@ export default class ArrivalsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/arrivals/new', {
         booking,
@@ -34,7 +35,7 @@ export default class ArrivalsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
       const newArrival: NewArrival = {
         ...req.body,
@@ -43,7 +44,7 @@ export default class ArrivalsController {
       }
 
       try {
-        await this.arrivalService.createArrival(token, premisesId, bookingId, newArrival)
+        await this.arrivalService.createArrival(callConfig, premisesId, bookingId, newArrival)
 
         req.flash('success', 'Booking marked as active')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -11,18 +11,22 @@ import updateRoomFactory from '../../../testutils/factories/updateRoom'
 import { ErrorsAndUserInput, SummaryListItem, TableRow } from '../../../@types/ui'
 import { PremisesService, BookingService } from '../../../services'
 import referenceDataFactory from '../../../testutils/factories/referenceData'
+import { CallConfig } from '../../../data/restClient'
+import extractCallConfig from '../../../utils/restUtils'
 
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/restUtils')
+jest.mock('../../../utils/restUtils')
 
 describe('BedspacesController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
 
   const referenceData = {
     characteristics: referenceDataFactory.characteristic('room').buildList(5),
   }
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -33,7 +37,8 @@ describe('BedspacesController', () => {
   const bedspacesController = new BedspacesController(premisesService, bedspaceService, bookingService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('new', () => {
@@ -49,7 +54,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/new', {
         premisesId,
         allCharacteristics: referenceData.characteristics,
@@ -78,7 +83,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.createRoom).toHaveBeenCalledWith(token, premisesId, {
+      expect(bedspaceService.createRoom).toHaveBeenCalledWith(callConfig, premisesId, {
         name: room.name,
         characteristicIds: [],
         notes: room.notes,
@@ -134,8 +139,8 @@ describe('BedspacesController', () => {
       request.params = { premisesId, roomId: room.id }
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(token, premisesId, room.id)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(callConfig)
+      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(callConfig, premisesId, room.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/edit', {
         allCharacteristics: referenceData.characteristics,
@@ -164,8 +169,8 @@ describe('BedspacesController', () => {
       request.params = { premisesId, roomId: room.id }
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(token, premisesId, room.id)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(callConfig)
+      expect(bedspaceService.getUpdateRoom).toHaveBeenCalledWith(callConfig, premisesId, room.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/edit', {
         allCharacteristics: referenceData.characteristics,
@@ -195,7 +200,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.updateRoom).toHaveBeenCalledWith(token, premisesId, room.id, {
+      expect(bedspaceService.updateRoom).toHaveBeenCalledWith(callConfig, premisesId, room.id, {
         name: room.name,
         notes: room.notes,
         characteristicIds: [],
@@ -257,9 +262,9 @@ describe('BedspacesController', () => {
         bookingTableRows,
       })
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(token, premises.id, room.id)
-      expect(bookingService.getTableRowsForBedspace).toHaveBeenCalledWith(token, premises.id, room.id)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bookingService.getTableRowsForBedspace).toHaveBeenCalledWith(callConfig, premises.id, room.id)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
@@ -3,6 +3,7 @@ import type { Request, Response, RequestHandler } from 'express'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BookingReportService from '../../../services/bookingReportService'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class BookingReportsController {
   constructor(private readonly bookingReportService: BookingReportService) {}
@@ -11,9 +12,9 @@ export default class BookingReportsController {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const { probationRegions: allProbationRegions } = await this.bookingReportService.getReferenceData(token)
+      const { probationRegions: allProbationRegions } = await this.bookingReportService.getReferenceData(callConfig)
 
       return res.render('temporary-accommodation/reports/bookings/new', {
         allProbationRegions,
@@ -28,12 +29,12 @@ export default class BookingReportsController {
     return async (req: Request, res: Response) => {
       try {
         const { probationRegionId } = req.body
-        const { token } = req.user
+        const callConfig = extractCallConfig(req)
 
         if (probationRegionId?.length) {
-          await this.bookingReportService.pipeBookingsForProbationRegion(token, res, probationRegionId)
+          await this.bookingReportService.pipeBookingsForProbationRegion(callConfig, res, probationRegionId)
         } else {
-          await this.bookingReportService.pipeBookings(token, res)
+          await this.bookingReportService.pipeBookings(callConfig, res)
         }
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.reports.bookings.new({}))

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -11,16 +11,19 @@ import { PremisesService, BookingService } from '../../../services'
 import BookingsController from './bookingsController'
 import { DateFormats } from '../../../utils/dateUtils'
 import { bookingActions, deriveBookingHistory } from '../../../utils/bookingUtils'
+import { CallConfig } from '../../../data/restClient'
+import extractCallConfig from '../../../utils/restUtils'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/bookingUtils')
+jest.mock('../../../utils/restUtils')
 
 describe('BookingsController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
   const roomId = 'roomId'
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -32,7 +35,8 @@ describe('BookingsController', () => {
   const bookingsController = new BookingsController(premisesService, bedspaceService, bookingService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('new', () => {
@@ -53,8 +57,8 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premisesId)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premisesId, roomId)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premisesId)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premisesId, roomId)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/new', {
         premises,
@@ -92,7 +96,7 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(bookingService.createForBedspace).toHaveBeenCalledWith(
-        token,
+        callConfig,
         premisesId,
         room,
         expect.objectContaining(newBooking),
@@ -204,9 +208,9 @@ describe('BookingsController', () => {
         actions: [],
       })
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premises.id, room.id)
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premises.id, booking.id)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
     })
   })
 
@@ -247,9 +251,9 @@ describe('BookingsController', () => {
         ],
       })
 
-      expect(premisesService.getPremises).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(token, premises.id, room.id)
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premises.id, booking.id)
+      expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
       expect(deriveBookingHistory).toHaveBeenCalledWith(booking)
     })
   })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -7,6 +7,7 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGeneric
 import BedspaceService from '../../../services/bedspaceService'
 import { DateFormats } from '../../../utils/dateUtils'
 import { bookingActions, deriveBookingHistory } from '../../../utils/bookingUtils'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class BookingsController {
   constructor(
@@ -20,10 +21,10 @@ export default class BookingsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId } = req.params
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(callConfig, premisesId)
+      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 
       return res.render('temporary-accommodation/bookings/new', {
         premises,
@@ -38,9 +39,9 @@ export default class BookingsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 
       const newBooking: NewBooking = {
         service: 'temporary-accommodation',
@@ -50,7 +51,7 @@ export default class BookingsController {
       }
 
       try {
-        const booking = await this.bookingsService.createForBedspace(token, premisesId, room, newBooking)
+        const booking = await this.bookingsService.createForBedspace(callConfig, premisesId, room, newBooking)
 
         req.flash('success', 'Booking created')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId: booking.id }))
@@ -68,12 +69,12 @@ export default class BookingsController {
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(callConfig, premisesId)
+      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/bookings/show', {
         premises,
@@ -87,12 +88,12 @@ export default class BookingsController {
   history(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const premises = await this.premisesService.getPremises(token, premisesId)
-      const room = await this.bedspacesService.getRoom(token, premisesId, roomId)
+      const premises = await this.premisesService.getPremises(callConfig, premisesId)
+      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/bookings/history', {
         premises,

--- a/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
@@ -8,16 +8,19 @@ import { DateFormats } from '../../../utils/dateUtils'
 import { CancellationsController } from '.'
 import cancellationFactory from '../../../testutils/factories/cancellation'
 import newCancellationFactory from '../../../testutils/factories/newCancellation'
+import extractCallConfig from '../../../utils/restUtils'
+import { CallConfig } from '../../../data/restClient'
 
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/restUtils')
 
 describe('CancellationsController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -28,7 +31,8 @@ describe('CancellationsController', () => {
   const cancellationsController = new CancellationsController(bookingService, cancellationService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('new', () => {
@@ -49,8 +53,8 @@ describe('CancellationsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
-      expect(cancellationService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premisesId, booking.id)
+      expect(cancellationService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/cancellations/new', {
         booking,
@@ -89,7 +93,7 @@ describe('CancellationsController', () => {
       await requestHandler(request, response, next)
 
       expect(cancellationService.createCancellation).toHaveBeenCalledWith(
-        token,
+        callConfig,
         premisesId,
         bookingId,
         expect.objectContaining(newCancellation),

--- a/server/controllers/temporary-accommodation/manage/cancellationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationsController.ts
@@ -5,6 +5,7 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { BookingService, CancellationService } from '../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class CanellationsController {
   constructor(
@@ -17,10 +18,12 @@ export default class CanellationsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
-      const { cancellationReasons: allCancellationReasons } = await this.cancellationService.getReferenceData(token)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
+      const { cancellationReasons: allCancellationReasons } = await this.cancellationService.getReferenceData(
+        callConfig,
+      )
 
       return res.render('temporary-accommodation/cancellations/new', {
         booking,
@@ -38,7 +41,7 @@ export default class CanellationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
       const newCancellation: NewCancellation = {
         ...req.body,
@@ -46,7 +49,7 @@ export default class CanellationsController {
       }
 
       try {
-        await this.cancellationService.createCancellation(token, premisesId, bookingId, newCancellation)
+        await this.cancellationService.createCancellation(callConfig, premisesId, bookingId, newCancellation)
 
         req.flash('success', 'Booking cancelled')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/confirmationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/confirmationsController.ts
@@ -5,6 +5,7 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { BookingService } from '../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import ConfirmationService from '../../../services/confirmationService'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class ConfirmationsController {
   constructor(
@@ -17,9 +18,9 @@ export default class ConfirmationsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/confirmations/new', {
         booking,
@@ -35,14 +36,14 @@ export default class ConfirmationsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
       const newConfirmation: NewConfirmation = {
         ...req.body,
       }
 
       try {
-        await this.confirmationService.createConfirmation(token, premisesId, bookingId, newConfirmation)
+        await this.confirmationService.createConfirmation(callConfig, premisesId, bookingId, newConfirmation)
 
         req.flash('success', 'Booking confirmed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -8,16 +8,19 @@ import departureFactory from '../../../testutils/factories/departure'
 import newDepartureFactory from '../../../testutils/factories/newDeparture'
 import { DateFormats } from '../../../utils/dateUtils'
 import DeparturesController from './departuresController'
+import { CallConfig } from '../../../data/restClient'
+import extractCallConfig from '../../../utils/restUtils'
 
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/restUtils')
 
 describe('DeparturesController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -28,7 +31,8 @@ describe('DeparturesController', () => {
   const departuresController = new DeparturesController(bookingService, departureService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('new', () => {
@@ -49,8 +53,8 @@ describe('DeparturesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
-      expect(departureService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premisesId, booking.id)
+      expect(departureService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/departures/new', {
         booking,
@@ -89,7 +93,7 @@ describe('DeparturesController', () => {
       await requestHandler(request, response, next)
 
       expect(departureService.createDeparture).toHaveBeenCalledWith(
-        token,
+        callConfig,
         premisesId,
         bookingId,
         expect.objectContaining(newDeparture),

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -5,6 +5,7 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { BookingService, DepartureService } from '../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class DeparturesController {
   constructor(private readonly bookingsService: BookingService, private readonly departureService: DepartureService) {}
@@ -14,11 +15,11 @@ export default class DeparturesController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
       const { departureReasons: allDepartureReasons, moveOnCategories: allMoveOnCategories } =
-        await this.departureService.getReferenceData(token)
+        await this.departureService.getReferenceData(callConfig)
 
       return res.render('temporary-accommodation/departures/new', {
         booking,
@@ -37,7 +38,7 @@ export default class DeparturesController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
       const newDeparture: NewDeparture = {
         ...req.body,
@@ -45,7 +46,7 @@ export default class DeparturesController {
       }
 
       try {
-        await this.departureService.createDeparture(token, premisesId, bookingId, newDeparture)
+        await this.departureService.createDeparture(callConfig, premisesId, bookingId, newDeparture)
 
         req.flash('success', 'Booking marked as closed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/extensionsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/extensionsController.test.ts
@@ -11,17 +11,20 @@ import ExtensionsController from './extensionsController'
 import extensionFactory from '../../../testutils/factories/extension'
 import newExtensionFactory from '../../../testutils/factories/newExtension'
 import { getLatestExtension } from '../../../utils/bookingUtils'
+import { CallConfig } from '../../../data/restClient'
+import extractCallConfig from '../../../utils/restUtils'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/bookingUtils')
+jest.mock('../../../utils/restUtils')
 
 describe('ExtensionsController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const bookingId = 'bookingId'
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -32,7 +35,8 @@ describe('ExtensionsController', () => {
   const extensionsController = new ExtensionsController(bookingService, extensionService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('new', () => {
@@ -54,7 +58,7 @@ describe('ExtensionsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/extensions/new', {
         booking,
@@ -87,7 +91,7 @@ describe('ExtensionsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingService.getBooking).toHaveBeenCalledWith(token, premisesId, booking.id)
+      expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premisesId, booking.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/extensions/new', {
         booking,
@@ -125,7 +129,7 @@ describe('ExtensionsController', () => {
       await requestHandler(request, response, next)
 
       expect(extensionService.createExtension).toHaveBeenCalledWith(
-        token,
+        callConfig,
         premisesId,
         bookingId,
         expect.objectContaining(newExtension),

--- a/server/controllers/temporary-accommodation/manage/extensionsController.ts
+++ b/server/controllers/temporary-accommodation/manage/extensionsController.ts
@@ -6,6 +6,7 @@ import { BookingService, ExtensionService } from '../../../services'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
 import { getLatestExtension } from '../../../utils/bookingUtils'
+import extractCallConfig from '../../../utils/restUtils'
 
 export default class ExtensionsController {
   constructor(private readonly bookingsService: BookingService, private readonly extensionService: ExtensionService) {}
@@ -15,9 +16,9 @@ export default class ExtensionsController {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
-      const booking = await this.bookingsService.getBooking(token, premisesId, bookingId)
+      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/extensions/new', {
         booking,
@@ -35,7 +36,7 @@ export default class ExtensionsController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
-      const { token } = req.user
+      const callConfig = extractCallConfig(req)
 
       const newExtension: NewExtension = {
         ...req.body,
@@ -43,7 +44,7 @@ export default class ExtensionsController {
       }
 
       try {
-        await this.extensionService.createExtension(token, premisesId, bookingId, newExtension)
+        await this.extensionService.createExtension(callConfig, premisesId, bookingId, newExtension)
 
         req.flash('success', 'Booking departure date changed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -13,11 +13,14 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../
 import BedspaceService from '../../../services/bedspaceService'
 import { allStatuses } from '../../../utils/premisesUtils'
 import referenceDataFactory from '../../../testutils/factories/referenceData'
+import extractCallConfig from '../../../utils/restUtils'
+import { CallConfig } from '../../../data/restClient'
 
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/restUtils')
 
 describe('PremisesController', () => {
-  const token = 'SOME_TOKEN'
+  const callConfig = { token: 'some-call-config-token' } as CallConfig
 
   const referenceData = {
     localAuthorities: referenceDataFactory.localAuthority().buildList(5),
@@ -26,7 +29,7 @@ describe('PremisesController', () => {
     pdus: referenceDataFactory.pdu().buildList(5),
   }
 
-  let request: DeepMocked<Request>
+  let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
@@ -36,7 +39,8 @@ describe('PremisesController', () => {
   const premisesController = new PremisesController(premisesService, bedspaceService)
 
   beforeEach(() => {
-    request = createMock<Request>({ user: { token } })
+    request = createMock<Request>()
+    ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
   describe('index', () => {
@@ -48,7 +52,7 @@ describe('PremisesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/index', { tableRows: [] })
 
-      expect(premisesService.tableRows).toHaveBeenCalledWith(token)
+      expect(premisesService.tableRows).toHaveBeenCalledWith(callConfig)
     })
   })
 
@@ -61,7 +65,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/new', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -85,7 +89,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/new', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -118,7 +122,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.create).toHaveBeenCalledWith(token, {
+      expect(premisesService.create).toHaveBeenCalledWith(callConfig, {
         ...newPremises,
         characteristicIds: [],
       })
@@ -165,8 +169,8 @@ describe('PremisesController', () => {
       request.params.premisesId = premises.id
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(token, premises.id)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(callConfig)
+      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(callConfig, premises.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/edit', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -198,8 +202,8 @@ describe('PremisesController', () => {
       request.params.premisesId = premises.id
       await requestHandler(request, response, next)
 
-      expect(premisesService.getReferenceData).toHaveBeenCalledWith(token)
-      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(token, premises.id)
+      expect(premisesService.getReferenceData).toHaveBeenCalledWith(callConfig)
+      expect(premisesService.getUpdatePremises).toHaveBeenCalledWith(callConfig, premises.id)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/edit', {
         allLocalAuthorities: referenceData.localAuthorities,
@@ -234,7 +238,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(premisesService.update).toHaveBeenCalledWith(token, premises.id, {
+      expect(premisesService.update).toHaveBeenCalledWith(callConfig, premises.id, {
         ...newPremises,
         characteristicIds: [],
       })
@@ -292,8 +296,8 @@ describe('PremisesController', () => {
         bedspaces: bedspaceDetails,
       })
 
-      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(token, premises.id)
-      expect(bedspaceService.getBedspaceDetails).toHaveBeenCalledWith(token, premises.id)
+      expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(bedspaceService.getBedspaceDetails).toHaveBeenCalledWith(callConfig, premises.id)
     })
   })
 })

--- a/server/data/applicationClient.test.ts
+++ b/server/data/applicationClient.test.ts
@@ -5,17 +5,18 @@ import config from '../config'
 import applicationSummaryFactory from '../testutils/factories/applicationSummary'
 import applicationFactory from '../testutils/factories/application'
 import paths from '../paths/api'
+import { CallConfig } from './restClient'
 
 describe('ApplicationClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let applicationClient: ApplicationClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    applicationClient = new ApplicationClient(token)
+    applicationClient = new ApplicationClient(callConfig)
   })
 
   afterEach(() => {
@@ -33,7 +34,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .post(paths.applications.new.pattern)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, application)
 
       const result = await applicationClient.create(application.person.crn)
@@ -49,7 +50,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.applications.show({ id: application.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, application)
 
       const result = await applicationClient.find(application.id)
@@ -65,7 +66,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .put(paths.applications.update({ id: application.id }), JSON.stringify({ data: application.data }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, application)
 
       const result = await applicationClient.update(application)
@@ -81,7 +82,7 @@ describe('ApplicationClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.applications.index.pattern)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, previousApplications)
 
       const result = await applicationClient.all()

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -1,14 +1,14 @@
 import type { ApprovedPremisesApplication as Application } from '@approved-premises/api'
 import { ApplicationSummary } from '../testutils/factories/applicationSummary'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 
 export default class ApplicationClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async find(applicationId: string): Promise<Application> {

--- a/server/data/applicationClient.ts
+++ b/server/data/applicationClient.ts
@@ -8,7 +8,7 @@ export default class ApplicationClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('applicationClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async find(applicationId: string): Promise<Application> {

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -15,17 +15,18 @@ import newArrivalFactory from '../testutils/factories/newArrival'
 import config from '../config'
 import confirmationFactory from '../testutils/factories/confirmation'
 import newConfirmationFactory from '../testutils/factories/newConfirmation'
+import { CallConfig } from './restClient'
 
 describe('BookingClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let bookingClient: BookingClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    bookingClient = new BookingClient(token)
+    bookingClient = new BookingClient(callConfig)
   })
 
   afterEach(() => {
@@ -48,7 +49,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/some-uuid/bookings`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, booking)
 
       const result = await bookingClient.create('some-uuid', payload)
@@ -64,7 +65,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, booking)
 
       const result = await bookingClient.find('premisesId', 'bookingId')
@@ -80,7 +81,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/some-uuid/bookings`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, bookings)
 
       const result = await bookingClient.allBookingsForPremisesId('some-uuid')
@@ -103,7 +104,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/${booking.id}/extensions`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, booking)
 
       const result = await bookingClient.extendBooking('premisesId', booking.id, payload)
@@ -122,7 +123,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/confirmations`, payload)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, confirmation)
 
       const result = await bookingClient.markAsConfirmed('premisesId', 'bookingId', payload)
@@ -143,7 +144,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/arrivals`, payload)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, arrival)
 
       const result = await bookingClient.markAsArrived('premisesId', 'bookingId', payload)
@@ -164,7 +165,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/cancellations`, newCancellation)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, cancellation)
 
       const result = await bookingClient.cancel('premisesId', 'bookingId', newCancellation)
@@ -180,7 +181,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId/cancellations/${cancellation.id}`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, cancellation)
 
       const result = await bookingClient.findCancellation('premisesId', 'bookingId', cancellation.id)
@@ -196,7 +197,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/departures`, departure)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, departure)
 
       const result = await bookingClient.markDeparture('premisesId', 'bookingId', departure)
@@ -212,7 +213,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/premises/premisesId/bookings/bookingId/departures/${departure.id}`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, departure)
 
       const result = await bookingClient.findDeparture('premisesId', 'bookingId', departure.id)
@@ -233,7 +234,7 @@ describe('BookingClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/bookings/bookingId/non-arrivals`, payload)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, nonArrival)
 
       const result = await bookingClient.markNonArrival('premisesId', 'bookingId', payload)

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -21,7 +21,7 @@ export default class BookingClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async create(premisesId: string, data: NewBooking): Promise<Booking> {

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -14,14 +14,14 @@ import type {
   Confirmation,
   NewNonarrival,
 } from '@approved-premises/api'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 
 export default class BookingClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async create(premisesId: string, data: NewBooking): Promise<Booking> {

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -2,6 +2,7 @@ import nock from 'nock'
 
 import config from '../config'
 import HmppsAuthClient from './hmppsAuthClient'
+import { CallConfig } from './restClient'
 import TokenStore from './tokenStore'
 
 jest.mock('./tokenStore')
@@ -10,6 +11,7 @@ const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
 
 const username = 'Bob'
 const token = { access_token: 'token-1', expires_in: 300 }
+const callConfig = { token: 'some-token' } as CallConfig
 
 describe('hmppsAuthClient', () => {
   let fakeHmppsAuthApi: nock.Scope
@@ -31,10 +33,10 @@ describe('hmppsAuthClient', () => {
 
       fakeHmppsAuthApi
         .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, response)
 
-      const output = await hmppsAuthClient.getUser(token.access_token)
+      const output = await hmppsAuthClient.getUser(callConfig)
       expect(output).toEqual(response)
     })
   })
@@ -43,10 +45,10 @@ describe('hmppsAuthClient', () => {
     it('should return data from api', async () => {
       fakeHmppsAuthApi
         .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${token.access_token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
 
-      const output = await hmppsAuthClient.getUserRoles(token.access_token)
+      const output = await hmppsAuthClient.getUserRoles(callConfig)
       expect(output).toEqual(['role1', 'role2'])
     })
   })

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -44,7 +44,7 @@ export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
 
   private static restClient(callConfig: CallConfig): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, callConfig.token)
+    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, callConfig)
   }
 
   getUser(callConfig: CallConfig): Promise<User> {
@@ -53,7 +53,7 @@ export default class HmppsAuthClient {
   }
 
   getUserRoles(callConfig: CallConfig): Promise<string[]> {
-    return HmppsAuthClient.restClient(callConfig.token)
+    return HmppsAuthClient.restClient(callConfig)
       .get({ path: '/api/user/me/roles' })
       .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
   }

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -5,7 +5,7 @@ import type TokenStore from './tokenStore'
 import logger from '../../logger'
 import config from '../config'
 import generateOauthClientToken from '../authentication/clientCredentials'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 
 const timeoutSpec = config.apis.hmppsAuth.timeout
 const hmppsAuthUrl = config.apis.hmppsAuth.url
@@ -43,17 +43,17 @@ export interface UserRole {
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
 
-  private static restClient(token: string): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, token)
+  private static restClient(callConfig: CallConfig): RestClient {
+    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, callConfig.token)
   }
 
-  getUser(token: string): Promise<User> {
+  getUser(callConfig: CallConfig): Promise<User> {
     logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(token).get({ path: '/api/user/me' }) as Promise<User>
+    return HmppsAuthClient.restClient(callConfig).get({ path: '/api/user/me' }) as Promise<User>
   }
 
-  getUserRoles(token: string): Promise<string[]> {
-    return HmppsAuthClient.restClient(token)
+  getUserRoles(callConfig: CallConfig): Promise<string[]> {
+    return HmppsAuthClient.restClient(callConfig.token)
       .get({ path: '/api/user/me/roles' })
       .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
   }

--- a/server/data/index.ts
+++ b/server/data/index.ts
@@ -22,20 +22,23 @@ import LostBedClient from './lostBedClient'
 import ApplicationClient from './applicationClient'
 import RoomClient from './roomClient'
 import ReportClient from './reportClient'
+import { CallConfig } from './restClient'
 
-type RestClientBuilder<T> = (token: string) => T
+type RestClientBuilder<T> = (callConfig: CallConfig) => T
 
 export const dataAccess = () => ({
   hmppsAuthClient: new HmppsAuthClient(new TokenStore(createRedisClient({ legacyMode: false }))),
-  premisesClientBuilder: ((token: string) => new PremisesClient(token)) as RestClientBuilder<PremisesClient>,
-  bookingClientBuilder: ((token: string) => new BookingClient(token)) as RestClientBuilder<BookingClient>,
-  referenceDataClientBuilder: ((token: string) =>
-    new ReferenceDataClient(token)) as RestClientBuilder<ReferenceDataClient>,
-  lostBedClientBuilder: ((token: string) => new LostBedClient(token)) as RestClientBuilder<LostBedClient>,
-  personClient: ((token: string) => new PersonClient(token)) as RestClientBuilder<PersonClient>,
-  applicationClientBuilder: ((token: string) => new ApplicationClient(token)) as RestClientBuilder<ApplicationClient>,
-  roomClientBuilder: ((token: string) => new RoomClient(token)) as RestClientBuilder<RoomClient>,
-  reportClientBuilder: ((token: string) => new ReportClient(token)) as RestClientBuilder<ReportClient>,
+  premisesClientBuilder: ((callConfig: CallConfig) =>
+    new PremisesClient(callConfig)) as RestClientBuilder<PremisesClient>,
+  bookingClientBuilder: ((callConfig: CallConfig) => new BookingClient(callConfig)) as RestClientBuilder<BookingClient>,
+  referenceDataClientBuilder: ((callConfig: CallConfig) =>
+    new ReferenceDataClient(callConfig)) as RestClientBuilder<ReferenceDataClient>,
+  lostBedClientBuilder: ((callConfig: CallConfig) => new LostBedClient(callConfig)) as RestClientBuilder<LostBedClient>,
+  personClient: ((callConfig: CallConfig) => new PersonClient(callConfig)) as RestClientBuilder<PersonClient>,
+  applicationClientBuilder: ((callConfig: CallConfig) =>
+    new ApplicationClient(callConfig)) as RestClientBuilder<ApplicationClient>,
+  roomClientBuilder: ((callConfig: CallConfig) => new RoomClient(callConfig)) as RestClientBuilder<RoomClient>,
+  reportClientBuilder: ((callConfig: CallConfig) => new ReportClient(callConfig)) as RestClientBuilder<ReportClient>,
 })
 
 export type DataAccess = ReturnType<typeof dataAccess>

--- a/server/data/lostBedClient.test.ts
+++ b/server/data/lostBedClient.test.ts
@@ -4,17 +4,18 @@ import LostBedClient from './lostBedClient'
 import config from '../config'
 import lostBedFactory from '../testutils/factories/lostBed'
 import newLostBedFactory from '../testutils/factories/newLostBed'
+import { CallConfig } from './restClient'
 
 describe('LostBedClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let lostBedClient: LostBedClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    lostBedClient = new LostBedClient(token)
+    lostBedClient = new LostBedClient(callConfig)
   })
 
   afterEach(() => {
@@ -33,7 +34,7 @@ describe('LostBedClient', () => {
 
       fakeApprovedPremisesApi
         .post(`/premises/premisesId/lost-beds`, newLostBed)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, lostBed)
 
       const result = await lostBedClient.create('premisesId', newLostBed)

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -1,13 +1,13 @@
 import type { LostBed, NewLostBed } from '@approved-premises/api'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 
 export default class LostBedClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async create(premisesId: string, lostBed: NewLostBed): Promise<LostBed> {

--- a/server/data/lostBedClient.ts
+++ b/server/data/lostBedClient.ts
@@ -7,7 +7,7 @@ export default class LostBedClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('lostBedClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async create(premisesId: string, lostBed: NewLostBed): Promise<LostBed> {

--- a/server/data/personClient.test.ts
+++ b/server/data/personClient.test.ts
@@ -4,17 +4,18 @@ import PersonClient from './personClient'
 import config from '../config'
 import riskFactory from '../testutils/factories/risks'
 import personFactory from '../testutils/factories/person'
+import { CallConfig } from './restClient'
 
 describe('PersonClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let personClient: PersonClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    personClient = new PersonClient(token)
+    personClient = new PersonClient(callConfig)
   })
 
   afterEach(() => {
@@ -32,7 +33,7 @@ describe('PersonClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/people/search?crn=crn`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, person)
 
       const result = await personClient.search('crn')
@@ -49,7 +50,7 @@ describe('PersonClient', () => {
 
       fakeApprovedPremisesApi
         .get(`/people/${crn}/risks`)
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, person)
 
       const result = await personClient.risks(crn)

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -7,7 +7,7 @@ export default class PersonClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async search(crn: string): Promise<Person> {

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -1,13 +1,13 @@
 import type { Person, PersonRisks } from '@approved-premises/api'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 
 export default class PersonClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async search(crn: string): Promise<Person> {

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -8,17 +8,18 @@ import config from '../config'
 import paths from '../paths/api'
 import dateCapacityFactory from '../testutils/factories/dateCapacity'
 import staffMemberFactory from '../testutils/factories/staffMember'
+import { CallConfig } from './restClient'
 
 describe('PremisesClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let premisesClient: PremisesClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    premisesClient = new PremisesClient(token)
+    premisesClient = new PremisesClient(callConfig)
   })
 
   afterEach(() => {
@@ -36,7 +37,7 @@ describe('PremisesClient', () => {
     it('should get all premises for the given service', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.index({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, premises)
 
       const output = await premisesClient.all()
@@ -50,7 +51,7 @@ describe('PremisesClient', () => {
     it('should get a single premises', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.show({ premisesId: premises.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, premises)
 
       const output = await premisesClient.find(premises.id)
@@ -65,7 +66,7 @@ describe('PremisesClient', () => {
     it('should get the capacity of a premises for a given date', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.capacity({ premisesId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, premisesCapacityItem)
 
       const output = await premisesClient.capacity(premisesId)
@@ -80,7 +81,7 @@ describe('PremisesClient', () => {
     it('should return a list of staff members', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.staffMembers.index({ premisesId: premises.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, staffMembers)
 
       const output = await premisesClient.getStaffMembers(premises.id)
@@ -98,7 +99,7 @@ describe('PremisesClient', () => {
 
       fakeApprovedPremisesApi
         .post(paths.premises.create({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, premises)
 
       const output = await premisesClient.create(payload)
@@ -116,7 +117,7 @@ describe('PremisesClient', () => {
 
       fakeApprovedPremisesApi
         .put(paths.premises.update({ premisesId: premises.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, premises)
 
       const output = await premisesClient.update(premises.id, payload)

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -13,7 +13,7 @@ export default class PremisesClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async all(): Promise<Array<Premises>> {

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -5,15 +5,15 @@ import type {
   StaffMember,
   UpdatePremises,
 } from '@approved-premises/api'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 
 export default class PremisesClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async all(): Promise<Array<Premises>> {

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -3,17 +3,18 @@ import nock from 'nock'
 import ReferenceDataClient from './referenceDataClient'
 import referenceDataFactory from '../testutils/factories/referenceData'
 import config from '../config'
+import { CallConfig } from './restClient'
 
 describe('PremisesClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let referenceDataClient: ReferenceDataClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    referenceDataClient = new ReferenceDataClient(token)
+    referenceDataClient = new ReferenceDataClient(callConfig)
   })
 
   afterEach(() => {
@@ -31,7 +32,7 @@ describe('PremisesClient', () => {
     it('should return an array of reference data', async () => {
       fakeApprovedPremisesApi
         .get('/reference-data/some-reference-data')
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, referenceData)
 
       const output = await referenceDataClient.getReferenceData('some-reference-data')

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -1,12 +1,12 @@
 import type { ReferenceData } from '@approved-premises/ui'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 
 export default class ReferenceDataClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async getReferenceData<T = ReferenceData>(objectType: string): Promise<Array<T>> {

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -6,7 +6,7 @@ export default class ReferenceDataClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('referenceDataClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async getReferenceData<T = ReferenceData>(objectType: string): Promise<Array<T>> {

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -6,17 +6,18 @@ import config from '../config'
 import paths from '../paths/api'
 import ReportClient from './reportClient'
 import probationRegionFactory from '../testutils/factories/probationRegion'
+import { CallConfig } from './restClient'
 
 describe('ReportClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let reportClient: ReportClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    reportClient = new ReportClient(token)
+    reportClient = new ReportClient(callConfig)
   })
 
   afterEach(() => {
@@ -34,7 +35,7 @@ describe('ReportClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
@@ -55,7 +56,7 @@ describe('ReportClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
@@ -78,7 +79,7 @@ describe('ReportClient', () => {
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .query({ probationRegionId: probationRegion.id })
         .reply(200, data, { 'content-type': 'some-content-type' })
 

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -1,13 +1,13 @@
 import { Response } from 'express'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 
 export default class ReportClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async bookings(response: Response, filename: string): Promise<void> {

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -7,7 +7,7 @@ export default class ReportClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async bookings(response: Response, filename: string): Promise<void> {

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -3,13 +3,13 @@ import { Response } from 'express'
 import nock from 'nock'
 
 import type { ApiConfig } from '../config'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 
 describe('restClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let restClient: RestClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     const apiConfig: ApiConfig = {
@@ -24,11 +24,11 @@ describe('restClient', () => {
 
     fakeApprovedPremisesApi = nock(apiConfig.url, {
       reqheaders: {
-        authorization: `Bearer ${token}`,
+        authorization: `Bearer ${callConfig.token}`,
         'X-SERVICE-NAME': 'approved-premises',
       },
     })
-    restClient = new RestClient('premisesClient', apiConfig, token)
+    restClient = new RestClient('premisesClient', apiConfig, callConfig)
   })
 
   afterEach(() => {
@@ -62,11 +62,11 @@ describe('restClient', () => {
 
       fakeApprovedPremisesApi = nock(apiConfig.url, {
         reqheaders: {
-          authorization: `Bearer ${token}`,
+          authorization: `Bearer ${callConfig.token}`,
         },
         badheaders: ['X-SERVICE-NAME'],
       })
-      restClient = new RestClient('premisesClient', apiConfig, token)
+      restClient = new RestClient('premisesClient', apiConfig, callConfig)
 
       fakeApprovedPremisesApi.get(`/some/path`).reply(200, { some: 'data' })
 

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -35,6 +35,10 @@ interface StreamRequest {
   errorLogger?: (e: UnsanitisedError) => void
 }
 
+export interface CallConfig {
+  token: string
+}
+
 export default class RestClient {
   agent: Agent
 

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -40,11 +40,18 @@ export interface CallConfig {
 }
 
 export default class RestClient {
-  agent: Agent
+  private readonly token: string
 
-  defaultHeaders: Record<string, string>
+  private readonly agent: Agent
 
-  constructor(private readonly name: string, private readonly config: ApiConfig, private readonly token: string) {
+  private readonly defaultHeaders: Record<string, string>
+
+  constructor(
+    private readonly name: string,
+    private readonly config: ApiConfig,
+    private readonly callConfig: CallConfig,
+  ) {
+    this.token = callConfig.token
     this.agent = config.url.startsWith('https') ? new HttpsAgent(config.agent) : new Agent(config.agent)
     this.defaultHeaders = config.serviceName ? { 'X-SERVICE-NAME': config.serviceName } : {}
   }

--- a/server/data/roomClient.test.ts
+++ b/server/data/roomClient.test.ts
@@ -6,18 +6,19 @@ import roomFactory from '../testutils/factories/room'
 import newRoomFactory from '../testutils/factories/newRoom'
 import updateRoomFactory from '../testutils/factories/updateRoom'
 import RoomClient from './roomClient'
+import { CallConfig } from './restClient'
 
 describe('Room Client', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let roomClient: RoomClient
 
-  const token = 'token-1'
+  const callConfig = { token: 'some-token' } as CallConfig
   const premisesId = 'premisesId'
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
     fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
-    roomClient = new RoomClient(token)
+    roomClient = new RoomClient(callConfig)
   })
 
   afterEach(() => {
@@ -35,7 +36,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .get(paths.premises.rooms.index({ premisesId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, rooms)
 
       const output = await roomClient.all(premisesId)
@@ -49,7 +50,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .get(paths.premises.rooms.show({ premisesId, roomId: room.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, room)
 
       const output = await roomClient.find(premisesId, room.id)
@@ -68,7 +69,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .post(paths.premises.rooms.create({ premisesId }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, room)
 
       const output = await roomClient.create(premisesId, payload)
@@ -85,7 +86,7 @@ describe('Room Client', () => {
 
       fakeApprovedPremisesApi
         .put(paths.premises.rooms.update({ premisesId, roomId: room.id }))
-        .matchHeader('authorization', `Bearer ${token}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, room)
 
       const output = await roomClient.update(premisesId, room.id, payload)

--- a/server/data/roomClient.ts
+++ b/server/data/roomClient.ts
@@ -1,5 +1,5 @@
 import type { Room, NewRoom } from '@approved-premises/api'
-import RestClient from './restClient'
+import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import api from '../paths/api'
 import { UpdateRoom } from '../@types/shared/models/UpdateRoom'
@@ -7,8 +7,8 @@ import { UpdateRoom } from '../@types/shared/models/UpdateRoom'
 export default class RoomClient {
   restClient: RestClient
 
-  constructor(token: string) {
-    this.restClient = new RestClient('bedspaceClient', config.apis.approvedPremises as ApiConfig, token)
+  constructor(callConfig: CallConfig) {
+    this.restClient = new RestClient('bedspaceClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
   }
 
   async all(premisesId: string): Promise<Array<Room>> {

--- a/server/data/roomClient.ts
+++ b/server/data/roomClient.ts
@@ -8,7 +8,7 @@ export default class RoomClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('bedspaceClient', config.apis.approvedPremises as ApiConfig, callConfig.token)
+    this.restClient = new RestClient('bedspaceClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
   async all(premisesId: string): Promise<Array<Room>> {

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,12 +1,14 @@
 import { RequestHandler } from 'express'
 import logger from '../../logger'
 import UserService from '../services/userService'
+import extractCallConfig from '../utils/restUtils'
 
 export default function populateCurrentUser(userService: UserService): RequestHandler {
   return async (req, res, next) => {
     try {
-      if (res.locals.user) {
-        const user = res.locals.user && (await userService.getUser(res.locals.user.token))
+      if (req.user) {
+        const callConfig = extractCallConfig(req)
+        const user = res.locals.user && (await userService.getUser(callConfig))
         if (user) {
           res.locals.user = { ...user, ...res.locals.user }
         } else {

--- a/server/services/arrivalService.test.ts
+++ b/server/services/arrivalService.test.ts
@@ -22,15 +22,14 @@ describe('ArrivalService', () => {
       const arrival = arrivalFactory.build()
       const payload = newArrivalFactory.build()
 
-      const token = 'some-token'
-      const callConfig = { token } as CallConfig
+      const callConfig = { token: 'some-token' } as CallConfig
 
       bookingClient.markAsArrived.mockResolvedValue(arrival)
 
       const postedArrival = await service.createArrival(callConfig, 'premisesID', 'bookingId', payload)
       expect(postedArrival).toEqual(arrival)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.markAsArrived).toHaveBeenCalledWith('premisesID', 'bookingId', payload)
     })
   })

--- a/server/services/arrivalService.test.ts
+++ b/server/services/arrivalService.test.ts
@@ -2,6 +2,7 @@ import ArrivalService from './arrivalService'
 import BookingClient from '../data/bookingClient'
 import arrivalFactory from '../testutils/factories/arrival'
 import newArrivalFactory from '../testutils/factories/newArrival'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -21,11 +22,12 @@ describe('ArrivalService', () => {
       const arrival = arrivalFactory.build()
       const payload = newArrivalFactory.build()
 
-      const token = 'SOME_TOKEN'
+      const token = 'some-token'
+      const callConfig = { token } as CallConfig
 
       bookingClient.markAsArrived.mockResolvedValue(arrival)
 
-      const postedArrival = await service.createArrival(token, 'premisesID', 'bookingId', payload)
+      const postedArrival = await service.createArrival(callConfig, 'premisesID', 'bookingId', payload)
       expect(postedArrival).toEqual(arrival)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/arrivalService.ts
+++ b/server/services/arrivalService.ts
@@ -11,7 +11,7 @@ export default class ArrivalService {
     bookingId: string,
     arrival: NewArrival,
   ): Promise<Arrival> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedArrival = await bookingClient.markAsArrived(premisesId, bookingId, arrival)
 

--- a/server/services/arrivalService.ts
+++ b/server/services/arrivalService.ts
@@ -1,11 +1,17 @@
 import type { Arrival, NewArrival } from '@approved-premises/api'
 import type { RestClientBuilder, BookingClient } from '../data'
+import { CallConfig } from '../data/restClient'
 
 export default class ArrivalService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async createArrival(token: string, premisesId: string, bookingId: string, arrival: NewArrival): Promise<Arrival> {
-    const bookingClient = this.bookingClientFactory(token)
+  async createArrival(
+    callConfig: CallConfig,
+    premisesId: string,
+    bookingId: string,
+    arrival: NewArrival,
+  ): Promise<Arrival> {
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedArrival = await bookingClient.markAsArrived(premisesId, bookingId, arrival)
 

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -22,8 +22,7 @@ describe('BedspaceService', () => {
 
   const service = new BedspaceService(roomClientFactory, referenceDataClientFactory)
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
   const premisesId = 'premisesId'
 
   beforeEach(() => {
@@ -41,7 +40,7 @@ describe('BedspaceService', () => {
 
       expect(result).toEqual(room)
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(callConfig)
       expect(roomClient.find).toHaveBeenCalledWith(premisesId, room.id)
     })
   })
@@ -104,7 +103,7 @@ describe('BedspaceService', () => {
         },
       ])
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(callConfig)
       expect(roomClient.all).toHaveBeenCalledWith(premisesId)
 
       expect(formatLines).toHaveBeenCalledWith('Some more notes')
@@ -160,7 +159,7 @@ describe('BedspaceService', () => {
         },
       })
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(callConfig)
       expect(roomClient.find).toHaveBeenCalledWith(premisesId, room.id)
 
       expect(formatLines).toHaveBeenCalledWith('Some notes')
@@ -214,7 +213,7 @@ describe('BedspaceService', () => {
       const postedRoom = await service.createRoom(callConfig, premisesId, newRoom)
       expect(postedRoom).toEqual(room)
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(callConfig)
       expect(roomClient.create).toHaveBeenCalledWith(premisesId, newRoom)
     })
   })
@@ -230,7 +229,7 @@ describe('BedspaceService', () => {
       const updatedRoom = await service.updateRoom(callConfig, premisesId, room.id, newRoom)
       expect(updatedRoom).toEqual(room)
 
-      expect(roomClientFactory).toHaveBeenCalledWith(token)
+      expect(roomClientFactory).toHaveBeenCalledWith(callConfig)
       expect(roomClient.update).toHaveBeenCalledWith(premisesId, room.id, newRoom)
     })
   })

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -6,6 +6,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import characteristicFactory from '../testutils/factories/characteristic'
 import { formatLines } from '../utils/viewUtils'
 import { formatCharacteristics, filterCharacteristics } from '../utils/characteristicUtils'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/roomClient')
 jest.mock('../data/referenceDataClient')
@@ -21,7 +22,8 @@ describe('BedspaceService', () => {
 
   const service = new BedspaceService(roomClientFactory, referenceDataClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
   const premisesId = 'premisesId'
 
   beforeEach(() => {
@@ -35,7 +37,7 @@ describe('BedspaceService', () => {
       const room = roomFactory.build()
       roomClient.find.mockResolvedValue(room)
 
-      const result = await service.getRoom(token, premisesId, room.id)
+      const result = await service.getRoom(callConfig, premisesId, room.id)
 
       expect(result).toEqual(room)
 
@@ -67,7 +69,7 @@ describe('BedspaceService', () => {
         text: 'Some attributes',
       }))
 
-      const result = await service.getBedspaceDetails(token, premisesId)
+      const result = await service.getBedspaceDetails(callConfig, premisesId)
 
       expect(result).toEqual([
         {
@@ -140,7 +142,7 @@ describe('BedspaceService', () => {
         text: 'Some attributes',
       }))
 
-      const result = await service.getSingleBedspaceDetails(token, premisesId, room.id)
+      const result = await service.getSingleBedspaceDetails(callConfig, premisesId, room.id)
 
       expect(result).toEqual({
         room,
@@ -191,7 +193,7 @@ describe('BedspaceService', () => {
 
       roomClient.find.mockResolvedValue(room)
 
-      const result = await service.getUpdateRoom(token, premisesId, room.id)
+      const result = await service.getUpdateRoom(callConfig, premisesId, room.id)
       expect(result).toEqual({
         ...room,
         characteristicIds: ['characteristic-a', 'characteristic-b'],
@@ -209,7 +211,7 @@ describe('BedspaceService', () => {
       })
       roomClient.create.mockResolvedValue(room)
 
-      const postedRoom = await service.createRoom(token, premisesId, newRoom)
+      const postedRoom = await service.createRoom(callConfig, premisesId, newRoom)
       expect(postedRoom).toEqual(room)
 
       expect(roomClientFactory).toHaveBeenCalledWith(token)
@@ -225,7 +227,7 @@ describe('BedspaceService', () => {
       })
       roomClient.update.mockResolvedValue(room)
 
-      const updatedRoom = await service.updateRoom(token, premisesId, room.id, newRoom)
+      const updatedRoom = await service.updateRoom(callConfig, premisesId, room.id, newRoom)
       expect(updatedRoom).toEqual(room)
 
       expect(roomClientFactory).toHaveBeenCalledWith(token)
@@ -252,7 +254,7 @@ describe('BedspaceService', () => {
         roomCharacteristic1,
       ])
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(callConfig)
       expect(result).toEqual({ characteristics: [roomCharacteristic1, roomCharacteristic2, genericCharacteristic] })
 
       expect(filterCharacteristics).toHaveBeenCalledWith(

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -1,6 +1,7 @@
 import type { Characteristic, Room, NewRoom, UpdateRoom } from '@approved-premises/api'
 import { SummaryList } from '../@types/ui'
 import { ReferenceDataClient, RestClientBuilder } from '../data'
+import { CallConfig } from '../data/restClient'
 import RoomClient from '../data/roomClient'
 import { formatCharacteristics, filterCharacteristics } from '../utils/characteristicUtils'
 import { formatLines } from '../utils/viewUtils'
@@ -15,18 +16,18 @@ export default class BedspaceService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getRoom(token: string, premisesId: string, roomId: string): Promise<Room> {
-    const roomClient = this.roomClientFactory(token)
+  async getRoom(callConfig: CallConfig, premisesId: string, roomId: string): Promise<Room> {
+    const roomClient = this.roomClientFactory(callConfig.token)
     const room = await roomClient.find(premisesId, roomId)
 
     return room
   }
 
   async getBedspaceDetails(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
   ): Promise<Array<{ room: Room; summaryList: SummaryList }>> {
-    const roomClient = this.roomClientFactory(token)
+    const roomClient = this.roomClientFactory(callConfig.token)
     const rooms = await roomClient.all(premisesId)
 
     return rooms
@@ -38,11 +39,11 @@ export default class BedspaceService {
   }
 
   async getSingleBedspaceDetails(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     roomId: string,
   ): Promise<{ room: Room; summaryList: SummaryList }> {
-    const roomClient = this.roomClientFactory(token)
+    const roomClient = this.roomClientFactory(callConfig.token)
     const room = await roomClient.find(premisesId, roomId)
 
     return {
@@ -51,8 +52,8 @@ export default class BedspaceService {
     }
   }
 
-  async getUpdateRoom(token: string, premisesId: string, roomId: string): Promise<UpdateRoom> {
-    const roomClient = this.roomClientFactory(token)
+  async getUpdateRoom(callConfig: CallConfig, premisesId: string, roomId: string): Promise<UpdateRoom> {
+    const roomClient = this.roomClientFactory(callConfig.token)
     const room = await roomClient.find(premisesId, roomId)
 
     return {
@@ -61,22 +62,22 @@ export default class BedspaceService {
     }
   }
 
-  async createRoom(token: string, premisesId: string, newRoom: NewRoom): Promise<Room> {
-    const roomClient = this.roomClientFactory(token)
+  async createRoom(callConfig: CallConfig, premisesId: string, newRoom: NewRoom): Promise<Room> {
+    const roomClient = this.roomClientFactory(callConfig.token)
     const room = await roomClient.create(premisesId, newRoom)
 
     return room
   }
 
-  async updateRoom(token: string, premisesId: string, roomId: string, updateRoom: UpdateRoom): Promise<Room> {
-    const roomClient = this.roomClientFactory(token)
+  async updateRoom(callConfig: CallConfig, premisesId: string, roomId: string, updateRoom: UpdateRoom): Promise<Room> {
+    const roomClient = this.roomClientFactory(callConfig.token)
     const room = await roomClient.update(premisesId, roomId, updateRoom)
 
     return room
   }
 
-  async getReferenceData(token: string): Promise<BedspaceReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(callConfig: CallConfig): Promise<BedspaceReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
 
     const characteristics = filterCharacteristics(
       await referenceDataClient.getReferenceData<Characteristic>('characteristics'),

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -17,7 +17,7 @@ export default class BedspaceService {
   ) {}
 
   async getRoom(callConfig: CallConfig, premisesId: string, roomId: string): Promise<Room> {
-    const roomClient = this.roomClientFactory(callConfig.token)
+    const roomClient = this.roomClientFactory(callConfig)
     const room = await roomClient.find(premisesId, roomId)
 
     return room
@@ -27,7 +27,7 @@ export default class BedspaceService {
     callConfig: CallConfig,
     premisesId: string,
   ): Promise<Array<{ room: Room; summaryList: SummaryList }>> {
-    const roomClient = this.roomClientFactory(callConfig.token)
+    const roomClient = this.roomClientFactory(callConfig)
     const rooms = await roomClient.all(premisesId)
 
     return rooms
@@ -43,7 +43,7 @@ export default class BedspaceService {
     premisesId: string,
     roomId: string,
   ): Promise<{ room: Room; summaryList: SummaryList }> {
-    const roomClient = this.roomClientFactory(callConfig.token)
+    const roomClient = this.roomClientFactory(callConfig)
     const room = await roomClient.find(premisesId, roomId)
 
     return {
@@ -53,7 +53,7 @@ export default class BedspaceService {
   }
 
   async getUpdateRoom(callConfig: CallConfig, premisesId: string, roomId: string): Promise<UpdateRoom> {
-    const roomClient = this.roomClientFactory(callConfig.token)
+    const roomClient = this.roomClientFactory(callConfig)
     const room = await roomClient.find(premisesId, roomId)
 
     return {
@@ -63,21 +63,21 @@ export default class BedspaceService {
   }
 
   async createRoom(callConfig: CallConfig, premisesId: string, newRoom: NewRoom): Promise<Room> {
-    const roomClient = this.roomClientFactory(callConfig.token)
+    const roomClient = this.roomClientFactory(callConfig)
     const room = await roomClient.create(premisesId, newRoom)
 
     return room
   }
 
   async updateRoom(callConfig: CallConfig, premisesId: string, roomId: string, updateRoom: UpdateRoom): Promise<Room> {
-    const roomClient = this.roomClientFactory(callConfig.token)
+    const roomClient = this.roomClientFactory(callConfig)
     const room = await roomClient.update(premisesId, roomId, updateRoom)
 
     return room
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<BedspaceReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     const characteristics = filterCharacteristics(
       await referenceDataClient.getReferenceData<Characteristic>('characteristics'),

--- a/server/services/bookingReportService.test.ts
+++ b/server/services/bookingReportService.test.ts
@@ -5,6 +5,7 @@ import BookingReportService from './bookingReportService'
 import { ReportClient } from '../data'
 import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../utils/reportUtils'
 import probationRegionFactory from '../testutils/factories/probationRegion'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/reportClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -17,7 +18,8 @@ describe('BookingReportService', () => {
   const ReportClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
 
   const service = new BookingReportService(ReportClientFactory, ReferenceDataClientFactory)
 
@@ -32,7 +34,7 @@ describe('BookingReportService', () => {
       const response = createMock<Response>()
       ;(bookingReportFilename as jest.MockedFunction<typeof bookingReportFilename>).mockReturnValue('some-filename')
 
-      await service.pipeBookings(token, response)
+      await service.pipeBookings(callConfig, response)
 
       expect(ReportClientFactory).toHaveBeenCalledWith(token)
       expect(bookingReportFilename).toHaveBeenCalled()
@@ -49,7 +51,7 @@ describe('BookingReportService', () => {
         bookingReportForProbationRegionFilename as jest.MockedFunction<typeof bookingReportForProbationRegionFilename>
       ).mockReturnValue('some-filename')
 
-      await service.pipeBookingsForProbationRegion(token, response, probationRegions[0].id)
+      await service.pipeBookingsForProbationRegion(callConfig, response, probationRegions[0].id)
 
       expect(ReportClientFactory).toHaveBeenCalledWith(token)
       expect(bookingReportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0])
@@ -67,7 +69,7 @@ describe('BookingReportService', () => {
 
       referenceDataClient.getReferenceData.mockResolvedValue(probationRegions)
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(callConfig)
 
       expect(result).toEqual({ probationRegions })
 

--- a/server/services/bookingReportService.test.ts
+++ b/server/services/bookingReportService.test.ts
@@ -18,8 +18,7 @@ describe('BookingReportService', () => {
   const ReportClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
 
   const service = new BookingReportService(ReportClientFactory, ReferenceDataClientFactory)
 
@@ -36,7 +35,7 @@ describe('BookingReportService', () => {
 
       await service.pipeBookings(callConfig, response)
 
-      expect(ReportClientFactory).toHaveBeenCalledWith(token)
+      expect(ReportClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingReportFilename).toHaveBeenCalled()
       expect(reportClient.bookings).toHaveBeenCalledWith(response, 'some-filename')
     })
@@ -53,7 +52,7 @@ describe('BookingReportService', () => {
 
       await service.pipeBookingsForProbationRegion(callConfig, response, probationRegions[0].id)
 
-      expect(ReportClientFactory).toHaveBeenCalledWith(token)
+      expect(ReportClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingReportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0])
       expect(reportClient.bookingsForProbationRegion).toHaveBeenCalledWith(
         response,
@@ -73,7 +72,7 @@ describe('BookingReportService', () => {
 
       expect(result).toEqual({ probationRegions })
 
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(callConfig)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('probation-regions')
     })
   })

--- a/server/services/bookingReportService.ts
+++ b/server/services/bookingReportService.ts
@@ -16,7 +16,7 @@ export default class BookingReportService {
   ) {}
 
   async pipeBookings(callConfig: CallConfig, response: Response): Promise<void> {
-    const reportClient = this.reportClientFactory(callConfig.token)
+    const reportClient = this.reportClientFactory(callConfig)
 
     const filename = bookingReportFilename()
 
@@ -28,7 +28,7 @@ export default class BookingReportService {
     response: Response,
     probationRegionId: string,
   ): Promise<void> {
-    const reportClient = this.reportClientFactory(callConfig.token)
+    const reportClient = this.reportClientFactory(callConfig)
 
     const probationRegion = (await this.getReferenceData(callConfig)).probationRegions.find(
       region => region.id === probationRegionId,
@@ -40,7 +40,7 @@ export default class BookingReportService {
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<BookingReportReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     const probationRegions = await referenceDataClient.getReferenceData('probation-regions')
 

--- a/server/services/bookingReportService.ts
+++ b/server/services/bookingReportService.ts
@@ -2,6 +2,7 @@ import type { ProbationRegion } from '@approved-premises/api'
 import { Response } from 'express'
 import type { RestClientBuilder, ReferenceDataClient } from '../data'
 import ReportClient from '../data/reportClient'
+import { CallConfig } from '../data/restClient'
 import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../utils/reportUtils'
 
 export type BookingReportReferenceData = {
@@ -14,18 +15,22 @@ export default class BookingReportService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async pipeBookings(token: string, response: Response): Promise<void> {
-    const reportClient = this.reportClientFactory(token)
+  async pipeBookings(callConfig: CallConfig, response: Response): Promise<void> {
+    const reportClient = this.reportClientFactory(callConfig.token)
 
     const filename = bookingReportFilename()
 
     await reportClient.bookings(response, filename)
   }
 
-  async pipeBookingsForProbationRegion(token: string, response: Response, probationRegionId: string): Promise<void> {
-    const reportClient = this.reportClientFactory(token)
+  async pipeBookingsForProbationRegion(
+    callConfig: CallConfig,
+    response: Response,
+    probationRegionId: string,
+  ): Promise<void> {
+    const reportClient = this.reportClientFactory(callConfig.token)
 
-    const probationRegion = (await this.getReferenceData(token)).probationRegions.find(
+    const probationRegion = (await this.getReferenceData(callConfig)).probationRegions.find(
       region => region.id === probationRegionId,
     )
 
@@ -34,8 +39,8 @@ export default class BookingReportService {
     await reportClient.bookingsForProbationRegion(response, filename, probationRegionId)
   }
 
-  async getReferenceData(token: string): Promise<BookingReportReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(callConfig: CallConfig): Promise<BookingReportReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
 
     const probationRegions = await referenceDataClient.getReferenceData('probation-regions')
 

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -21,8 +21,7 @@ describe('BookingService', () => {
   const bookingClientFactory = jest.fn()
 
   const service = new BookingService(bookingClientFactory)
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
 
   const premisesId = 'premiseId'
   const bedId = 'bedId'
@@ -43,7 +42,7 @@ describe('BookingService', () => {
       const postedBooking = await service.create(callConfig, premisesId, newBooking)
       expect(postedBooking).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.create).toHaveBeenCalledWith(premisesId, newBooking)
     })
   })
@@ -65,7 +64,7 @@ describe('BookingService', () => {
       const postedBooking = await service.createForBedspace(callConfig, premisesId, room, newBooking)
       expect(postedBooking).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.create).toHaveBeenCalledWith(premisesId, {
         serviceName: 'temporary-accommodation',
         bedId,
@@ -89,7 +88,7 @@ describe('BookingService', () => {
       const retrievedBooking = await service.find(callConfig, premisesId, booking.id)
       expect(retrievedBooking).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
     })
   })
@@ -227,7 +226,7 @@ describe('BookingService', () => {
         ],
       ])
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
 
       expect(formatStatus).toHaveBeenCalledTimes(4)
@@ -243,7 +242,7 @@ describe('BookingService', () => {
 
       expect(result).toEqual(booking)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
     })
   })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -9,6 +9,7 @@ import { DateFormats } from '../utils/dateUtils'
 import roomFactory from '../testutils/factories/room'
 import bedFactory from '../testutils/factories/bed'
 import { formatStatus } from '../utils/bookingUtils'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/bookingClient')
 jest.mock('../data/referenceDataClient')
@@ -20,7 +21,8 @@ describe('BookingService', () => {
   const bookingClientFactory = jest.fn()
 
   const service = new BookingService(bookingClientFactory)
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
 
   const premisesId = 'premiseId'
   const bedId = 'bedId'
@@ -38,7 +40,7 @@ describe('BookingService', () => {
       const newBooking = newBookingFactory.build()
       bookingClient.create.mockResolvedValue(booking)
 
-      const postedBooking = await service.create(token, premisesId, newBooking)
+      const postedBooking = await service.create(callConfig, premisesId, newBooking)
       expect(postedBooking).toEqual(booking)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
@@ -60,7 +62,7 @@ describe('BookingService', () => {
         ],
       })
 
-      const postedBooking = await service.createForBedspace(token, premisesId, room, newBooking)
+      const postedBooking = await service.createForBedspace(callConfig, premisesId, room, newBooking)
       expect(postedBooking).toEqual(booking)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
@@ -84,7 +86,7 @@ describe('BookingService', () => {
 
       bookingClient.find.mockResolvedValue(booking)
 
-      const retrievedBooking = await service.find(token, premisesId, booking.id)
+      const retrievedBooking = await service.find(callConfig, premisesId, booking.id)
       expect(retrievedBooking).toEqual(booking)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)
@@ -128,7 +130,7 @@ describe('BookingService', () => {
         ],
       })
 
-      const rows = await service.getTableRowsForBedspace(token, premisesId, room)
+      const rows = await service.getTableRowsForBedspace(callConfig, premisesId, room)
 
       expect(rows).toEqual([
         [
@@ -237,7 +239,7 @@ describe('BookingService', () => {
       const booking = bookingFactory.build()
       bookingClient.find.mockResolvedValue(booking)
 
-      const result = await service.getBooking(token, premisesId, booking.id)
+      const result = await service.getBooking(callConfig, premisesId, booking.id)
 
       expect(result).toEqual(booking)
 

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -6,22 +6,28 @@ import BookingClient from '../data/bookingClient'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from '../utils/dateUtils'
 import { formatStatus } from '../utils/bookingUtils'
+import { CallConfig } from '../data/restClient'
 
 export default class BookingService {
   UPCOMING_WINDOW_IN_DAYS = 5
 
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async create(token: string, premisesId: string, booking: NewBooking): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async create(callConfig: CallConfig, premisesId: string, booking: NewBooking): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedBooking = await bookingClient.create(premisesId, booking)
 
     return confirmedBooking
   }
 
-  async createForBedspace(token: string, premisesId: string, room: Room, booking: NewBooking): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async createForBedspace(
+    callConfig: CallConfig,
+    premisesId: string,
+    room: Room,
+    booking: NewBooking,
+  ): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedBooking = await bookingClient.create(premisesId, {
       serviceName: 'temporary-accommodation',
@@ -32,16 +38,16 @@ export default class BookingService {
     return confirmedBooking
   }
 
-  async find(token: string, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async find(callConfig: CallConfig, premisesId: string, bookingId: string): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking
   }
 
-  async getTableRowsForBedspace(token: string, premisesId: string, room: Room): Promise<Array<TableRow>> {
-    const bookingClient = this.bookingClientFactory(token)
+  async getTableRowsForBedspace(callConfig: CallConfig, premisesId: string, room: Room): Promise<Array<TableRow>> {
+    const bookingClient = this.bookingClientFactory(callConfig.token)
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
     const bedId = room.beds[0].id
@@ -71,8 +77,8 @@ export default class BookingService {
       })
   }
 
-  async getBooking(token: string, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(token)
+  async getBooking(callConfig: CallConfig, premisesId: string, bookingId: string): Promise<Booking> {
+    const bookingClient = this.bookingClientFactory(callConfig.token)
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -14,7 +14,7 @@ export default class BookingService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async create(callConfig: CallConfig, premisesId: string, booking: NewBooking): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedBooking = await bookingClient.create(premisesId, booking)
 
@@ -27,7 +27,7 @@ export default class BookingService {
     room: Room,
     booking: NewBooking,
   ): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedBooking = await bookingClient.create(premisesId, {
       serviceName: 'temporary-accommodation',
@@ -39,7 +39,7 @@ export default class BookingService {
   }
 
   async find(callConfig: CallConfig, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const booking = await bookingClient.find(premisesId, bookingId)
 
@@ -47,7 +47,7 @@ export default class BookingService {
   }
 
   async getTableRowsForBedspace(callConfig: CallConfig, premisesId: string, room: Room): Promise<Array<TableRow>> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
     const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
     const bedId = room.beds[0].id
@@ -78,7 +78,7 @@ export default class BookingService {
   }
 
   async getBooking(callConfig: CallConfig, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
     const booking = await bookingClient.find(premisesId, bookingId)
 
     return booking

--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -17,8 +17,7 @@ describe('CancellationService', () => {
   const BookingClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
 
   const service = new CancellationService(BookingClientFactory, ReferenceDataClientFactory)
 
@@ -38,7 +37,7 @@ describe('CancellationService', () => {
       const postedDeparture = await service.createCancellation(callConfig, 'premisesId', 'bookingId', newCancellation)
       expect(postedDeparture).toEqual(cancellation)
 
-      expect(BookingClientFactory).toHaveBeenCalledWith(token)
+      expect(BookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.cancel).toHaveBeenCalledWith('premisesId', 'bookingId', newCancellation)
     })
   })
@@ -53,7 +52,7 @@ describe('CancellationService', () => {
 
       expect(result).toEqual({ cancellationReasons })
 
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(callConfig)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('cancellation-reasons')
     })
   })
@@ -67,7 +66,7 @@ describe('CancellationService', () => {
 
       expect(requestedDeparture).toEqual(cancellation)
 
-      expect(BookingClientFactory).toHaveBeenCalledWith(token)
+      expect(BookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.findCancellation).toHaveBeenCalledWith('premisesId', 'bookingId', cancellation.id)
     })
   })

--- a/server/services/cancellationService.test.ts
+++ b/server/services/cancellationService.test.ts
@@ -5,6 +5,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import newCancellationFactory from '../testutils/factories/newCancellation'
 import cancellationFactory from '../testutils/factories/cancellation'
 import referenceDataFactory from '../testutils/factories/referenceData'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -16,7 +17,8 @@ describe('CancellationService', () => {
   const BookingClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
 
   const service = new CancellationService(BookingClientFactory, ReferenceDataClientFactory)
 
@@ -33,7 +35,7 @@ describe('CancellationService', () => {
 
       bookingClient.cancel.mockResolvedValue(cancellation)
 
-      const postedDeparture = await service.createCancellation(token, 'premisesId', 'bookingId', newCancellation)
+      const postedDeparture = await service.createCancellation(callConfig, 'premisesId', 'bookingId', newCancellation)
       expect(postedDeparture).toEqual(cancellation)
 
       expect(BookingClientFactory).toHaveBeenCalledWith(token)
@@ -47,7 +49,7 @@ describe('CancellationService', () => {
 
       referenceDataClient.getReferenceData.mockResolvedValue(cancellationReasons)
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(callConfig)
 
       expect(result).toEqual({ cancellationReasons })
 
@@ -61,7 +63,7 @@ describe('CancellationService', () => {
       const cancellation = cancellationFactory.build()
       bookingClient.findCancellation.mockResolvedValue(cancellation)
 
-      const requestedDeparture = await service.getCancellation(token, 'premisesId', 'bookingId', cancellation.id)
+      const requestedDeparture = await service.getCancellation(callConfig, 'premisesId', 'bookingId', cancellation.id)
 
       expect(requestedDeparture).toEqual(cancellation)
 

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -19,7 +19,7 @@ export default class CancellationService {
     bookingId: string,
     cancellation: NewCancellation,
   ): Promise<Cancellation> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedCancellation = await bookingClient.cancel(premisesId, bookingId, cancellation)
 
@@ -32,7 +32,7 @@ export default class CancellationService {
     bookingId: string,
     cancellationId: string,
   ): Promise<Cancellation> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const booking = await bookingClient.findCancellation(premisesId, bookingId, cancellationId)
 
@@ -40,7 +40,7 @@ export default class CancellationService {
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<CancellationReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     const cancellationReasons = await referenceDataClient.getReferenceData('cancellation-reasons')
 

--- a/server/services/cancellationService.ts
+++ b/server/services/cancellationService.ts
@@ -1,6 +1,7 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import type { Cancellation, NewCancellation } from '@approved-premises/api'
 import type { BookingClient, RestClientBuilder, ReferenceDataClient } from '../data'
+import { CallConfig } from '../data/restClient'
 
 export type CancellationReferenceData = {
   cancellationReasons: Array<ReferenceData>
@@ -13,12 +14,12 @@ export default class CancellationService {
   ) {}
 
   async createCancellation(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
     cancellation: NewCancellation,
   ): Promise<Cancellation> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedCancellation = await bookingClient.cancel(premisesId, bookingId, cancellation)
 
@@ -26,20 +27,20 @@ export default class CancellationService {
   }
 
   async getCancellation(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
     cancellationId: string,
   ): Promise<Cancellation> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const booking = await bookingClient.findCancellation(premisesId, bookingId, cancellationId)
 
     return booking
   }
 
-  async getReferenceData(token: string): Promise<CancellationReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(callConfig: CallConfig): Promise<CancellationReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
 
     const cancellationReasons = await referenceDataClient.getReferenceData('cancellation-reasons')
 

--- a/server/services/confirmationService.test.ts
+++ b/server/services/confirmationService.test.ts
@@ -2,6 +2,7 @@ import BookingClient from '../data/bookingClient'
 import ConfirmationService from './confirmationService'
 import newConfirmationFactory from '../testutils/factories/newConfirmation'
 import confirmationFactory from '../testutils/factories/confirmation'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -10,7 +11,8 @@ describe('ConfirmationService', () => {
 
   const BookingClientFactory = jest.fn()
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
   const premisesId = 'premisesId'
   const bookingId = 'bookingId'
 
@@ -28,7 +30,7 @@ describe('ConfirmationService', () => {
 
       bookingClient.markAsConfirmed.mockResolvedValue(confirmation)
 
-      const returnedConfirmation = await service.createConfirmation(token, premisesId, bookingId, newConfirmation)
+      const returnedConfirmation = await service.createConfirmation(callConfig, premisesId, bookingId, newConfirmation)
       expect(returnedConfirmation).toEqual(confirmation)
 
       expect(BookingClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/confirmationService.test.ts
+++ b/server/services/confirmationService.test.ts
@@ -11,8 +11,7 @@ describe('ConfirmationService', () => {
 
   const BookingClientFactory = jest.fn()
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
   const premisesId = 'premisesId'
   const bookingId = 'bookingId'
 
@@ -33,7 +32,7 @@ describe('ConfirmationService', () => {
       const returnedConfirmation = await service.createConfirmation(callConfig, premisesId, bookingId, newConfirmation)
       expect(returnedConfirmation).toEqual(confirmation)
 
-      expect(BookingClientFactory).toHaveBeenCalledWith(token)
+      expect(BookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.markAsConfirmed).toHaveBeenCalledWith(premisesId, bookingId, newConfirmation)
     })
   })

--- a/server/services/confirmationService.ts
+++ b/server/services/confirmationService.ts
@@ -1,16 +1,17 @@
 import type { Confirmation, NewConfirmation } from '@approved-premises/api'
 import type { BookingClient, RestClientBuilder } from '../data'
+import { CallConfig } from '../data/restClient'
 
 export default class ConfirmationService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async createConfirmation(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
     confirmation: NewConfirmation,
   ): Promise<Confirmation> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     return bookingClient.markAsConfirmed(premisesId, bookingId, confirmation)
   }

--- a/server/services/confirmationService.ts
+++ b/server/services/confirmationService.ts
@@ -11,7 +11,7 @@ export default class ConfirmationService {
     bookingId: string,
     confirmation: NewConfirmation,
   ): Promise<Confirmation> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     return bookingClient.markAsConfirmed(premisesId, bookingId, confirmation)
   }

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -8,6 +8,7 @@ import departureFactory from '../testutils/factories/departure'
 import referenceDataFactory from '../testutils/factories/referenceData'
 import newDepartureFactory from '../testutils/factories/newDeparture'
 import { DateFormats } from '../utils/dateUtils'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/bookingClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -16,7 +17,8 @@ describe('DepartureService', () => {
   const bookingClient = new BookingClient(null) as jest.Mocked<BookingClient>
   const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
 
   const DepartureClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
@@ -36,7 +38,7 @@ describe('DepartureService', () => {
 
       bookingClient.markDeparture.mockResolvedValue(departure)
 
-      const postedDeparture = await service.createDeparture(token, 'premisesId', 'bookingId', newDeparture)
+      const postedDeparture = await service.createDeparture(callConfig, 'premisesId', 'bookingId', newDeparture)
       expect(postedDeparture).toEqual(departure)
 
       expect(DepartureClientFactory).toHaveBeenCalledWith(token)
@@ -49,7 +51,7 @@ describe('DepartureService', () => {
       const departure: Departure = departureFactory.build()
       bookingClient.findDeparture.mockResolvedValue(departure)
 
-      const requestedDeparture = await service.getDeparture(token, 'premisesId', 'bookingId', departure.id)
+      const requestedDeparture = await service.getDeparture(callConfig, 'premisesId', 'bookingId', departure.id)
 
       expect(requestedDeparture).toEqual({
         ...departure,
@@ -75,7 +77,7 @@ describe('DepartureService', () => {
         )
       })
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(callConfig)
 
       expect(result).toEqual({
         departureReasons,

--- a/server/services/departureService.test.ts
+++ b/server/services/departureService.test.ts
@@ -17,8 +17,7 @@ describe('DepartureService', () => {
   const bookingClient = new BookingClient(null) as jest.Mocked<BookingClient>
   const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
 
   const DepartureClientFactory = jest.fn()
   const ReferenceDataClientFactory = jest.fn()
@@ -41,7 +40,7 @@ describe('DepartureService', () => {
       const postedDeparture = await service.createDeparture(callConfig, 'premisesId', 'bookingId', newDeparture)
       expect(postedDeparture).toEqual(departure)
 
-      expect(DepartureClientFactory).toHaveBeenCalledWith(token)
+      expect(DepartureClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.markDeparture).toHaveBeenCalledWith('premisesId', 'bookingId', newDeparture)
     })
   })
@@ -58,7 +57,7 @@ describe('DepartureService', () => {
         dateTime: DateFormats.isoDateToUIDate(departure.dateTime),
       })
 
-      expect(DepartureClientFactory).toHaveBeenCalledWith(token)
+      expect(DepartureClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.findDeparture).toHaveBeenCalledWith('premisesId', 'bookingId', departure.id)
     })
   })
@@ -84,7 +83,7 @@ describe('DepartureService', () => {
         moveOnCategories,
       })
 
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(callConfig)
 
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('departure-reasons')
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('move-on-categories')

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -2,6 +2,7 @@ import type { ReferenceData } from '@approved-premises/ui'
 import type { Departure, NewDeparture } from '@approved-premises/api'
 import type { RestClientBuilder, BookingClient, ReferenceDataClient } from '../data'
 import { DateFormats } from '../utils/dateUtils'
+import { CallConfig } from '../data/restClient'
 
 export type DepartureReferenceData = {
   departureReasons: Array<ReferenceData>
@@ -15,28 +16,33 @@ export default class DepartureService {
   ) {}
 
   async createDeparture(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
     departure: NewDeparture,
   ): Promise<Departure> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedDeparture = await bookingClient.markDeparture(premisesId, bookingId, departure)
 
     return confirmedDeparture
   }
 
-  async getDeparture(token: string, premisesId: string, bookingId: string, departureId: string): Promise<Departure> {
-    const departureClient = this.bookingClientFactory(token)
+  async getDeparture(
+    callConfig: CallConfig,
+    premisesId: string,
+    bookingId: string,
+    departureId: string,
+  ): Promise<Departure> {
+    const departureClient = this.bookingClientFactory(callConfig.token)
 
     const departure = await departureClient.findDeparture(premisesId, bookingId, departureId)
 
     return { ...departure, dateTime: DateFormats.isoDateToUIDate(departure.dateTime) }
   }
 
-  async getReferenceData(token: string): Promise<DepartureReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(callConfig: CallConfig): Promise<DepartureReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
 
     const [departureReasons, moveOnCategories] = await Promise.all([
       referenceDataClient.getReferenceData('departure-reasons'),

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -21,7 +21,7 @@ export default class DepartureService {
     bookingId: string,
     departure: NewDeparture,
   ): Promise<Departure> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedDeparture = await bookingClient.markDeparture(premisesId, bookingId, departure)
 
@@ -34,7 +34,7 @@ export default class DepartureService {
     bookingId: string,
     departureId: string,
   ): Promise<Departure> {
-    const departureClient = this.bookingClientFactory(callConfig.token)
+    const departureClient = this.bookingClientFactory(callConfig)
 
     const departure = await departureClient.findDeparture(premisesId, bookingId, departureId)
 
@@ -42,7 +42,7 @@ export default class DepartureService {
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<DepartureReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     const [departureReasons, moveOnCategories] = await Promise.all([
       referenceDataClient.getReferenceData('departure-reasons'),

--- a/server/services/extensionService.test.ts
+++ b/server/services/extensionService.test.ts
@@ -1,4 +1,5 @@
 import BookingClient from '../data/bookingClient'
+import { CallConfig } from '../data/restClient'
 import extensionFactory from '../testutils/factories/extension'
 import newExtensionFactory from '../testutils/factories/newExtension'
 import ExtensionService from './extensionService'
@@ -6,7 +7,8 @@ import ExtensionService from './extensionService'
 jest.mock('../data/bookingClient.ts')
 
 describe('ExtensionService', () => {
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
   const premiseId = 'premisesId'
   const bookingId = 'bookingId'
 
@@ -27,7 +29,7 @@ describe('ExtensionService', () => {
 
       bookingClient.extendBooking.mockResolvedValue(extension)
 
-      const postedExtension = await service.createExtension(token, premiseId, bookingId, payload)
+      const postedExtension = await service.createExtension(callConfig, premiseId, bookingId, payload)
       expect(postedExtension).toEqual(extension)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/extensionService.test.ts
+++ b/server/services/extensionService.test.ts
@@ -7,8 +7,7 @@ import ExtensionService from './extensionService'
 jest.mock('../data/bookingClient.ts')
 
 describe('ExtensionService', () => {
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
   const premiseId = 'premisesId'
   const bookingId = 'bookingId'
 
@@ -32,7 +31,7 @@ describe('ExtensionService', () => {
       const postedExtension = await service.createExtension(callConfig, premiseId, bookingId, payload)
       expect(postedExtension).toEqual(extension)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.extendBooking).toHaveBeenCalledWith(premiseId, bookingId, payload)
     })
   })

--- a/server/services/extensionService.ts
+++ b/server/services/extensionService.ts
@@ -11,7 +11,7 @@ export default class ExtensionService {
     bookingId: string,
     extension: NewExtension,
   ): Promise<Extension> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedExtension = await bookingClient.extendBooking(premisesId, bookingId, extension)
 

--- a/server/services/extensionService.ts
+++ b/server/services/extensionService.ts
@@ -1,16 +1,17 @@
 import type { Extension, NewExtension } from '@approved-premises/api'
 import type { RestClientBuilder, BookingClient } from '../data'
+import { CallConfig } from '../data/restClient'
 
 export default class ExtensionService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async createExtension(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
     extension: NewExtension,
   ): Promise<Extension> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedExtension = await bookingClient.extendBooking(premisesId, bookingId, extension)
 

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -7,6 +7,7 @@ import ReferenceDataClient from '../data/referenceDataClient'
 import lostBedFactory from '../testutils/factories/lostBed'
 import newLostBedFactory from '../testutils/factories/newLostBed'
 import referenceDataFactory from '../testutils/factories/referenceData'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/lostBedClient.ts')
 jest.mock('../data/referenceDataClient.ts')
@@ -31,10 +32,11 @@ describe('LostBedService', () => {
       const lostBed: LostBed = lostBedFactory.build()
       const newLostBed: NewLostBed = newLostBedFactory.build()
 
-      const token = 'SOME_TOKEN'
+      const token = 'some-token'
+      const callConfig = { token } as CallConfig
       lostBedClient.create.mockResolvedValue(lostBed)
 
-      const postedLostBed = await service.createLostBed(token, 'premisesID', newLostBed)
+      const postedLostBed = await service.createLostBed(callConfig, 'premisesID', newLostBed)
 
       expect(postedLostBed).toEqual(lostBed)
       expect(LostBedClientFactory).toHaveBeenCalledWith(token)
@@ -45,7 +47,8 @@ describe('LostBedService', () => {
   describe('getReferenceData', () => {
     it('should return the lost bed reasons data needed', async () => {
       const lostBedReasons = referenceDataFactory.buildList(2)
-      const token = 'SOME_TOKEN'
+      const token = 'some-token'
+      const callConfig = { token } as CallConfig
 
       referenceDataClient.getReferenceData.mockImplementation(category => {
         return Promise.resolve(
@@ -55,7 +58,7 @@ describe('LostBedService', () => {
         )
       })
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(callConfig)
 
       expect(result).toEqual(lostBedReasons)
       expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -32,14 +32,13 @@ describe('LostBedService', () => {
       const lostBed: LostBed = lostBedFactory.build()
       const newLostBed: NewLostBed = newLostBedFactory.build()
 
-      const token = 'some-token'
-      const callConfig = { token } as CallConfig
+      const callConfig = { token: 'some-token' } as CallConfig
       lostBedClient.create.mockResolvedValue(lostBed)
 
       const postedLostBed = await service.createLostBed(callConfig, 'premisesID', newLostBed)
 
       expect(postedLostBed).toEqual(lostBed)
-      expect(LostBedClientFactory).toHaveBeenCalledWith(token)
+      expect(LostBedClientFactory).toHaveBeenCalledWith(callConfig)
       expect(lostBedClient.create).toHaveBeenCalledWith('premisesID', newLostBed)
     })
   })
@@ -47,8 +46,7 @@ describe('LostBedService', () => {
   describe('getReferenceData', () => {
     it('should return the lost bed reasons data needed', async () => {
       const lostBedReasons = referenceDataFactory.buildList(2)
-      const token = 'some-token'
-      const callConfig = { token } as CallConfig
+      const callConfig = { token: 'some-token' } as CallConfig
 
       referenceDataClient.getReferenceData.mockImplementation(category => {
         return Promise.resolve(
@@ -61,7 +59,7 @@ describe('LostBedService', () => {
       const result = await service.getReferenceData(callConfig)
 
       expect(result).toEqual(lostBedReasons)
-      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(token)
+      expect(ReferenceDataClientFactory).toHaveBeenCalledWith(callConfig)
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('lost-bed-reasons')
     })
   })

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -1,6 +1,7 @@
 import type { ReferenceData } from '@approved-premises/ui'
 import type { LostBed, NewLostBed } from '@approved-premises/api'
 import type { RestClientBuilder, LostBedClient, ReferenceDataClient } from '../data'
+import { CallConfig } from '../data/restClient'
 
 export type LostBedReferenceData = Array<ReferenceData>
 export default class LostBedService {
@@ -9,16 +10,16 @@ export default class LostBedService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async createLostBed(token: string, premisesId: string, lostBed: NewLostBed): Promise<LostBed> {
-    const lostBedClient = this.lostBedClientFactory(token)
+  async createLostBed(callConfig: CallConfig, premisesId: string, lostBed: NewLostBed): Promise<LostBed> {
+    const lostBedClient = this.lostBedClientFactory(callConfig.token)
 
     const confirmedLostBed = await lostBedClient.create(premisesId, lostBed)
 
     return confirmedLostBed
   }
 
-  async getReferenceData(token: string): Promise<LostBedReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(callConfig: CallConfig): Promise<LostBedReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
 
     const reasons = await referenceDataClient.getReferenceData('lost-bed-reasons')
 

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -11,7 +11,7 @@ export default class LostBedService {
   ) {}
 
   async createLostBed(callConfig: CallConfig, premisesId: string, lostBed: NewLostBed): Promise<LostBed> {
-    const lostBedClient = this.lostBedClientFactory(callConfig.token)
+    const lostBedClient = this.lostBedClientFactory(callConfig)
 
     const confirmedLostBed = await lostBedClient.create(premisesId, lostBed)
 
@@ -19,7 +19,7 @@ export default class LostBedService {
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<LostBedReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     const reasons = await referenceDataClient.getReferenceData('lost-bed-reasons')
 

--- a/server/services/nonArrivalService.test.ts
+++ b/server/services/nonArrivalService.test.ts
@@ -13,8 +13,7 @@ describe('NonarrivalService', () => {
 
   const service = new NonarrivalService(bookingClientFactory)
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -34,7 +33,7 @@ describe('NonarrivalService', () => {
 
       expect(postedNonArrival).toEqual(nonArrival)
 
-      expect(bookingClientFactory).toHaveBeenCalledWith(token)
+      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.markNonArrival).toHaveBeenCalledWith('premisesID', 'bookingId', newNonArrival)
     })
   })

--- a/server/services/nonArrivalService.test.ts
+++ b/server/services/nonArrivalService.test.ts
@@ -3,6 +3,7 @@ import type { Nonarrival } from '@approved-premises/api'
 import NonarrivalService from './nonArrivalService'
 import BookingClient from '../data/bookingClient'
 import NonArrivalFactory from '../testutils/factories/nonArrival'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/bookingClient.ts')
 
@@ -12,7 +13,8 @@ describe('NonarrivalService', () => {
 
   const service = new NonarrivalService(bookingClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -28,7 +30,7 @@ describe('NonarrivalService', () => {
       }
       bookingClient.markNonArrival.mockResolvedValue(nonArrival)
 
-      const postedNonArrival = await service.createNonArrival(token, 'premisesID', 'bookingId', newNonArrival)
+      const postedNonArrival = await service.createNonArrival(callConfig, 'premisesID', 'bookingId', newNonArrival)
 
       expect(postedNonArrival).toEqual(nonArrival)
 

--- a/server/services/nonArrivalService.ts
+++ b/server/services/nonArrivalService.ts
@@ -1,16 +1,17 @@
 import type { NewNonarrival, Nonarrival } from '@approved-premises/api'
 import type { RestClientBuilder, BookingClient } from '../data'
+import { CallConfig } from '../data/restClient'
 
 export default class NonarrivalService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
   async createNonArrival(
-    token: string,
+    callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
     nonArrival: NewNonarrival,
   ): Promise<Nonarrival> {
-    const bookingClient = this.bookingClientFactory(token)
+    const bookingClient = this.bookingClientFactory(callConfig.token)
 
     const confirmedNonArrival = await bookingClient.markNonArrival(premisesId, bookingId, nonArrival)
 

--- a/server/services/nonArrivalService.ts
+++ b/server/services/nonArrivalService.ts
@@ -11,7 +11,7 @@ export default class NonarrivalService {
     bookingId: string,
     nonArrival: NewNonarrival,
   ): Promise<Nonarrival> {
-    const bookingClient = this.bookingClientFactory(callConfig.token)
+    const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedNonArrival = await bookingClient.markNonArrival(premisesId, bookingId, nonArrival)
 

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -15,8 +15,7 @@ describe('PersonService', () => {
 
   const service = new PersonService(personClientFactory)
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -32,7 +31,7 @@ describe('PersonService', () => {
 
       expect(postedPerson).toEqual(person)
 
-      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClientFactory).toHaveBeenCalledWith(callConfig)
       expect(personClient.search).toHaveBeenCalledWith('crn')
     })
   })
@@ -47,7 +46,7 @@ describe('PersonService', () => {
 
       expect(postedPerson).toEqual(uiRisks)
 
-      expect(personClientFactory).toHaveBeenCalledWith(token)
+      expect(personClientFactory).toHaveBeenCalledWith(callConfig)
       expect(personClient.risks).toHaveBeenCalledWith('crn')
     })
   })

--- a/server/services/personService.test.ts
+++ b/server/services/personService.test.ts
@@ -5,6 +5,7 @@ import PersonClient from '../data/personClient'
 import PersonFactory from '../testutils/factories/person'
 import risksFactory from '../testutils/factories/risks'
 import { mapApiPersonRisksForUi } from '../utils/utils'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/personClient.ts')
 
@@ -14,7 +15,8 @@ describe('PersonService', () => {
 
   const service = new PersonService(personClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -26,7 +28,7 @@ describe('PersonService', () => {
       const person: Person = PersonFactory.build()
       personClient.search.mockResolvedValue(person)
 
-      const postedPerson = await service.findByCrn(token, 'crn')
+      const postedPerson = await service.findByCrn(callConfig, 'crn')
 
       expect(postedPerson).toEqual(person)
 
@@ -41,7 +43,7 @@ describe('PersonService', () => {
       const uiRisks = mapApiPersonRisksForUi(apiRisks)
       personClient.risks.mockResolvedValue(apiRisks)
 
-      const postedPerson = await service.getPersonRisks(token, 'crn')
+      const postedPerson = await service.getPersonRisks(callConfig, 'crn')
 
       expect(postedPerson).toEqual(uiRisks)
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -3,19 +3,20 @@ import type { Person } from '@approved-premises/api'
 import type { RestClientBuilder, PersonClient } from '../data'
 
 import { mapApiPersonRisksForUi } from '../utils/utils'
+import { CallConfig } from '../data/restClient'
 
 export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
 
-  async findByCrn(token: string, crn: string): Promise<Person> {
-    const personClient = this.personClientFactory(token)
+  async findByCrn(callConfig: CallConfig, crn: string): Promise<Person> {
+    const personClient = this.personClientFactory(callConfig.token)
 
     const person = await personClient.search(crn)
     return person
   }
 
-  async getPersonRisks(token: string, crn: string): Promise<PersonRisksUI> {
-    const personClient = this.personClientFactory(token)
+  async getPersonRisks(callConfig: CallConfig, crn: string): Promise<PersonRisksUI> {
+    const personClient = this.personClientFactory(callConfig.token)
 
     const risks = await personClient.risks(crn)
 

--- a/server/services/personService.ts
+++ b/server/services/personService.ts
@@ -9,14 +9,14 @@ export default class PersonService {
   constructor(private readonly personClientFactory: RestClientBuilder<PersonClient>) {}
 
   async findByCrn(callConfig: CallConfig, crn: string): Promise<Person> {
-    const personClient = this.personClientFactory(callConfig.token)
+    const personClient = this.personClientFactory(callConfig)
 
     const person = await personClient.search(crn)
     return person
   }
 
   async getPersonRisks(callConfig: CallConfig, crn: string): Promise<PersonRisksUI> {
-    const personClient = this.personClientFactory(callConfig.token)
+    const personClient = this.personClientFactory(callConfig)
 
     const risks = await personClient.risks(crn)
 

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -15,6 +15,7 @@ import { formatCharacteristics, filterCharacteristics } from '../utils/character
 import probationRegionFactory from '../testutils/factories/probationRegion'
 import pduFactory from '../testutils/factories/pdu'
 import pduJson from '../data/pdus.json'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/premisesClient')
 jest.mock('../data/referenceDataClient')
@@ -34,7 +35,8 @@ describe('PremisesService', () => {
 
   const service = new PremisesService(premisesClientFactory, referenceDataClientFactory)
 
-  const token = 'SOME_TOKEN'
+  const token = 'some-token'
+  const callConfig = { token } as CallConfig
   const premisesId = 'premisesId'
 
   beforeEach(() => {
@@ -48,7 +50,7 @@ describe('PremisesService', () => {
       const staffMembers = staffMemberFactory.buildList(5)
       premisesClient.getStaffMembers.mockResolvedValue(staffMembers)
 
-      const result = await service.getStaffMembers(token, premisesId)
+      const result = await service.getStaffMembers(callConfig, premisesId)
 
       expect(result).toEqual(staffMembers)
 
@@ -94,7 +96,7 @@ describe('PremisesService', () => {
         premisesCharacteristic1,
       ])
 
-      const result = await service.getReferenceData(token)
+      const result = await service.getReferenceData(callConfig)
       expect(result).toEqual({
         localAuthorities: [localAuthority1, localAuthority2, localAuthority3],
         characteristics: [premisesCharacteristic1, premisesCharacteristic2, genericCharacteristic],
@@ -123,7 +125,7 @@ describe('PremisesService', () => {
       const premises = [premises4, premises1, premises3, premises2]
       premisesClient.all.mockResolvedValue(premises)
 
-      const rows = await service.tableRows(token)
+      const rows = await service.tableRows(callConfig)
 
       expect(rows).toEqual([
         [
@@ -204,7 +206,7 @@ describe('PremisesService', () => {
       const premisesC = premisesFactory.build({ name: 'c' })
       premisesClient.all.mockResolvedValue([premisesC, premisesB, premisesA])
 
-      const result = await service.getPremisesSelectList(token)
+      const result = await service.getPremisesSelectList(callConfig)
 
       expect(result).toEqual([
         { text: premisesA.name, value: premisesA.id },
@@ -242,7 +244,7 @@ describe('PremisesService', () => {
 
       premisesClient.find.mockResolvedValue(premises)
 
-      const result = await service.getUpdatePremises(token, premises.id)
+      const result = await service.getUpdatePremises(callConfig, premises.id)
       expect(result).toEqual({
         ...premises,
         localAuthorityAreaId: 'local-authority',
@@ -259,7 +261,7 @@ describe('PremisesService', () => {
       const premises = premisesFactory.build()
       premisesClient.find.mockResolvedValue(premises)
 
-      const result = await service.getPremises(token, premises.id)
+      const result = await service.getPremises(callConfig, premises.id)
 
       expect(result).toEqual(premises)
 
@@ -302,7 +304,7 @@ describe('PremisesService', () => {
       }))
       ;(formatStatus as jest.MockedFn<typeof formatStatus>).mockReturnValue('Online')
 
-      const result = await service.getPremisesDetails(token, premises.id)
+      const result = await service.getPremisesDetails(callConfig, premises.id)
 
       expect(result).toEqual({
         premises,
@@ -361,7 +363,7 @@ describe('PremisesService', () => {
       premisesClient.capacity.mockResolvedValue([])
       ;(getDateRangesWithNegativeBeds as jest.Mock).mockReturnValue([])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(callConfig, premisesId)
 
       expect(result).toBe('')
     })
@@ -375,7 +377,7 @@ describe('PremisesService', () => {
       ])
       ;(getDateRangesWithNegativeBeds as jest.Mock).mockReturnValue([])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(callConfig, premisesId)
 
       expect(result).toBe('')
     })
@@ -390,7 +392,7 @@ describe('PremisesService', () => {
       premisesClient.capacity.mockResolvedValue(capacityStub)
       ;(getDateRangesWithNegativeBeds as jest.Mock).mockReturnValue([{ start: capacityStub[0].date }])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(callConfig, premisesId)
 
       expect(result).toEqual([
         '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity on 1 January 2022</h4>',
@@ -416,7 +418,7 @@ describe('PremisesService', () => {
         },
       ])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(callConfig, premisesId)
 
       expect(result).toEqual([
         '<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the period 1 January 2022 to 1 February 2022</h4>',
@@ -443,7 +445,7 @@ describe('PremisesService', () => {
         },
       ])
 
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(callConfig, premisesId)
 
       expect(result).toEqual([
         `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>
@@ -468,7 +470,7 @@ describe('PremisesService', () => {
           end: capacityStub[3].date,
         },
       ])
-      const result = await service.getOvercapacityMessage(token, premisesId)
+      const result = await service.getOvercapacityMessage(callConfig, premisesId)
 
       expect(result).toEqual([
         `<h4 class="govuk-!-margin-top-0 govuk-!-margin-bottom-2">The premises is over capacity for the periods:</h4>
@@ -486,7 +488,7 @@ describe('PremisesService', () => {
       })
       premisesClient.create.mockResolvedValue(premises)
 
-      const createdPremises = await service.create(token, newPremises)
+      const createdPremises = await service.create(callConfig, newPremises)
       expect(createdPremises).toEqual(premises)
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)
@@ -503,7 +505,7 @@ describe('PremisesService', () => {
       })
       premisesClient.update.mockResolvedValue(premises)
 
-      const updatedPremises = await service.update(token, premises.id, newPremises)
+      const updatedPremises = await service.update(callConfig, premises.id, newPremises)
       expect(updatedPremises).toEqual(premises)
 
       expect(premisesClientFactory).toHaveBeenCalledWith(token)

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -35,8 +35,7 @@ describe('PremisesService', () => {
 
   const service = new PremisesService(premisesClientFactory, referenceDataClientFactory)
 
-  const token = 'some-token'
-  const callConfig = { token } as CallConfig
+  const callConfig = { token: 'some-token' } as CallConfig
   const premisesId = 'premisesId'
 
   beforeEach(() => {
@@ -54,7 +53,7 @@ describe('PremisesService', () => {
 
       expect(result).toEqual(staffMembers)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.getStaffMembers).toHaveBeenCalledWith(premisesId)
     })
   })
@@ -194,7 +193,7 @@ describe('PremisesService', () => {
         ],
       ])
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.all).toHaveBeenCalled()
     })
   })
@@ -214,7 +213,7 @@ describe('PremisesService', () => {
         { text: premisesC.name, value: premisesC.id },
       ])
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.all).toHaveBeenCalled()
     })
   })
@@ -265,7 +264,7 @@ describe('PremisesService', () => {
 
       expect(result).toEqual(premises)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
     })
   })
@@ -342,7 +341,7 @@ describe('PremisesService', () => {
         },
       })
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
 
       expect(escape).toHaveBeenCalledWith('10 Example Street')
@@ -491,7 +490,7 @@ describe('PremisesService', () => {
       const createdPremises = await service.create(callConfig, newPremises)
       expect(createdPremises).toEqual(premises)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.create).toHaveBeenCalledWith(newPremises)
     })
   })
@@ -508,7 +507,7 @@ describe('PremisesService', () => {
       const updatedPremises = await service.update(callConfig, premises.id, newPremises)
       expect(updatedPremises).toEqual(premises)
 
-      expect(premisesClientFactory).toHaveBeenCalledWith(token)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.update).toHaveBeenCalledWith(premises.id, newPremises)
     })
   })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -15,6 +15,7 @@ import { DateFormats } from '../utils/dateUtils'
 import { getDateRangesWithNegativeBeds, formatStatus, NegativeDateRange } from '../utils/premisesUtils'
 import { escape, formatLines } from '../utils/viewUtils'
 import { formatCharacteristics, filterCharacteristics } from '../utils/characteristicUtils'
+import { CallConfig } from '../data/restClient'
 
 export type PremisesReferenceData = {
   localAuthorities: Array<LocalAuthorityArea>
@@ -29,16 +30,16 @@ export default class PremisesService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getStaffMembers(token: string, premisesId: string): Promise<Array<StaffMember>> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getStaffMembers(callConfig: CallConfig, premisesId: string): Promise<Array<StaffMember>> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
 
     const staffMembers = await premisesClient.getStaffMembers(premisesId)
 
     return staffMembers
   }
 
-  async getReferenceData(token: string): Promise<PremisesReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(token)
+  async getReferenceData(callConfig: CallConfig): Promise<PremisesReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
 
     const localAuthorities = (
       (await referenceDataClient.getReferenceData('local-authority-areas')) as Array<LocalAuthorityArea>
@@ -58,8 +59,8 @@ export default class PremisesService {
     return { localAuthorities, characteristics, probationRegions, pdus }
   }
 
-  async tableRows(token: string): Promise<Array<TableRow>> {
-    const premisesClient = this.premisesClientFactory(token)
+  async tableRows(callConfig: CallConfig): Promise<Array<TableRow>> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.all()
 
     return premises
@@ -79,15 +80,18 @@ export default class PremisesService {
       })
   }
 
-  async getPremises(token: string, id: string): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getPremises(callConfig: CallConfig, id: string): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.find(id)
 
     return premises
   }
 
-  async getPremisesDetails(token: string, id: string): Promise<{ premises: Premises; summaryList: SummaryList }> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getPremisesDetails(
+    callConfig: CallConfig,
+    id: string,
+  ): Promise<{ premises: Premises; summaryList: SummaryList }> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.find(id)
 
     const summaryList = await this.summaryListForPremises(premises)
@@ -95,8 +99,8 @@ export default class PremisesService {
     return { premises, summaryList }
   }
 
-  async getOvercapacityMessage(token: string, premisesId: string): Promise<string[] | string> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getOvercapacityMessage(callConfig: CallConfig, premisesId: string): Promise<string[] | string> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premisesDateCapacities = await premisesClient.capacity(premisesId)
 
     const overcapacityDateRanges = getDateRangesWithNegativeBeds(premisesDateCapacities)
@@ -106,8 +110,8 @@ export default class PremisesService {
     return overcapacityMessage ? [overcapacityMessage] : ''
   }
 
-  async getPremisesSelectList(token: string): Promise<Array<{ text: string; value: string }>> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getPremisesSelectList(callConfig: CallConfig): Promise<Array<{ text: string; value: string }>> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.all()
 
     return premises
@@ -125,8 +129,8 @@ export default class PremisesService {
       })
   }
 
-  async getUpdatePremises(token: string, id: string): Promise<UpdatePremises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async getUpdatePremises(callConfig: CallConfig, id: string): Promise<UpdatePremises> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.find(id)
 
     return {
@@ -138,15 +142,15 @@ export default class PremisesService {
     }
   }
 
-  async create(token: string, newPremises: NewPremises): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async create(callConfig: CallConfig, newPremises: NewPremises): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.create(newPremises)
 
     return premises
   }
 
-  async update(token: string, id: string, updatePremises: UpdatePremises): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(token)
+  async update(callConfig: CallConfig, id: string, updatePremises: UpdatePremises): Promise<Premises> {
+    const premisesClient = this.premisesClientFactory(callConfig.token)
     const premises = await premisesClient.update(id, updatePremises)
 
     return premises

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -31,7 +31,7 @@ export default class PremisesService {
   ) {}
 
   async getStaffMembers(callConfig: CallConfig, premisesId: string): Promise<Array<StaffMember>> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
 
     const staffMembers = await premisesClient.getStaffMembers(premisesId)
 
@@ -39,7 +39,7 @@ export default class PremisesService {
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<PremisesReferenceData> {
-    const referenceDataClient = this.referenceDataClientFactory(callConfig.token)
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     const localAuthorities = (
       (await referenceDataClient.getReferenceData('local-authority-areas')) as Array<LocalAuthorityArea>
@@ -60,7 +60,7 @@ export default class PremisesService {
   }
 
   async tableRows(callConfig: CallConfig): Promise<Array<TableRow>> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.all()
 
     return premises
@@ -81,7 +81,7 @@ export default class PremisesService {
   }
 
   async getPremises(callConfig: CallConfig, id: string): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.find(id)
 
     return premises
@@ -91,7 +91,7 @@ export default class PremisesService {
     callConfig: CallConfig,
     id: string,
   ): Promise<{ premises: Premises; summaryList: SummaryList }> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.find(id)
 
     const summaryList = await this.summaryListForPremises(premises)
@@ -100,7 +100,7 @@ export default class PremisesService {
   }
 
   async getOvercapacityMessage(callConfig: CallConfig, premisesId: string): Promise<string[] | string> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premisesDateCapacities = await premisesClient.capacity(premisesId)
 
     const overcapacityDateRanges = getDateRangesWithNegativeBeds(premisesDateCapacities)
@@ -111,7 +111,7 @@ export default class PremisesService {
   }
 
   async getPremisesSelectList(callConfig: CallConfig): Promise<Array<{ text: string; value: string }>> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.all()
 
     return premises
@@ -130,7 +130,7 @@ export default class PremisesService {
   }
 
   async getUpdatePremises(callConfig: CallConfig, id: string): Promise<UpdatePremises> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.find(id)
 
     return {
@@ -143,14 +143,14 @@ export default class PremisesService {
   }
 
   async create(callConfig: CallConfig, newPremises: NewPremises): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.create(newPremises)
 
     return premises
   }
 
   async update(callConfig: CallConfig, id: string, updatePremises: UpdatePremises): Promise<Premises> {
-    const premisesClient = this.premisesClientFactory(callConfig.token)
+    const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.update(id, updatePremises)
 
     return premises

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,9 +1,10 @@
 import UserService from './userService'
 import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
+import { CallConfig } from '../data/restClient'
 
 jest.mock('../data/hmppsAuthClient')
 
-const token = 'some token'
+const callConfig = { token: 'some-token' } as CallConfig
 
 describe('User service', () => {
   let hmppsAuthClient: jest.Mocked<HmppsAuthClient>
@@ -17,14 +18,14 @@ describe('User service', () => {
     it('Retrieves and formats user name', async () => {
       hmppsAuthClient.getUser.mockResolvedValue({ name: 'john smith' } as User)
 
-      const result = await userService.getUser(token)
+      const result = await userService.getUser(callConfig)
 
       expect(result.displayName).toEqual('John Smith')
     })
     it('Propagates error', async () => {
       hmppsAuthClient.getUser.mockRejectedValue(new Error('some error'))
 
-      await expect(userService.getUser(token)).rejects.toEqual(new Error('some error'))
+      await expect(userService.getUser(callConfig)).rejects.toEqual(new Error('some error'))
     })
   })
 })

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -11,7 +11,7 @@ export default class UserService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
   async getUser(callConfig: CallConfig): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getUser(callConfig.token)
+    const user = await this.hmppsAuthClient.getUser(callConfig)
     return { ...user, displayName: convertToTitleCase(user.name) }
   }
 }

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,5 +1,6 @@
 import { convertToTitleCase } from '../utils/utils'
 import type HmppsAuthClient from '../data/hmppsAuthClient'
+import { CallConfig } from '../data/restClient'
 
 interface UserDetails {
   name: string
@@ -9,8 +10,8 @@ interface UserDetails {
 export default class UserService {
   constructor(private readonly hmppsAuthClient: HmppsAuthClient) {}
 
-  async getUser(token: string): Promise<UserDetails> {
-    const user = await this.hmppsAuthClient.getUser(token)
+  async getUser(callConfig: CallConfig): Promise<UserDetails> {
+    const user = await this.hmppsAuthClient.getUser(callConfig.token)
     return { ...user, displayName: convertToTitleCase(user.name) }
   }
 }

--- a/server/utils/restUtils.test.ts
+++ b/server/utils/restUtils.test.ts
@@ -1,0 +1,13 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Request } from 'express'
+import extractCallConfig from './restUtils'
+
+describe('extractCallConfig', () => {
+  it('extracts the token from the given request', () => {
+    const request = createMock<Request>({
+      user: { token: 'some-token' },
+    })
+
+    expect(extractCallConfig(request)).toEqual({ token: 'some-token' })
+  })
+})

--- a/server/utils/restUtils.ts
+++ b/server/utils/restUtils.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express'
+import { CallConfig } from '../data/restClient'
+
+export default function extractCallConfig(req: Request): CallConfig {
+  return { token: req.user.token }
+}


### PR DESCRIPTION
This is a refactoring PR as part of our work to limit users to properties of their own region. Our intent is to store the user region in the session, which we will then pass back to the API on each call, within an `X-USER-REGION` header. To do this, we need to pass additional information from the request into the RestClient.

To do this, we replace the token that `RestClient` currently takes, with `CallConfig` object, and an `extractCallConfig` helper function used by our controllers to create a `CallConfig` from our request. For now, the `callConfig` only contains the token, but we will expand this in a future PR.

The PR is split into 3 broad steps:
- Controllers passing a callConfig into our services
- Services passing a callConfig into our clients
- Clients passing a callConfig into our RestClient

