### PR TITLE
Fix filterBlanksFromData

### DIFF
--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -2,8 +2,8 @@ import { createMock } from '@golevelup/ts-jest'
 import { Response } from 'express'
 import nock from 'nock'
 import type { ApiConfig } from '../config'
-import RestClient, { CallConfig } from './restClient'
 import probationRegionFactory from '../testutils/factories/probationRegion'
+import RestClient, { CallConfig } from './restClient'
 
 describe('restClient', () => {
   let fakeApprovedPremisesApi: nock.Scope

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -93,13 +93,15 @@ describe('restClient', () => {
   describe('post', () => {
     it('should filter out blank values', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null } as any
+      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null, falseItem: false } as any
 
-      fakeApprovedPremisesApi.post(`/some/path`, { some: 'data' }).reply(201, { some: 'data' })
+      fakeApprovedPremisesApi
+        .post(`/some/path`, { some: 'data', falseItem: false })
+        .reply(201, { some: 'data', falseItem: false })
 
       const result = await restClient.post({ path: '/some/path', data })
 
-      expect(result).toEqual({ some: 'data' })
+      expect(result).toEqual({ some: 'data', falseItem: false })
       expect(nock.isDone()).toBeTruthy()
     })
   })
@@ -107,13 +109,15 @@ describe('restClient', () => {
   describe('put', () => {
     it('should filter out blank values', async () => {
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null } as any
+      const data = { some: 'data', empty: '', undefinedItem: undefined, nullItem: null, falseItem: false } as any
 
-      fakeApprovedPremisesApi.put(`/some/path`, { some: 'data' }).reply(201, { some: 'data' })
+      fakeApprovedPremisesApi
+        .put(`/some/path`, { some: 'data', falseItem: false })
+        .reply(201, { some: 'data', falseItem: false })
 
       const result = await restClient.put({ path: '/some/path', data })
 
-      expect(result).toEqual({ some: 'data' })
+      expect(result).toEqual({ some: 'data', falseItem: false })
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -210,7 +210,7 @@ export default class RestClient {
   }
 
   private filterBlanksFromData(data: Record<string, unknown>): Record<string, unknown> {
-    Object.keys(data).forEach(k => !data[k] && delete data[k])
+    Object.keys(data).forEach(k => typeof data[k] !== 'boolean' && !data[k] && delete data[k])
 
     return data
   }


### PR DESCRIPTION
We have a `filterBlanksFromData` method which strips out any empty variables that are passed to the API. However, this also strips out any literal `false` values, which we do want to send.

This updates the `filterBlanksFromData` helper to check if the item is a literal boolean before checking it is ‘falsy’ (i.e. null, undefined or a blank string). This ensures any literal `false` values are sent to the API as expected.

This is based on [Approved Premises' similar PR](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/594), though we do not make similar changes to the Apply integration tests, as TA is still relying on the API extracting the fields they test, rather than the UI sending the,