### PR TITLE
Add an error message for non-unique premises names

### DIFF
--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -12,7 +12,8 @@
       "isInFuture": "The submitted at date must be in the past"
     },
     "name": {
-      "empty": "You must enter a name"
+      "empty": "You must enter a name",
+      "notUnique": "The name must be unique to this property"
     },
     "arrivalDate": {
       "empty": "You must enter a start date",


### PR DESCRIPTION
This fixes [this](https://dxw-moj.sentry.io/issues/3910364212/) error via Sentry

## Screenshots of UI changes

### Before
![temporary-accommodation-dev hmpps service justice gov uk_properties](https://user-images.githubusercontent.com/94137563/216072188-acb1e7c5-bd3b-4407-bca8-f116dc6d3789.png)

### After
![localhost_3000_properties_new](https://user-images.githubusercontent.com/94137563/216072195-1579280d-6af5-4017-8519-e38e13b1b611.png)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
