### PR TITLE
Fixes table row query in booking search e2e tests

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -21,13 +21,14 @@ export default class BookingSearchPage extends Page {
 
   checkBookingDetailsAndClickView(premises: Premises, booking: Booking) {
     cy.get('tr')
+      .filter(
+        `:contains(${booking.person.name}):contains(${booking.person.crn}):contains(${
+          premises.addressLine1
+        }):contains(${DateFormats.isoDateToUIDate(booking.arrivalDate, {
+          format: 'short',
+        })}):contains(${DateFormats.isoDateToUIDate(booking.departureDate, { format: 'short' })})`,
+      )
       .children()
-      .should('contain', booking.person.name)
-      .and('contain', booking.person.crn)
-      .and('contain', premises.addressLine1)
-      .and('contain', DateFormats.isoDateToUIDate(booking.arrivalDate, { format: 'short' }))
-      .and('contain', DateFormats.isoDateToUIDate(booking.departureDate, { format: 'short' }))
-      .get('td')
       .eq(5)
       .contains('View')
       .click()


### PR DESCRIPTION
# Changes in this PR

This new table query ensures that all the booking details are present in a single table row, and then clicks the view button for that row. The previous code had in fact only checked that each relevant booking details was present anywhere in the table, before always clicking the view button on the first table row. This was causing E2E tests to fail.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
