### PR TITLE
Propagate errors with empty 'invalid-params'

### DIFF
--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -125,6 +125,23 @@ describe('catchValidationErrorOrPropogate', () => {
     expect(response.redirect).toHaveBeenCalledWith('some/url')
   })
 
+  it('throws the error if the invalid-params array is empty', () => {
+    const error = createMock<SanitisedError>({
+      data: {
+        'invalid-params': [],
+      },
+    })
+
+    let thrownError = null
+    try {
+      catchValidationErrorOrPropogate(request, response, error, 'some/url')
+    } catch (e) {
+      thrownError = e
+    }
+
+    expect(thrownError).toEqual(error)
+  })
+
   it('throws the error if the error is not the type we expect', () => {
     const err = new Error()
     expect(() => catchValidationErrorOrPropogate(request, response, err, 'some/url')).toThrowError(err)

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -87,7 +87,7 @@ export const insertGenericError = (error: SanitisedError | Error, propertyName: 
 
 const extractValidationErrors = (error: SanitisedError | Error, context: string) => {
   if ('data' in error) {
-    if (error.data['invalid-params']) {
+    if (error.data['invalid-params'] && error.data['invalid-params'].length) {
       return generateErrors(error.data['invalid-params'], context)
     }
     if (error instanceof ValidationError) {


### PR DESCRIPTION
We previously attempted to handle any API error with an 'invalid-params' array present. However, if this were empty, we would swallow the original API error, then throw a new error when attempting to render the empty errors array. This gave us the worst of both worlds - it didn't present a friendly error to the user, and it obscured the underlying error to developers.

We now check that the array is non-empty, and if it is empty, we simply allow the error to propagate.