### PR TITLE
Rename closed booking status to departed

### DIFF
--- a/cypress_shared/components/bookingInfo.ts
+++ b/cypress_shared/components/bookingInfo.ts
@@ -44,7 +44,7 @@ export default class BookingInfoComponent extends Component {
         this.shouldShowKeyAndValues(keyText, latestExtension.notes.split('\n'))
       }
     } else if (status === 'departed') {
-      this.shouldShowKeyAndValue('Status', 'Closed')
+      this.shouldShowKeyAndValue('Status', 'Departed')
       this.shouldShowKeyAndValue('Departure reason', this.booking.departure.reason.name)
       this.shouldShowKeyAndValue('Move on category', this.booking.departure.moveOnCategory.name)
       this.shouldShowKeyAndValues('Notes', this.booking.departure.notes.split('\n'))

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -54,7 +54,7 @@ export default class BedspaceShowPage extends Page {
         } else if (status === 'arrived') {
           cy.get('td').eq(3).contains('Active')
         } else if (status === 'departed') {
-          cy.get('td').eq(3).contains('Closed')
+          cy.get('td').eq(3).contains('Departed')
         }
 
         cy.get('td').eq(4).contains('View')

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit.ts
@@ -13,7 +13,7 @@ export default class BookingDepartureEditPage extends BookingDepartureEditablePa
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(premises: Premises, room: Room, private readonly booking: Booking) {
-    super('Update closed booking')
+    super('Update departed booking')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -13,7 +13,7 @@ export default class BookingDepartureNewPage extends BookingDepartureEditablePag
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(premises: Premises, room: Room, booking: Booking) {
-    super('Mark booking as closed')
+    super('Mark booking as departed')
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -1,8 +1,9 @@
 import type { Booking, Premises } from '@approved-premises/api'
-import type { BookingSearchApiStatus, BookingSearchUiStatus } from '@approved-premises/ui'
+import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
+import { convertApiStatusToUiStatus } from '../../../../server/utils/bookingSearchUtils'
 
 export default class BookingSearchPage extends Page {
   constructor() {
@@ -14,8 +15,9 @@ export default class BookingSearchPage extends Page {
     return new BookingSearchPage()
   }
 
-  checkBookingStatus(status: BookingSearchUiStatus) {
-    const capitalisedStatus = status.charAt(0).toUpperCase() + status.slice(1)
+  checkBookingStatus(status: BookingSearchApiStatus) {
+    const uiStatus = convertApiStatusToUiStatus(status)
+    const capitalisedStatus = uiStatus.charAt(0).toUpperCase() + uiStatus.slice(1)
     cy.get('h2').contains(`${capitalisedStatus} bookings`)
   }
 
@@ -34,8 +36,9 @@ export default class BookingSearchPage extends Page {
       .click()
   }
 
-  clickOtherBookingStatusLink(status: BookingSearchUiStatus) {
-    const capitalisedStatus = status.charAt(0).toUpperCase() + status.slice(1)
+  clickOtherBookingStatusLink(status: BookingSearchApiStatus) {
+    const uiStatus = convertApiStatusToUiStatus(status)
+    const capitalisedStatus = uiStatus.charAt(0).toUpperCase() + uiStatus.slice(1)
     cy.contains(capitalisedStatus).click()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -43,14 +43,14 @@ export default class BookingShowPage extends Page {
   clickMarkDepartedBookingButton(): void {
     cy.get('.moj-page-header-actions').within(() => {
       cy.get('button').contains('Actions').click()
-      cy.get('a').contains('Mark as closed').click()
+      cy.get('a').contains('Mark as departed').click()
     })
   }
 
   clickEditDepartedBookingButton(): void {
     cy.get('.moj-page-header-actions').within(() => {
       cy.get('button').contains('Actions').click()
-      cy.get('a').contains('Update closed booking').click()
+      cy.get('a').contains('Update departed booking').click()
     })
   }
 

--- a/e2e/tests/bookingSearch.feature
+++ b/e2e/tests/bookingSearch.feature
@@ -18,4 +18,4 @@ Feature: Manage Temporary Accommodation - Booking search
         Then I should see a summary of the booking on the active bookings page
         And I mark the booking as departed
         And I'm searching bookings
-        Then I should see a summary of the booking on the closed bookings page
+        Then I should see a summary of the booking on the departed bookings page

--- a/e2e/tests/stepDefinitions/manage/bookingSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingSearch.ts
@@ -44,13 +44,13 @@ Then('I should see a summary of the booking on the active bookings page', () => 
   })
 })
 
-Then('I should see a summary of the booking on the closed bookings page', () => {
+Then('I should see a summary of the booking on the departed bookings page', () => {
   cy.then(function _() {
     const bookingSearchPage = Page.verifyOnPage(BookingSearchPage)
     bookingSearchPage.checkBookingStatus('provisional')
 
-    bookingSearchPage.clickOtherBookingStatusLink('closed')
-    bookingSearchPage.checkBookingStatus('closed')
+    bookingSearchPage.clickOtherBookingStatusLink('departed')
+    bookingSearchPage.checkBookingStatus('departed')
 
     bookingSearchPage.checkBookingDetailsAndClickView(this.premises, this.booking)
   })

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -91,7 +91,7 @@ Given('I attempt to edit the departed booking with required details missing', ()
 Then('I should see the booking with the departed status', () => {
   cy.then(function _() {
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
-    bookingShowPage.shouldShowBanner('Booking marked as closed')
+    bookingShowPage.shouldShowBanner('Booking marked as departed')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
@@ -105,7 +105,7 @@ Then('I should see the booking with the departed status', () => {
 Then('I should see the booking with the edited departure details', () => {
   cy.then(function _() {
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
-    bookingShowPage.shouldShowBanner('Closed booking updated')
+    bookingShowPage.shouldShowBanner('Departed booking updated')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -54,10 +54,10 @@ context('Booking search', () => {
     page.checkBookingStatus('confirmed')
 
     // And I click the Active bookings link
-    page.clickOtherBookingStatusLink('active')
+    page.clickOtherBookingStatusLink('arrived')
 
     // Then I navigate to the Find an active booking page
-    page.checkBookingStatus('active')
+    page.checkBookingStatus('arrived')
 
     // And I click the Departed bookings link
     page.clickOtherBookingStatusLink('departed')

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -59,11 +59,11 @@ context('Booking search', () => {
     // Then I navigate to the Find an active booking page
     page.checkBookingStatus('active')
 
-    // And I click the Closed bookings link
-    page.clickOtherBookingStatusLink('closed')
+    // And I click the Departed bookings link
+    page.clickOtherBookingStatusLink('departed')
 
-    // Then I navigate to the Find a closed booking page
-    page.checkBookingStatus('closed')
+    // Then I navigate to the Find a departed booking page
+    page.checkBookingStatus('departed')
   })
 
   it('navigates back to the dashboard from the view bookings page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -87,7 +87,7 @@ context('Booking departure', () => {
 
     // And I should be redirected to the show booking page
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    bookingShowPage.shouldShowBanner('Booking marked as closed')
+    bookingShowPage.shouldShowBanner('Booking marked as departed')
   })
 
   it('shows errors when the API returns an error when marking a booking as departed', () => {
@@ -170,7 +170,7 @@ context('Booking departure', () => {
 
     // And I should be redirected to the show booking page
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    bookingShowPage.shouldShowBanner('Closed booking updated')
+    bookingShowPage.shouldShowBanner('Departed booking updated')
   })
 
   it('shows errors when the API returns an error when editing a departed booking', () => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -261,6 +261,4 @@ export interface SideNavObj {
   active: boolean
 }
 
-export type BookingSearchUiStatus = 'provisional' | 'confirmed' | 'active' | 'departed'
-
 export type BookingSearchApiStatus = 'provisional' | 'confirmed' | 'arrived' | 'departed'

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -261,6 +261,6 @@ export interface SideNavObj {
   active: boolean
 }
 
-export type BookingSearchUiStatus = 'provisional' | 'confirmed' | 'active' | 'closed'
+export type BookingSearchUiStatus = 'provisional' | 'confirmed' | 'active' | 'departed'
 
 export type BookingSearchApiStatus = 'provisional' | 'confirmed' | 'arrived' | 'departed'

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -85,7 +85,7 @@ describe('BookingSearchController', () => {
 
     it('renders the table view for departed bookings', async () => {
       bookingSearchService.getTableRowsForFindBooking.mockResolvedValue([])
-      ;(convertApiStatusToUiStatus as jest.MockedFn<typeof convertApiStatusToUiStatus>).mockReturnValue('closed')
+      ;(convertApiStatusToUiStatus as jest.MockedFn<typeof convertApiStatusToUiStatus>).mockReturnValue('departed')
 
       const requestHandler = bookingSearchController.index('departed')
 
@@ -94,7 +94,7 @@ describe('BookingSearchController', () => {
       expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'departed')
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
-        uiStatus: 'closed',
+        uiStatus: 'departed',
         tableHeadings: [],
         bookingTableRows: [],
         sideNavArr: [],

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -13,12 +13,10 @@ export default class BookingSearchController {
 
       const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status)
 
-      const uiStatus = convertApiStatusToUiStatus(status)
-
       return res.render(`temporary-accommodation/booking-search/results`, {
-        uiStatus,
-        sideNavArr: createSideNavArr(uiStatus),
-        tableHeadings: createTableHeadings(uiStatus),
+        uiStatus: convertApiStatusToUiStatus(status),
+        sideNavArr: createSideNavArr(status),
+        tableHeadings: createTableHeadings(status),
         bookingTableRows,
       })
     }

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -117,7 +117,7 @@ describe('DeparturesController', () => {
         expect.objectContaining(newDeparture),
       )
 
-      expect(request.flash).toHaveBeenCalledWith('success', 'Booking marked as closed')
+      expect(request.flash).toHaveBeenCalledWith('success', 'Booking marked as departed')
       expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId }))
     })
 
@@ -230,7 +230,7 @@ describe('DeparturesController', () => {
         expect.objectContaining(newDeparture),
       )
 
-      expect(request.flash).toHaveBeenCalledWith('success', 'Closed booking updated')
+      expect(request.flash).toHaveBeenCalledWith('success', 'Departed booking updated')
       expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId }))
     })
 

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -54,7 +54,7 @@ export default class DeparturesController {
       try {
         await this.departureService.createDeparture(callConfig, premisesId, bookingId, newDeparture)
 
-        req.flash('success', 'Booking marked as closed')
+        req.flash('success', 'Booking marked as departed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(req, res, err, paths.bookings.departures.new({ premisesId, roomId, bookingId }))
@@ -106,7 +106,7 @@ export default class DeparturesController {
       try {
         await this.departureService.createDeparture(callConfig, premisesId, bookingId, newDeparture)
 
-        req.flash('success', 'Closed booking updated')
+        req.flash('success', 'Departed booking updated')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -12,7 +12,7 @@ const allBookingsPath = temporaryAccommodationPath.path('bookings')
 
 const confirmationsPath = singleBookingPath.path('confirm')
 const arrivalsPath = singleBookingPath.path('mark-as-active')
-const departuresPath = singleBookingPath.path('mark-as-closed')
+const departuresPath = singleBookingPath.path('mark-as-departed')
 const extensionsPath = singleBookingPath.path('extend')
 const cancellationsPath = singleBookingPath.path('cancellations')
 
@@ -74,8 +74,8 @@ const paths = {
       active: {
         index: allBookingsPath.path('active'),
       },
-      closed: {
-        index: allBookingsPath.path('closed'),
+      departed: {
+        index: allBookingsPath.path('departed'),
       },
       confirmed: {
         index: allBookingsPath.path('confirmed'),

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -268,8 +268,8 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.bookings.search.active.index.pattern, bookingSearchController.index('arrived'), {
     auditEvent: 'VIEW_SEARCH_ACTIVE_BOOKINGS',
   })
-  get(paths.bookings.search.closed.index.pattern, bookingSearchController.index('departed'), {
-    auditEvent: 'VIEW_SEARCH_CLOSED_BOOKINGS',
+  get(paths.bookings.search.departed.index.pattern, bookingSearchController.index('departed'), {
+    auditEvent: 'VIEW_SEARCH_DEPARTED_BOOKINGS',
   })
   get(paths.bookings.search.confirmed.index.pattern, bookingSearchController.index('confirmed'), {
     auditEvent: 'VIEW_SEARCH_CONFIRMED_BOOKINGS',

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -21,8 +21,8 @@ describe('bookingSearchUtils', () => {
           active: false,
         },
         {
-          text: 'Closed',
-          href: paths.bookings.search.closed.index({}),
+          text: 'Departed',
+          href: paths.bookings.search.departed.index({}),
           active: false,
         },
       ]
@@ -68,7 +68,7 @@ describe('bookingSearchUtils', () => {
     })
   })
 
-  it('returns table headings with end date sorted ascending for active and closed booking status', () => {
+  it('returns table headings with end date sorted ascending for active and departed booking status', () => {
     const tableHeadings = [
       {
         text: 'Name',
@@ -100,7 +100,7 @@ describe('bookingSearchUtils', () => {
     ]
 
     expect(createTableHeadings('active')).toEqual(tableHeadings)
-    expect(createTableHeadings('closed')).toEqual(tableHeadings)
+    expect(createTableHeadings('departed')).toEqual(tableHeadings)
   })
 })
 
@@ -109,6 +109,6 @@ describe('convertApiStatusToUiStatus', () => {
     expect(convertApiStatusToUiStatus('provisional')).toEqual('provisional')
     expect(convertApiStatusToUiStatus('confirmed')).toEqual('confirmed')
     expect(convertApiStatusToUiStatus('arrived')).toEqual('active')
-    expect(convertApiStatusToUiStatus('departed')).toEqual('closed')
+    expect(convertApiStatusToUiStatus('departed')).toEqual('departed')
   })
 })

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -68,7 +68,7 @@ describe('bookingSearchUtils', () => {
     })
   })
 
-  it('returns table headings with end date sorted ascending for active and departed booking status', () => {
+  it('returns table headings with end date sorted ascending for arrived and departed booking status', () => {
     const tableHeadings = [
       {
         text: 'Name',
@@ -99,7 +99,7 @@ describe('bookingSearchUtils', () => {
       },
     ]
 
-    expect(createTableHeadings('active')).toEqual(tableHeadings)
+    expect(createTableHeadings('arrived')).toEqual(tableHeadings)
     expect(createTableHeadings('departed')).toEqual(tableHeadings)
   })
 })

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -20,9 +20,9 @@ export function createSideNavArr(status: BookingSearchUiStatus): Array<SideNavOb
       active: status === 'active',
     },
     {
-      text: 'Closed',
-      href: paths.bookings.search.closed.index({}),
-      active: status === 'closed',
+      text: 'Departed',
+      href: paths.bookings.search.departed.index({}),
+      active: status === 'departed',
     },
   ]
 }
@@ -50,7 +50,7 @@ export function createTableHeadings(status: BookingSearchUiStatus): Array<TableC
     {
       text: 'End date',
       attributes: {
-        'aria-sort': ['active', 'closed'].includes(status) ? 'ascending' : 'none',
+        'aria-sort': ['active', 'departed'].includes(status) ? 'ascending' : 'none',
       },
     },
     {
@@ -63,8 +63,6 @@ export function convertApiStatusToUiStatus(status: BookingSearchApiStatus): Book
   switch (status) {
     case 'arrived':
       return 'active'
-    case 'departed':
-      return 'closed'
     default:
       return status
   }

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -1,33 +1,35 @@
-import type { BookingSearchApiStatus, BookingSearchUiStatus } from '@approved-premises/ui'
+import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import { SideNavObj, TableCell } from '../@types/ui/index'
 import paths from '../paths/temporary-accommodation/manage'
 
-export function createSideNavArr(status: BookingSearchUiStatus): Array<SideNavObj> {
+export function createSideNavArr(status: BookingSearchApiStatus): Array<SideNavObj> {
+  const uiStatus = convertApiStatusToUiStatus(status)
   return [
     {
       text: 'Provisional',
       href: paths.bookings.search.provisional.index({}),
-      active: status === 'provisional',
+      active: uiStatus === 'provisional',
     },
     {
       text: 'Confirmed',
       href: paths.bookings.search.confirmed.index({}),
-      active: status === 'confirmed',
+      active: uiStatus === 'confirmed',
     },
     {
       text: 'Active',
       href: paths.bookings.search.active.index({}),
-      active: status === 'active',
+      active: uiStatus === 'active',
     },
     {
       text: 'Departed',
       href: paths.bookings.search.departed.index({}),
-      active: status === 'departed',
+      active: uiStatus === 'departed',
     },
   ]
 }
 
-export function createTableHeadings(status: BookingSearchUiStatus): Array<TableCell> {
+export function createTableHeadings(status: BookingSearchApiStatus): Array<TableCell> {
+  const uiStatus = convertApiStatusToUiStatus(status)
   return [
     {
       text: 'Name',
@@ -44,13 +46,13 @@ export function createTableHeadings(status: BookingSearchUiStatus): Array<TableC
     {
       text: 'Start date',
       attributes: {
-        'aria-sort': ['provisional', 'confirmed'].includes(status) ? 'ascending' : 'none',
+        'aria-sort': ['provisional', 'confirmed'].includes(uiStatus) ? 'ascending' : 'none',
       },
     },
     {
       text: 'End date',
       attributes: {
-        'aria-sort': ['active', 'departed'].includes(status) ? 'ascending' : 'none',
+        'aria-sort': ['active', 'departed'].includes(uiStatus) ? 'ascending' : 'none',
       },
     },
     {
@@ -59,7 +61,7 @@ export function createTableHeadings(status: BookingSearchUiStatus): Array<TableC
   ]
 }
 
-export function convertApiStatusToUiStatus(status: BookingSearchApiStatus): BookingSearchUiStatus {
+export function convertApiStatusToUiStatus(status: BookingSearchApiStatus): string {
   switch (status) {
     case 'arrived':
       return 'active'

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -47,12 +47,12 @@ describe('bookingUtils', () => {
       ])
     })
 
-    it('returns mark as closed and extend actions for an arrived booking', () => {
+    it('returns mark as departed and extend actions for an arrived booking', () => {
       const booking = bookingFactory.arrived().build()
 
       expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
         {
-          text: 'Mark as closed',
+          text: 'Mark as departed',
           classes: 'govuk-button--secondary',
           href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
         },
@@ -64,12 +64,12 @@ describe('bookingUtils', () => {
       ])
     })
 
-    it('returns edit closed booking for a departed booking', () => {
+    it('returns edit departed booking for a departed booking', () => {
       const booking = bookingFactory.departed().build()
 
       expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
         {
-          text: 'Update closed booking',
+          text: 'Update departed booking',
           classes: 'govuk-button--secondary',
           href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
         },

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -36,7 +36,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
     case 'arrived':
       items.push(
         {
-          text: 'Mark as closed',
+          text: 'Mark as departed',
           classes: 'govuk-button--secondary',
           href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
         },
@@ -49,7 +49,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
       break
     case 'departed':
       items.push({
-        text: 'Update closed booking',
+        text: 'Update departed booking',
         classes: 'govuk-button--secondary',
         href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
       })
@@ -89,7 +89,7 @@ export const allStatuses: Array<{ name: string; id: Booking['status']; tagClass:
     tagClass: 'govuk-tag--green',
   },
   {
-    name: 'Closed',
+    name: 'Departed',
     id: 'departed',
     tagClass: 'govuk-tag--red',
   },

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -25,7 +25,7 @@
         <h2 class="govuk-heading-s">
             <a class="govuk-link" href="{{ paths.bookings.search.provisional.index({}) }}">View all bookings</a>
         </h2>
-        <p class="govuk-body">View and manage provisional, confirmed, active and closed bookings</p>
+        <p class="govuk-body">View and manage provisional, confirmed, active and departed bookings</p>
         </div>
     </div>
 

--- a/server/views/temporary-accommodation/departures/edit.njk
+++ b/server/views/temporary-accommodation/departures/edit.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - EdUpdateit closed booking" %}
+{% set pageTitle = applicationName + " - EdUpdateit departed booking" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
@@ -18,7 +18,7 @@
 
   {% include "../../_messages.njk" %}
 
-  <h1>Update closed booking</h1>
+  <h1>Update departed booking</h1>
 
   {{ showErrorSummary(errorSummary) }}
 

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Mark booking as closed" %}
+{% set pageTitle = applicationName + " - Mark booking as departed" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
@@ -18,7 +18,7 @@
 
   {% include "../../_messages.njk" %}
 
-  <h1>Mark booking as closed</h1>
+  <h1>Mark booking as departed</h1>
 
   {{ showErrorSummary(errorSummary) }}
 


### PR DESCRIPTION
# Changes in this PR

This PR renames the 'closed' UI booking status to departed, in advance of further anticipated changes to booking state as part of turnaround development.

It also includes some minor refactoring to remove an unnecessary UI type.

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
