### PR TITLE
Update bedspace search and premises editing to only present PDUs associated with users region

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -46,7 +46,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
       .contains('What is the PDU?')
       .siblings('select')
       .children('option')
-      .contains(exact(this.premises.pdu))
+      .contains(exact(this.premises.probationDeliveryUnit.name))
       .should('be.selected')
 
     cy.get('legend')

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -85,7 +85,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
 
     this.getSelectInputByIdAndSelectAnEntry('localAuthorityAreaId', '')
     this.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
-    this.getSelectInputByIdAndSelectAnEntry('pdu', '')
+    this.getSelectInputByIdAndSelectAnEntry('probationDeliveryUnitId', '')
 
     cy.get('legend')
       .contains('Does the property have any of the following attributes?')

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
@@ -26,7 +26,7 @@ export default abstract class PremisesEditablePage extends Page {
     this.getSelectInputByIdAndSelectAnEntry('probationRegionId', newOrUpdatePremises.probationRegionId)
 
     this.getLabel('What is the PDU?')
-    this.getSelectInputByIdAndSelectAnEntry('pdu', newOrUpdatePremises.pdu)
+    this.getSelectInputByIdAndSelectAnEntry('probationDeliveryUnitId', newOrUpdatePremises.probationDeliveryUnitId)
 
     this.getLegend('What is the status of this property?')
     this.checkRadioByNameAndValue('status', newOrUpdatePremises.status)

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -53,6 +53,7 @@ export default class PremisesShowPage extends Page {
                       postcode: addressLines[addressLines.length - 1],
                       status,
                       pdu: pdu.name,
+                      probationDeliveryUnit: pdu,
                     })
 
                     cy.wrap(premises).as(alias)

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -78,7 +78,7 @@ export default class PremisesShowPage extends Page {
       ])
       this.shouldShowKeyAndValue('Local authority', this.premises.localAuthorityArea.name)
       this.shouldShowKeyAndValue('Probation region', this.premises.probationRegion.name)
-      this.shouldShowKeyAndValue('PDU', this.premises.pdu)
+      this.shouldShowKeyAndValue('PDU', this.premises.probationDeliveryUnit.name)
       this.shouldShowKeyAndValues(
         'Attributes',
         this.premises.characteristics.map(({ name }) => name),

--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -20,7 +20,7 @@ Given('I search for a bedspace', () => {
     const page = Page.verifyOnPage(BedspaceSearchPage)
 
     const searchParameters = bedSearchParametersFactory.build({
-      probationDeliveryUnit: this.premises.pdu,
+      probationDeliveryUnit: this.premises.probationDeliveryUnit.id,
     })
 
     page.completeForm(searchParameters)

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -101,12 +101,12 @@ Given('I attempt to create a premises with the PDU missing', () => {
       })
 
     const newPremises = newPremisesFactory.fromPremises(premises).build({
-      pdu: '',
+      probationDeliveryUnitId: '',
     })
 
     page.completeForm(newPremises)
 
-    cy.wrap(['pdu']).as('missing')
+    cy.wrap(['probationDeliveryUnitId']).as('missing')
   })
 })
 
@@ -160,12 +160,12 @@ Given('I attempt to edit the premises to remove the PDU', () => {
     const page = Page.verifyOnPage(PremisesEditPage, this.premises)
 
     const updatePremises = updatePremisesFactory.fromPremises(this.premises).build({
-      pdu: '',
+      probationDeliveryUnitId: '',
     })
 
     page.completeForm(updatePremises)
 
-    cy.wrap(['pdu']).as('missing')
+    cy.wrap(['probationDeliveryUnitId']).as('missing')
   })
 })
 

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -193,7 +193,7 @@ context('Premises', () => {
       'town',
       'postcode',
       'probationRegionId',
-      'pdu',
+      'probationDeliveryUnitId',
       'status',
     ])
     page.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
@@ -206,7 +206,7 @@ context('Premises', () => {
       'town',
       'postcode',
       'probationRegionId',
-      'pdu',
+      'probationDeliveryUnitId',
       'status',
     ])
   })
