### PR TITLE
Update typescript and govuk-frontend versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29,7 +29,7 @@
         "express-prom-bundle": "^6.5.0",
         "express-session": "^1.17.3",
         "fishery": "^2.2.2",
-        "govuk-frontend": "^4.4.0",
+        "govuk-frontend": "^4.5.0",
         "helmet": "^6.0.0",
         "http-errors": "^2.0.0",
         "jquery": "^3.6.1",
@@ -9672,9 +9672,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.4.1.tgz",
-      "integrity": "sha512-Jm1LUWiH9vy47b6HSH/ksSb4ueBrtTTgyLBk+3X2qqAmmFUc1AXWLSYHid07YYu1tvn9RnodWk5Bac5Ywqk6tA==",
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.5.0.tgz",
+      "integrity": "sha512-gZHDqf5vdlHjmx0NGJiNT12XLyR3d5KCS4AnlC3xTWOObJ0kQROrkIFyp3w4/PY3EQiYdgacVaJ6lizzygnzYw==",
       "engines": {
         "node": ">= 4.2.0"
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -104,7 +104,7 @@
         "start-server-and-test": "^1.14.0",
         "supertest": "^6.3.0",
         "ts-jest": "^29.0.0",
-        "typescript": "^4.9.3"
+        "typescript": "^4.9.5"
       },
       "engines": {
         "node": "^18",
@@ -15049,9 +15049,9 @@
       }
     },
     "node_modules/typescript": {
-      "version": "4.9.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.4.tgz",
-      "integrity": "sha512-Uz+dTXYzxXXbsFpM86Wh3dKCxrQqUcVMxwU54orwlJjOpO3ao8L7j5lH+dWfTwgCwIuM9GQ2kvVotzYJMXTBZg==",
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
       "dev": true,
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -135,7 +135,7 @@
     "express-prom-bundle": "^6.5.0",
     "express-session": "^1.17.3",
     "fishery": "^2.2.2",
-    "govuk-frontend": "^4.4.0",
+    "govuk-frontend": "^4.5.0",
     "helmet": "^6.0.0",
     "http-errors": "^2.0.0",
     "jquery": "^3.6.1",

--- a/package.json
+++ b/package.json
@@ -210,6 +210,6 @@
     "start-server-and-test": "^1.14.0",
     "supertest": "^6.3.0",
     "ts-jest": "^29.0.0",
-    "typescript": "^4.9.3"
+    "typescript": "^4.9.5"
   }
 }


### PR DESCRIPTION
Update typescript version to 4.9.5, and govuk-frontend to 4.5.0. This is in response to [this](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui/703/workflows/84936035-70e6-4638-a264-50439f12fa1c/jobs/1222) `check_outdated` failure on CircleCI