### PR TITLE
Deployments to dev and test don't try to update Jira

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -88,7 +88,6 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_dev
           env: 'dev'
-          jira_update: true
           context: hmpps-common-vars
           filters:
             branches:
@@ -116,7 +115,6 @@ workflows:
       - hmpps/deploy_env:
           name: deploy_test
           env: 'test'
-          jira_update: true
           context:
             - hmpps-common-vars
             - hmpps-temporary-accommodation-ui-stage


### PR DESCRIPTION
The team use Trello so this templating config isn't appropriate for us.

We wondered why our test deploys sometimes fail in CircleCI and want to remove this from our investigation.