@@ -299,13 +299,19 @@ context('Premises', () => {
     // And I clear required fields
     cy.task('stubPremisesUpdateErrors', {
       premises,
-      params: ['addressLine1', 'town', 'postcode', 'probationRegionId', 'pdu'],
+      params: ['addressLine1', 'town', 'postcode', 'probationRegionId', 'probationDeliveryUnitId'],
     })
     page.clearForm()
     page.clickSubmit()
 
     // Then I should see error messages relating to those fields
-    page.shouldShowErrorMessagesForFields(['addressLine1', 'town', 'postcode', 'probationRegionId', 'pdu'])
+    page.shouldShowErrorMessagesForFields([
+      'addressLine1',
+      'town',
+      'postcode',
+      'probationRegionId',
+      'probationDeliveryUnitId',
+    ])
   })
 
   it('should navigate back from the edit premises page to the premises show page', () => {

--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -113,6 +113,7 @@ export type { PremisesSummary } from './models/PremisesSummary';
 export type { PrisonCaseNote } from './models/PrisonCaseNote';
 export type { ProbationDeliveryUnit } from './models/ProbationDeliveryUnit';
 export type { ProbationRegion } from './models/ProbationRegion';
+export type { ProbationDeliveryUnit } from './models/ProbationDeliveryUnit'
 export type { Problem } from './models/Problem';
 export type { PropertyStatus } from './models/PropertyStatus';
 export type { Reallocation } from './models/Reallocation';

--- a/server/@types/shared/models/TemporaryAccommodationPremises.ts
+++ b/server/@types/shared/models/TemporaryAccommodationPremises.ts
@@ -2,11 +2,12 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { Premises } from './Premises';
+import type { Premises } from './Premises'
+import { ProbationDeliveryUnit } from './ProbationDeliveryUnit'
 
-export type TemporaryAccommodationPremises = (Premises & {
-    pdu?: string;
+export type TemporaryAccommodationPremises = Premises & {
+  pdu?: string
 } & {
-    pdu: string;
-});
-
+  pdu: string
+  probationDeliveryUnit: ProbationDeliveryUnit
+}

--- a/server/@types/shared/models/UpdatePremises.ts
+++ b/server/@types/shared/models/UpdatePremises.ts
@@ -2,19 +2,18 @@
 /* tslint:disable */
 /* eslint-disable */
 
-import type { PropertyStatus } from './PropertyStatus';
+import type { PropertyStatus } from './PropertyStatus'
 
 export type UpdatePremises = {
-    addressLine1: string;
-    addressLine2?: string;
-    town?: string;
-    postcode: string;
-    notes?: string;
-    localAuthorityAreaId?: string;
-    probationRegionId: string;
-    characteristicIds: Array<string>;
-    status: PropertyStatus;
-    pdu?: string;
-    probationDeliveryUnitId?: string;
-};
-
+  addressLine1: string
+  addressLine2?: string
+  town?: string
+  postcode: string
+  notes?: string
+  localAuthorityAreaId?: string
+  probationRegionId: string
+  characteristicIds: Array<string>
+  status: PropertyStatus
+  pdu?: string
+  probationDeliveryUnitId?: string
+}

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -18,7 +18,7 @@ import {
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, reallocateErrors } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import PremisesController from './premisesController'
 
 jest.mock('../../../utils/validation')
@@ -195,7 +195,6 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(reallocateErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, paths.premises.new({}))
     })
   })
@@ -321,7 +320,6 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(reallocateErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -7,7 +7,7 @@ import PremisesService from '../../../services/premisesService'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, reallocateErrors } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -64,7 +64,6 @@ export default class PremisesController {
         req.flash('success', 'Property created')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
-        reallocateErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.new({}))
       }
     }
@@ -117,7 +116,6 @@ export default class PremisesController {
         req.flash('success', 'Property updated')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
-        reallocateErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.edit({ premisesId }))
       }
     }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -93,7 +93,7 @@
     "probationRegionId": {
       "empty": "You must choose a probation region"
     },
