### PR TITLE
Load premises more efficiently by using the new summary endpoint

### DIFF
--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -13,7 +13,7 @@ const stubPremises = (premises: Array<Premises>) =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: '/premises',
+      urlPath: '/premises/summary',
     },
     response: {
       status: 200,

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,6 +1,7 @@
 import { path } from 'static-path'
 
 const premisesPath = path('/premises')
+const premisesSummaryPath = path('/premises/summary')
 const singlePremisesPath = premisesPath.path(':premisesId')
 
 const lostBedsPath = singlePremisesPath.path('lost-beds')
@@ -19,7 +20,7 @@ const managePaths = {
   premises: {
     create: premisesPath,
     update: singlePremisesPath,
-    index: premisesPath,
+    index: premisesSummaryPath,
     show: singlePremisesPath,
     rooms: {
       index: roomsPath,


### PR DESCRIPTION
Dependant on https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/570 being merged and deployed first.

# Changes in this PR

This should be a pure refactor where the same list of premises is shown except now the request - which is to a new endpoint - should be much faster.

Hopefully this will handle much better in production and in dev where we run lots of e2e tests that add more and more premises.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
