### PR TITLE
Ensure booking confirmation screen handles all classes of CRN error

### DIFF
--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,6 +1,6 @@
+import crypto from 'crypto'
 import express, { NextFunction, Request, Response, Router } from 'express'
 import helmet from 'helmet'
-import crypto from 'crypto'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()

--- a/server/middleware/setUpWebSecurity.ts
+++ b/server/middleware/setUpWebSecurity.ts
@@ -1,6 +1,7 @@
 import crypto from 'crypto'
 import express, { NextFunction, Request, Response, Router } from 'express'
 import helmet from 'helmet'
+import config from '../config'
 
 export default function setUpWebSecurity(): Router {
   const router = express.Router()
@@ -26,6 +27,7 @@ export default function setUpWebSecurity(): Router {
           scriptSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           styleSrc: ["'self'", (_req: Request, res: Response) => `'nonce-${res.locals.cspNonce}'`],
           fontSrc: ["'self'"],
+          formAction: [`'self' ${config.apis.hmppsAuth.externalUrl}`],
         },
       },
       referrerPolicy: { policy: 'strict-origin-when-cross-origin' },


### PR DESCRIPTION
We update our Content Security Policy to allow the HMPPS Auth URL as a possible form action target.

Currently, if a 403 error occurs on a GET request, this will be captured by the error handling setup in errorHandler.ts, and the user will be redirected to the sign out URL, which then redirects to the HMPSS Auth URL. However, if a 403 error occurs on a POST request, this second redirect may not occur, and the user may, depending on their choice of browser, be frozen on the form page they just submitted.

Due to CSP implementation details that vary between browsers, adding the HMPPS Auth URL to our form action targets allows this second redirect to occur as expected.

For further details, see: https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Content-Security-Policy/form-action