### PR TITLE
Extract reusable location header component

### DIFF
--- a/cypress_shared/components/locationHeader.ts
+++ b/cypress_shared/components/locationHeader.ts
@@ -1,0 +1,45 @@
+import { Premises, Room } from '../../server/@types/shared'
+import Component from './component'
+
+export default class LocationHeaderComponent extends Component {
+  constructor(
+    private readonly details: { premises?: Premises; room?: Room; crn?: string },
+    private readonly hideAddress: boolean = false,
+  ) {
+    super()
+  }
+
+  shouldShowLocationDetails(): void {
+    const { premises, room, crn } = this.details
+
+    cy.get('.location-header').within(() => {
+      if (room) {
+        cy.get('h2').contains('Bedspace reference').siblings('p').should('contain', room.name)
+      } else {
+        cy.contains('Bedspace reference').should('not.exist')
+      }
+
+      if (premises) {
+        cy.get('h2').contains('Property reference').siblings('p').should('contain', premises.name)
+      } else {
+        cy.contains('Property reference').should('not.exist')
+      }
+
+      if (premises && !this.hideAddress) {
+        cy.get('h2')
+          .contains('Property address')
+          .siblings('p')
+          .should('contain', premises.addressLine1)
+          .should('contain', premises.postcode)
+      } else {
+        cy.contains('Property address').should('not.exist')
+      }
+
+      if (crn) {
+        cy.get('p').should('contain', `CRN: ${crn}`)
+      } else {
+        cy.contains(`CRN: ${crn}`).should('not.exist')
+      }
+    })
+  }
+}

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -6,7 +6,7 @@ import Component from '../components/component'
 export type PageElement = Cypress.Chainable<JQuery>
 
 export default abstract class Page extends Component {
-  static verifyOnPage<T>(constructor: new (...args: unknown[]) => T, ...args: unknown[]): T {
+  static verifyOnPage<T, Args extends unknown[]>(constructor: new (...args: Args) => T, ...args: Args): T {
     return new constructor(...args)
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
@@ -1,10 +1,15 @@
 import type { Premises, Room, UpdateRoom } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import BedspaceEditablePage from './bedspaceEditable'
 
 export default class BedspaceEditPage extends BedspaceEditablePage {
-  constructor(private readonly premises: Premises, private readonly room: Room) {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
+  constructor(premises: Premises, private readonly room: Room) {
     super('Edit a bedspace')
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
   static visit(premises: Premises, room: Room): BedspaceEditPage {
@@ -13,12 +18,7 @@ export default class BedspaceEditPage extends BedspaceEditablePage {
   }
 
   shouldShowBedspaceDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.room.name)
-      cy.get('p').should('contain', this.premises.name)
-      cy.get('p').should('contain', this.premises.addressLine1)
-      cy.get('p').should('contain', this.premises.postcode)
-    })
+    this.locationHeaderComponent.shouldShowLocationDetails()
 
     cy.get('legend')
       .contains('Does the bedspace have any of the following attributes?')

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceNew.ts
@@ -1,11 +1,16 @@
 import type { NewRoom } from '@approved-premises/api'
 import { Premises } from '../../../../server/@types/shared'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import BedspaceEditablePage from './bedspaceEditable'
 
 export default class BedspaceNewPage extends BedspaceEditablePage {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   constructor(private readonly premises: Premises) {
     super('Add a bedspace')
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises })
   }
 
   static visit(premises: Premises): BedspaceNewPage {
@@ -14,11 +19,7 @@ export default class BedspaceNewPage extends BedspaceEditablePage {
   }
 
   shouldShowBedspaceDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.premises.name)
-      cy.get('p').should('contain', this.premises.addressLine1)
-      cy.get('p').should('contain', this.premises.postcode)
-    })
+    this.locationHeaderComponent.shouldShowLocationDetails()
   }
 
   completeForm(newRoom: NewRoom): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -1,20 +1,28 @@
 import type { Booking, Room } from '@approved-premises/api'
 
+import { Premises } from '../../../../server/@types/shared'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BedspaceShowPage extends Page {
-  constructor(private readonly room: Room) {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
+  constructor(premises: Premises, private readonly room: Room) {
     super('View a bedspace')
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises })
   }
 
