### PR TITLE
Fix E2E test environment variables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e --\
-              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},CYPRESS_acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID<< parameters.environment >>},CYPRESS_acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME<< parameters.environment >>}"  \
+              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME<< parameters.environment >>}"  \
               --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots


### PR DESCRIPTION
We were setting the wrong environment variables for the test user's probation region (we had a superfluous "CYPRESS_" in the variable name), so we fix that here