### PR TITLE
Users can sort bookings by start and end date

### DIFF
--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -1,7 +1,7 @@
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import BookingSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSearch'
 import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
-import bookingSearchResultsFactory from '../../../../server/testutils/factories/bookingSearchResults'
+import { bookingSearchResultsFactory } from '../../../../server/testutils/factories/index'
 import Page from '../../../../cypress_shared/pages/page'
 
 context('Booking search', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@aws-sdk/client-sqs": "^3.245.0",
-        "@ministryofjustice/frontend": "^1.6.0",
+        "@ministryofjustice/frontend": "^1.6.5",
         "@sentry/node": "^7.14.1",
         "@sentry/tracing": "^7.14.1",
         "@types/path-to-regexp": "^1.7.0",

--- a/package.json
+++ b/package.json
@@ -124,7 +124,7 @@
   },
   "dependencies": {
     "@aws-sdk/client-sqs": "^3.245.0",
-    "@ministryofjustice/frontend": "^1.6.0",
+    "@ministryofjustice/frontend": "^1.6.5",
     "@sentry/node": "^7.14.1",
     "@sentry/tracing": "^7.14.1",
     "@types/path-to-regexp": "^1.7.0",

--- a/server/services/bookingSearchService.test.ts
+++ b/server/services/bookingSearchService.test.ts
@@ -36,8 +36,18 @@ describe('BookingService', () => {
           { text: booking1.person.name },
           { text: booking1.person.crn },
           { text: booking1.premises.addressLine1 },
-          { text: DateFormats.isoDateToUIDate(booking1.booking.startDate, { format: 'short' }) },
-          { text: DateFormats.isoDateToUIDate(booking1.booking.endDate, { format: 'short' }) },
+          {
+            text: DateFormats.isoDateToUIDate(booking1.booking.startDate, { format: 'short' }),
+            attributes: {
+              'data-sort-value': booking1.booking.startDate,
+            },
+          },
+          {
+            text: DateFormats.isoDateToUIDate(booking1.booking.endDate, { format: 'short' }),
+            attributes: {
+              'data-sort-value': booking1.booking.endDate,
+            },
+          },
           {
             html: `<a href="${paths.bookings.show({
               premisesId: booking1.premises.id,
@@ -52,8 +62,18 @@ describe('BookingService', () => {
           { text: booking2.person.name },
           { text: booking2.person.crn },
           { text: booking2.premises.addressLine1 },
-          { text: DateFormats.isoDateToUIDate(booking2.booking.startDate, { format: 'short' }) },
-          { text: DateFormats.isoDateToUIDate(booking2.booking.endDate, { format: 'short' }) },
+          {
+            text: DateFormats.isoDateToUIDate(booking2.booking.startDate, { format: 'short' }),
+            attributes: {
+              'data-sort-value': booking2.booking.startDate,
+            },
+          },
+          {
+            text: DateFormats.isoDateToUIDate(booking2.booking.endDate, { format: 'short' }),
+            attributes: {
+              'data-sort-value': booking2.booking.endDate,
+            },
+          },
           {
             html: `<a href="${paths.bookings.show({
               premisesId: booking2.premises.id,
@@ -68,8 +88,18 @@ describe('BookingService', () => {
           { text: booking3.person.name },
           { text: booking3.person.crn },
           { text: booking3.premises.addressLine1 },
-          { text: DateFormats.isoDateToUIDate(booking3.booking.startDate, { format: 'short' }) },
-          { text: DateFormats.isoDateToUIDate(booking3.booking.endDate, { format: 'short' }) },
+          {
+            text: DateFormats.isoDateToUIDate(booking3.booking.startDate, { format: 'short' }),
+            attributes: {
+              'data-sort-value': booking3.booking.startDate,
+            },
+          },
+          {
+            text: DateFormats.isoDateToUIDate(booking3.booking.endDate, { format: 'short' }),
+            attributes: {
+              'data-sort-value': booking3.booking.endDate,
+            },
+          },
           {
             html: `<a href="${paths.bookings.show({
               premisesId: booking3.premises.id,

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -18,8 +18,14 @@ export default class BookingSearchService {
         this.textValue(summary.person.name),
         this.textValue(summary.person.crn),
         this.textValue(summary.premises.addressLine1),
-        this.textValue(DateFormats.isoDateToUIDate(summary.booking.startDate, { format: 'short' })),
-        this.textValue(DateFormats.isoDateToUIDate(summary.booking.endDate, { format: 'short' })),
+        this.dateSortValue(
+          DateFormats.isoDateToUIDate(summary.booking.startDate, { format: 'short' }),
+          summary.booking.startDate,
+        ),
+        this.dateSortValue(
+          DateFormats.isoDateToUIDate(summary.booking.endDate, { format: 'short' }),
+          summary.booking.endDate,
+        ),
         this.htmlValue(
           `<a href="${paths.bookings.show({
             premisesId: summary.premises.id,
@@ -37,5 +43,14 @@ export default class BookingSearchService {
 
   private htmlValue(value: string) {
     return { html: value }
+  }
+
+  private dateSortValue(uiDate: string, isoDate: string) {
+    return {
+      text: uiDate,
+      attributes: {
+        'data-sort-value': `${isoDate}`,
+      },
+    }
   }
 }

--- a/server/views/temporary-accommodation/booking-search/active.njk
+++ b/server/views/temporary-accommodation/booking-search/active.njk
@@ -29,6 +29,9 @@
 
     {{ govukTable({
     captionClasses: "govuk-table__caption--m",
+    attributes: {
+    'data-module': 'moj-sortable-table'
+    },
     head: [
       {
         text: "Name"
@@ -40,22 +43,35 @@
         text: "Location"
       },
       {
-        text: "Start"
+        text: "Start",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
-        text: "End"
+        text: "End",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
         html: '<span class="govuk-visually-hidden">Actions</span>'
       }
     ],
     rows: bookingTableRows
-  }) }}
+    }) }}
 
     </div>
 
 </div>
 
-
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+  $(document).ready(function () {
+  window
+      .MOJFrontend
+      .initAll() })
+</script>
+{% endblock %}
 
 {% endblock %}

--- a/server/views/temporary-accommodation/booking-search/closed.njk
+++ b/server/views/temporary-accommodation/booking-search/closed.njk
@@ -29,6 +29,9 @@
 
     {{ govukTable({
     captionClasses: "govuk-table__caption--m",
+    attributes: {
+    'data-module': 'moj-sortable-table'
+    },
     head: [
       {
         text: "Name"
@@ -40,22 +43,35 @@
         text: "Location"
       },
       {
-        text: "Start"
+        text: "Start",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
-        text: "End"
+        text: "End",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
         html: '<span class="govuk-visually-hidden">Actions</span>'
       }
     ],
     rows: bookingTableRows
-  }) }}
+    }) }}
 
     </div>
 
 </div>
 
