### PR TITLE
Use decodeURIComponent in getUrlEncodedCypressEnv

### DIFF
--- a/e2e/tests/stepDefinitions/utils.ts
+++ b/e2e/tests/stepDefinitions/utils.ts
@@ -4,5 +4,5 @@ export const throwMissingCypressEnvError = (field: string) => {
 
 export const getUrlEncodedCypressEnv = (field: string) => {
   const value = Cypress.env(field)
-  return value && decodeURI(value)
+  return value && decodeURIComponent(value)
 }


### PR DESCRIPTION
We use decodeURIComponent rather than decodeURI, as only URI *component* encoding encodes commas, which is what we want