-    "pdu": {
+    "probationDeliveryUnitId": {
       "empty": "You must choose a PDU"
     },
     "status": {

--- a/server/services/bedspaceSearchService.ts
+++ b/server/services/bedspaceSearchService.ts
@@ -30,9 +30,7 @@ export default class BedspaceSearchService {
       await referenceDataClient.getReferenceData('probation-delivery-units', {
         probationRegionId: callConfig.probationRegion.id,
       })
-    )
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(pdu => ({ ...pdu, id: pdu.name }))
+    ).sort((a, b) => a.name.localeCompare(b.name))
 
     return { pdus }
   }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -139,7 +139,7 @@ describe('PremisesService', () => {
             text: premises1.bedCount.toString(),
           },
           {
-            text: premises1.pdu,
+            text: premises1.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises1.status}</strong>`,
@@ -158,7 +158,7 @@ describe('PremisesService', () => {
             text: premises2.bedCount.toString(),
           },
           {
-            text: premises2.pdu,
+            text: premises2.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises2.status}</strong>`,
@@ -177,7 +177,7 @@ describe('PremisesService', () => {
             text: premises3.bedCount.toString(),
           },
           {
-            text: premises3.pdu,
+            text: premises3.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises3.status}</strong>`,
@@ -196,7 +196,7 @@ describe('PremisesService', () => {
             text: premises4.bedCount.toString(),
           },
           {
-            text: premises4.pdu,
+            text: premises4.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises4.status}</strong>`,
@@ -255,6 +255,10 @@ describe('PremisesService', () => {
           name: 'A probation region',
           id: 'a-probation-region',
         }),
+        probationDeliveryUnit: pduFactory.build({
+          name: 'A probation delivery unit',
+          id: 'a-probation-delivery-unit',
+        }),
       })
 
       premisesClient.find.mockResolvedValue(premises)
