### PR TITLE
Users can search bookings grouped by status

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -1,4 +1,4 @@
-import type { Booking, Premises, Room } from '@approved-premises/api'
+import type { Booking, BookingSearchStatus, Premises, Room } from '@approved-premises/api'
 import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
@@ -8,9 +8,14 @@ export default class BookingSearchPage extends Page {
     super('Find a booking')
   }
 
-  static visit(): BookingSearchPage {
-    cy.visit(paths.bookings.search({}))
+  static visit(status: BookingSearchStatus): BookingSearchPage {
+    cy.visit(paths.bookings.search[status].index({}))
     return new BookingSearchPage()
+  }
+
+  checkBookingStatus(status: BookingSearchStatus) {
+    const capitalisedStatus = status.charAt(0).toUpperCase() + status.slice(1)
+    cy.get('h2').contains(`${capitalisedStatus} bookings`)
   }
 
   checkBookingDetails(premises: Premises, room: Room, booking: Booking) {
@@ -37,5 +42,10 @@ export default class BookingSearchPage extends Page {
       .within(() => {
         cy.get('td').eq(5).contains('View').click()
       })
+  }
+
+  clickOtherBookingStatusLink(status: BookingSearchStatus) {
+    const capitalisedStatus = status.charAt(0).toUpperCase() + status.slice(1)
+    cy.contains(capitalisedStatus).click()
   }
 }

--- a/integration_tests/mockApis/bookingSearch.ts
+++ b/integration_tests/mockApis/bookingSearch.ts
@@ -1,14 +1,14 @@
 import { SuperAgentRequest } from 'superagent'
+import type { BookingSearchResults, BookingSearchStatus } from '@approved-premises/api'
 import paths from '../../server/paths/api'
-import type { BookingSearchResults } from '../../server/@types/shared/models/BookingSearchResults'
 import { stubFor } from '../../wiremock'
 
 export default {
-  stubFindBookings: (args: { bookings: BookingSearchResults }): SuperAgentRequest =>
+  stubFindBookings: (args: { bookings: BookingSearchResults; status: BookingSearchStatus }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: paths.bookings.search({}),
+        url: `${paths.bookings.search({})}?status=${args.status}`,
       },
       response: {
         status: 200,

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -10,14 +10,14 @@ context('Booking search', () => {
     setupTestUser()
   })
 
-  it('navigates to the find a booking page', () => {
+  it('navigates to the find a provisional booking page', () => {
     // Given I am signed in
     cy.signIn()
 
     // And there are bookings in the database
     const bookings = bookingSearchResultsFactory.build()
 
-    cy.task('stubFindBookings', { bookings })
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
 
     // When I visit the dashboard
     const dashboard = DashboardPage.visit()
@@ -25,8 +25,44 @@ context('Booking search', () => {
     // And I click the Find a booking tile
     dashboard.clickFindABookingLink()
 
-    // Then I navigate to the Find a booking page
-    Page.verifyOnPage(BookingSearchPage)
+    // Then I navigate to the Find a provisional booking page
+    const page = Page.verifyOnPage(BookingSearchPage)
+    page.checkBookingStatus('provisional')
+  })
+
+  it('navigates to the find a booking pages for each status', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings of all relevant status types in the database
+    const bookings = bookingSearchResultsFactory.build()
+
+    const statuses = ['provisional', 'active', 'closed', 'confirmed']
+
+    statuses.forEach(status => {
+      cy.task('stubFindBookings', { bookings, status })
+    })
+
+    // And I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // And I click the Confirmed bookings link
+    page.clickOtherBookingStatusLink('confirmed')
+
+    // Then I navigate to the Find a confirmed booking page
+    page.checkBookingStatus('confirmed')
+
+    // And I click the Active bookings link
+    page.clickOtherBookingStatusLink('active')
+
+    // Then I navigate to the Find an active booking page
+    page.checkBookingStatus('active')
+
+    // And I click the Closed bookings link
+    page.clickOtherBookingStatusLink('closed')
+
+    // Then I navigate to the Find a closed booking page
+    page.checkBookingStatus('closed')
   })
 
   it('navigates back to the dashboard from the find a booking page', () => {
@@ -36,10 +72,10 @@ context('Booking search', () => {
     // And there are bookings in the database
     const bookings = bookingSearchResultsFactory.build()
 
-    cy.task('stubFindBookings', { bookings })
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
 
     // When I visit the Find a booking page
-    const page = BookingSearchPage.visit()
+    const page = BookingSearchPage.visit('provisional')
 
     // And I click the previous bread crumb
     page.clickBreadCrumbUp()

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,7 +45,7 @@
         "passport-oauth2": "^1.6.1",
         "path-to-regexp": "^6.2.1",
         "prom-client": "^14.1.0",
-        "qs": "^6.11.0",
+        "qs": "^6.11.1",
         "redis": "^4.3.1",
         "reflect-metadata": "^0.1.13",
         "static-path": "^0.0.4",

--- a/package.json
+++ b/package.json
@@ -159,7 +159,7 @@
     "passport-oauth2": "^1.6.1",
     "path-to-regexp": "^6.2.1",
     "prom-client": "^14.1.0",
-    "qs": "^6.11.0",
+    "qs": "^6.11.1",
     "redis": "^4.3.1",
     "reflect-metadata": "^0.1.13",
     "static-path": "^0.0.4",

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -254,3 +254,9 @@ export type OasysImportArrays =
   | ArrayOfOASysRiskManagementPlanQuestions
 
 export type JourneyType = 'applications' | 'assessments'
+
+export interface SideNavObj {
+  text: string
+  href: string
+  active: boolean
+}

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -4,8 +4,10 @@ import BookingSearchController from './bookingSearchController'
 import { CallConfig } from '../../../data/restClient'
 import { BookingSearchService } from '../../../services'
 import extractCallConfig from '../../../utils/restUtils'
+import { createSideNavArr } from '../../../utils/bookingSearchUtils'
 
 jest.mock('../../../utils/restUtils')
+jest.mock('../../../utils/bookingSearchUtils')
 
 describe('BookingSearchController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -22,20 +24,67 @@ describe('BookingSearchController', () => {
   beforeEach(() => {
     request = createMock<Request>()
     ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+    ;(createSideNavArr as jest.MockedFn<typeof createSideNavArr>).mockReturnValue([])
   })
 
   describe('index', () => {
-    it('renders the table view of all bookings', async () => {
+    it('renders the table view for provisional bookings', async () => {
       bookingSearchService.getTableRowsForFindBooking.mockResolvedValue([])
 
-      const requestHandler = bookingSearchController.index()
+      const requestHandler = bookingSearchController.index('provisional')
 
       await requestHandler(request, response, next)
 
-      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig)
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'provisional')
 
-      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookingSearch/index', {
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/provisional', {
         bookingTableRows: [],
+        sideNavArr: [],
+      })
+    })
+
+    it('renders the table view for active bookings', async () => {
+      bookingSearchService.getTableRowsForFindBooking.mockResolvedValue([])
+
+      const requestHandler = bookingSearchController.index('active')
+
+      await requestHandler(request, response, next)
+
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'active')
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/active', {
+        bookingTableRows: [],
+        sideNavArr: [],
+      })
+    })
+
+    it('renders the table view for confirmed bookings', async () => {
+      bookingSearchService.getTableRowsForFindBooking.mockResolvedValue([])
+
+      const requestHandler = bookingSearchController.index('confirmed')
+
+      await requestHandler(request, response, next)
+
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'confirmed')
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/confirmed', {
+        bookingTableRows: [],
+        sideNavArr: [],
+      })
+    })
+
+    it('renders the table view for closed bookings', async () => {
+      bookingSearchService.getTableRowsForFindBooking.mockResolvedValue([])
+
+      const requestHandler = bookingSearchController.index('closed')
+
+      await requestHandler(request, response, next)
+
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'closed')
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/closed', {
+        bookingTableRows: [],
+        sideNavArr: [],
       })
     })
   })

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -1,17 +1,21 @@
 import type { Request, RequestHandler, Response } from 'express'
 import { BookingSearchService } from 'server/services'
