### PR TITLE
Reduce duplication in integration test setup

### DIFF
--- a/cypress_shared/utils/setupTestUser.ts
+++ b/cypress_shared/utils/setupTestUser.ts
@@ -1,8 +1,11 @@
-import referenceData from '../../server/testutils/factories/referenceData'
+import referenceDataFactory from '../../server/testutils/factories/referenceData'
 import userFactory from '../../server/testutils/factories/user'
 
-export default function stubActingUser() {
-  const probationRegion = referenceData.probationRegion().build()
+export default function setupTestUser() {
+  cy.task('stubSignIn')
+  cy.task('stubAuthUser')
+
+  const probationRegion = referenceDataFactory.probationRegion().build()
   const actingUser = userFactory.build({ region: probationRegion })
 
   cy.wrap(actingUser).as('actingUser')

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -2,14 +2,14 @@ import DashboardPage from '../../cypress_shared/pages/temporary-accommodation/da
 import AuthSignInPage from '../../cypress_shared/pages/authSignIn'
 import Page from '../../cypress_shared/pages/page'
 import AuthManageDetailsPage from '../../cypress_shared/pages/authManageDetails'
-import stubActingUser from '../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../cypress_shared/utils/setupTestUser'
+import referenceDataFactory from '../../server/testutils/factories/referenceData'
+import userFactory from '../../server/testutils/factories/user'
 
 context('SignIn', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('Unauthenticated user directed to auth', () => {
@@ -63,7 +63,11 @@ context('SignIn', () => {
 
     cy.task('stubVerifyToken', true)
     cy.task('stubAuthUser', 'bobby brown')
-    stubActingUser()
+
+    const probationRegion = referenceDataFactory.probationRegion().build()
+    const actingUser = userFactory.build({ region: probationRegion })
+
+    cy.task('stubActingUser', actingUser)
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/integration_tests/tests/temporary-accommodation/cookies.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/cookies.cy.ts
@@ -1,11 +1,9 @@
-import stubActingUser from '../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../cypress_shared/utils/setupTestUser'
 
 context('Cookies', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('should navigate to the cookie policy page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
@@ -6,14 +6,12 @@ import Page from '../../../../cypress_shared/pages/page'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import BookingArrivalNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew'
 import arrivalFactory from '../../../../server/testutils/factories/arrival'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking arrival', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the booking arrival page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -9,14 +9,12 @@ import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommo
 import BedspaceNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceNew'
 import BedspaceEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Bedspace', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('should navigate to the create bedspace page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -7,14 +7,12 @@ import newBookingFactory from '../../../../server/testutils/factories/newBooking
 import Page from '../../../../cypress_shared/pages/page'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the create booking page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
@@ -6,14 +6,12 @@ import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommod
 import BookingCancellationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew'
 import cancellationFactory from '../../../../server/testutils/factories/cancellation'
 import newCancellationFactory from '../../../../server/testutils/factories/newCancellation'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking cancellation', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the booking cancellation page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
@@ -6,14 +6,12 @@ import newConfirmationFactory from '../../../../server/testutils/factories/newCo
 import Page from '../../../../cypress_shared/pages/page'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import BookingConfirmationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking confirmation', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the confirm booking page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -6,14 +6,12 @@ import Page from '../../../../cypress_shared/pages/page'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import departureFactory from '../../../../server/testutils/factories/departure'
 import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking departure', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the booking departure page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
@@ -6,14 +6,12 @@ import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommod
 import extensionFactory from '../../../../server/testutils/factories/extension'
 import newExtensionFactory from '../../../../server/testutils/factories/newExtension'
 import BookingExtensionNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking extension', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the booking extension page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/history.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/history.cy.ts
@@ -5,14 +5,12 @@ import Page from '../../../../cypress_shared/pages/page'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import BookingHistoryPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingHistory'
 import { deriveBookingHistory } from '../../../../server/utils/bookingUtils'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking history', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('navigates to the booking history page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -8,14 +8,12 @@ import Page from '../../../../cypress_shared/pages/page'
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
 import PremisesEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesEdit'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Premises', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('should navigate to the list premises page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -4,14 +4,12 @@ import { bookingReportForProbationRegionFilename } from '../../../../server/util
 import Page from '../../../../cypress_shared/pages/page'
 import BookingReportNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingReportNew'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
-import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Report', () => {
   beforeEach(() => {
     cy.task('reset')
-    cy.task('stubSignIn')
-    cy.task('stubAuthUser')
-    stubActingUser()
+    setupTestUser()
   })
 
   it('should navigate to the booking report page', () => {


### PR DESCRIPTION
We had a fair amount if duplication in the beforeEach blocks of our integration tests, which the addition of user regions made worse. We now reduce duplication by expanding the responsibilities of `stubActingUser`, which is now renamed to `setupTestUser`.