### PR TITLE
E2E tests read reference data from page

### DIFF
--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,4 +1,4 @@
-import { PersonRisksUI } from '../../server/@types/ui'
+import { PersonRisksUI, ReferenceData } from '../../server/@types/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
 import { exact } from '../../server/utils/utils'
@@ -230,5 +230,24 @@ export default abstract class Page extends Component {
     cy.get(`[data-cy-check-your-answers-section="${taskName}"]`).within(() => {
       cy.get('.box-title').should('contain', taskTitle)
     })
+  }
+
+  getSelectOptionsAsReferenceData(label: string, alias: string): void {
+    cy.get('label')
+      .contains(label)
+      .siblings('select')
+      .children('option')
+      .then(elements => {
+        const items: ReferenceData[] = elements
+          .toArray()
+          .filter(element => element.value !== '')
+          .map(element => ({
+            id: element.value,
+            name: element.text,
+            isActive: true,
+            serviceScope: 'temporary-accommodation',
+          }))
+        cy.wrap(items).as(alias)
+      })
   }
 }

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -250,4 +250,20 @@ export default abstract class Page extends Component {
         cy.wrap(items).as(alias)
       })
   }
+
+  getCheckboxItemsAsReferenceData(legend: string, alias: string): void {
+    cy.get('legend')
+      .contains(legend)
+      .siblings('.govuk-checkboxes')
+      .children('.govuk-checkboxes__item')
+      .then(elements => {
+        const items: ReferenceData[] = elements.toArray().map(element => {
+          const id = Cypress.$(element).children('input').attr('value')
+          const name = Cypress.$(element).children('label').text().trim()
+
+          return { id, name, isActive: true, serviceScope: 'temporary-accommodation' }
+        })
+        cy.wrap(items).as(alias)
+      })
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
@@ -36,4 +36,16 @@ export default abstract class PremisesEditablePage extends Page {
 
     this.clickSubmit()
   }
+
+  getPdus(alias: string): void {
+    this.getSelectOptionsAsReferenceData('What is the PDU?', alias)
+  }
+
+  getLocalAuthorities(alias: string): void {
+    this.getSelectOptionsAsReferenceData('What is the local authority (optional)?', alias)
+  }
+
+  getCharacteristics(alias: string): void {
+    this.getCheckboxItemsAsReferenceData('Does the property have any of the following attributes?', alias)
+  }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -196,7 +196,7 @@ export interface ReferenceData {
   id: string
   name: string
   isActive: boolean
-  serviceScope: string
+  serviceScope: 'approved-premises' | 'temporary-accommodation' | '*'
 }
 
 export interface PersonRisksUI {

--- a/server/services/bedspaceSearchService.ts
+++ b/server/services/bedspaceSearchService.ts
@@ -22,7 +22,7 @@ export default class BedspaceSearchService {
   }
 
   async getReferenceData(): Promise<BedspaceSearchReferenceData> {
-    const pdus = pduJson.sort((a, b) => a.name.localeCompare(b.name))
+    const pdus = pduJson.sort((a, b) => a.name.localeCompare(b.name)) as Array<ReferenceData>
 
     return { pdus }
   }

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -53,7 +53,7 @@ export default class PremisesService {
       a.name.localeCompare(b.name),
     )
 
-    const pdus = pduJson.sort((a, b) => a.name.localeCompare(b.name))
+    const pdus = pduJson.sort((a, b) => a.name.localeCompare(b.name)) as Array<ReferenceData>
 
     return { localAuthorities, characteristics, probationRegions, pdus }
   }

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -1,8 +1,8 @@
-import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
-import { NewPremises } from '@approved-premises/api'
-import referenceDataFactory from './referenceData'
+import { Factory } from 'fishery'
+import { NewPremises } from '../../@types/shared'
 import { unique } from '../../utils/utils'
+import referenceDataFactory from './referenceData'
 
 export default Factory.define<NewPremises>(() => ({
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -1,10 +1,22 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
-import { NewPremises } from '../../@types/shared'
+import { NewPremises, Premises } from '../../@types/shared'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
 
-export default Factory.define<NewPremises>(() => ({
+class NewPremisesFactory extends Factory<NewPremises> {
+  /* istanbul ignore next */
+  fromPremises(premises: Premises) {
+    return this.params({
+      ...premises,
+      localAuthorityAreaId: premises.localAuthorityArea.id,
+      characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
+      probationRegionId: premises.probationRegion.id,
+    })
+  }
+}
+
+export default NewPremisesFactory.define(() => ({
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   addressLine1: faker.address.streetAddress(),
   addressLine2: faker.address.secondaryAddress(),
@@ -16,6 +28,6 @@ export default Factory.define<NewPremises>(() => ({
   ),
   probationRegionId: referenceDataFactory.probationRegion().build().id,
   pdu: referenceDataFactory.pdu().build().id,
-  status: faker.helpers.arrayElement(['active', 'archived']),
+  status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
 }))

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -2,7 +2,11 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
 import type { ApArea, TemporaryAccommodationPremises as Premises } from '@approved-premises/api'
+import { ReferenceData } from '../../@types/ui'
 import { unique } from '../../utils/utils'
+import characteristicFactory from './characteristic'
+import localAuthorityFactory from './localAuthority'
+import probationRegionFactory from './probationRegion'
 import referenceDataFactory from './referenceData'
 
 class PremisesFactory extends Factory<Premises> {
@@ -15,6 +19,32 @@ class PremisesFactory extends Factory<Premises> {
   archived() {
     return this.params({
       status: 'archived',
+    })
+  }
+
+  /* istanbul ignore next */
+  forEnvironment(
+    probationRegion: ReferenceData,
+    pdus: ReferenceData[],
+    localAuthorities: ReferenceData[],
+    characteristics: ReferenceData[],
+  ) {
+    return this.params({
+      probationRegion: probationRegionFactory.build({
+        ...probationRegion,
+      }),
+      localAuthorityArea: localAuthorityFactory.build({
+        ...faker.helpers.arrayElement(localAuthorities),
+      }),
+      pdu: faker.helpers.arrayElement(pdus).id,
+      characteristics: faker.helpers
+        .arrayElements(characteristics, faker.datatype.number({ min: 1, max: 5 }))
+        .map(characteristic =>
+          characteristicFactory.build({
+            ...characteristic,
+            modelScope: 'premises',
+          }),
+        ),
     })
   }
 }

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -19,12 +19,12 @@ import { filterCharacteristics } from '../../utils/characteristicUtils'
 class ReferenceDataFactory extends Factory<ReferenceData> {
   departureReasons() {
     const data = faker.helpers.arrayElement(departureReasonsJson)
-    return this.params(data)
+    return this.params(data as ReferenceData)
   }
 
   moveOnCategories() {
     const data = faker.helpers.arrayElement(moveOnCategoriesJson)
-    return this.params(data)
+    return this.params(data as ReferenceData)
   }
 
   destinationProviders() {
@@ -39,7 +39,7 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
 
   lostBedReasons() {
     const data = faker.helpers.arrayElement(lostBedReasonsJson)
-    return this.params(data)
+    return this.params(data as ReferenceData)
   }
 
   nonArrivalReason() {
@@ -58,11 +58,11 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
   }
 
   probationRegion(): Factory<ReferenceData> {
-    return Factory.define<ReferenceData>(() => faker.helpers.arrayElement(probationRegionsJson))
+    return Factory.define<ReferenceData>(() => faker.helpers.arrayElement(probationRegionsJson) as ReferenceData)
   }
 
   pdu(): Factory<ReferenceData> {
-    return Factory.define<ReferenceData>(() => faker.helpers.arrayElement(pdusJson))
+    return Factory.define<ReferenceData>(() => faker.helpers.arrayElement(pdusJson) as ReferenceData)
   }
 }
 

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -1,8 +1,8 @@
-import { Factory } from 'fishery'
-import { faker } from '@faker-js/faker/locale/en_GB'
 import type { UpdatePremises } from '@approved-premises/api'
-import referenceDataFactory from './referenceData'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
 import { unique } from '../../utils/utils'
+import referenceDataFactory from './referenceData'
 
 export default Factory.define<UpdatePremises>(() => ({
   addressLine1: faker.address.streetAddress(),

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -1,10 +1,22 @@
-import type { UpdatePremises } from '@approved-premises/api'
+import type { Premises, UpdatePremises } from '@approved-premises/api'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
 
-export default Factory.define<UpdatePremises>(() => ({
+class UpdatePremisesFactory extends Factory<UpdatePremises> {
+  /* istanbul ignore next */
+  fromPremises(premises: Premises) {
+    return this.params({
+      ...premises,
+      localAuthorityAreaId: premises.localAuthorityArea.id,
+      characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
+      probationRegionId: premises.probationRegion.id,
+    })
+  }
+}
+
+export default UpdatePremisesFactory.define(() => ({
   addressLine1: faker.address.streetAddress(),
   addressLine2: faker.address.secondaryAddress(),
   town: faker.address.city(),
@@ -15,6 +27,6 @@ export default Factory.define<UpdatePremises>(() => ({
   ),
   probationRegionId: referenceDataFactory.probationRegion().build().id,
   pdu: referenceDataFactory.pdu().build().id,
-  status: faker.helpers.arrayElement(['active', 'archived']),
+  status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
 }))


### PR DESCRIPTION
We want to update our premises editing page to only display PDUs that are relevant to the current user.

By default, we would expect this to break our E2E tests, as when creating/editing a premises, they first construct a Premises object using reference data known by the tests, and then use this to guide creating/editing the premises. More often than not, we'd expect the PDU chosen by the E2E tests to not exist in the PDU dropdown shown to the test user, causing an error when the E2E test tries to select a PDU that isn't there.

To fix this, and to make our tests more robust against future changes to PDUs, rather than relying on a prior, known set of PDUs, we read the available PDUs from the page. We also take this as an opportunity to make a similar change for other reference data we need to know when creating/editing a premises.