### PR TITLE
Frontend handling of API 5XX

### DIFF
--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -111,11 +111,9 @@ describe('catchValidationErrorOrPropogate', () => {
   })
 
   it('gets errors from a ValidationError type', () => {
-    const error = createMock<ValidationError<TaskListPage>>({
-      data: {
-        crn: 'You must enter a valid crn',
-        error: 'You must enter a valid arrival date',
-      },
+    const error = new ValidationError<TaskListPage>({
+      crn: 'You must enter a valid crn',
+      error: 'You must enter a valid arrival date',
     })
 
     catchValidationErrorOrPropogate(request, response, error, 'some/url')


### PR DESCRIPTION
TA contains multiple endpoints that receive POSTed form data that is then forward to the API. In these endpoints, the API call is generally wrapped in a try...catch block, and any error is passed to `catchValidationErrorOrPropogate`.

In cases where the error is expected - for instance, a field is required but the user has left it blank - this allows us to display friendly error messages that link to the relevant part of the form. The API tells us in an `invalid-params` block which fields have failed validation and why, and this allows us to lookup an error message in our errors.json file. For example:

![localhost_3000_properties_8250ed36-dc8c-44c4-bfff-13d1a7b127e9_edit (1)](https://user-images.githubusercontent.com/94137563/221213743-fe5254ff-da53-4dd6-9387-72fed4051276.png)

However, even in cases where the API does not give the UI an `invalid-params` block, `catchValidationErrorOrPropogate` will *attempt* to handler errors in such a way that they are rendered nicely. This can give us results such as this:

![image](https://user-images.githubusercontent.com/94137563/221214697-a5a5c2df-8562-40d6-b718-971bcf0f60ac.png)
![image](https://user-images.githubusercontent.com/94137563/221214779-30ca521b-9341-4b9a-8750-e8702651f1a1.png)

In this instance the 500 status field from the API has been wrongly interpreted as relating to the "status" field in the form.

This PR changes our error handling so that if the API give an error that does not contain an `invalid-params` block, and isn't a UI-generated `ValidationError`, `catchValidationErrorOrPropogate` will simply allow the error to propagate, resulting in the user seeing our standard error screen ("Something went wrong. The error has been logged. Please try again" on production, and a stack trace elsewhere)