### PR TITLE
Add E2E testing for editing/cancelling voids

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -1,4 +1,4 @@
-import type { Booking, TemporaryAccommodationLostBed as LostBed, Room } from '@approved-premises/api'
+import type { Booking, TemporaryAccommodationLostBed as LostBed, Room, UpdateLostBed } from '@approved-premises/api'
 
 import { Premises } from '../../../../server/@types/shared'
 import config from '../../../../server/config'
@@ -62,7 +62,7 @@ export default class BedspaceShowPage extends Page {
       })
   }
 
-  shouldShowLostBedDetails(lostBed: LostBed): void {
+  shouldShowLostBedDetails(lostBedOrLostBedUpdate: LostBed | UpdateLostBed): void {
     cy.get('tr')
       .contains('Void')
       .parent()
@@ -70,10 +70,10 @@ export default class BedspaceShowPage extends Page {
       .within(() => {
         cy.get('td')
           .eq(1)
-          .contains(DateFormats.isoDateToUIDate(lostBed.startDate, { format: 'short' }))
+          .contains(DateFormats.isoDateToUIDate(lostBedOrLostBedUpdate.startDate, { format: 'short' }))
         cy.get('td')
           .eq(2)
-          .contains(DateFormats.isoDateToUIDate(lostBed.endDate, { format: 'short' }))
+          .contains(DateFormats.isoDateToUIDate(lostBedOrLostBedUpdate.endDate, { format: 'short' }))
       })
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedCancel.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedCancel.ts
@@ -27,6 +27,10 @@ export default class LostBedCancelPage extends Page {
     this.locationHeaderComponent.shouldShowLocationDetails()
   }
 
+  clearForm(): void {
+    super.getTextInputByIdAndClear('notes')
+  }
+
   completeForm(cancelLostBed: NewLostBedCancellation): void {
     super.getTextInputByIdAndClear('notes')
     this.getLabel('Notes')

--- a/e2e/tests/lostBed.feature
+++ b/e2e/tests/lostBed.feature
@@ -14,3 +14,21 @@ Feature: Manage Temporary Accommodation - Lost beds
         Given I'm marking a bedspace as void
         And I attempt to mark a bedspace as void with required details missing
         Then I should see a list of the problems encountered voiding the bedspace
+    
+    Scenario: Editing a void booking
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I edit the void booking
+        Then I should see confirmation for my updated void booking
+
+    Scenario: Showing void booking editing errors
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I attempt to edit the void booking with required details missing
+        Then I should see a list of the problems encountered voiding the bedspace
+
+    Scenario: Cancelling a void booking
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I cancel the void booking
+        Then I should see confirmation that the void is cancelled

--- a/e2e/tests/stepDefinitions/manage/lostBed.ts
+++ b/e2e/tests/stepDefinitions/manage/lostBed.ts
@@ -2,8 +2,12 @@ import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import Page from '../../../../cypress_shared/pages/page'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
 import LostBedNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedNew'
+import LostBedEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedEdit'
+import LostBedCancelPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedCancel'
 import newLostBedFactory from '../../../../server/testutils/factories/newLostBed'
+import updateLostBedFactory from '../../../../server/testutils/factories/updateLostBed'
 import lostBedFactory from '../../../../server/testutils/factories/lostBed'
+import cancelLostBedFactory from '../../../../server/testutils/factories/newLostBedCancellation'
 import LostBedShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedShow'
 
 Given(`I'm marking a bedspace as void`, () => {
@@ -52,5 +56,70 @@ Then('I should see a list of the problems encountered voiding the bedspace', () 
   cy.then(function _() {
     const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
     lostBedNewPage.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
+  })
+})
+
+Given('I edit the void booking', () => {
+  cy.then(function _() {
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    lostBedShowPage.clickEditVoidLink()
+
+    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room, this.lostBed)
+    const lostBedUpdate = updateLostBedFactory.build()
+    cy.wrap(lostBedUpdate).as('lostBedUpdate')
+
+    lostBedEditPage.clearForm()
+    lostBedEditPage.completeForm(lostBedUpdate)
+  })
+})
+
+Then('I should see confirmation for my updated void booking', () => {
+  cy.then(function _() {
+    const updatedLostBed = { ...this.lostBed, ...this.lostBedUpdate }
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, updatedLostBed)
+
+    lostBedShowPage.shouldShowBanner('Void booking updated')
+    lostBedShowPage.shouldShowLostBedDetails()
+
+    lostBedShowPage.clickBreadCrumbUp()
+
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    bedspaceShowPage.shouldShowLostBedDetails(this.lostBedUpdate)
+  })
+})
+
+Given('I attempt to edit the void booking with required details missing', () => {
+  cy.then(function _() {
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    lostBedShowPage.clickEditVoidLink()
+    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room, this.lostBed)
+
+    lostBedEditPage.clearForm()
+    lostBedEditPage.clickSubmit()
+    lostBedEditPage.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
+  })
+})
+
+Given('I cancel the void booking', () => {
+  cy.then(function _() {
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    lostBedShowPage.clickCancelVoidLink()
+
+    const lostBedCancelPage = Page.verifyOnPage(LostBedCancelPage, this.premises, this.room, this.lostBed)
+    const lostBedCancellation = cancelLostBedFactory.build()
+    cy.wrap(lostBedCancellation).as('lostBedCancellation')
+
+    lostBedCancelPage.clearForm()
+    lostBedCancelPage.completeForm(lostBedCancellation)
+  })
+})
+
+Then('I should see confirmation that the void is cancelled', () => {
+  cy.then(function _() {
+    const cancelledLostBed = { ...this.lostBed, status: 'cancelled', cancellation: this.lostBedCancellation }
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, cancelledLostBed)
+
+    lostBedShowPage.shouldShowBanner('Void booking cancelled')
+    lostBedShowPage.shouldShowLostBedDetails()
   })
 })


### PR DESCRIPTION
# Context

[Adds end to end testing for both editing and cancelling void bookings](https://trello.com/c/Ppl3xo7G/904-e2e-testing-for-voids-functionality).

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