-  static visit(premisesId: string, room: Room): BedspaceShowPage {
-    cy.visit(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))
-    return new BedspaceShowPage(room)
+  static visit(premises: Premises, room: Room): BedspaceShowPage {
+    cy.visit(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))
+    return new BedspaceShowPage(premises, room)
   }
 
   shouldShowBedspaceDetails(): void {
+    this.locationHeaderComponent.shouldShowLocationDetails()
+
     cy.get('h2').should('contain', this.room.name)
 
     this.shouldShowKeyAndValues(

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -1,8 +1,8 @@
 import type { Booking, NewArrival } from '@approved-premises/api'
-import paths from '../../../../server/paths/temporary-accommodation/manage'
-import Page from '../../page'
 import errorLookups from '../../../../server/i18n/en/errors.json'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import Page from '../../page'
 
 export default class BookingArrivalNewPage extends Page {
   private readonly bookingInfoComponent: BookingInfoComponent

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -2,15 +2,19 @@ import type { Booking, NewArrival } from '@approved-premises/api'
 import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingArrivalNewPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(private readonly booking: Booking) {
     super('Mark booking as active')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)
+    this.locationHeaderComponent = new LocationHeaderComponent({ crn: this.booking.person.crn })
   }
 
   static visit(premisesId: string, roomId: string, booking: Booking): BookingArrivalNewPage {
@@ -19,10 +23,7 @@ export default class BookingArrivalNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-    })
-
+    this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('arrivalDate', this.booking.arrivalDate)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
@@ -1,15 +1,19 @@
 import type { Booking, NewCancellation } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingCancellationNewPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(private readonly booking: Booking) {
     super('Cancel booking')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)
+    this.locationHeaderComponent = new LocationHeaderComponent({ crn: booking.person.crn })
   }
 
   static visit(premisesId: string, roomId: string, booking: Booking): BookingCancellationNewPage {
@@ -18,10 +22,7 @@ export default class BookingCancellationNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-    })
-
+    this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('date', this.booking.departureDate)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
@@ -1,11 +1,16 @@
 import type { Booking, Premises, Room } from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingConfirmPage extends Page {
-  constructor(private readonly premises: Premises, private readonly room: Room, private readonly booking?: Booking) {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
+  constructor(premises: Premises, room: Room, booking?: Booking) {
     super('Confirm CRN')
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking?.person.crn })
   }
 
   static visit(premises: Premises, room: Room, booking: Booking): BookingConfirmPage {
@@ -14,13 +19,6 @@ export default class BookingConfirmPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      if (this.booking) {
-        cy.get('p').should('contain', this.booking.person.crn)
-      }
-      cy.get('p').should('contain', this.room.name)
-      cy.get('p').should('contain', this.premises.addressLine1)
-      cy.get('p').should('contain', this.premises.postcode)
-    })
+    this.locationHeaderComponent.shouldShowLocationDetails()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
@@ -1,14 +1,18 @@
 import type { Booking, NewConfirmation } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingConfirmationNewPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(private readonly booking: Booking) {
+  constructor(booking: Booking) {
     super('Mark booking as confirmed')
 
+    this.locationHeaderComponent = new LocationHeaderComponent({ crn: booking.person.crn })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -18,10 +22,7 @@ export default class BookingConfirmationNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-    })
-
+    this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -1,14 +1,18 @@
 import type { Booking, NewDeparture } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingDepartureNewPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(private readonly booking: Booking) {
     super('Mark booking as closed')
 
+    this.locationHeaderComponent = new LocationHeaderComponent({ crn: booking.person.crn })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -18,10 +22,7 @@ export default class BookingDepartureNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-    })
-
+    this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('dateTime', this.booking.departureDate)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -3,14 +3,18 @@ import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { getLatestExtension } from '../../../../server/utils/bookingUtils'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingExtensionNewPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(private readonly booking: Booking) {
     super('Extend or shorten booking')
 
+    this.locationHeaderComponent = new LocationHeaderComponent({ crn: booking.person.crn })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -20,10 +24,7 @@ export default class BookingExtensionNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-    })
-
+    this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowDateInputs('newDepartureDate', this.booking.departureDate)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -1,9 +1,9 @@
 import type { Booking, NewExtension } from '@approved-premises/api'
-import paths from '../../../../server/paths/temporary-accommodation/manage'
-import Page from '../../page'
 import errorLookups from '../../../../server/i18n/en/errors.json'
