### PR TITLE
Add a person's name and date of birth to bookings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e:ci --\
-              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>}"  \
+              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"  \
               --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots
@@ -145,7 +145,7 @@ workflows:
             - deploy_preprod
       - hmpps/deploy_env:
           name: deploy_prod
-          env: "prod"
+          env: 'prod'
           slack_notification: true
           slack_channel_name: << pipeline.parameters.releases-slack-channel >>
           context:

--- a/cypress_shared/components/locationHeader.ts
+++ b/cypress_shared/components/locationHeader.ts
@@ -3,14 +3,14 @@ import Component from './component'
 
 export default class LocationHeaderComponent extends Component {
   constructor(
-    private readonly details: { premises?: Premises; room?: Room; crn?: string },
+    private readonly details: { premises?: Premises; room?: Room },
     private readonly hideAddress: boolean = false,
   ) {
     super()
   }
 
   shouldShowLocationDetails(): void {
-    const { premises, room, crn } = this.details
+    const { premises, room } = this.details
 
     cy.get('.location-header').within(() => {
       if (room) {
@@ -33,12 +33,6 @@ export default class LocationHeaderComponent extends Component {
           .should('contain', premises.postcode)
       } else {
         cy.contains('Property address').should('not.exist')
-      }
-
-      if (crn) {
-        cy.get('p').should('contain', `CRN: ${crn}`)
-      } else {
-        cy.contains(`CRN: ${crn}`).should('not.exist')
       }
     })
   }

--- a/cypress_shared/components/popDetailsHeader.ts
+++ b/cypress_shared/components/popDetailsHeader.ts
@@ -1,0 +1,17 @@
+import Component from './component'
+import { Person } from '../../server/@types/shared'
+import { DateFormats } from '../../server/utils/dateUtils'
+
+export default class PopDetailsHeaderComponent extends Component {
+  constructor(private readonly person: Person) {
+    super()
+  }
+
+  shouldShowPopDetails(): void {
+    cy.get('.pop-details-header').within(() => {
+      cy.get('p').should('contain', `Name: ${this.person.name}`)
+      cy.get('p').should('contain', `CRN: ${this.person.crn}`)
+      cy.get('p').should('contain', `Date of birth: ${DateFormats.isoDateToUIDate(this.person.dateOfBirth)}`)
+    })
+  }
+}

--- a/cypress_shared/fixtures/person-dev.json
+++ b/cypress_shared/fixtures/person-dev.json
@@ -1,0 +1,11 @@
+{
+  "name": "Ben Davies",
+  "crn": "X371199",
+  "dateOfBirth": "1993-04-24",
+  "nomsNumber": "A7779DY",
+  "status": "InCustody",
+  "prisonName": "1-3",
+  "religionOrBelief": "Apostolic",
+  "nationality": "British",
+  "sex": "Male"
+}

--- a/cypress_shared/fixtures/person-local.json
+++ b/cypress_shared/fixtures/person-local.json
@@ -1,0 +1,11 @@
+{
+  "name": "Aadland Bertrand",
+  "crn": "X320741",
+  "dateOfBirth": "2065-07-19",
+  "nomsNumber": "A1234AI",
+  "status": "InCustody",
+  "prisonName": "Leeds",
+  "religionOrBelief": "",
+  "nationality": "",
+  "sex": "Male"
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -3,9 +3,12 @@ import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingArrivalNewPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   private readonly bookingInfoComponent: BookingInfoComponent
@@ -14,7 +17,8 @@ export default class BookingArrivalNewPage extends Page {
     super('Mark booking as active')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: this.booking.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
   static visit(premises: Premises, room: Room, booking: Booking): BookingArrivalNewPage {
@@ -23,6 +27,7 @@ export default class BookingArrivalNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
@@ -2,10 +2,13 @@ import type { Booking, NewCancellation, Premises, Room } from '@approved-premise
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingCancellationNewPage extends Page {
   private readonly locationHeaderComponent: LocationHeaderComponent
+
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
 
   private readonly bookingInfoComponent: BookingInfoComponent
 
@@ -13,7 +16,8 @@ export default class BookingCancellationNewPage extends Page {
     super('Cancel booking')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
   static visit(premises: Premises, room: Room, booking: Booking): BookingCancellationNewPage {
@@ -22,6 +26,7 @@ export default class BookingCancellationNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
@@ -1,24 +1,30 @@
-import type { Booking, Premises, Room } from '@approved-premises/api'
+import type { Person, Premises, Room } from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingConfirmPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-  constructor(premises: Premises, room: Room, booking?: Booking) {
+  constructor(premises: Premises, room: Room, person: Person) {
     super('Confirm CRN')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking?.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(person)
+
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingConfirmPage {
+  static visit(premises: Premises, room: Room, person: Person): BookingConfirmPage {
     cy.visit(paths.bookings.confirm({ premisesId: premises.id, roomId: room.id }))
-    return new BookingConfirmPage(premises, room, booking)
+    return new BookingConfirmPage(premises, room, person)
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
@@ -2,9 +2,12 @@ import type { Booking, NewConfirmation, Premises, Room } from '@approved-premise
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingConfirmationNewPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   private readonly bookingInfoComponent: BookingInfoComponent
@@ -12,7 +15,8 @@ export default class BookingConfirmationNewPage extends Page {
   constructor(premises: Premises, room: Room, booking: Booking) {
     super('Mark booking as confirmed')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -22,6 +26,7 @@ export default class BookingConfirmationNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -2,9 +2,12 @@ import type { Booking, NewDeparture, Premises, Room } from '@approved-premises/a
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingDepartureNewPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   private readonly bookingInfoComponent: BookingInfoComponent
@@ -12,7 +15,8 @@ export default class BookingDepartureNewPage extends Page {
   constructor(premises: Premises, room: Room, private readonly booking: Booking) {
     super('Mark booking as closed')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -22,6 +26,7 @@ export default class BookingDepartureNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -4,9 +4,12 @@ import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { getLatestExtension } from '../../../../server/utils/bookingUtils'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingExtensionNewPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   private readonly bookingInfoComponent: BookingInfoComponent
@@ -14,7 +17,8 @@ export default class BookingExtensionNewPage extends Page {
   constructor(premises: Premises, room: Room, private readonly booking: Booking) {
     super('Extend or shorten booking')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -24,6 +28,7 @@ export default class BookingExtensionNewPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
@@ -3,9 +3,12 @@ import type { Booking, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingHistoryPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   private readonly bookingInfoComponents: BookingInfoComponent[]
@@ -13,7 +16,8 @@ export default class BookingHistoryPage extends Page {
   constructor(premises: Premises, room: Room, booking: Booking, historicBookings: Booking[]) {
     super('Booking history')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
     this.bookingInfoComponents = historicBookings.map(historicBooking => new BookingInfoComponent(historicBooking))
   }
 
@@ -23,6 +27,7 @@ export default class BookingHistoryPage extends Page {
   }
 
   shouldShowBookingHistory(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
 
     this.bookingInfoComponents.forEach((bookingInfoComponent, index) => {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -3,6 +3,7 @@ import { Premises, Room } from '../../../../server/@types/shared'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import BookingEditablePage from './bookingEditable'
+import errorLookups from '../../../../server/i18n/en/errors.json'
 
 export default class BookingNewPage extends BookingEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
@@ -20,6 +21,15 @@ export default class BookingNewPage extends BookingEditablePage {
 
   completeForm(newBooking: NewBooking): void {
     super.completeEditableForm(newBooking)
+  }
+
+  enterCrn(crn: string): void {
+    super.getTextInputByIdAndEnterDetails('crn', crn)
+  }
+
+  shouldShowCrnDoesNotExistErrorMessage(): void {
+    cy.get('.govuk-error-summary').should('contain', errorLookups.generic.crn.doesNotExist)
+    cy.get(`[data-cy-error-crn]`).should('contain', errorLookups.generic.crn.doesNotExist)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -3,9 +3,12 @@ import type { Booking, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingShowPage extends Page {
+  private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
+
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   private readonly bookingInfoComponent: BookingInfoComponent
@@ -13,7 +16,8 @@ export default class BookingShowPage extends Page {
   constructor(premises: Premises, room: Room, booking: Booking) {
     super('View a booking')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, crn: booking.person.crn })
+    this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
@@ -62,6 +66,7 @@ export default class BookingShowPage extends Page {
   }
 
   shouldShowBookingDetails(): void {
+    this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
   }

--- a/e2e.local.env
+++ b/e2e.local.env
@@ -6,3 +6,4 @@ CYPRESS_keyworker_name="Kelby Tabert"
 CYPRESS_lost_bed_reason_id=2f46e769-17a5-4b5c-b04a-a5a9a5b3f773
 CYPRESS_acting_user_probation_region_id=43606be0-9836-441d-9bc1-5586de9ac931
 CYPRESS_acting_user_probation_region_name=South%20West
+CYPRESS_environment=local

--- a/integration_tests/mockApis/person.ts
+++ b/integration_tests/mockApis/person.ts
@@ -39,6 +39,16 @@ export default {
         status: 404,
       },
     }),
+  stubFindPersonForbidden: (args: { person: Person }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `/people/search?crn=${args.person.crn}`,
+      },
+      response: {
+        status: 403,
+      },
+    }),
   stubPersonRisks: (args: { person: Person; risks: PersonRisks }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -23,6 +23,7 @@ export const controllers = (services: Services) => {
     services.premisesService,
     services.bedspaceService,
     services.bookingService,
+    services.personService,
   )
 
   const confirmationsController = new ConfirmationsController(

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -5,6 +5,7 @@
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -24,7 +25,8 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  {{ locationHeader({ premises: premises, room: room, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -19,14 +20,15 @@
 
   <p>Confirm that the CRN is correct. This information cannot be changed once a bedspace has been booked.</p>
 
-  {{ locationHeader({ premises: premises, room: room, crn: crn }) }}
+  {{ popDetailsHeader(person) }}
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.bookings.create({ premisesId: premises.id, roomId: room.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        <input type="hidden" name="crn" value="{{ crn }}"/>
+        <input type="hidden" name="crn" value="{{ person.crn }}"/>
         <input type="hidden" name="arrivalDate" value="{{ arrivalDate }}"/>
         <input type="hidden" name="departureDate" value="{{ departureDate }}"/>
 

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -19,7 +20,8 @@
 
   <h1>Booking history</h1>
 
-  {{ locationHeader({ room: room, premises: premises, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ room: room, premises: premises }) }}
 
   {% for historicBookingDetail in history | reverse %}
     <div data-cy-history-index="{{ loop.revindex0 }}">

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -2,6 +2,7 @@
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
@@ -29,7 +30,8 @@
     items: actions
   }) }}
 
-  {{ locationHeader({ room: room, premises: premises, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ room: room, premises: premises }) }}
 
   {{ bookingInfo(booking, paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })) }}
 

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -6,6 +6,7 @@
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -25,7 +26,8 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  {{ locationHeader({ premises: premises, room: room, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -5,11 +5,6 @@
 <div class="location-header">
   {% set premises = locationDetails.premises %}
   {% set room = locationDetails.room %}
-  {% set crn = locationDetails.crn %}
-
-  {%if crn %}
-    <p><span class="govuk-!-font-weight-bold">CRN:</span> {{ crn }}</p>
-  {% endif %}
 
   {% if room %}
     <h2>Bedspace reference</h2>

--- a/server/views/temporary-accommodation/components/pop-details-header/macro.njk
+++ b/server/views/temporary-accommodation/components/pop-details-header/macro.njk
@@ -1,0 +1,13 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro popDetailsHeader(person) %}
+
+<div class="pop-details-header">
+  {% if person %}
+    <p><span class="govuk-!-font-weight-bold">Name:</span> {{ person.name }}<br />
+    <span class="govuk-!-font-weight-bold">CRN:</span> {{ person.crn }}<br />
+    <span class="govuk-!-font-weight-bold">Date of birth:</span> {{formatDate(person.dateOfBirth)}}</p>
+  {% endif %}
+</div>
+
+{% endmacro %}

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -3,6 +3,7 @@
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -20,7 +21,8 @@
 
   <h1>Mark booking as confirmed</h1>
 
-  {{ locationHeader({ premises: premises, room: room, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -6,6 +6,7 @@
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -25,7 +26,8 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  {{ locationHeader({ premises: premises, room: room, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   {{ bookingInfo(booking) }}
 

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -5,6 +5,7 @@
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -24,7 +25,8 @@
 
   {{ showErrorSummary(errorSummary) }}
 
-  {{ locationHeader({ premises: premises, room: room, crn: booking.person.crn }) }}
+  {{ popDetailsHeader(booking.person) }}
+  {{ locationHeader({ premises: premises, room: room }) }}
 
   {{ bookingInfo(booking) }}
 


### PR DESCRIPTION
# Changes in this PR

This PR allows [the PoP's name and date of birth](https://trello.com/c/59XvRBTe/676-add-a-persons-name-and-dob-to-bookings) to be rendered on booking related pages.

To achieve this I have separated the locationDetailsHeader into two components, locationDetailsHeader and popDetailsHeader. The former header now exclusively renders location related data, while the latter header renders the CRN as before, together with the PoP's name and date of birth.

I have also added json representations of Persons available in the local and dev environments, to support end to end testing.

## Screenshots of UI changes

### Before

![Screenshot 2023-03-21 at 13 50 24](https://user-images.githubusercontent.com/70749355/226627222-1645a01f-68c8-4c4f-8415-7c1ffc6d6f68.png)

![Screenshot 2023-03-21 at 13 50 02](https://user-images.githubusercontent.com/70749355/226627289-a47ed32e-183c-4c9c-bc90-dca94e3509ac.png)

### After

![Screenshot 2023-03-21 at 13 48 39](https://user-images.githubusercontent.com/70749355/226627362-10f37327-0c50-4064-838f-d8cd2bf102b8.png)

![Screenshot 2023-03-21 at 13 49 35](https://user-images.githubusercontent.com/70749355/226627431-e2e2b06f-bf79-4a73-aa5e-b15513f14342.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
