### PR TITLE
Update reference field text for premises and bedspaces

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceNew.ts
@@ -22,7 +22,7 @@ export default class BedspaceNewPage extends BedspaceEditablePage {
   }
 
   completeForm(newRoom: NewRoom): void {
-    this.getLabel('Enter a reference name')
+    this.getLabel('Enter a reference')
     this.getTextInputByIdAndEnterDetails('name', newRoom.name)
 
     super.completeEditableForm(newRoom)

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
@@ -14,7 +14,7 @@ export default class PremisesNewPage extends PremisesEditablePage {
   }
 
   completeForm(newPremises: NewPremises): void {
-    this.getLabel('Enter a reference name')
+    this.getLabel('Enter a reference')
     this.getTextInputByIdAndEnterDetails('name', newPremises.name)
 
     super.completeEditableForm(newPremises)

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -12,8 +12,8 @@
       "isInFuture": "The submitted at date must be in the past"
     },
     "name": {
-      "empty": "You must enter a name",
-      "notUnique": "The name must be unique to this property"
+      "empty": "You must enter a reference",
+      "notUnique": "The reference must be unique to this property"
     },
     "arrivalDate": {
       "empty": "You must enter a start date",

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -34,7 +34,7 @@
 
         {{ govukInput({
           label: {
-            text: "Enter a reference name",
+            text: "Enter a reference",
             classes: "govuk-label--m"
           },
           hint: {

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -25,7 +25,7 @@
 
         {{ govukInput({
           label: {
-            text: "Enter a reference name",
+            text: "Enter a reference",
             classes: "govuk-label--m"
           },
           hint: {


### PR DESCRIPTION
We want the user to enter a unique reference for premises and bedspaces. We remove the word "name" to reduce the emphasis on this being human readable, and update the associated error messages for this field