### PR TITLE
Reduce dependency on suppressImplicitAnyIndexErrors

### DIFF
--- a/server/form-pages/apply/add-documents/attachDocuments.ts
+++ b/server/form-pages/apply/add-documents/attachDocuments.ts
@@ -1,5 +1,5 @@
 import type { ApprovedPremisesApplication, Document } from '@approved-premises/api'
-import { DataServices, TaskListErrors } from '@approved-premises/ui'
+import { DataServices, PageResponse, TaskListErrors } from '@approved-premises/ui'
 import { Page } from '../../utils/decorators'
 
 import { CallConfig } from '../../../data/restClient'
@@ -59,7 +59,7 @@ export default class AttachDocuments implements TasklistPage {
   }
 
   response() {
-    const response = {}
+    const response: PageResponse = {}
 
     this.body.selectedDocuments.forEach(d => {
       response[d.fileName] = d.description || 'No description'

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -120,7 +120,7 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
 }
 
 export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
-  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/))
+  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/)) as Array<keyof T>
   return fields.every(field => !body[field])
 }
 

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -84,7 +84,10 @@ export const convertObjectsToCheckboxItems = (
   })
 }
 
-export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: string): Array<RadioItem> {
+export function convertKeyValuePairToRadioItems<T extends Record<string, string>>(
+  object: T,
+  checkedItem: string,
+): Array<RadioItem> {
   return Object.keys(object).map(key => {
     return {
       value: key,
@@ -94,7 +97,7 @@ export function convertKeyValuePairToRadioItems<T>(object: T, checkedItem: strin
   })
 }
 
-export function convertKeyValuePairToCheckBoxItems<T>(
+export function convertKeyValuePairToCheckBoxItems<T extends Record<string, string>>(
   object: T,
   checkedItems: Array<string> = [],
 ): Array<CheckBoxItem> {
@@ -117,9 +120,9 @@ export function convertArrayToRadioItems(array: Array<string>, checkedItem: stri
   })
 }
 
-export function convertKeyValuePairsToSummaryListItems<T>(
+export function convertKeyValuePairsToSummaryListItems<T extends Record<string, string>>(
   values: T,
-  titles: Record<string, string>,
+  titles: Record<keyof T, string>,
 ): Array<SummaryListItem> {
   return Object.keys(values).map(key => {
     return {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -24,7 +24,7 @@ jest.mock('../i18n/en/errors.json', () => {
         empty: 'You must enter a valid arrival date',
       },
     },
-    cancellation: {
+    bookingCancellation: {
       date: {
         empty: 'You must enter a valid cancellation dae',
       },
@@ -92,7 +92,7 @@ describe('catchValidationErrorOrPropogate', () => {
       },
     })
 
-    const context = 'cancellation'
+    const context = 'bookingCancellation'
 
     catchValidationErrorOrPropogate(request, response, error, 'some/url', context)
 


### PR DESCRIPTION
This PR gives us some quick wins to reduce our dependency on suppressImplicitAnyIndexErrors, which is deprecated as of TypeScript 5