### PR TITLE
Prevent double click on form buttons

### DIFF
--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -37,9 +37,10 @@
         }}
 
         {{ govukButton({
-                    name: 'submit',
-                    text: "Save and continue"
-                }) }}
+          name: 'submit',
+          text: "Save and continue",
+          preventDoubleClick: true
+        }) }}
       </form>
     </div>
   </div>

--- a/server/views/applications/pages/check-your-answers/review.njk
+++ b/server/views/applications/pages/check-your-answers/review.njk
@@ -135,7 +135,8 @@
         <input type="hidden" name="reviewed" value="1"/>
 
         {{ govukButton({
-            text: "Continue"
+          text: "Continue",
+          preventDoubleClick: true
         }) }}
       </form>
 

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -43,7 +43,8 @@
         {% block questions %}{% endblock %}
 
         {{ govukButton({
-            text: "Submit"
+          text: "Submit",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -132,7 +132,8 @@
         <p>If you've entered the wrong CRN, go back to the CRN screen.</p>
 
         {{ govukButton({
-            text: "Save and continue"
+          text: "Save and continue",
+          preventDoubleClick: true
         }) }}
 
         <p>

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -49,8 +49,9 @@
           }}
 
           {{ govukButton({
-            text: "Save and continue"
-        }) }}
+            text: "Save and continue",
+            preventDoubleClick: true
+          }) }}
 
         </form>
       </div>

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -56,8 +56,9 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ govukButton({
-          text: "Submit application"
-          }) }}
+          text: "Submit application",
+          preventDoubleClick: true
+        }) }}
       </form>
 
       {{ govukButton({

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -27,8 +27,9 @@
         <p class="govuk-body">You can leave and return to your application at any time. Your progress will be saved.</p>
 
         {{ govukButton({
-            text: "Start now",
-            isStartButton: true
+          text: "Start now",
+          isStartButton: true,
+          preventDoubleClick: true
         }) }}
 
         <h2>Before you start</h2>

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -72,7 +72,8 @@
         ) }}
 
         {{ govukButton({
-          text: "Submit"
+          text: "Submit",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/temporary-accommodation/bedspaces/_editable.njk
+++ b/server/views/temporary-accommodation/bedspaces/_editable.njk
@@ -33,5 +33,6 @@
 }) }}
 
 {{ govukButton({
-  text: "Submit"
+  text: "Submit",
+  preventDoubleClick: true
 }) }}

--- a/server/views/temporary-accommodation/bookings/_editable.njk
+++ b/server/views/temporary-accommodation/bookings/_editable.njk
@@ -52,5 +52,6 @@
 }}
 
 {{ govukButton({
-  text: "Submit"
+  text: "Submit",
+  preventDoubleClick: true
 }) }}

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -37,7 +37,8 @@
             href: paths.bookings.new({ premisesId: premises.id, roomId: room.id })
           }) }}
           {{ govukButton({
-            text: "Submit"
+            text: "Submit",
+            preventDoubleClick: true
           }) }}
         </div>
       </form>

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -71,7 +71,8 @@
         ) }}
 
         {{ govukButton({
-          text: "Submit"
+          text: "Submit",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -40,7 +40,8 @@
         ) }}
 
         {{ govukButton({
-          text: "Submit"
+          text: "Submit",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -83,7 +83,8 @@
         ) }}
 
         {{ govukButton({
-          text: "Submit"
+          text: "Submit",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -58,7 +58,8 @@
         ) }}
 
         {{ govukButton({
-          text: "Submit"
+          text: "Submit",
+          preventDoubleClick: true
         }) }}
       </form>
     </div>

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -164,5 +164,6 @@
 ) }}
 
 {{ govukButton({
-  text: "Submit"
+  text: "Submit",
+  preventDoubleClick: true
 }) }}


### PR DESCRIPTION
We add the preventDoubleClick attribute on form submission buttons across the service. While this cannot eliminate double-POSTing entirely, it can reduce its prevalence. We make an exception for the bookings report form button, as this does not take the user to a new page, and preventing the button here from being clicked more than once may be counter intuitive