### PR TITLE
Load build info from correct location in order to fix Sentry

### DIFF
--- a/server/applicationVersion.ts
+++ b/server/applicationVersion.ts
@@ -3,12 +3,17 @@
 
 import fs from 'fs'
 
+function getBuild() {
+  try {
+    // eslint-disable-next-line import/no-unresolved,global-require
+    return require('../build-info.json')
+  } catch (ex) {
+    return null
+  }
+}
 const packageData = JSON.parse(fs.readFileSync('./package.json').toString())
-const { buildNumber, gitRef } = fs.existsSync('./build-info.json')
-  ? JSON.parse(fs.readFileSync('./build-info.json').toString())
-  : {
-      buildNumber: packageData.version,
-      gitRef: 'unknown',
-    }
-
+const { buildNumber, gitRef } = getBuild() || {
+  buildNumber: packageData.version,
+  gitRef: 'unknown',
+}
 export default { buildNumber, gitRef, packageData }


### PR DESCRIPTION
Sentry isn't being passed the source maps and so is unable to present meaningful stacke traces when errors occur.

During the build the build-info.json file is populated. Data here can then be accessed and forwarded to Sentry as we are already configured[1].

We copy the implementation made in AP [2][3].

[1] https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/47e261d69589ed6419afb576dec0c35b67bb5157/server/middleware/setUpSentry.ts#L17
[2] https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/588
[3] https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/590

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
