### PR TITLE
Ensure booking confirmation screen handles all classes of CRN error (Part 2)

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
@@ -1,6 +1,6 @@
 import type { NewBooking } from '@approved-premises/api'
-import Page from '../../page'
 import errorLookups from '../../../../server/i18n/en/errors.json'
+import Page from '../../page'
 
 export default abstract class BookingEditablePage extends Page {
   shouldShowDateConflictErrorMessages(): void {
@@ -8,6 +8,11 @@ export default abstract class BookingEditablePage extends Page {
       cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
       cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
     })
+  }
+
+  shouldShowUserPermissionErrorMessage(): void {
+    cy.get('.govuk-error-summary').should('contain', errorLookups.generic.crn.userPermission)
+    cy.get(`[data-cy-error-crn]`).should('contain', errorLookups.generic.crn.userPermission)
   }
 
   shouldShowEndDateHint(date: string): void {

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -20,20 +20,20 @@ export default {
     }),
   stubBookingCreateErrors: (args: { premisesId: string; params: Array<string> }) =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings`, 'POST')),
-  stubBookingCreateConflictError: (premisesId: string) =>
+  stubBookingCreateApiError: (args: { premisesId: string; errorCode: number; errorTitle: string }) =>
     stubFor({
       request: {
         method: 'POST',
-        url: `/premises/${premisesId}/bookings`,
+        url: `/premises/${args.premisesId}/bookings`,
       },
       response: {
-        status: 409,
+        status: args.errorCode,
         headers: {
           'Content-Type': 'application/problem+json;charset=UTF-8',
         },
         jsonBody: {
-          title: 'Conflict',
-          status: 409,
+          title: args.errorTitle,
+          status: args.errorCode,
         },
       },
     }),

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -87,6 +87,8 @@ export default class BookingsController {
         if (err.status === 409) {
           insertGenericError(err, 'arrivalDate', 'conflict')
           insertGenericError(err, 'departureDate', 'conflict')
+        } else if (err.status === 403) {
+          insertGenericError(err, 'crn', 'userPermission')
         }
 
         catchValidationErrorOrPropogate(req, res, err, paths.bookings.new({ premisesId, roomId }))


### PR DESCRIPTION
# Changes in this PR

If we receive a 403 from the API, we assume this is due to the CRN being unavailable to the user, and present the appropriate error for this case. If our assumption is wrong, and we are receiving a 403 due to the user being logged out, after being redirected back to the create booking page, we will get another 403 from the API, and be redirected to the login page as before.

Examining the API project, we can receive a 403 from the booking endpoint if the API itself receives a 403 itself from either the Prison API of the Community API. See:
* [PremisesController.kt](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/7ce8cbc280f3805f9c91f9c7f5a538f9d41c5a7a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/PremisesController.kt#L296)
* [OffenderService.kt (getOffenderByCrn)
](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/7ce8cbc280f3805f9c91f9c7f5a538f9d41c5a7a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt#L77)
* [OffenderService.kt (getInmateDetailByNomsNumber)
](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/7ce8cbc280f3805f9c91f9c7f5a538f9d41c5a7a/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/service/OffenderService.kt#L130)

## Screenshots of UI changes

![localhost_3000_properties_59c37f37-253f-4ede-8d47-7cc2f01d1434_bedspaces_afe52f7c-46f3-4b58-b704-7bdbaed4c742_bookings_new](https://user-images.githubusercontent.com/94137563/226413513-1524f045-8522-4126-a05c-88c9b8accbba.png)


# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
