### PR TITLE
Add debug sentry endpoint

### DIFF
--- a/integration_tests/tests/health.cy.ts
+++ b/integration_tests/tests/health.cy.ts
@@ -27,4 +27,13 @@ context('Healthcheck', () => {
       })
     })
   })
+
+  context('Sentry check', () => {
+    it('Throws a test error', () => {
+      cy.request({ url: '/debug-sentry', method: 'GET', failOnStatusCode: false }).then(response => {
+        expect(response.status).to.equal(500)
+        expect(response.body).to.contain('Test Sentry error thrown.')
+      })
+    })
+  })
 })

--- a/server/middleware/setUpHealthChecks.ts
+++ b/server/middleware/setUpHealthChecks.ts
@@ -20,5 +20,9 @@ export default function setUpHealthChecks(): Router {
     }),
   )
 
+  router.get('/debug-sentry', (_req, res) => {
+    throw new Error('Test Sentry error thrown.')
+  })
+
   return router
 }


### PR DESCRIPTION

# Context

Our goal is to have confidence production errors are being tracking for this app. Currently the prod environment isn't appearing at all. No errors, no transactions, just some session info for the dev and test environment.

However, when we make the AP UI throw an error we can see errors come through!

We follow this sentry guide for node to force an error from the frontend to test the connection: https://docs.sentry.io/platforms/node/guides/expressc

This will confirm our only slight theory is that receiving an error forces the environment to be recognised.

I really wanted to add a simple request test for this but fell into a rabbit hole. Is this the type of thing that's possibel without using jest and mocks? I wanted to write the following and would be eager to know if something like it is possible:

```
describe "sentry"
  it "returns a 500 error"
    expect{ get "/debug-sentry" }.to raise_error(Error('Test Sentry error thrown.'))
```

## Screenshots of UI changes

![Screenshot 2023-02-20 at 17 13 43](https://user-images.githubusercontent.com/912473/220168625-4547c001-a779-4977-a50a-1f9965495f55.png)



# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