-
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+  $(document).ready(function () {
+  window
+      .MOJFrontend
+      .initAll() })
+</script>
+{% endblock %}
 
 {% endblock %}

--- a/server/views/temporary-accommodation/booking-search/confirmed.njk
+++ b/server/views/temporary-accommodation/booking-search/confirmed.njk
@@ -29,6 +29,9 @@
 
     {{ govukTable({
     captionClasses: "govuk-table__caption--m",
+    attributes: {
+    'data-module': 'moj-sortable-table'
+    },
     head: [
       {
         text: "Name"
@@ -40,22 +43,35 @@
         text: "Location"
       },
       {
-        text: "Start"
+        text: "Start",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
-        text: "End"
+        text: "End",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
         html: '<span class="govuk-visually-hidden">Actions</span>'
       }
     ],
     rows: bookingTableRows
-  }) }}
+    }) }}
 
     </div>
 
 </div>
 
-
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+  $(document).ready(function () {
+  window
+      .MOJFrontend
+      .initAll() })
+</script>
+{% endblock %}
 
 {% endblock %}

--- a/server/views/temporary-accommodation/booking-search/provisional.njk
+++ b/server/views/temporary-accommodation/booking-search/provisional.njk
@@ -29,6 +29,9 @@
 
     {{ govukTable({
     captionClasses: "govuk-table__caption--m",
+    attributes: {
+    'data-module': 'moj-sortable-table'
+    },
     head: [
       {
         text: "Name"
@@ -40,10 +43,16 @@
         text: "Location"
       },
       {
-        text: "Start"
+        text: "Start",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
-        text: "End"
+        text: "End",
+        attributes: {
+          "aria-sort": "none"
+        }
       },
       {
         html: '<span class="govuk-visually-hidden">Actions</span>'
@@ -56,6 +65,14 @@
 
 </div>
 
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+  $(document).ready(function () {
+  window
+      .MOJFrontend
+      .initAll() })
 
+</script>
+{% endblock %}
 
 {% endblock %}


### PR DESCRIPTION
# Changes in this PR

Allows users to sort booking in the Find a booking journey by start and end date.

These changes remain feature flagged outside of dev and local environments, and without E2E testing, whilst we await API support.

## Screenshots of UI changes

### Before

![Screenshot 2023-04-04 at 10 56 33](https://user-images.githubusercontent.com/70749355/230316623-1a3a5e40-df25-419f-8b96-b25473a5e24d.png)

### After

![Screenshot 2023-04-06 at 09 15 48](https://user-images.githubusercontent.com/70749355/230316813-fdde9d26-e111-462c-b97d-10c91e864d17.png)

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
