### PR TITLE
Users can download a report for their region only

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
@@ -1,5 +1,6 @@
 import type { ProbationRegion } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import { exact } from '../../../../server/utils/utils'
 import Page from '../../page'
 
 export default class BookingReportNewPage extends Page {
@@ -12,10 +13,13 @@ export default class BookingReportNewPage extends Page {
     return new BookingReportNewPage()
   }
 
-  completeForm(probationRegion: ProbationRegion): void {
-    this.getLabel('Select a probation region')
-    this.getSelectInputByIdAndSelectAnEntry('probationRegionId', probationRegion.id)
-
-    this.clickSubmit()
+  shouldPreselectProbationRegion(probationRegion: ProbationRegion): void {
+    cy.get('label')
+      .contains('Select a probation region')
+      .siblings('select')
+      .children('option')
+      .should('have.length', 2)
+      .contains(exact(probationRegion.name))
+      .should('be.selected')
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
@@ -22,4 +22,8 @@ export default class BookingReportNewPage extends Page {
       .contains(exact(probationRegion.name))
       .should('be.selected')
   }
+
+  clearForm(): void {
+    this.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
+  }
 }

--- a/e2e/tests/report.feature
+++ b/e2e/tests/report.feature
@@ -6,3 +6,8 @@ Feature: Manage Temporary Accommodation - Report
         Given I'm downloading a booking report
         And I download a report for the preselected probation region
         Then I should download a booking report
+
+    Scenario: Showing report download errors
+        Given I'm downloading a booking report
+        And I clear the preselected probation region and attempt to download a report
+        Then I should see a list of the problems encountered downloading the report

--- a/e2e/tests/report.feature
+++ b/e2e/tests/report.feature
@@ -2,12 +2,7 @@ Feature: Manage Temporary Accommodation - Report
     Background:
         Given I am logged in
 
-    Scenario: Downloading a booking report for all probation regions
-        Given I'm downloading a booking report
-        And I select to download a report for all probation regions
-        Then I should download a booking report
-
     Scenario: Downloading a booking report for a probation region
         Given I'm downloading a booking report
-        And I select a probation region to download a report for
+        And I download a report for the preselected probation region
         Then I should download a booking report

--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -3,29 +3,33 @@ import path from 'path'
 import Page from '../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import BookingReportNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingReportNew'
-import referenceDataFactory from '../../../../server/testutils/factories/referenceData'
-import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
+import probationRegionFactory from '../../../../server/testutils/factories/probationRegion'
+import { bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
+import { getUrlEncodedCypressEnv, throwMissingCypressEnvError } from '../utils'
+
+const actingUserProbationRegionId =
+  Cypress.env('acting_user_probation_region_id') || throwMissingCypressEnvError('acting_user_probation_region_id')
+const actingUserProbationRegionName =
+  getUrlEncodedCypressEnv('acting_user_probation_region_name') ||
+  throwMissingCypressEnvError('acting_user_probation_region_name')
 
 Given("I'm downloading a booking report", () => {
   const dashboardPage = Page.verifyOnPage(DashboardPage)
+
   dashboardPage.clickReportsLink()
 })
 
-Given('I select to download a report for all probation regions', () => {
+Given('I download a report for the preselected probation region', () => {
   const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
 
+  const probationRegion = probationRegionFactory.build({
+    id: actingUserProbationRegionId,
+    name: actingUserProbationRegionName,
+  })
+
+  bookingReportPage.shouldPreselectProbationRegion(probationRegion)
   bookingReportPage.expectDownload(10000)
   bookingReportPage.clickSubmit()
-
-  cy.wrap(bookingReportFilename()).as('filename')
-})
-
-Given('I select a probation region to download a report for', () => {
-  const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
-
-  const probationRegion = referenceDataFactory.probationRegion().build()
-  bookingReportPage.expectDownload(10000)
-  bookingReportPage.completeForm(probationRegion)
 
   cy.wrap(bookingReportForProbationRegionFilename(probationRegion)).as('filename')
 })

--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -34,10 +34,26 @@ Given('I download a report for the preselected probation region', () => {
   cy.wrap(bookingReportForProbationRegionFilename(probationRegion)).as('filename')
 })
 
+Given('I clear the preselected probation region and attempt to download a report', () => {
+  const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
+
+  bookingReportPage.clearForm()
+  bookingReportPage.clickSubmit()
+
+  cy.wrap(['probationRegionId']).as('missing')
+})
+
 Then('I should download a booking report', () => {
   cy.then(function _() {
     const filePath = path.join(Cypress.config('downloadsFolder'), this.filename)
 
     cy.readFile(filePath).should('have.length.above', 0)
+  })
+})
+
+Then('I should see a list of the problems encountered downloading the report', () => {
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BookingReportNewPage)
+    page.shouldShowErrorMessagesForFields(this.missing)
   })
 })

--- a/integration_tests/mockApis/report.ts
+++ b/integration_tests/mockApis/report.ts
@@ -17,15 +17,20 @@ export default {
         body: data,
       },
     }),
