### PR TITLE
Update package-lock.json to Typescript v5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -93,7 +93,7 @@
         "eslint-plugin-no-only-tests": "^3.1.0",
         "eslint-plugin-prettier": "^4.2.1",
         "jest": "^29.0.0",
-        "jest-html-reporter": "^3.7.0",
+        "jest-html-reporter": "^3.7.1",
         "jest-junit": "^15.0.0",
         "jsonwebtoken": "^9.0.0",
         "lint-staged": "^13.0.3",
@@ -107,7 +107,7 @@
         "start-server-and-test": "^2.0.0",
         "supertest": "^6.3.0",
         "ts-jest": "^29.0.0",
-        "typescript": "^4.9.5"
+        "typescript": "^5.0.0"
       },
       "engines": {
         "node": "^18",
@@ -11667,9 +11667,9 @@
       }
     },
     "node_modules/jest-html-reporter": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-3.7.0.tgz",
-      "integrity": "sha512-Bdr71uiCWidOkLvoV2xCvRCTaojjQTuaRplNeEWFeuxAleuHXh/dTuzq0zzwjRqgZjOA6Qoe8LGrkBIb7oXlzQ==",
+      "version": "3.7.1",
+      "resolved": "https://registry.npmjs.org/jest-html-reporter/-/jest-html-reporter-3.7.1.tgz",
+      "integrity": "sha512-gWD6ngP1I100kFjx3ChfmpwaugeMkEApg1ZcVMQMYKB7q2z+EzL7HP6C8a7M3n+2EB1BUJBlRrVGtr6aL4VuOw==",
       "dev": true,
       "dependencies": {
         "@babel/core": "^7.9.0",
@@ -11689,7 +11689,7 @@
       },
       "peerDependencies": {
         "jest": "19.x - 29.x",
-        "typescript": "^3.7.x || ^4.3.x"
+        "typescript": "^3.7.x || ^4.3.x || ^5.x"
       }
     },
     "node_modules/jest-junit": {
@@ -16582,15 +16582,15 @@
       "dev": true
     },
     "node_modules/typescript": {
-      "version": "4.9.5",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
-      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.0.2.tgz",
+      "integrity": "sha512-wVORMBGO/FAs/++blGNeAVdbNKtIh1rbBL2EyQ1+J9lClJ93KiiKe8PmFIVdXhHcyv44SL9oglmfeSsndo0jRw==",
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
       },
       "engines": {
-        "node": ">=4.2.0"
+        "node": ">=12.20"
       }
     },
     "node_modules/typescript-json-schema": {

--- a/package.json
+++ b/package.json
@@ -207,7 +207,7 @@
     "eslint-plugin-no-only-tests": "^3.1.0",
     "eslint-plugin-prettier": "^4.2.1",
     "jest": "^29.0.0",
-    "jest-html-reporter": "^3.7.0",
+    "jest-html-reporter": "^3.7.1",
     "jest-junit": "^15.0.0",
     "jsonwebtoken": "^9.0.0",
     "lint-staged": "^13.0.3",


### PR DESCRIPTION
# Changes in this PR

Updates package-lock.json file to reflect Typescript v5 change (this discrepancy was causing CI to fail). Also updates jest-html-reporter.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
