### PR TITLE
Change PDU name handling for E2E tests

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -42,7 +42,7 @@ export default class PremisesShowPage extends Page {
                       .map(text => text.trim())
 
                     const pduName = pduElement.text().trim()
-                    const pdu = pduJson.find(p => p.name === pduName)?.id as string
+                    const pdu = pduJson.find(p => pduName.startsWith(p.name))?.id as string
 
                     const premises = premisesFactory.build({
                       id,


### PR DESCRIPTION
# Changes in this PR

At the moment we don't have an API endpoint for PDU information, so for our E2E testing we are reliant on names stored in the UI matching those stored in the API. Some of the PDU names stored in the API are very long, so they have been shortened in the UI. However this has caused E2E tests to fail when these PDUs have been selected.

This PR changes the PDU name checking to ensure that an API PDU name (e.g. 'North West Lancashire (Blackpool and lower tier LAs in Lancashire - Fylde, Wyre and Lancaster)' starts with the UI substring (e.g. 'North West Lancashire'), rather than checking for an exact match.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