-  stubBookingReportError: (data: string) =>
+  stubBookingReportError: (args: { data: string; probationRegionId: string }) =>
     stubFor({
       request: {
         method: 'GET',
-        url: api.reports.bookings({}),
+        urlPath: api.reports.bookings({}),
+        queryParameters: {
+          probationRegionId: {
+            equalTo: args.probationRegionId,
+          },
+        },
       },
       response: {
         status: 500,
-        body: data,
+        body: args.data,
       },
     }),
   stubBookingReportForRegion: (args: { data: string; probationRegionId: string }) =>

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -88,6 +88,22 @@ context('Report', () => {
     })
   })
 
+  it('should show an error when the user does not select a probation region', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // When I visit the booking report page
+    cy.task('stubBookingReportReferenceData')
+    const page = BookingReportNewPage.visit()
+
+    // And I clear the probation region
+    page.clearForm()
+    page.clickSubmit()
+
+    // Then I should see an messages relating to the probation region
+    page.shouldShowErrorMessagesForFields(['probationRegionId'])
+  })
+
   it('navigates back from the booking report page to the dashboard page', () => {
     // Given I am signed in
     cy.signIn()

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -1,9 +1,8 @@
 import path from 'path'
 import premisesFactory from '../../../../server/testutils/factories/premises'
-import { bookingReportFilename, bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
+import { bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
 import Page from '../../../../cypress_shared/pages/page'
 import BookingReportNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingReportNew'
-import referenceData from '../../../../server/testutils/factories/referenceData'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import stubActingUser from '../../../../cypress_shared/utils/stubActingUser'
 
@@ -33,33 +32,6 @@ context('Report', () => {
     Page.verifyOnPage(BookingReportNewPage)
   })
 
-  it('allows me to download a booking report for all regions', () => {
-    // Given I am signed in
-    cy.signIn()
-
-    // When I visit the booking report page
-    cy.task('stubBookingReportReferenceData')
-    const page = BookingReportNewPage.visit()
-
-    // And I submit the form without choosing a region out the form
-    cy.task('stubBookingReport', 'some-data')
-
-    page.expectDownload()
-    page.clickSubmit()
-
-    // Then a report should have been requested from the API
-    cy.task('verifyBookingReport').then(requests => {
-      expect(requests).to.have.length(1)
-    })
-
-    // And the report should be downloded
-    const filePath = path.join(Cypress.config('downloadsFolder'), bookingReportFilename())
-
-    cy.readFile(filePath).then(file => {
-      expect(file).equals('some-data')
-    })
-  })
-
   it('does not download a file when the API returns an error', () => {
     // Given I am signed in
     cy.signIn()
@@ -68,8 +40,11 @@ context('Report', () => {
     cy.task('stubBookingReportReferenceData')
     const page = BookingReportNewPage.visit()
 
-    // And I submit the form without choosing a region out the form
-    cy.task('stubBookingReportError', 'some-data')
+    // And I fill out the form
+    cy.then(function _() {
+      const probationRegion = this.actingUserProbationRegion
+      cy.task('stubBookingReportError', { data: 'some-data', probationRegionId: probationRegion.id })
+    })
 
     page.expectDownload()
     page.clickSubmit()
@@ -77,7 +52,7 @@ context('Report', () => {
     cy.get('h1').contains('Internal Server Error')
   })
 
-  it('allows me to download a booking report for a region', () => {
+  it("allows me to download a booking report for the acting user's region", () => {
     // Given I am signed in
     cy.signIn()
 
@@ -85,26 +60,31 @@ context('Report', () => {
     cy.task('stubBookingReportReferenceData')
     const page = BookingReportNewPage.visit()
 
-    // And I fill out the form
-    const probationRegion = referenceData.probationRegion().build()
+    cy.then(function _() {
+      // Then I should see the user's probation region preselected
+      page.shouldPreselectProbationRegion(this.actingUserProbationRegion)
 
-    cy.task('stubBookingReportForRegion', { data: 'some-data', probationRegionId: probationRegion.id })
-    page.expectDownload()
-    page.completeForm(probationRegion)
+      // And when I fill out the form
+      const probationRegion = this.actingUserProbationRegion
 
-    // Then a report should have been requested from the API
-    cy.task('verifyBookingReportForRegion', probationRegion.id).then(requests => {
-      expect(requests).to.have.length(1)
-    })
+      cy.task('stubBookingReportForRegion', { data: 'some-data', probationRegionId: probationRegion.id })
+      page.expectDownload()
+      page.clickSubmit()
 
-    // And the report should be downloded
-    const filePath = path.join(
-      Cypress.config('downloadsFolder'),
-      bookingReportForProbationRegionFilename(probationRegion),
-    )
+      // Then a report should have been requested from the API
+      cy.task('verifyBookingReportForRegion', probationRegion.id).then(requests => {
+        expect(requests).to.have.length(1)
+      })
 
-    cy.readFile(filePath).then(file => {
-      expect(file).equals('some-data')
+      // And the report should be downloded
+      const filePath = path.join(
+        Cypress.config('downloadsFolder'),
+        bookingReportForProbationRegionFilename(probationRegion),
+      )
+
+      cy.readFile(filePath).then(file => {
+        expect(file).equals('some-data')
+      })
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.test.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, NextFunction } from 'express'
 import { createMock, DeepMocked } from '@golevelup/ts-jest'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import { BookingReportsController } from '.'
 import BookingReportService from '../../../services/bookingReportService'
 import { CallConfig } from '../../../data/restClient'
@@ -105,6 +105,22 @@ describe('BookingReportsController', () => {
         request,
         response,
         err,
+        paths.reports.bookings.new({}),
+      )
+    })
+
+    it('renders with errors if the probation region is not specified', async () => {
+      const requestHandler = bookingReportsController.create()
+
+      request.body = {}
+
+      await requestHandler(request, response, next)
+
+      expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'probationRegionId', 'empty')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        (insertGenericError as jest.MockedFunction<typeof insertGenericError>).mock.lastCall[0],
         paths.reports.bookings.new({}),
       )
     })

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
@@ -4,6 +4,7 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BookingReportService from '../../../services/bookingReportService'
 import extractCallConfig from '../../../utils/restUtils'
+import filterProbationRegions from '../../../utils/userUtils'
 
 export default class BookingReportsController {
   constructor(private readonly bookingReportService: BookingReportService) {}
@@ -17,9 +18,10 @@ export default class BookingReportsController {
       const { probationRegions: allProbationRegions } = await this.bookingReportService.getReferenceData(callConfig)
 
       return res.render('temporary-accommodation/reports/bookings/new', {
-        allProbationRegions,
+        allProbationRegions: filterProbationRegions(allProbationRegions, req),
         errors,
         errorSummary: requestErrorSummary,
+        probationRegionId: req.session.probationRegion.id,
         ...userInput,
       })
     }
@@ -31,11 +33,7 @@ export default class BookingReportsController {
         const { probationRegionId } = req.body
         const callConfig = extractCallConfig(req)
 
-        if (probationRegionId?.length) {
-          await this.bookingReportService.pipeBookingsForProbationRegion(callConfig, res, probationRegionId)
-        } else {
-          await this.bookingReportService.pipeBookings(callConfig, res)
-        }
+        await this.bookingReportService.pipeBookingsForProbationRegion(callConfig, res, probationRegionId)
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.reports.bookings.new({}))
       }

--- a/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingReportsController.ts
@@ -1,7 +1,7 @@
 import type { Request, Response, RequestHandler } from 'express'
 
 import paths from '../../../paths/temporary-accommodation/manage'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import BookingReportService from '../../../services/bookingReportService'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
@@ -32,6 +32,12 @@ export default class BookingReportsController {
       try {
         const { probationRegionId } = req.body
         const callConfig = extractCallConfig(req)
+
+        if (!probationRegionId) {
+          const error = new Error()
+          insertGenericError(error, 'probationRegionId', 'empty')
+          throw error
+        }
 
         await this.bookingReportService.pipeBookingsForProbationRegion(callConfig, res, probationRegionId)
       } catch (err) {

--- a/server/views/temporary-accommodation/reports/bookings/new.njk
+++ b/server/views/temporary-accommodation/reports/bookings/new.njk
@@ -28,7 +28,7 @@
                 text: "Select a probation region",
                 classes: "govuk-label--m"
             },
-            items: convertObjectsToSelectOptions(allProbationRegions, "All", "name", "id", "probationRegionId"),
+            items: convertObjectsToSelectOptions(allProbationRegions, 'Select a probation region', "name", "id", "probationRegionId"),
             fieldName: "probationRegionId"
           },
           fetchContext()


### PR DESCRIPTION
# Changes in this PR

* Similar to property creation/editing, the dropdown the booking report regions is limited to the users current region, which is preselected

## Screenshots of UI changes

### Before
![before1](https://user-images.githubusercontent.com/94137563/216319766-d6055624-abc7-4f9f-b562-537061abaf1a.png)

### After
![after1](https://user-images.githubusercontent.com/94137563/216319774-e6498fa7-83bf-4859-a50c-8c1e7117bbee.png)

![after2](https://user-images.githubusercontent.com/94137563/216319783-b5f1e9ea-125e-4305-a98c-3cad6b97fa57.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