@@ -265,6 +269,7 @@ describe('PremisesService', () => {
         localAuthorityAreaId: 'local-authority',
         characteristicIds: ['characteristic-a', 'characteristic-b'],
         probationRegionId: 'a-probation-region',
+        pdu: 'a-probation-delivery-unit',
       })
 
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
@@ -306,7 +311,7 @@ describe('PremisesService', () => {
         probationRegion: probationRegionFactory.build({
           name: 'A probation region',
         }),
-        pdu: 'A PDU',
+        probationDeliveryUnit: pduFactory.build({ name: 'A PDU' }),
         status: 'active',
         notes: 'Some notes',
       })

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -269,7 +269,7 @@ describe('PremisesService', () => {
         localAuthorityAreaId: 'local-authority',
         characteristicIds: ['characteristic-a', 'characteristic-b'],
         probationRegionId: 'a-probation-region',
-        pdu: 'a-probation-delivery-unit',
+        probationDeliveryUnitId: 'a-probation-delivery-unit',
       })
 
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
@@ -398,17 +398,19 @@ describe('PremisesService', () => {
   describe('update', () => {
     it('on success updates the premises and returns the updated premises', async () => {
       const premises = premisesFactory.build()
-      const newPremises = updatePremisesFactory.build({
+      const updatePremises = updatePremisesFactory.build({
         postcode: premises.postcode,
         notes: premises.notes,
       })
       premisesClient.update.mockResolvedValue(premises)
 
-      const updatedPremises = await service.update(callConfig, premises.id, newPremises)
+      const updatedPremises = await service.update(callConfig, premises.id, updatePremises)
       expect(updatedPremises).toEqual(premises)
 
       expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(premisesClient.update).toHaveBeenCalledWith(premises.id, newPremises)
+      expect(premisesClient.update).toHaveBeenCalledWith(premises.id, {
+        ...updatePremises,
+      })
     })
   })
 })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -56,9 +56,7 @@ export default class PremisesService {
       await referenceDataClient.getReferenceData('probation-delivery-units', {
         probationRegionId: callConfig.probationRegion.id,
       })
-    )
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(pdu => ({ ...pdu, id: pdu.name }))
+    ).sort((a, b) => a.name.localeCompare(b.name))
 
     return { localAuthorities, characteristics, probationRegions, pdus }
   }

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -130,7 +130,7 @@ export default class PremisesService {
       localAuthorityAreaId: premises.localAuthorityArea?.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.probationDeliveryUnit.id,
+      probationDeliveryUnitId: premises.probationDeliveryUnit.id,
     }
   }
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -74,7 +74,7 @@ export default class PremisesService {
         return [
           this.textValue(entry.shortAddress),
           this.textValue(`${entry.bedCount}`),
-          this.textValue(entry.pdu),
+          this.textValue(entry.probationDeliveryUnit.name),
           this.htmlValue(statusTag(entry.status)),
           this.htmlValue(
             `<a href="${paths.premises.show({
@@ -132,7 +132,7 @@ export default class PremisesService {
       localAuthorityAreaId: premises.localAuthorityArea?.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.pdu,
+      pdu: premises.probationDeliveryUnit.id,
     }
   }
 
@@ -171,7 +171,7 @@ export default class PremisesService {
         },
         {
           key: this.textValue('PDU'),
-          value: this.textValue(premises.pdu),
+          value: this.textValue(premises.probationDeliveryUnit.name),
         },
         {
           key: this.textValue('Attributes'),

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
-import { NewPremises, Premises } from '../../@types/shared'
+import { NewPremises, TemporaryAccommodationPremises as Premises } from '../../@types/shared'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
 
@@ -12,6 +12,7 @@ class NewPremisesFactory extends Factory<NewPremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
+      pdu: premises.probationDeliveryUnit.id,
     })
   }
 }

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -12,7 +12,7 @@ class NewPremisesFactory extends Factory<NewPremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.probationDeliveryUnit.id,
+      probationDeliveryUnitId: premises.probationDeliveryUnit.id,
     })
   }
 }
@@ -28,7 +28,7 @@ export default NewPremisesFactory.define(() => ({
     characteristic => characteristic.id,
   ),
   probationRegionId: referenceDataFactory.probationRegion().build().id,
-  pdu: referenceDataFactory.pdu().build().id,
+  probationDeliveryUnitId: referenceDataFactory.pdu().build().id,
   status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
 }))

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -6,6 +6,7 @@ import { ReferenceData } from '../../@types/ui'
 import { unique } from '../../utils/utils'
 import characteristicFactory from './characteristic'
 import localAuthorityFactory from './localAuthority'
+import pduFactory from './pdu'
 import probationRegionFactory from './probationRegion'
 import referenceDataFactory from './referenceData'
 
@@ -29,6 +30,8 @@ class PremisesFactory extends Factory<Premises> {
     localAuthorities: ReferenceData[],
     characteristics: ReferenceData[],
   ) {
+    const pdu = pduFactory.build({ ...faker.helpers.arrayElement(pdus) })
+
     return this.params({
       probationRegion: probationRegionFactory.build({
         ...probationRegion,
@@ -36,7 +39,8 @@ class PremisesFactory extends Factory<Premises> {
       localAuthorityArea: localAuthorityFactory.build({
         ...faker.helpers.arrayElement(localAuthorities),
       }),
-      pdu: faker.helpers.arrayElement(pdus).id,
+      pdu: pdu.id,
+      probationDeliveryUnit: pdu,
       characteristics: faker.helpers
         .arrayElements(characteristics, faker.datatype.number({ min: 1, max: 5 }))
         .map(characteristic =>
@@ -49,26 +53,31 @@ class PremisesFactory extends Factory<Premises> {
   }
 }
 
-export default PremisesFactory.define(() => ({
-  id: faker.datatype.uuid(),
-  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
-  addressLine1: faker.address.streetAddress(),
-  addressLine2: faker.address.secondaryAddress(),
-  town: faker.address.cityName(),
-  postcode: faker.address.zipCode(),
-  bedCount: 50,
-  availableBedsForToday: faker.datatype.number({ min: 0, max: 50 }),
-  apAreaId: faker.random.alphaNumeric(2, { casing: 'upper' }),
-  probationRegion: referenceDataFactory.probationRegion().build(),
-  apArea: apAreaFactory.build(),
-  localAuthorityArea: referenceDataFactory.localAuthority().build(),
-  pdu: referenceDataFactory.pdu().build().id,
-  characteristics: unique(
-    referenceDataFactory.characteristic('premises').buildList(faker.datatype.number({ min: 1, max: 5 })),
-  ),
-  status: faker.helpers.arrayElement(['active', 'archived'] as const),
-  notes: faker.lorem.lines(5),
-}))
+export default PremisesFactory.define(() => {
+  const pdu = referenceDataFactory.pdu().build()
+
+  return {
+    id: faker.datatype.uuid(),
+    name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+    addressLine1: faker.address.streetAddress(),
+    addressLine2: faker.address.secondaryAddress(),
+    town: faker.address.cityName(),
+    postcode: faker.address.zipCode(),
+    bedCount: 50,
+    availableBedsForToday: faker.datatype.number({ min: 0, max: 50 }),
+    apAreaId: faker.random.alphaNumeric(2, { casing: 'upper' }),
+    probationRegion: referenceDataFactory.probationRegion().build(),
+    apArea: apAreaFactory.build(),
+    localAuthorityArea: referenceDataFactory.localAuthority().build(),
+    pdu: pdu.id,
+    probationDeliveryUnit: pdu,
+    characteristics: unique(
+      referenceDataFactory.characteristic('premises').buildList(faker.datatype.number({ min: 1, max: 5 })),
+    ),
+    status: faker.helpers.arrayElement(['active', 'archived'] as const),
+    notes: faker.lorem.lines(5),
+  }
+})
 
 const apAreaFactory = Factory.define<ApArea>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -12,7 +12,7 @@ class UpdatePremisesFactory extends Factory<UpdatePremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.probationDeliveryUnit.id,
+      probationDeliveryUnitId: premises.probationDeliveryUnit.id,
     })
   }
 }
@@ -27,7 +27,7 @@ export default UpdatePremisesFactory.define(() => ({
     characteristic => characteristic.id,
   ),
   probationRegionId: referenceDataFactory.probationRegion().build().id,
-  pdu: referenceDataFactory.pdu().build().id,
+  probationDeliveryUnitId: referenceDataFactory.pdu().build().id,
   status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
 }))

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -1,4 +1,4 @@
-import type { Premises, UpdatePremises } from '@approved-premises/api'
+import type { TemporaryAccommodationPremises as Premises, UpdatePremises } from '@approved-premises/api'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 import { unique } from '../../utils/utils'
@@ -12,6 +12,7 @@ class UpdatePremisesFactory extends Factory<UpdatePremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
+      pdu: premises.probationDeliveryUnit.id,
     })
   }
 }

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -96,8 +96,8 @@
       text: "What is the PDU?",
       classes: "govuk-label--m"
     },
-    items: convertObjectsToSelectOptions(allPdus, 'Select a PDU', 'name', 'id', 'pdu'),
-    fieldName: "pdu"
+    items: convertObjectsToSelectOptions(allPdus, 'Select a PDU', 'name', 'id', 'probationDeliveryUnitId'),
+    fieldName: "probationDeliveryUnitId"
   },
   fetchContext()
 ) }}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -56,7 +56,10 @@ stubs.push({
   },
 })
 
-const createRequiredFields = [...getCombinations(['addressLine1', 'postcode', 'probationRegionId', 'status']), ['pdu']]
+const createRequiredFields = [
+  ...getCombinations(['addressLine1', 'postcode', 'probationRegionId', 'status']),
+  ['probationDeliveryUnitId'],
+]
 
 createRequiredFields.forEach((fields: Array<string>) => {
   stubs.push(errorStub(fields, `/premises`, 'POST'))
@@ -121,7 +124,7 @@ premises.forEach(item => {
 
   const updateRequiredFields = [
     ...getCombinations(['addressLine1', 'postcode', 'probationRegionId', 'status']),
-    ['pdu'],
+    ['probationDeliveryUnitId'],
   ]
 
   updateRequiredFields.forEach((fields: Array<string>) => {


### PR DESCRIPTION
# Changes in this PR

This PR updates the UI to retrieve the list of PDUs from an API endpoint, rather than using a UI-side JSON file. This allows us to send the API a query parameter that the API will use to send us only the PDUs for our region.

This PR is ahead of the API, and makes some assumptions about the API and the shared types. The assumed shared types are in the "Update shared types" commit, and should be replaced with the 'real' shared types before merging

## API assumptions

I've generally assumed this will follow the lead of the bedspace search work, and move towards using "probation delivery unit", rather than the abbreviated "PDU".

- We'll have a new type `ProbationDeliveryUnit`, with fields `name` and `id`
- `pdu` on `TemporaryAccommodationPremises` will continue to give the PDU *name*, for backwards compatibility
- `TemporaryAccommodationPremises` will have a new field `probationDeliveryUnit`, which will be a `ProbationDeliveryUnit` object, similar to `probationRegion` and `localAuthorityArea`
- The PDUs for a region will be available at `/reference-data/probation-delivery-units?probationRegionId=<< probation region ID >>`, and this will return an array of `ProbationDeliveryUnit`s

On `NewPremises` and `UpdatePremises`:
- We deprecate `pdu`, and use a new `probationDeliveryUnitId` field
- If `pdu` is present, it's coming from the old UI and should be interpreted as a PDU *name*. If `probationDeliveryUnitId` is present it's coming from the new UI and should be interpreted as a PDU *ID*.
- **If both are missing, the "empty" error goes against the `probationDeliveryUnitId` field**
- A frontend update to go in before the API change to handle `probationDeliveryUnitId` errors

Note that the PDUs initially seeded in the dev environment don't match those the UI is aware of from [`pdu.json`](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/main/server/data/pdus.json). E.g., in our JSON we have "Essex South". In the [dev seed](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/resources/db/migration/local%2Bdev/R__2_create_premises.sql) we have "Essex South (Basildon, Brentwood, Rochford and Castlepoint, Southend-on-Sea)".

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