-import BookingInfoComponent from '../../../components/bookingInfo'
+import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { getLatestExtension } from '../../../../server/utils/bookingUtils'
+import BookingInfoComponent from '../../../components/bookingInfo'
+import Page from '../../page'
 
 export default class BookingExtensionNewPage extends Page {
   private readonly bookingInfoComponent: BookingInfoComponent

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
@@ -2,19 +2,18 @@ import type { Booking, Premises, Room } from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingHistoryPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponents: BookingInfoComponent[]
 
-  constructor(
-    private readonly premises: Premises,
-    private readonly room: Room,
-    private readonly booking: Booking,
-    historicBookings: Booking[],
-  ) {
+  constructor(premises: Premises, room: Room, booking: Booking, historicBookings: Booking[]) {
     super('Booking history')
 
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
     this.bookingInfoComponents = historicBookings.map(historicBooking => new BookingInfoComponent(historicBooking))
   }
 
@@ -24,12 +23,7 @@ export default class BookingHistoryPage extends Page {
   }
 
   shouldShowBookingHistory(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-      cy.get('p').should('contain', this.room.name)
-      cy.get('p').should('contain', this.premises.addressLine1)
-      cy.get('p').should('contain', this.premises.postcode)
-    })
+    this.locationHeaderComponent.shouldShowLocationDetails()
 
     this.bookingInfoComponents.forEach((bookingInfoComponent, index) => {
       cy.get(`[data-cy-history-index="${index}"]`).within(() => {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
@@ -1,8 +1,8 @@
 import type { Booking, Premises, Room } from '@approved-premises/api'
 
-import Page from '../../page'
-import BookingInfoComponent from '../../../components/bookingInfo'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import BookingInfoComponent from '../../../components/bookingInfo'
+import Page from '../../page'
 
 export default class BookingHistoryPage extends Page {
   private readonly bookingInfoComponents: BookingInfoComponent[]

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -1,19 +1,29 @@
 import type { NewBooking } from '@approved-premises/api'
+import { Premises, Room } from '../../../../server/@types/shared'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import BookingEditablePage from './bookingEditable'
 
 export default class BookingNewPage extends BookingEditablePage {
-  constructor() {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
+  constructor(premises: Premises, room: Room) {
     super('Book bedspace')
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
-  static visit(premisesId: string, roomId: string): BookingNewPage {
-    cy.visit(paths.bookings.new({ premisesId, roomId }))
-    return new BookingNewPage()
+  static visit(premises: Premises, room: Room): BookingNewPage {
+    cy.visit(paths.bookings.new({ premisesId: premises.id, roomId: room.id }))
+    return new BookingNewPage(premises, room)
   }
 
   completeForm(newBooking: NewBooking): void {
     super.completeEditableForm(newBooking)
+  }
+
+  shouldShowBookingDetails(): void {
+    this.locationHeaderComponent.shouldShowLocationDetails()
   }
 
   shouldShowPrefilledBookingDetails(newBooking: NewBooking): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -1,8 +1,8 @@
 import type { Booking, Premises, Room } from '@approved-premises/api'
 
-import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import Page from '../../page'
 
 export default class BookingShowPage extends Page {
   private readonly bookingInfoComponent: BookingInfoComponent

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -7,7 +7,7 @@ import Page from '../../page'
 export default class BookingShowPage extends Page {
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(private readonly premises: Premises, private readonly room: Room, private readonly booking: Booking) {
+  constructor(premises: Premises, room: Room, booking: Booking) {
     super('View a booking')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -2,14 +2,18 @@ import type { Booking, Premises, Room } from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import Page from '../../page'
 
 export default class BookingShowPage extends Page {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(premises: Premises, room: Room, booking: Booking) {
     super('View a booking')
 
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -58,13 +62,7 @@ export default class BookingShowPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.booking.person.crn)
-      cy.get('p').should('contain', this.room.name)
-      cy.get('p').should('contain', this.premises.addressLine1)
-      cy.get('p').should('contain', this.premises.postcode)
-    })
-
+    this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -2,11 +2,16 @@ import type { TemporaryAccommodationPremises as Premises, UpdatePremises } from 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { formatStatus } from '../../../../server/utils/premisesUtils'
 import { exact } from '../../../../server/utils/utils'
+import LocationHeaderComponent from '../../../components/locationHeader'
 import PremisesEditablePage from './premisesEditable'
 
 export default class PremisesEditPage extends PremisesEditablePage {
+  private readonly locationHeaderComponent: LocationHeaderComponent
+
   constructor(private readonly premises: Premises) {
     super('Edit a property')
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises }, true)
   }
 
   static visit(premises: Premises): PremisesEditPage {
@@ -15,9 +20,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
   }
 
   shouldShowPremisesDetails(): void {
-    cy.get('.location-header').within(() => {
-      cy.get('p').should('contain', this.premises.name)
-    })
+    this.locationHeaderComponent.shouldShowLocationDetails()
 
     cy.get('label').contains('Address line 1').siblings('input').should('have.value', this.premises.addressLine1)
     cy.get('label').contains('Address line 2').siblings('input').should('have.value', this.premises.addressLine2)

--- a/e2e/tests/stepDefinitions/manage/arrival.ts
+++ b/e2e/tests/stepDefinitions/manage/arrival.ts
@@ -53,7 +53,7 @@ Then('I should see the booking with the arrived status', () => {
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premise, this.room)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })

--- a/e2e/tests/stepDefinitions/manage/arrival.ts
+++ b/e2e/tests/stepDefinitions/manage/arrival.ts
@@ -39,7 +39,7 @@ Given('I attempt to mark the booking as arrived with required details missing', 
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
     bookingShowPage.clickMarkArrivedBookingButton()
 
-    const bookingArrivalPage = Page.verifyOnPage(BookingArrivalNewPage, this.premises.id, this.room.id, this.booking)
+    const bookingArrivalPage = Page.verifyOnPage(BookingArrivalNewPage, this.booking)
     bookingArrivalPage.clearForm()
     bookingArrivalPage.clickSubmit()
   })
@@ -60,7 +60,7 @@ Then('I should see the booking with the arrived status', () => {
 
 Then('I should see a list of the problems encountered marking the booking as arrived', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingArrivalNewPage, this.premises.id, this.room.id, this.booking)
+    const page = Page.verifyOnPage(BookingArrivalNewPage, this.booking)
 
     page.shouldShowErrorMessagesForFields(['arrivalDate', 'expectedDepartureDate'])
   })

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -38,7 +38,7 @@ Given('I create a bedspace with all necessary details', () => {
 
 Given("I'm editing the bedspace", () => {
   cy.then(function _() {
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     bedspaceShowPage.clickBedspaceEditLink()
 
     const bedspaceEditPage = Page.verifyOnPage(BedspaceEditPage, this.premises, this.room)
@@ -66,8 +66,8 @@ Given('I edit the bedspace details', () => {
 })
 
 Then('I should see a confirmation for my new bedspace', () => {
-  cy.get('@room').then(room => {
-    const page = Page.verifyOnPage(BedspaceShowPage, room)
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     page.shouldShowBanner('Bedspace created')
 
     page.shouldShowBedspaceDetails()
@@ -75,8 +75,8 @@ Then('I should see a confirmation for my new bedspace', () => {
 })
 
 Then('I should see a confirmation for my updated bedspace', () => {
-  cy.get('@room').then(room => {
-    const page = Page.verifyOnPage(BedspaceShowPage, room)
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     page.shouldShowBanner('Bedspace updated')
 
     page.shouldShowBedspaceDetails()

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -13,8 +13,12 @@ const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('
 
 Given("I'm creating a booking", () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BedspaceShowPage, this.premise, this.room)
-    page.clickBookBedspaceLink()
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premise, this.room)
+    bedspaceShowPage.clickBookBedspaceLink()
+
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    bookingNewPage.shouldShowBookingDetails()
+
     cy.wrap([]).as('historicBookings')
   })
 })
@@ -48,7 +52,7 @@ Given('I create a booking with all necessary details', () => {
 
 Given('I attempt to create a booking with required details missing', () => {
   cy.then(function _() {
-    const bookingNewPage = Page.verifyOnPage(BookingNewPage)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
     bookingNewPage.clickSubmit()
 
     const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room)

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -12,8 +12,8 @@ import { throwMissingCypressEnvError } from '../utils'
 const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('offender_crn')
 
 Given("I'm creating a booking", () => {
-  cy.get('@room').then(room => {
-    const page = Page.verifyOnPage(BedspaceShowPage, room)
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BedspaceShowPage, this.premise, this.room)
     page.clickBookBedspaceLink()
     cy.wrap([]).as('historicBookings')
   })
@@ -21,7 +21,7 @@ Given("I'm creating a booking", () => {
 
 Given('I create a booking with all necessary details', () => {
   cy.then(function _() {
-    const bookingNewPage = Page.verifyOnPage(BookingNewPage)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
 
     const newBooking = newBookingFactory.build({
       crn: offenderCrn,
@@ -66,12 +66,14 @@ Then('I should see a confirmation for my new booking', () => {
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })
 
 Then('I should see a list of the problems encountered creating the booking', () => {
-  const page = Page.verifyOnPage(BookingNewPage)
-  page.shouldShowErrorMessagesForFields(['crn', 'arrivalDate', 'departureDate'])
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    page.shouldShowErrorMessagesForFields(['crn', 'arrivalDate', 'departureDate'])
+  })
 })

--- a/e2e/tests/stepDefinitions/manage/cancellation.ts
+++ b/e2e/tests/stepDefinitions/manage/cancellation.ts
@@ -52,7 +52,7 @@ Then('I should see the booking with the cancelled status', () => {
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })

--- a/e2e/tests/stepDefinitions/manage/confirmation.ts
+++ b/e2e/tests/stepDefinitions/manage/confirmation.ts
@@ -40,7 +40,7 @@ Then('I should see the booking with the confirmed status', () => {
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -60,7 +60,7 @@ Then('I should see the booking with the departed status', () => {
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })

--- a/e2e/tests/stepDefinitions/manage/extension.ts
+++ b/e2e/tests/stepDefinitions/manage/extension.ts
@@ -44,12 +44,7 @@ Given('I attempt to extend the booking with required details missing', () => {
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
     bookingShowPage.clickExtendBookingButton()
 
-    const bookingExtensionPage = Page.verifyOnPage(
-      BookingExtensionNewPage,
-      this.premises.id,
-      this.room.id,
-      this.booking,
-    )
+    const bookingExtensionPage = Page.verifyOnPage(BookingExtensionNewPage, this.booking)
     bookingExtensionPage.clearForm()
     bookingExtensionPage.clickSubmit()
   })
@@ -70,7 +65,7 @@ Then('I should see the booking with the extended departure date', () => {
 
 Then('I should see a list of the problems encountered extending the booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingExtensionNewPage, this.premises.id, this.room.id, this.booking)
+    const page = Page.verifyOnPage(BookingExtensionNewPage, this.booking)
 
     page.shouldShowErrorMessagesForFields(['newDepartureDate'])
   })

--- a/e2e/tests/stepDefinitions/manage/extension.ts
+++ b/e2e/tests/stepDefinitions/manage/extension.ts
@@ -58,7 +58,7 @@ Then('I should see the booking with the extended departure date', () => {
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
   })
 })

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -2,15 +2,15 @@ import { EnterCRNPage, ListPage, SelectOffencePage, StartPage } from '../../../c
 
 import { mapApiPersonRisksForUi } from '../../../server/utils/utils'
 
-import activeOffenceFactory from '../../../server/testutils/factories/activeOffence'
-import applicationFactory from '../../../server/testutils/factories/application'
 import ApplyHelper from '../../../cypress_shared/helpers/apply'
-import Page from '../../../cypress_shared/pages/page'
-import personFactory from '../../../server/testutils/factories/person'
-import risksFactory, { tierEnvelopeFactory } from '../../../server/testutils/factories/risks'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
+import Page from '../../../cypress_shared/pages/page'
 import setupTestUser from '../../../cypress_shared/utils/setupTestUser'
 import ExamplePage from '../../../server/form-pages/apply/example-page/example-task/examplePage'
+import activeOffenceFactory from '../../../server/testutils/factories/activeOffence'
+import applicationFactory from '../../../server/testutils/factories/application'
+import personFactory from '../../../server/testutils/factories/person'
+import risksFactory, { tierEnvelopeFactory } from '../../../server/testutils/factories/risks'
 
 context('Apply', () => {
   beforeEach(() => {

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -69,10 +69,10 @@ context('Apply', () => {
       expect(body.convictionId).equal(selectedOffence.convictionId)
       expect(body.deliusEventNumber).equal(selectedOffence.deliusEventNumber)
       expect(body.offenceId).equal(selectedOffence.offenceId)
-    })
 
-    // Then I should be on the Sentence Type page
-    Page.verifyOnPage(ExamplePage, this.application)
+      // Then I should be on the Sentence Type page
+      Page.verifyOnPage(ExamplePage, body, this.application)
+    })
   })
 
   it("creates and updates an application given a person's CRN", function test() {
@@ -167,6 +167,6 @@ context('Apply', () => {
     confirmationPage.clickBackToDashboard()
 
     // Then I am taken back to the dashboard
-    Page.verifyOnPage(ListPage)
+    Page.verifyOnPage(ListPage, applications, [], [])
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
@@ -1,12 +1,12 @@
-import premisesFactory from '../../../../server/testutils/factories/premises'
-import roomFactory from '../../../../server/testutils/factories/room'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingArrivalNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import arrivalFactory from '../../../../server/testutils/factories/arrival'
 import bookingFactory from '../../../../server/testutils/factories/booking'
 import newArrivalFactory from '../../../../server/testutils/factories/newArrival'
-import Page from '../../../../cypress_shared/pages/page'
-import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-import BookingArrivalNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew'
-import arrivalFactory from '../../../../server/testutils/factories/arrival'
-import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
 
 context('Booking arrival', () => {
   beforeEach(() => {

--- a/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
@@ -34,7 +34,7 @@ context('Booking arrival', () => {
     bookingShow.clickMarkArrivedBookingButton()
 
     // Then I navigate to the booking confirmation page
-    Page.verifyOnPage(BookingArrivalNewPage, premises.id, room.id, booking)
+    Page.verifyOnPage(BookingArrivalNewPage, booking)
   })
 
   it('allows me to mark a booking as arrived', () => {
@@ -152,6 +152,6 @@ context('Booking arrival', () => {
     page.clickBack()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BookingShowPage, booking)
+    Page.verifyOnPage(BookingShowPage, premises, room, booking)
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -239,7 +239,7 @@ context('Bedspace', () => {
     page.clickBreadCrumbUp()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BedspaceShowPage, premises)
+    Page.verifyOnPage(BedspaceShowPage, room)
   })
 
   it('shows a single bedspace', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -61,7 +61,7 @@ context('Bedspace', () => {
     premisesShowPage.clickBedpaceViewLink(rooms[0])
 
     // And I click the edit bedspace link
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, rooms[0])
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, premises, rooms[0])
     bedspaceShowPage.clickBedspaceEditLink()
 
     // Then I navigate to the edit bedspace page
@@ -90,7 +90,7 @@ context('Bedspace', () => {
     premisesShowPage.clickBedpaceViewLink(rooms[0])
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BedspaceShowPage, rooms[0])
+    Page.verifyOnPage(BedspaceShowPage, premises, rooms[0])
   })
 
   it('allows me to create a bedspace', () => {
@@ -132,7 +132,7 @@ context('Bedspace', () => {
     })
 
     // And I should be redirected to the show bedspace page
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, premises, room)
     bedspaceShowPage.shouldShowBanner('Bedspace created')
   })
 
@@ -214,7 +214,7 @@ context('Bedspace', () => {
     })
 
     // And I should be redirected to the show bedspace page
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, premises, room)
     bedspaceShowPage.shouldShowBanner('Bedspace updated')
   })
 
@@ -239,7 +239,7 @@ context('Bedspace', () => {
     page.clickBreadCrumbUp()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BedspaceShowPage, room)
+    Page.verifyOnPage(BedspaceShowPage, premises, room)
   })
 
   it('shows a single bedspace', () => {
@@ -262,7 +262,7 @@ context('Bedspace', () => {
     cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
 
     // When I visit the show bedspace page
-    const page = BedspaceShowPage.visit(premises.id, room)
+    const page = BedspaceShowPage.visit(premises, room)
 
     // Then I should see the bedspace details
     page.shouldShowBedspaceDetails()
@@ -285,7 +285,7 @@ context('Bedspace', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room: rooms[0] })
 
     // When I visit the show bedspace page
-    const page = BedspaceShowPage.visit(premises.id, rooms[0])
+    const page = BedspaceShowPage.visit(premises, rooms[0])
 
     // And I click the previous bread crumb
     page.clickBreadCrumbUp()

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -219,7 +219,7 @@ context('Booking', () => {
     page.clickBreadCrumbUp()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BedspaceShowPage, premises)
+    Page.verifyOnPage(BedspaceShowPage, room)
   })
 
   it('navigates back from the confirm booking page to the new booking page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -27,7 +27,7 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the show bedspace page
-    const bedspaceShow = BedspaceShowPage.visit(premises.id, room)
+    const bedspaceShow = BedspaceShowPage.visit(premises, room)
 
     // Add I click the book bedspace link
     bedspaceShow.clickBookBedspaceLink()
@@ -55,7 +55,7 @@ context('Booking', () => {
     cy.task('stubBooking', { premisesId: premises.id, booking: bookings[0] })
 
     // When I visit the show bedspace page
-    const bedspaceShowPage = BedspaceShowPage.visit(premises.id, room)
+    const bedspaceShowPage = BedspaceShowPage.visit(premises, room)
 
     // Add I click the booking link
     bedspaceShowPage.clickBookingLink(bookings[0])
@@ -219,7 +219,7 @@ context('Booking', () => {
     page.clickBreadCrumbUp()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BedspaceShowPage, room)
+    Page.verifyOnPage(BedspaceShowPage, premises, room)
   })
 
   it('navigates back from the confirm booking page to the new booking page', () => {
@@ -299,6 +299,6 @@ context('Booking', () => {
     page.clickBreadCrumbUp()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BedspaceShowPage, room)
+    Page.verifyOnPage(BedspaceShowPage, premises, room)
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -33,7 +33,7 @@ context('Booking', () => {
     bedspaceShow.clickBookBedspaceLink()
 
     // Then I navigate to the new booking page
-    Page.verifyOnPage(BookingNewPage)
+    Page.verifyOnPage(BookingNewPage, premises, room)
   })
 
   it('navigates to the show booking page', () => {
@@ -76,9 +76,12 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the new booking page
-    const bookingNewPage = BookingNewPage.visit(premises.id, room.id)
+    const bookingNewPage = BookingNewPage.visit(premises, room)
 
-    // And I fill out the form
+    // Then I should see the booking details
+    bookingNewPage.shouldShowBookingDetails()
+
+    // And when I fill out the form
     const booking = bookingFactory.build()
     const newBooking = newBookingFactory.build({
       ...booking,
@@ -125,7 +128,7 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the new booking page
-    const page = BookingNewPage.visit(premises.id, room.id)
+    const page = BookingNewPage.visit(premises, room)
 
     // And I enter a start date
     page.completeDateInputs('arrivalDate', '2022-07-08')
@@ -146,7 +149,7 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the new booking page
-    const bookingNewPage = BookingNewPage.visit(premises.id, room.id)
+    const bookingNewPage = BookingNewPage.visit(premises, room)
 
     // And I miss required fields
     bookingNewPage.clickSubmit()
@@ -161,7 +164,7 @@ context('Booking', () => {
     bookingConfirmPage.clickSubmit()
 
     // Then I should see error messages relating to those fields
-    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage)
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
     returnedBookingNewPage.shouldShowErrorMessagesForFields(['crn', 'arrivalDate', 'departureDate'])
   })
 
@@ -177,7 +180,7 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the new booking page
-    const bookingNewPage = BookingNewPage.visit(premises.id, room.id)
+    const bookingNewPage = BookingNewPage.visit(premises, room)
 
     // And I fill out the form with dates that conflict with an existing booking
     const booking = bookingFactory.build()
@@ -195,7 +198,7 @@ context('Booking', () => {
     bookingConfirmPage.clickSubmit()
 
     // Then I should see error messages for the date fields
-    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage)
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
 
     returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
     returnedBookingNewPage.shouldShowDateConflictErrorMessages()
@@ -213,7 +216,7 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the new booking page
-    const page = BookingNewPage.visit(premises.id, room.id)
+    const page = BookingNewPage.visit(premises, room)
 
     // And I click the previous bread crumb
     page.clickBreadCrumbUp()
@@ -234,7 +237,7 @@ context('Booking', () => {
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
     // When I visit the new booking page
-    const bookingNewPage = BookingNewPage.visit(premises.id, room.id)
+    const bookingNewPage = BookingNewPage.visit(premises, room)
 
     // And I fill out the form
     const booking = bookingFactory.build()
@@ -250,7 +253,7 @@ context('Booking', () => {
     bookingConfirmPage.clickBack()
 
     // Then I navigate to the new booking page
-    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage)
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
     returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
   })
 

--- a/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
@@ -35,7 +35,7 @@ context('Booking cancellation', () => {
     bookingShow.clickCancelBookingButton()
 
     // Then I navigate to the booking cancellation page
-    Page.verifyOnPage(BookingCancellationNewPage, premises.id, room.id, booking)
+    Page.verifyOnPage(BookingCancellationNewPage, booking)
   })
 
   it('allows me to mark a booking as cancelled', () => {
@@ -130,6 +130,6 @@ context('Booking cancellation', () => {
     page.clickBack()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BookingShowPage, booking)
+    Page.verifyOnPage(BookingShowPage, premises, room, booking)
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
@@ -1,12 +1,12 @@
-import premisesFactory from '../../../../server/testutils/factories/premises'
-import roomFactory from '../../../../server/testutils/factories/room'
-import bookingFactory from '../../../../server/testutils/factories/booking'
 import Page from '../../../../cypress_shared/pages/page'
-import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import BookingCancellationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import bookingFactory from '../../../../server/testutils/factories/booking'
 import cancellationFactory from '../../../../server/testutils/factories/cancellation'
 import newCancellationFactory from '../../../../server/testutils/factories/newCancellation'
-import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
 
 context('Booking cancellation', () => {
   beforeEach(() => {

--- a/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
@@ -34,7 +34,7 @@ context('Booking confirmation', () => {
     bookingShow.clickConfirmBookingButton()
 
     // Then I navigate to the booking confirmation page
-    Page.verifyOnPage(BookingConfirmationNewPage, premises.id, room.id, booking)
+    Page.verifyOnPage(BookingConfirmationNewPage, booking)
   })
 
   it('allows me to confirm a booking', () => {
@@ -97,6 +97,6 @@ context('Booking confirmation', () => {
     page.clickBack()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BookingShowPage, booking)
+    Page.verifyOnPage(BookingShowPage, premises, room, booking)
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
@@ -1,12 +1,12 @@
-import premisesFactory from '../../../../server/testutils/factories/premises'
-import roomFactory from '../../../../server/testutils/factories/room'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingConfirmationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 import bookingFactory from '../../../../server/testutils/factories/booking'
 import confirmationFactory from '../../../../server/testutils/factories/confirmation'
 import newConfirmationFactory from '../../../../server/testutils/factories/newConfirmation'
-import Page from '../../../../cypress_shared/pages/page'
-import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-import BookingConfirmationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew'
-import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
 
 context('Booking confirmation', () => {
   beforeEach(() => {

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -1,12 +1,12 @@
+import Page from '../../../../cypress_shared/pages/page'
+import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import bookingFactory from '../../../../server/testutils/factories/booking'
+import departureFactory from '../../../../server/testutils/factories/departure'
+import newDepartureFactory from '../../../../server/testutils/factories/newDeparture'
 import premisesFactory from '../../../../server/testutils/factories/premises'
 import roomFactory from '../../../../server/testutils/factories/room'
-import bookingFactory from '../../../../server/testutils/factories/booking'
-import newDepartureFactory from '../../../../server/testutils/factories/newDeparture'
-import Page from '../../../../cypress_shared/pages/page'
-import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-import departureFactory from '../../../../server/testutils/factories/departure'
-import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
-import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 
 context('Booking departure', () => {
   beforeEach(() => {

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -35,7 +35,7 @@ context('Booking departure', () => {
     bookingShow.clickMarkDepartedBookingButton()
 
     // Then I navigate to the booking departure page
-    Page.verifyOnPage(BookingDepartureNewPage, premises.id, room.id, booking)
+    Page.verifyOnPage(BookingDepartureNewPage, booking)
   })
 
   it('allows me to mark a booking as departed', () => {
@@ -132,6 +132,6 @@ context('Booking departure', () => {
     page.clickBack()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BookingShowPage, booking)
+    Page.verifyOnPage(BookingShowPage, premises, room, booking)
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
@@ -1,12 +1,12 @@
-import premisesFactory from '../../../../server/testutils/factories/premises'
-import roomFactory from '../../../../server/testutils/factories/room'
-import bookingFactory from '../../../../server/testutils/factories/booking'
 import Page from '../../../../cypress_shared/pages/page'
+import BookingExtensionNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import bookingFactory from '../../../../server/testutils/factories/booking'
 import extensionFactory from '../../../../server/testutils/factories/extension'
 import newExtensionFactory from '../../../../server/testutils/factories/newExtension'
-import BookingExtensionNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew'
-import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
+import premisesFactory from '../../../../server/testutils/factories/premises'
+import roomFactory from '../../../../server/testutils/factories/room'
 
 context('Booking extension', () => {
   beforeEach(() => {

--- a/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
@@ -34,7 +34,7 @@ context('Booking extension', () => {
     bookingShow.clickExtendBookingButton()
 
     // Then I navigate to the booking extension page
-    Page.verifyOnPage(BookingExtensionNewPage, premises.id, room.id, booking)
+    Page.verifyOnPage(BookingExtensionNewPage, booking)
   })
 
   it('allows me to extend a booking', () => {
@@ -151,6 +151,6 @@ context('Booking extension', () => {
     page.clickBack()
 
     // Then I navigate to the show bedspace page
-    Page.verifyOnPage(BookingShowPage, booking)
+    Page.verifyOnPage(BookingShowPage, premises, room, booking)
   })
 })

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -4,6 +4,7 @@
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -23,9 +24,7 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-  </div>
+  {{ locationHeader({ crn: booking.person.crn }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -1,6 +1,7 @@
-{% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Edit a bedspace" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -1,5 +1,6 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -25,16 +26,7 @@
 
         {{ showErrorSummary(errorSummary) }}
 
-        <div class="location-header">
-          <h2>Bedspace reference</h2>
-          <p>{{ name }}</p>
-
-          <h2>Property reference</h2>
-          <p>{{ premises.name }}</p>
-
-          <h2>Property address</h2>
-          <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-        </div>
+        {{ locationHeader({ premises: premises, room: fetchContext() }) }}
       
         {% include "./_editable.njk" %}  
       </form>

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -25,13 +26,7 @@
 
         {{ showErrorSummary(errorSummary) }}
 
-        <div class="location-header">
-          <h2>Property reference</h2>
-          <p>{{ premises.name }}</p>
-
-          <h2>Property address</h2>
-          <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-        </div>
+        {{ locationHeader({ premises: premises }) }}
 
         {{ govukInput({
           label: {

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -1,7 +1,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Add a bedspace" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -30,13 +31,7 @@
       }]
   }) }}
 
-  <div class="location-header">
-    <h2>Property reference</h2>
-    <p>{{ premises.name }}</p>
-
-    <h2>Property address</h2>
-    <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-  </div>
+  {{ locationHeader({ premises: premises }) }}
 
   <div class="edit-bar">
     <div class="edit-bar__container">

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -1,7 +1,6 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
-
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
 {% extends "../../partials/layout.njk" %}

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -18,15 +19,7 @@
 
   <p>Confirm that the CRN is correct. This information cannot be changed once a bedspace has been booked.</p>
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ crn }}</p>
-
-    <h2>Bedspace reference</h2>
-    <p>{{ room.name }}</p>
-
-    <h2>Property address</h2>
-    <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-  </div>
+  {{ locationHeader({ premises: premises, room: room, crn: crn }) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -1,7 +1,8 @@
-{% extends "../../partials/layout.njk" %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Book bedspace" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../components/booking-info/macro.njk" import bookingInfo %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -18,15 +19,7 @@
 
   <h1>Booking history</h1>
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-
-    <h2>Bedspace reference</h2>
-    <p>{{ room.name }}</p>
-
-    <h2>Property address</h2>
-    <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-  </div>
+  {{ locationHeader({ room: room, premises: premises, crn: booking.person.crn }) }}
 
   {% for historicBookingDetail in history | reverse %}
     <div data-cy-history-index="{{ loop.revindex0 }}">

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -1,6 +1,7 @@
-{% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Book bedspace" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -1,5 +1,6 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -20,13 +21,7 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  <div class="location-header">
-    <h2>Bedspace reference</h2>
-    <p>{{ room.name }}</p>
-
-    <h2>Property address</h2>
-    <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-  </div>
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
@@ -28,15 +29,7 @@
     items: actions
   }) }}
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-
-    <h2>Bedspace reference</h2>
-    <p>{{ room.name }}</p>
-
-    <h2>Property address</h2>
-    <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
-  </div>
+  {{ locationHeader({ room: room, premises: premises, crn: booking.person.crn }) }}
 
   {{ bookingInfo(booking, paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })) }}
 

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -5,6 +5,7 @@
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -24,9 +25,7 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-  </div>
+  {{ locationHeader({ crn: booking.person.crn }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -1,0 +1,30 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro locationHeader(locationDetails, hideAddress = false) %}
+
+<div class="location-header">
+  {% set premises = locationDetails.premises %}
+  {% set room = locationDetails.room %}
+  {% set crn = locationDetails.crn %}
+
+  {%if crn %}
+    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ crn }}</p>
+  {% endif %}
+
+  {% if room %}
+    <h2>Bedspace reference</h2>
+    <p>{{ room.name }}</p>
+  {% endif %}
+
+  {% if premises %}
+    <h2>Property reference</h2>
+    <p>{{ premises.name }}</p>
+
+    {% if not hideAddress %}
+      <h2>Property address</h2>
+      <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
+    {% endif %}
+  {% endif %}
+</div>
+
+{% endmacro %}

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -19,9 +20,7 @@
 
   <h1>Mark booking as confirmed</h1>
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-  </div>
+  {{ locationHeader({ crn: booking.person.crn }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -5,6 +5,7 @@
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -24,9 +25,7 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-  </div>
+  {{ locationHeader({ crn: booking.person.crn }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -4,6 +4,7 @@
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -23,9 +24,7 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  <div class="location-header">
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ booking.person.crn }}</p>
-  </div>
+  {{ locationHeader({ crn: booking.person.crn }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -1,9 +1,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
-{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../../partials/layout.njk" %}
 

--- a/server/views/temporary-accommodation/premises/edit.njk
+++ b/server/views/temporary-accommodation/premises/edit.njk
@@ -1,7 +1,8 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
-{% extends "../../partials/layout.njk" %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Add a property" %}
 {% set mainClasses = "app-container govuk-body" %}

--- a/server/views/temporary-accommodation/premises/edit.njk
+++ b/server/views/temporary-accommodation/premises/edit.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/location-header/macro.njk" import locationHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -25,10 +26,7 @@
 
         {{ showErrorSummary(errorSummary) }}
 
-        <div class="location-header">
-          <h2>Property reference</h2>
-          <p>{{ name }}</p>
-        </div>
+        {{ locationHeader({ premises: fetchContext() }, true) }}
       
         {% include "./_editable.njk" %}  
       </form>


### PR DESCRIPTION
# Changes in this PR

This PR first does some tidy up, most significantly adding better type safety to Page.verifyOnPage, which then necessitates some fixes. We then add then use a reusable location header component, replacing a lot of repeated code. This PR should cause no user-visible changes

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
