### PR TITLE
Encode E2E environment variable

### DIFF
--- a/e2e.local.env
+++ b/e2e.local.env
@@ -4,5 +4,5 @@ CYPRESS_offender_crn=X320741
 CYPRESS_offender_name="Aadland Bertrand"
 CYPRESS_keyworker_name="Kelby Tabert"
 CYPRESS_lost_bed_reason_id=2f46e769-17a5-4b5c-b04a-a5a9a5b3f773
-CYPRESS_acting_user_probation_region_id=c5acff6c-d0d2-4b89-9f4d-89a15cfa3891
-CYPRESS_acting_user_probation_region_id="North East"
+CYPRESS_acting_user_probation_region_id=a02b7727-63aa-46f2-80f1-e0b05b31903c
+CYPRESS_acting_user_probation_region_name=North%20West

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,5 +1,5 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
-import throwMissingCypressEnvError from './utils'
+import { throwMissingCypressEnvError } from './utils'
 
 Given('I am logged in', () => {
   const username = Cypress.env('username') || throwMissingCypressEnvError('username')

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -6,7 +6,7 @@ import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommod
 import bookingFactory from '../../../../server/testutils/factories/booking'
 import newBookingFactory from '../../../../server/testutils/factories/newBooking'
 import personFactory from '../../../../server/testutils/factories/person'
-import throwMissingCypressEnvError from '../utils'
+import { throwMissingCypressEnvError } from '../utils'
 
 const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('offender_crn')
 

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -10,7 +10,7 @@ import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommo
 import PremisesEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesEdit'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import Page from '../../../../cypress_shared/pages/page'
-import throwMissingCypressEnvError from '../utils'
+import { throwMissingCypressEnvError } from '../utils'
 
 const actingUserProbationRegionId =
   Cypress.env('acting_user_probation_region_id') || throwMissingCypressEnvError('acting_user_probation_region_id')

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -10,12 +10,13 @@ import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommo
 import PremisesEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesEdit'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import Page from '../../../../cypress_shared/pages/page'
-import { throwMissingCypressEnvError } from '../utils'
+import { throwMissingCypressEnvError, getUrlEncodedCypressEnv } from '../utils'
 
 const actingUserProbationRegionId =
   Cypress.env('acting_user_probation_region_id') || throwMissingCypressEnvError('acting_user_probation_region_id')
 const actingUserProbationRegionName =
-  Cypress.env('acting_user_probation_region_name') || throwMissingCypressEnvError('acting_user_probation_region_name')
+  getUrlEncodedCypressEnv('acting_user_probation_region_name') ||
+  throwMissingCypressEnvError('acting_user_probation_region_name')
 
 Given("I'm creating a premises", () => {
   const dashboardPage = Page.verifyOnPage(DashboardPage)

--- a/e2e/tests/stepDefinitions/utils.ts
+++ b/e2e/tests/stepDefinitions/utils.ts
@@ -1,5 +1,8 @@
-const throwMissingCypressEnvError = (field: string) => {
+export const throwMissingCypressEnvError = (field: string) => {
   throw new Error(`Missing Cypress env variable for '${field}'`)
 }
 
-export default throwMissingCypressEnvError
+export const getUrlEncodedCypressEnv = (field: string) => {
+  const value = Cypress.env(field)
+  return value && decodeURI(value)
+}


### PR DESCRIPTION
We need to pass our test user's probation region name into Cypress. However, this may contain a comma, and Cypress does not support values containing commas. See https://github.com/cypress-io/cypress/issues/4543

We solve this by urlencoding the value, and decoding it within the test