### PR TITLE
Remove offender_crn E2E environment var

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,7 +64,7 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e:ci --\
-              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},offender_crn=${OFFENDER_CRN_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"  \
+              --env "username=${CYPRESS_USERNAME_<< parameters.environment >>},password=${CYPRESS_PASSWORD_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"  \
               --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots

--- a/e2e.local.env
+++ b/e2e.local.env
@@ -1,6 +1,5 @@
 CYPRESS_username=JimSnowLdap
 CYPRESS_password=secret
-CYPRESS_offender_crn=X320741
 CYPRESS_offender_name="Aadland Bertrand"
 CYPRESS_keyworker_name="Kelby Tabert"
 CYPRESS_lost_bed_reason_id=2f46e769-17a5-4b5c-b04a-a5a9a5b3f773

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -12,7 +12,6 @@ import devPersonData from '../../../../cypress_shared/fixtures/person-dev.json'
 import localPersonData from '../../../../cypress_shared/fixtures/person-local.json'
 
 const environment = Cypress.env('environment') || throwMissingCypressEnvError('environment')
-const offenderCrn = Cypress.env('offender_crn') || throwMissingCypressEnvError('offender_crn')
 
 const person = personFactory.build(environment === 'local' ? localPersonData : devPersonData)
 
@@ -33,7 +32,7 @@ Given('I create a booking with all necessary details', () => {
     const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
 
     const newBooking = newBookingFactory.build({
-      crn: offenderCrn,
+      crn: person.crn,
     })
 
     const booking = bookingFactory.provisional().build({


### PR DESCRIPTION
# Changes in this PR

We remove the offender_crn variable now that we have a complete Person model to use in our E2E tests. The conflict between the two may have caused E2E tests to fail in the dev environment.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
