### PR TITLE
Fix premises alias in E2E tests

### DIFF
--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -43,7 +43,9 @@ Given("I'm viewing an existing premises", () => {
   premisesListPage.samplePremises(1, 'premisesList')
 
   cy.then(function _() {
-    premisesListPage.clickPremisesViewLink(this.premisesList[0])
+    const premises = this.premisesList[0]
+    cy.wrap(premises).as('premises')
+    premisesListPage.clickPremisesViewLink(premises)
   })
 })
 


### PR DESCRIPTION
We previously changed our "I'm viewing an existing premises" E2E test step to alias a single-element array containing a premises as 'premisesList', when previously it had been aliasing this single premises as 'premises'.

This broke our bedspace and bookings E2E tests, as these depended on a premises being aliased to 'premises'. We now alias the single element from 'premisesList' as 'premises', restoring our bedspace and bookings tests