+import type { BookingSearchStatus } from '@approved-premises/api'
 import extractCallConfig from '../../../utils/restUtils'
+import { createSideNavArr } from '../../../utils/bookingSearchUtils'
 
 export default class BookingSearchController {
   constructor(private readonly bookingSearchService: BookingSearchService) {}
 
-  index(): RequestHandler {
+  index(status: BookingSearchStatus): RequestHandler {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
 
-      const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig)
+      const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status)
 
-      return res.render('temporary-accommodation/bookingSearch/index', { bookingTableRows })
+      const sideNavArr = createSideNavArr(status)
+
+      return res.render(`temporary-accommodation/booking-search/${status}`, { sideNavArr, bookingTableRows })
     }
   }
 }

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -1,6 +1,7 @@
 import type {
   Arrival,
   Booking,
+  BookingSearchStatus,
   Cancellation,
   Confirmation,
   Departure,
@@ -18,6 +19,7 @@ import type { BookingSearchResults } from 'server/@types/shared/models/BookingSe
 import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
+import { createQueryString } from '../utils/utils'
 
 export default class BookingClient {
   restClient: RestClient
@@ -106,8 +108,12 @@ export default class BookingClient {
     return response as Nonarrival
   }
 
-  async index(): Promise<BookingSearchResults> {
-    const response = await this.restClient.get({ path: paths.bookings.search({}) })
+  async search(status: BookingSearchStatus): Promise<BookingSearchResults> {
+    const queryString: string = createQueryString({ status })
+
+    const path = `${paths.bookings.search({ status })}${queryString ? `?${queryString}` : ''}`
+
+    const response = await this.restClient.get({ path })
 
     return response as BookingSearchResults
   }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -11,7 +11,9 @@ const singleRoomPath = singlePremisesPath.path('rooms').path(':roomId')
 
 const bedsPath = path('/beds')
 const searchBedsPath = bedsPath.path('search')
+
 const bookingsPath = path('/bookings')
+const searchBookingsPath = bookingsPath.path('search')
 
 const managePaths = {
   premises: {
@@ -37,7 +39,7 @@ const managePaths = {
     search: searchBedsPath,
   },
   bookings: {
-    search: bookingsPath.path('search'),
+    search: searchBookingsPath,
   },
 }
 

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -67,7 +67,20 @@ const paths = {
       edit: cancellationsPath.path('edit'),
       update: cancellationsPath,
     },
-    search: allBookingsPath,
+    search: {
+      provisional: {
+        index: allBookingsPath.path('provisional'),
+      },
+      active: {
+        index: allBookingsPath.path('active'),
+      },
+      closed: {
+        index: allBookingsPath.path('closed'),
+      },
+      confirmed: {
+        index: allBookingsPath.path('confirmed'),
+      },
+    },
   },
   lostBeds: {
     new: lostBedsPath.path('new'),

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -264,8 +264,17 @@ export default function routes(controllers: Controllers, services: Services, rou
   })
 
   if (!config.flags.bookingSearchDisabled) {
-    get(paths.bookings.search.pattern, bookingSearchController.index(), {
-      auditEvent: 'VIEW_SEARCH_BOOKINGS',
+    get(paths.bookings.search.provisional.index.pattern, bookingSearchController.index('provisional'), {
+      auditEvent: 'VIEW_SEARCH_PROVISIONAL_BOOKINGS',
+    })
+    get(paths.bookings.search.active.index.pattern, bookingSearchController.index('active'), {
+      auditEvent: 'VIEW_SEARCH_ACTIVE_BOOKINGS',
+    })
+    get(paths.bookings.search.closed.index.pattern, bookingSearchController.index('closed'), {
+      auditEvent: 'VIEW_SEARCH_CLOSED_BOOKINGS',
+    })
+    get(paths.bookings.search.confirmed.index.pattern, bookingSearchController.index('confirmed'), {
+      auditEvent: 'VIEW_SEARCH_CONFIRMED_BOOKINGS',
     })
   }
 

--- a/server/services/bookingSearchService.test.ts
+++ b/server/services/bookingSearchService.test.ts
@@ -1,8 +1,7 @@
-import bookingSearchResultFactory from '../testutils/factories/bookingSearchResult'
 import BookingClient from '../data/bookingClient'
 import BookingSearchService from './bookingSearchService'
 import { CallConfig } from '../data/restClient'
-import bookingSearchResultsFactory from '../testutils/factories/bookingSearchResults'
+import { bookingSearchResultFactory, bookingSearchResultsFactory } from '../testutils/factories/index'
 import { DateFormats } from '../utils/dateUtils'
 import paths from '../paths/temporary-accommodation/manage'
 
@@ -22,15 +21,15 @@ describe('BookingService', () => {
   })
 
   describe('getTableRowsForFindBooking', () => {
-    it('returns a table view of all bookings', async () => {
+    it('returns a table view of all returned bookings', async () => {
       const booking1 = bookingSearchResultFactory.build()
       const booking2 = bookingSearchResultFactory.build()
       const booking3 = bookingSearchResultFactory.build()
       const bookings = bookingSearchResultsFactory.build({ resultsCount: 3, results: [booking1, booking2, booking3] })
 
-      bookingClient.index.mockResolvedValue(bookings)
+      bookingClient.search.mockResolvedValue(bookings)
 
-      const rows = await service.getTableRowsForFindBooking(callConfig)
+      const rows = await service.getTableRowsForFindBooking(callConfig, 'provisional')
 
       expect(rows).toEqual([
         [
@@ -86,9 +85,9 @@ describe('BookingService', () => {
 
     it('returns an empty array if no bookings exist', async () => {
       const bookings = bookingSearchResultsFactory.build({ resultsCount: 0, results: [] })
-      bookingClient.index.mockResolvedValue(bookings)
+      bookingClient.search.mockResolvedValue(bookings)
 
-      const rows = await service.getTableRowsForFindBooking(callConfig)
+      const rows = await service.getTableRowsForFindBooking(callConfig, 'provisional')
 
       expect(rows).toEqual([])
     })

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -1,4 +1,5 @@
 import type { TableRow } from '@approved-premises/ui'
+import type { BookingSearchStatus } from '@approved-premises/api'
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { CallConfig } from '../data/restClient'
@@ -8,9 +9,9 @@ import paths from '../paths/temporary-accommodation/manage'
 export default class BookingSearchService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async getTableRowsForFindBooking(callConfig: CallConfig): Promise<Array<TableRow>> {
+  async getTableRowsForFindBooking(callConfig: CallConfig, status: BookingSearchStatus): Promise<Array<TableRow>> {
     const bookingClient = this.bookingClientFactory(callConfig)
-    const bookingSummaries = await bookingClient.index()
+    const bookingSummaries = await bookingClient.search(status)
 
     return bookingSummaries.results.map(summary => {
       return [

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -1,0 +1,33 @@
+import paths from '../paths/temporary-accommodation/manage'
+import { createSideNavArr } from './bookingSearchUtils'
+
+describe('bookingSearchUtils', () => {
+  describe('createSideNavArr', () => {
+    it('returns side nav with given status selected', () => {
+      const sideNavArr = [
+        {
+          text: 'Provisional',
+          href: paths.bookings.search.provisional.index({}),
+          active: true,
+        },
+        {
+          text: 'Confirmed',
+          href: paths.bookings.search.confirmed.index({}),
+          active: false,
+        },
+        {
+          text: 'Active',
+          href: paths.bookings.search.active.index({}),
+          active: false,
+        },
+        {
+          text: 'Closed',
+          href: paths.bookings.search.closed.index({}),
+          active: false,
+        },
+      ]
+
+      expect(createSideNavArr('provisional')).toEqual(sideNavArr)
+    })
+  })
+})

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -1,0 +1,28 @@
+import { BookingSearchStatus } from '@approved-premises/api'
+import { SideNavObj } from '../@types/ui/index'
+import paths from '../paths/temporary-accommodation/manage'
+
+export function createSideNavArr(status: BookingSearchStatus): Array<SideNavObj> {
+  return [
+    {
+      text: 'Provisional',
+      href: paths.bookings.search.provisional.index({}),
+      active: status === 'provisional',
+    },
+    {
+      text: 'Confirmed',
+      href: paths.bookings.search.confirmed.index({}),
+      active: status === 'confirmed',
+    },
+    {
+      text: 'Active',
+      href: paths.bookings.search.active.index({}),
+      active: status === 'active',
+    },
+    {
+      text: 'Closed',
+      href: paths.bookings.search.closed.index({}),
+      active: status === 'closed',
+    },
+  ]
+}

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -3,6 +3,7 @@ import Case from 'case'
 import type { ApprovedPremisesApplication, PersonRisks } from '@approved-premises/api'
 import type { PersonRisksUI, SummaryListItem } from '@approved-premises/ui'
 
+import qs, { IStringifyOptions } from 'qs'
 import escapeRegExp from 'lodash.escaperegexp'
 import { DateFormats } from './dateUtils'
 import { SessionDataError } from './errors'
@@ -133,3 +134,10 @@ export function unique<T extends { id: string }>(elements: Array<T>): Array<T> {
 }
 
 export const exact = (text: string) => new RegExp(`^${escapeRegExp(text)}$`)
+
+export const createQueryString = (
+  params: Record<string, unknown> | string,
+  options: IStringifyOptions = { encode: false, indices: false },
+): string => {
+  return qs.stringify(params, options)
+}

--- a/server/views/temporary-accommodation/booking-search/active.njk
+++ b/server/views/temporary-accommodation/booking-search/active.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
@@ -11,7 +12,20 @@
 
   <h1>Find a booking</h1>
 
-  <h2>List of bookings</h2>
+  <div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-one-third">
+
+    {{ mojSideNavigation({
+      label: 'Side navigation',
+      items: sideNavArr
+    }) }}
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+    <h2>Active bookings</h2>
 
     {{ govukTable({
     captionClasses: "govuk-table__caption--m",
@@ -37,5 +51,11 @@
     ],
     rows: bookingTableRows
   }) }}
+
+    </div>
+
+</div>
+
+
 
 {% endblock %}

--- a/server/views/temporary-accommodation/booking-search/closed.njk
+++ b/server/views/temporary-accommodation/booking-search/closed.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+{% extends "../../partials/layout.njk" %}
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% set pageTitle = applicationName + " - Find a booking" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ breadCrumb('Find a booking', []) }}
+
+  <h1>Find a booking</h1>
+
+  <div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-one-third">
+
+    {{ mojSideNavigation({
+      label: 'Side navigation',
+      items: sideNavArr
+    }) }}
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+    <h2>Closed bookings</h2>
+
+    {{ govukTable({
+    captionClasses: "govuk-table__caption--m",
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "CRN"
+      },
+      {
+        text: "Location"
+      },
+      {
+        text: "Start"
+      },
+      {
+        text: "End"
+      },
+      {
+        html: '<span class="govuk-visually-hidden">Actions</span>'
+      }
+    ],
+    rows: bookingTableRows
+  }) }}
+
+    </div>
+
+</div>
+
+
+
+{% endblock %}

--- a/server/views/temporary-accommodation/booking-search/confirmed.njk
+++ b/server/views/temporary-accommodation/booking-search/confirmed.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+{% extends "../../partials/layout.njk" %}
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% set pageTitle = applicationName + " - Find a booking" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ breadCrumb('Find a booking', []) }}
+
+  <h1>Find a booking</h1>
+
+  <div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-one-third">
+
+    {{ mojSideNavigation({
+      label: 'Side navigation',
+      items: sideNavArr
+    }) }}
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+    <h2>Confirmed bookings</h2>
+
+    {{ govukTable({
+    captionClasses: "govuk-table__caption--m",
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "CRN"
+      },
+      {
+        text: "Location"
+      },
+      {
+        text: "Start"
+      },
+      {
+        text: "End"
+      },
+      {
+        html: '<span class="govuk-visually-hidden">Actions</span>'
+      }
+    ],
+    rows: bookingTableRows
+  }) }}
+
+    </div>
+
+</div>
+
+
+
+{% endblock %}

--- a/server/views/temporary-accommodation/booking-search/provisional.njk
+++ b/server/views/temporary-accommodation/booking-search/provisional.njk
@@ -1,0 +1,61 @@
+{% from "govuk/components/table/macro.njk" import govukTable %}
+{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+{% extends "../../partials/layout.njk" %}
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% set pageTitle = applicationName + " - Find a booking" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ breadCrumb('Find a booking', []) }}
+
+  <h1>Find a booking</h1>
+
+  <div class="govuk-grid-row">
+
+  <div class="govuk-grid-column-one-third">
+
+    {{ mojSideNavigation({
+      label: 'Side navigation',
+      items: sideNavArr
+    }) }}
+
+    </div>
+
+    <div class="govuk-grid-column-two-thirds">
+
+    <h2>Provisional bookings</h2>
+
+    {{ govukTable({
+    captionClasses: "govuk-table__caption--m",
+    head: [
+      {
+        text: "Name"
+      },
+      {
+        text: "CRN"
+      },
+      {
+        text: "Location"
+      },
+      {
+        text: "Start"
+      },
+      {
+        text: "End"
+      },
+      {
+        html: '<span class="govuk-visually-hidden">Actions</span>'
+      }
+    ],
+    rows: bookingTableRows
+  }) }}
+
+    </div>
+
+</div>
+
+
+
+{% endblock %}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -24,7 +24,7 @@
     <div class="card">
       <div class="card-body">
         <h2 class="govuk-heading-s">
-            <a class="govuk-link" href="{{ paths.bookings.search({}) }}">Find a booking</a>
+            <a class="govuk-link" href="{{ paths.bookings.search.provisional.index({}) }}">Find a booking</a>
         </h2>
         <p class="govuk-body">View and manage provisional, confirmed, active and closed bookings</p>
         </div>


### PR DESCRIPTION
# Changes in this PR

This PR allows users to view bookings grouped by status via the Find a booking journey.

These changes remain feature flagged outside of local and dev environments.

Whilst we await API support, the changes are not E2E tested.

## Screenshots of UI changes

### Before

![Screenshot 2023-04-04 at 10 57 35](https://user-images.githubusercontent.com/70749355/229757028-56ea4bf3-f28b-47ba-a3ee-9bf3595028de.png)

### After

![Screenshot 2023-04-04 at 10 56 33](https://user-images.githubusercontent.com/70749355/229756870-74cb5c18-299c-43e2-93c2-7badb5dcd4ee.png)

![Screenshot 2023-04-04 at 10 56 40](https://user-images.githubusercontent.com/70749355/229756901-ba397723-22df-486f-9b4e-01e4ca59a451.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
