### PR TITLE
Fix error check in premises E2E tests

### DIFF
--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -66,7 +66,7 @@ Given('I attempt to create a premises with required details missing', () => {
   const page = Page.verifyOnPage(PremisesNewPage)
   page.clickSubmit()
 
-  cy.wrap(['name', 'addressLine1', 'postcode', 'probationRegionId', 'status']).as('missing')
+  cy.wrap(['name', 'addressLine1', 'postcode', 'status']).as('missing')
 })
 
 Given('I attempt to create a premises with the PDU missing', () => {


### PR DESCRIPTION
We now longer expect to see an error related to missing probation region, as this will be pre-selected