### PR TITLE
New booking confirmation page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
@@ -1,0 +1,26 @@
+import type { Booking, Premises, Room } from '@approved-premises/api'
+
+import paths from '../../../../server/paths/temporary-accommodation/manage'
+import Page from '../../page'
+
+export default class BookingConfirmPage extends Page {
+  constructor(private readonly premises: Premises, private readonly room: Room, private readonly booking?: Booking) {
+    super('Confirm CRN')
+  }
+
+  static visit(premises: Premises, room: Room, booking: Booking): BookingConfirmPage {
+    cy.visit(paths.bookings.confirm({ premisesId: premises.id, roomId: room.id }))
+    return new BookingConfirmPage(premises, room, booking)
+  }
+
+  shouldShowBookingDetails(): void {
+    cy.get('.location-header').within(() => {
+      if (this.booking) {
+        cy.get('p').should('contain', this.booking.person.crn)
+      }
+      cy.get('p').should('contain', this.room.name)
+      cy.get('p').should('contain', this.premises.addressLine1)
+      cy.get('p').should('contain', this.premises.postcode)
+    })
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -15,4 +15,11 @@ export default class BookingNewPage extends BookingEditablePage {
   completeForm(newBooking: NewBooking): void {
     super.completeEditableForm(newBooking)
   }
+
+  shouldShowPrefilledBookingDetails(newBooking: NewBooking): void {
+    this.shouldShowDateInputs('arrivalDate', newBooking.arrivalDate)
+    this.shouldShowDateInputs('departureDate', newBooking.departureDate)
+
+    cy.get('#crn').should('have.value', newBooking.crn)
+  }
 }

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -1,6 +1,7 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import Page from '../../../../cypress_shared/pages/page'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import BookingConfirmPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirm'
 import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import bookingFactory from '../../../../server/testutils/factories/booking'
@@ -20,7 +21,7 @@ Given("I'm creating a booking", () => {
 
 Given('I create a booking with all necessary details', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingNewPage)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage)
 
     const newBooking = newBookingFactory.build({
       crn: offenderCrn,
@@ -33,15 +34,28 @@ Given('I create a booking with all necessary details', () => {
       }),
     })
 
+    bookingNewPage.completeForm(newBooking)
+
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, booking)
+    bookingConfirmPage.shouldShowBookingDetails()
+
+    bookingConfirmPage.clickSubmit()
+
     cy.wrap(booking).as('booking')
     this.historicBookings.push(booking)
-    page.completeForm(newBooking)
   })
 })
 
 Given('I attempt to create a booking with required details missing', () => {
-  const page = Page.verifyOnPage(BookingNewPage)
-  page.clickSubmit()
+  cy.then(function _() {
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage)
+    bookingNewPage.clickSubmit()
+
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room)
+    bookingConfirmPage.shouldShowBookingDetails()
+
+    bookingConfirmPage.clickSubmit()
+  })
 })
 
 Then('I should see a confirmation for my new booking', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -176,6 +176,7 @@ context('Booking', () => {
     page.completeForm(newBooking)
 
     // Then I should see error messages for the date fields
+    page.shouldShowPrefilledBookingDetails(newBooking)
     page.shouldShowDateConflictErrorMessages()
   })
 

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -3,7 +3,6 @@ import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommo
 import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
-import bedFactory from '../../../../server/testutils/factories/bed'
 import bookingFactory from '../../../../server/testutils/factories/booking'
 import newBookingFactory from '../../../../server/testutils/factories/newBooking'
 import premisesFactory from '../../../../server/testutils/factories/premises'
@@ -45,9 +44,7 @@ context('Booking', () => {
     const room = roomFactory.build()
     const bookings = bookingFactory
       .params({
-        bed: bedFactory.build({
-          id: room.beds[0].id,
-        }),
+        bed: room.beds[0],
       })
       .buildList(5)
 
@@ -81,11 +78,7 @@ context('Booking', () => {
     const page = BookingNewPage.visit(premises.id, room.id)
 
     // And I fill out the form
-    const booking = bookingFactory.build({
-      bed: bedFactory.build({
-        id: room.beds[0].id,
-      }),
-    })
+    const booking = bookingFactory.build()
     const newBooking = newBookingFactory.build({
       ...booking,
     })
@@ -173,11 +166,7 @@ context('Booking', () => {
     const page = BookingNewPage.visit(premises.id, room.id)
 
     // And I fill out the form with dates that conflict with an existing booking
-    const booking = bookingFactory.build({
-      bed: bedFactory.build({
-        id: room.beds[0].id,
-      }),
-    })
+    const booking = bookingFactory.build()
     const newBooking = newBookingFactory.build({
       ...booking,
     })
@@ -240,9 +229,7 @@ context('Booking', () => {
     const room = roomFactory.build()
     const bookings = bookingFactory
       .params({
-        bed: bedFactory.build({
-          id: room.beds[0].id,
-        }),
+        bed: room.beds[0],
       })
       .buildList(5)
 

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -1,13 +1,13 @@
-import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
-import premisesFactory from '../../../../server/testutils/factories/premises'
-import roomFactory from '../../../../server/testutils/factories/room'
-import bookingFactory from '../../../../server/testutils/factories/booking'
-import bedFactory from '../../../../server/testutils/factories/bed'
-import newBookingFactory from '../../../../server/testutils/factories/newBooking'
 import Page from '../../../../cypress_shared/pages/page'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import bedFactory from '../../../../server/testutils/factories/bed'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import newBookingFactory from '../../../../server/testutils/factories/newBooking'
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
 
 context('Booking', () => {
   beforeEach(() => {

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -222,6 +222,38 @@ context('Booking', () => {
     Page.verifyOnPage(BedspaceShowPage, premises)
   })
 
+  it('navigates back from the confirm booking page to the new booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a room the database
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSingleRoom', { premisesId: premises.id, room })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises.id, room.id)
+
+    // And I fill out the form
+    const booking = bookingFactory.build()
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // And I click the back link
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, room, booking)
+    bookingConfirmPage.clickBack()
+
+    // Then I navigate to the new booking page
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage)
+    returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
+  })
+
   it('shows a single booking', () => {
     // Given I am signed in
     cy.signIn()

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -128,8 +128,6 @@ describe('BookingsController', () => {
       }
       request.body = {
         ...newBooking,
-        ...DateFormats.convertIsoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
-        ...DateFormats.convertIsoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
       }
 
       bedspaceService.getRoom.mockResolvedValue(room)

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -1,22 +1,22 @@
-import type { NextFunction, Request, Response } from 'express'
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
+import type { NextFunction, Request, Response } from 'express'
+import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import { BookingService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
-import premisesFactory from '../../../testutils/factories/premises'
-import roomFactory from '../../../testutils/factories/room'
 import bookingFactory from '../../../testutils/factories/booking'
 import newBookingFactory from '../../../testutils/factories/newBooking'
-import { BookingService, PremisesService } from '../../../services'
-import BookingsController from './bookingsController'
-import { DateFormats } from '../../../utils/dateUtils'
+import premisesFactory from '../../../testutils/factories/premises'
+import roomFactory from '../../../testutils/factories/room'
 import { bookingActions, deriveBookingHistory } from '../../../utils/bookingUtils'
-import { CallConfig } from '../../../data/restClient'
+import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import BookingsController from './bookingsController'
 
-jest.mock('../../../utils/validation')
 jest.mock('../../../utils/bookingUtils')
 jest.mock('../../../utils/restUtils')
+jest.mock('../../../utils/validation')
 
 describe('BookingsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -7,7 +7,12 @@ import BedspaceService from '../../../services/bedspaceService'
 import { bookingActions, deriveBookingHistory } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import {
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  insertGenericError,
+  setUserInput,
+} from '../../../utils/validation'
 
 export default class BookingsController {
   constructor(
@@ -32,6 +37,31 @@ export default class BookingsController {
         errors,
         errorSummary: requestErrorSummary,
         ...userInput,
+      })
+    }
+  }
+
+  confirm(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const { premisesId, roomId } = req.params
+      const { crn } = req.body
+
+      const { arrivalDate } = DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'arrivalDate')
+      const { departureDate } = DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'departureDate')
+
+      const callConfig = extractCallConfig(req)
+
+      const premises = await this.premisesService.getPremises(callConfig, premisesId)
+      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+
+      setUserInput(req)
+
+      return res.render('temporary-accommodation/bookings/confirm', {
+        premises,
+        room,
+        crn,
+        arrivalDate,
+        departureDate,
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -76,8 +76,6 @@ export default class BookingsController {
       const newBooking: NewBooking = {
         service: 'temporary-accommodation',
         ...req.body,
-        ...DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'arrivalDate'),
-        ...DateFormats.convertDateAndTimeInputsToIsoString(req.body, 'departureDate'),
       }
 
       try {

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -3,11 +3,11 @@ import type { Request, RequestHandler, Response } from 'express'
 import type { NewBooking } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { BookingService, PremisesService } from '../../../services'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import BedspaceService from '../../../services/bedspaceService'
-import { DateFormats } from '../../../utils/dateUtils'
 import { bookingActions, deriveBookingHistory } from '../../../utils/bookingUtils'
+import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 
 export default class BookingsController {
   constructor(

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -35,6 +35,7 @@ const paths = {
   },
   bookings: {
     new: bookingsPath.path('new'),
+    confirm: bookingsPath.path('confirm'),
     create: bookingsPath,
     show: singleBookingPath,
     history: singleBookingPath.path('history'),

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -81,6 +81,9 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.premises.bedspaces.show.pattern, bedspacesController.show(), { auditEvent: 'VIEW_BEDSPACE' })
 
   get(paths.bookings.new.pattern, bookingsController.new(), { auditEvent: 'VIEW_BOOKING_CREATE' })
+  post(paths.bookings.confirm.pattern, bookingsController.confirm(), {
+    auditEvent: 'VIEW_BOOKING_CONFIRM',
+  })
   post(paths.bookings.create.pattern, bookingsController.create(), {
     redirectAuditEventSpecs: [
       {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -11,6 +11,7 @@ import {
   catchValidationErrorOrPropogate,
   fetchErrorsAndUserInput,
   insertGenericError,
+  setUserInput,
 } from './validation'
 
 jest.mock('../i18n/en/errors.json', () => {
@@ -220,6 +221,20 @@ describe('fetchErrorsAndUserInput', () => {
     const result = fetchErrorsAndUserInput(request)
 
     expect(result).toEqual({ errors, errorSummary, userInput })
+  })
+})
+
+describe('setUserInput', () => {
+  const request = createMock<Request>({})
+
+  it('sets the request body as the user input flash message', () => {
+    request.body = {
+      some: 'field',
+    }
+
+    setUserInput(request)
+
+    expect(request.flash).toHaveBeenCalledWith('userInput', request.body)
   })
 })
 

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,17 +1,17 @@
-import { Request, Response } from 'express'
 import { createMock } from '@golevelup/ts-jest'
+import { Request, Response } from 'express'
 
 import type { ErrorMessages, ErrorSummary } from '@approved-premises/ui'
+import type TaskListPage from '../form-pages/tasklistPage'
+import errorLookups from '../i18n/en/errors.json'
 import { SanitisedError } from '../sanitisedError'
+import { TasklistAPIError, ValidationError } from './errors'
 import {
   catchAPIErrorOrPropogate,
   catchValidationErrorOrPropogate,
   fetchErrorsAndUserInput,
   insertGenericError,
 } from './validation'
-import errorLookups from '../i18n/en/errors.json'
-import { TasklistAPIError, ValidationError } from './errors'
-import type TaskListPage from '../form-pages/tasklistPage'
 
 jest.mock('../i18n/en/errors.json', () => {
   return {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -2,8 +2,8 @@ import type { Request, Response } from 'express'
 import jsonpath from 'jsonpath'
 
 import type { ErrorMessage, ErrorMessages, ErrorSummary, ErrorsAndUserInput } from '@approved-premises/ui'
-import { SanitisedError } from '../sanitisedError'
 import errorLookup from '../i18n/en/errors.json'
+import { SanitisedError } from '../sanitisedError'
 import { TasklistAPIError } from './errors'
 
 interface InvalidParams {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -57,6 +57,10 @@ export const fetchErrorsAndUserInput = (request: Request): ErrorsAndUserInput =>
   return { errors, errorSummary, userInput }
 }
 
+export const setUserInput = (request: Request): void => {
+  request.flash('userInput', request.body)
+}
+
 export const errorSummary = (field: string, text: string): ErrorSummary => {
   return {
     text,

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -1,0 +1,53 @@
+{% extends "../../partials/layout.njk" %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% set pageTitle = applicationName + " - Book bedspace" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.bookings.new({ premisesId: premises.id, roomId: room.id })
+  }) }}
+  
+  <h1>Confirm CRN</h1>
+
+  <p>Confirm that the CRN is correct. This information cannot be changed once a bedspace has been booked.</p>
+
+  <div class="location-header">
+    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ crn }}</p>
+
+    <h2>Bedspace reference</h2>
+    <p>{{ room.name }}</p>
+
+    <h2>Property address</h2>
+    <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
+  </div>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.bookings.create({ premisesId: premises.id, roomId: room.id }) }}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        <input type="hidden" name="crn" value="{{ crn }}"/>
+        <input type="hidden" name="arrivalDate" value="{{ arrivalDate }}"/>
+        <input type="hidden" name="departureDate" value="{{ departureDate }}"/>
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Back",
+            classes: "govuk-button--secondary",
+            href: paths.bookings.new({ premisesId: premises.id, roomId: room.id })
+          }) }}
+          {{ govukButton({
+            text: "Submit"
+          }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -29,7 +29,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.create({ premisesId: premises.id, roomId: room.id }) }}" method="post">
+      <form action="{{ paths.bookings.confirm({ premisesId: premises.id, roomId: room.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
       
         {% include "./_editable.njk" %}  


### PR DESCRIPTION
# Changes in this PR

This PR adds an intermediate confirmation screen between the new booking page, where the user enters the CRN and the booking dates, and creating the booking.

A known issue is that this makes the flow less pleasant if there are any errors - blank fields, non-existent CRN, overlapping dates, etc., as the user will go from the form, to the confirm page, then back to the form with the errors. This cannot be fully addressed without making changes to the API

## Screenshots of UI changes

![localhost_3000_properties_b6a87a7e-1b6a-4c96-b7ff-8c0dc414796d_bedspaces_467deeb6-33ca-4d34-8713-60faaf230318_bookings_confirm](https://user-images.githubusercontent.com/94137563/220372908-b1a241bb-13c7-48f1-95e4-842f4b0209cb.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
