### PR TITLE
Add/Edit property region dropdown only shows appropriate regions for role

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e --\
-              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>}"  \
+              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},CYPRESS_acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID<< parameters.environment >>},CYPRESS_acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME<< parameters.environment >>}"  \
               --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -31,6 +31,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
       .contains('What is the probation region?')
       .siblings('select')
       .children('option')
+      .should('have.length', 2)
       .contains(exact(this.premises.probationRegion.name))
       .should('be.selected')
 

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -1,9 +1,8 @@
 import type { UpdatePremises, TemporaryAccommodationPremises as Premises } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { formatStatus } from '../../../../server/utils/premisesUtils'
+import { exact } from '../../../../server/utils/utils'
 import PremisesEditablePage from './premisesEditable'
-
-const exact = (text: string) => new RegExp(`^${text}$`)
 
 export default class PremisesEditPage extends PremisesEditablePage {
   constructor(private readonly premises: Premises) {

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
@@ -1,6 +1,7 @@
-import type { NewPremises } from '@approved-premises/api'
+import type { NewPremises, ProbationRegion } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import PremisesEditablePage from './premisesEditable'
+import { exact } from '../../../../server/utils/utils'
 
 export default class PremisesNewPage extends PremisesEditablePage {
   constructor() {
@@ -17,5 +18,15 @@ export default class PremisesNewPage extends PremisesEditablePage {
     this.getTextInputByIdAndEnterDetails('name', newPremises.name)
 
     super.completeEditableForm(newPremises)
+  }
+
+  shouldPreselectProbationRegion(probationRegion: ProbationRegion): void {
+    cy.get('label')
+      .contains('What is the probation region?')
+      .siblings('select')
+      .children('option')
+      .should('have.length', 2)
+      .contains(exact(probationRegion.name))
+      .should('be.selected')
   }
 }

--- a/e2e.local.env
+++ b/e2e.local.env
@@ -4,3 +4,5 @@ CYPRESS_offender_crn=X320741
 CYPRESS_offender_name="Aadland Bertrand"
 CYPRESS_keyworker_name="Kelby Tabert"
 CYPRESS_lost_bed_reason_id=2f46e769-17a5-4b5c-b04a-a5a9a5b3f773
+CYPRESS_acting_user_probation_region_id=c5acff6c-d0d2-4b89-9f4d-89a15cfa3891
+CYPRESS_acting_user_probation_region_id="North East"

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -49,6 +49,8 @@ Given('I create a premises with all necessary details', () => {
     probationRegion,
   })
 
+  page.shouldPreselectProbationRegion(probationRegion)
+
   const newPremises = newPremisesFactory.build({
     ...premises,
     localAuthorityAreaId: premises.localAuthorityArea.id,

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -3,12 +3,19 @@ import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import premisesFactory from '../../../../server/testutils/factories/premises'
 import newPremisesFactory from '../../../../server/testutils/factories/newPremises'
 import updatePremisesFactory from '../../../../server/testutils/factories/updatePremises'
+import probationRegionFactory from '../../../../server/testutils/factories/probationRegion'
 import PremisesNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesNew'
 import PremisesListPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesList'
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 import PremisesEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesEdit'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import Page from '../../../../cypress_shared/pages/page'
+import throwMissingCypressEnvError from '../utils'
+
+const actingUserProbationRegionId =
+  Cypress.env('acting_user_probation_region_id') || throwMissingCypressEnvError('acting_user_probation_region_id')
+const actingUserProbationRegionName =
+  Cypress.env('acting_user_probation_region_name') || throwMissingCypressEnvError('acting_user_probation_region_name')
 
 Given("I'm creating a premises", () => {
   const dashboardPage = Page.verifyOnPage(DashboardPage)
@@ -33,8 +40,13 @@ Given("I'm viewing an existing premises", () => {
 Given('I create a premises with all necessary details', () => {
   const page = Page.verifyOnPage(PremisesNewPage)
 
+  const probationRegion = probationRegionFactory.build({
+    id: actingUserProbationRegionId,
+    name: actingUserProbationRegionName,
+  })
   const premises = premisesFactory.build({
     id: 'unknown',
+    probationRegion,
   })
 
   const newPremises = newPremisesFactory.build({
@@ -57,8 +69,14 @@ Given('I attempt to create a premises with required details missing', () => {
 
 Given('I attempt to create a premises with the PDU missing', () => {
   const page = Page.verifyOnPage(PremisesNewPage)
+
+  const probationRegion = probationRegionFactory.build({
+    id: actingUserProbationRegionId,
+    name: actingUserProbationRegionName,
+  })
   const premises = premisesFactory.build({
     id: 'unknown',
+    probationRegion,
     pdu: '',
   })
 
@@ -87,9 +105,15 @@ Given("I'm editing the premises", () => {
 Given('I edit the premises details', () => {
   cy.get('@premises').then((premises: Premises) => {
     const page = Page.verifyOnPage(PremisesEditPage, premises)
+
+    const probationRegion = probationRegionFactory.build({
+      id: actingUserProbationRegionId,
+      name: actingUserProbationRegionName,
+    })
     const updatedPremises = premisesFactory.build({
       id: premises.id,
       name: premises.name,
+      probationRegion,
     })
 
     const updatePremises = updatePremisesFactory.build({
@@ -118,9 +142,15 @@ Given('I attempt to edit the premises to remove required details', () => {
 Given('I attempt to edit the premises to remove the PDU', () => {
   cy.then(function _() {
     const page = Page.verifyOnPage(PremisesEditPage, this.premises)
+
+    const probationRegion = probationRegionFactory.build({
+      id: actingUserProbationRegionId,
+      name: actingUserProbationRegionName,
+    })
     const updatedPremises = premisesFactory.build({
       id: this.premises.id,
       name: this.premises.name,
+      probationRegion,
       pdu: '',
     })
 

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -154,7 +154,10 @@ context('Premises', () => {
 
       const page = PremisesNewPage.visit()
 
-      // And I fill out the form
+      // Then I should see the user's probation region preselected
+      page.shouldPreselectProbationRegion(this.actingUserProbationRegion)
+
+      // And when I fill out the form
       page.completeForm(newPremises)
 
       // Then a premises should have been created in the API

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -138,40 +138,44 @@ context('Premises', () => {
     cy.task('stubPremisesReferenceData')
 
     // When I visit the new premises page
-    const premises = premisesFactory.build()
-    const newPremises = newPremisesFactory.build({
-      ...premises,
-      localAuthorityAreaId: premises.localAuthorityArea.id,
-      characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
-      probationRegionId: premises.probationRegion.id,
+    cy.then(function _() {
+      const premises = premisesFactory.build({
+        probationRegion: this.actingUserProbationRegion,
+      })
+      const newPremises = newPremisesFactory.build({
+        ...premises,
+        localAuthorityAreaId: premises.localAuthorityArea.id,
+        characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
+        probationRegionId: premises.probationRegion.id,
+      })
+
+      cy.task('stubPremisesCreate', premises)
+      cy.task('stubSinglePremises', premises)
+
+      const page = PremisesNewPage.visit()
+
+      // And I fill out the form
+      page.completeForm(newPremises)
+
+      // Then a premises should have been created in the API
+      cy.task('verifyPremisesCreate').then(requests => {
+        expect(requests).to.have.length(1)
+        const requestBody = JSON.parse(requests[0].body)
+
+        expect(requestBody.name).equal(newPremises.name)
+        expect(requestBody.addressLine1).equal(newPremises.addressLine1)
+        expect(requestBody.addressLine2).equal(newPremises.addressLine2)
+        expect(requestBody.town).equal(newPremises.town)
+        expect(requestBody.postcode).equal(newPremises.postcode)
+        expect(requestBody.localAuthorityAreaId).equal(newPremises.localAuthorityAreaId)
+        expect(requestBody.characteristicIds).members(newPremises.characteristicIds)
+        expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(newPremises.notes)
+      })
+
+      // And I should be redirected to the show premises page
+      const premisesNewPage = PremisesNewPage.verifyOnPage(PremisesShowPage, premises)
+      premisesNewPage.shouldShowBanner('Property created')
     })
-
-    cy.task('stubPremisesCreate', premises)
-    cy.task('stubSinglePremises', premises)
-
-    const page = PremisesNewPage.visit()
-
-    // And I fill out the form
-    page.completeForm(newPremises)
-
-    // Then a premises should have been created in the API
-    cy.task('verifyPremisesCreate').then(requests => {
-      expect(requests).to.have.length(1)
-      const requestBody = JSON.parse(requests[0].body)
-
-      expect(requestBody.name).equal(newPremises.name)
-      expect(requestBody.addressLine1).equal(newPremises.addressLine1)
-      expect(requestBody.addressLine2).equal(newPremises.addressLine2)
-      expect(requestBody.town).equal(newPremises.town)
-      expect(requestBody.postcode).equal(newPremises.postcode)
-      expect(requestBody.localAuthorityAreaId).equal(newPremises.localAuthorityAreaId)
-      expect(requestBody.characteristicIds).members(newPremises.characteristicIds)
-      expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(newPremises.notes)
-    })
-
-    // And I should be redirected to the show premises page
-    const premisesNewPage = PremisesNewPage.verifyOnPage(PremisesShowPage, premises)
-    premisesNewPage.shouldShowBanner('Property created')
   })
 
   it('should show errors when the create API returns an error', () => {
@@ -194,6 +198,7 @@ context('Premises', () => {
       'pdu',
       'status',
     ])
+    page.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
     page.clickSubmit()
 
     // Then I should see error messages relating to those fields
@@ -236,39 +241,46 @@ context('Premises', () => {
     // And there is reference data in the database
     cy.task('stubPremisesReferenceData')
 
-    // And there is a premises in the database
-    const premises = premisesFactory.build()
-    cy.task('stubSinglePremises', premises)
+    cy.then(function _() {
+      // And there is a premises in the database
+      const premises = premisesFactory.build({
+        probationRegion: this.actingUserProbationRegion,
+      })
+      cy.task('stubSinglePremises', premises)
 
-    // When I visit the edit premises page
-    const page = PremisesEditPage.visit(premises)
+      // When I visit the edit premises page
+      const page = PremisesEditPage.visit(premises)
 
-    // Then I should see the premises details
-    page.shouldShowPremisesDetails()
+      // Then I should see the premises details
+      page.shouldShowPremisesDetails()
 
-    // And when I fill out the form
-    cy.task('stubPremisesUpdate', premises)
-    const updatePremises = updatePremisesFactory.build()
-    page.completeForm(updatePremises)
+      // And when I fill out the form
+      cy.task('stubPremisesUpdate', premises)
 
-    // Then the premises should have been update in the API
-    cy.task('verifyPremisesUpdate', premises).then(requests => {
-      expect(requests).to.have.length(1)
-      const requestBody = JSON.parse(requests[0].body)
+      const updatePremises = updatePremisesFactory.build({
+        probationRegionId: this.actingUserProbationRegion.id,
+      })
+      page.completeForm(updatePremises)
 
-      expect(requestBody.addressLine1).equal(updatePremises.addressLine1)
-      expect(requestBody.addressLine2).equal(updatePremises.addressLine2)
-      expect(requestBody.town).equal(updatePremises.town)
-      expect(requestBody.postcode).equal(updatePremises.postcode)
-      expect(requestBody.localAuthorityAreaId).equal(updatePremises.localAuthorityAreaId)
-      expect(requestBody.characteristicIds).members(updatePremises.characteristicIds)
-      expect(requestBody.status).equal(updatePremises.status)
-      expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(updatePremises.notes)
+      // Then the premises should have been update in the API
+      cy.task('verifyPremisesUpdate', premises).then(requests => {
+        expect(requests).to.have.length(1)
+        const requestBody = JSON.parse(requests[0].body)
+
+        expect(requestBody.addressLine1).equal(updatePremises.addressLine1)
+        expect(requestBody.addressLine2).equal(updatePremises.addressLine2)
+        expect(requestBody.town).equal(updatePremises.town)
+        expect(requestBody.postcode).equal(updatePremises.postcode)
+        expect(requestBody.localAuthorityAreaId).equal(updatePremises.localAuthorityAreaId)
+        expect(requestBody.characteristicIds).members(updatePremises.characteristicIds)
+        expect(requestBody.status).equal(updatePremises.status)
+        expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(updatePremises.notes)
+      })
+
+      // And I should be redirected to the show premises page
+      const premisesShowPage = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
+      premisesShowPage.shouldShowBanner('Property updated')
     })
-
-    // And I should be redirected to the show premises page
-    const premisesShowPage = PremisesShowPage.verifyOnPage(PremisesShowPage, premises)
-    premisesShowPage.shouldShowBanner('Property updated')
   })
 
   it('should show errors when the update API returns an error', () => {

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -16,6 +16,8 @@ import referenceDataFactory from '../../../testutils/factories/referenceData'
 import extractCallConfig from '../../../utils/restUtils'
 import { CallConfig } from '../../../data/restClient'
 import { PropertyStatus } from '../../../@types/shared'
+import filterProbationRegions from '../../../utils/userUtils'
+import probationRegionFactory from '../../../testutils/factories/probationRegion'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
@@ -27,6 +29,7 @@ jest.mock('../../../utils/premisesUtils', () => {
     getActiveStatuses: jest.fn(),
   }
 })
+jest.mock('../../../utils/userUtils')
 
 describe('PremisesController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -51,6 +54,12 @@ describe('PremisesController', () => {
     },
   ]
 
+  const filteredRegions = [
+    probationRegionFactory.build({
+      name: 'filtered-region',
+    }),
+  ]
+
   let request: Request
 
   const response: DeepMocked<Response> = createMock<Response>({})
@@ -61,7 +70,11 @@ describe('PremisesController', () => {
   const premisesController = new PremisesController(premisesService, bedspaceService)
 
   beforeEach(() => {
-    request = createMock<Request>()
+    request = createMock<Request>({
+      session: {
+        probationRegion: probationRegionFactory.build(),
+      },
+    })
     ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
   })
 
@@ -82,6 +95,7 @@ describe('PremisesController', () => {
     it('renders the form', async () => {
       premisesService.getReferenceData.mockResolvedValue(referenceData)
       ;(getActiveStatuses as jest.Mock).mockReturnValue(allActiveStatuses)
+      ;(filterProbationRegions as jest.MockedFunction<typeof filterProbationRegions>).mockReturnValue(filteredRegions)
 
       const requestHandler = premisesController.new()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
@@ -94,10 +108,11 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/new', {
         allLocalAuthorities: referenceData.localAuthorities,
         allCharacteristics: referenceData.characteristics,
-        allProbationRegions: referenceData.probationRegions,
+        allProbationRegions: filteredRegions,
         allPdus: referenceData.pdus,
         allStatuses: allActiveStatuses,
         characteristicIds: [],
+        probationRegionId: request.session.probationRegion.id,
         errors: {},
         errorSummary: [],
       })
@@ -106,6 +121,7 @@ describe('PremisesController', () => {
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
       premisesService.getReferenceData.mockResolvedValue(referenceData)
       ;(getActiveStatuses as jest.Mock).mockReturnValue(allActiveStatuses)
+      ;(filterProbationRegions as jest.MockedFunction<typeof filterProbationRegions>).mockReturnValue(filteredRegions)
 
       const requestHandler = premisesController.new()
 
@@ -120,10 +136,11 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/new', {
         allLocalAuthorities: referenceData.localAuthorities,
         allCharacteristics: referenceData.characteristics,
-        allProbationRegions: referenceData.probationRegions,
+        allProbationRegions: filteredRegions,
         allPdus: referenceData.pdus,
         allStatuses: allActiveStatuses,
         characteristicIds: [],
+        probationRegionId: request.session.probationRegion.id,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,
@@ -183,6 +200,7 @@ describe('PremisesController', () => {
     it('renders the form', async () => {
       premisesService.getReferenceData.mockResolvedValue(referenceData)
       ;(getActiveStatuses as jest.Mock).mockReturnValue(allActiveStatuses)
+      ;(filterProbationRegions as jest.MockedFunction<typeof filterProbationRegions>).mockReturnValue(filteredRegions)
 
       const premises = premisesFactory.build()
       const updatePremises = updatePremisesFactory.build({
@@ -203,10 +221,11 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/edit', {
         allLocalAuthorities: referenceData.localAuthorities,
         allCharacteristics: referenceData.characteristics,
-        allProbationRegions: referenceData.probationRegions,
+        allProbationRegions: filteredRegions,
         allPdus: referenceData.pdus,
         allStatuses: allActiveStatuses,
         characteristicIds: [],
+        probationRegionId: request.session.probationRegion.id,
         errors: {},
         errorSummary: [],
         ...updatePremises,
@@ -216,6 +235,7 @@ describe('PremisesController', () => {
     it('renders the form with errors and user input if an error has been sent to the flash', async () => {
       premisesService.getReferenceData.mockResolvedValue(referenceData)
       ;(getActiveStatuses as jest.Mock).mockReturnValue(allActiveStatuses)
+      ;(filterProbationRegions as jest.MockedFunction<typeof filterProbationRegions>).mockReturnValue(filteredRegions)
 
       const premises = premisesFactory.build()
       const updatePremises = updatePremisesFactory.build({
@@ -238,10 +258,11 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/edit', {
         allLocalAuthorities: referenceData.localAuthorities,
         allCharacteristics: referenceData.characteristics,
-        allProbationRegions: referenceData.probationRegions,
+        allProbationRegions: filteredRegions,
         allPdus: referenceData.pdus,
         allStatuses: allActiveStatuses,
         characteristicIds: [],
+        probationRegionId: request.session.probationRegion.id,
         errors: errorsAndUserInput.errors,
         errorSummary: errorsAndUserInput.errorSummary,
         ...errorsAndUserInput.userInput,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -7,6 +7,7 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../
 import BedspaceService from '../../../services/bedspaceService'
 import { allStatuses, getActiveStatuses } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
+import filterProbationRegions from '../../../utils/userUtils'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -36,12 +37,13 @@ export default class PremisesController {
       return res.render('temporary-accommodation/premises/new', {
         allLocalAuthorities,
         allCharacteristics,
-        allProbationRegions,
+        allProbationRegions: filterProbationRegions(allProbationRegions, req),
         allPdus,
         allStatuses: getActiveStatuses(allStatuses),
         characteristicIds: [],
         errors,
         errorSummary,
+        probationRegionId: req.session.probationRegion.id,
         ...userInput,
       })
     }
@@ -86,7 +88,7 @@ export default class PremisesController {
       return res.render('temporary-accommodation/premises/edit', {
         allLocalAuthorities,
         allCharacteristics,
-        allProbationRegions,
+        allProbationRegions: filterProbationRegions(allProbationRegions, req),
         allPdus,
         allStatuses: getActiveStatuses(allStatuses),
         characteristicIds: [],

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -1,0 +1,24 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Request } from 'express'
+import probationRegionFactory from '../testutils/factories/probationRegion'
+import filterProbationRegions from './userUtils'
+
+describe('filterProbationRegions', () => {
+  it('filters given probation regions by the region on the request session', () => {
+    const nonUserRegion1 = probationRegionFactory.build({
+      id: 'some-non-user-region-1',
+    })
+    const nonUserRegion2 = probationRegionFactory.build({
+      id: 'some-non-user-region-2',
+    })
+    const userRegion = probationRegionFactory.build({
+      id: 'user-region',
+    })
+
+    const request = createMock<Request>()
+
+    request.session.probationRegion = probationRegionFactory.build({ id: 'user-region' })
+
+    expect(filterProbationRegions([nonUserRegion1, userRegion, nonUserRegion2], request)).toEqual([userRegion])
+  })
+})

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -1,0 +1,6 @@
+import { Request } from 'express'
+import { ProbationRegion } from '../@types/shared'
+
+export default function filterProbationRegions(regions: ProbationRegion[], request: Request) {
+  return [regions.find(region => region.id === request.session.probationRegion.id)]
+}

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -8,6 +8,7 @@ import {
   removeBlankSummaryListItems,
   mapApiPersonRisksForUi,
   unique,
+  exact,
 } from './utils'
 import risksFactory from '../testutils/factories/risks'
 import { DateFormats } from './dateUtils'
@@ -240,5 +241,18 @@ describe('unique', () => {
         id: 'efg',
       },
     ])
+  })
+
+  describe('exact', () => {
+    it('returns a RegExp that only matches the exact given string', () => {
+      const regExp = exact('some-string')
+
+      expect(regExp.exec('some-string')).toBeTruthy()
+      expect(regExp.exec('some-string-inside-another-string')).toBeFalsy()
+      expect(regExp.exec('a-string-containg-some-string')).toBeFalsy()
+      expect(regExp.exec('Some-String')).toBeFalsy()
+      expect(regExp.exec('some string')).toBeFalsy()
+      expect(regExp.exec(' some-string ')).toBeFalsy()
+    })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -105,3 +105,5 @@ export function unique<T extends { id: string }>(elements: Array<T>): Array<T> {
     (element, index) => elements.findIndex(searchElement => searchElement.id === element.id) === index,
   )
 }
+
+export const exact = (text: string) => new RegExp(`^${text}$`)


### PR DESCRIPTION
# Changes in this PR

- When adding or editing a property, the user can only set the probation region as their own

## Screenshots of UI changes

### Before
![before](https://user-images.githubusercontent.com/94137563/216311001-479236e9-f73b-41b6-a819-e52a8225dd10.png)

### After
![after](https://user-images.githubusercontent.com/94137563/216310988-3f24739a-010a-453b-9714-cf92e78e961f.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
