### PR TITLE
Update cancellation reasons JSON for Wiremock/E2E tests

### DIFF
--- a/wiremock/stubs/cancellation-reasons.json
+++ b/wiremock/stubs/cancellation-reasons.json
@@ -1,15 +1,15 @@
 [
   {
     "id": "3d57413f-ca94-424a-b026-bf9e99ed28fe",
-    "name": "Alternative suitable accommodation provided by LHA"
+    "name": "Alternative suitable accommodation provided by Local Authority"
   },
   {
     "id": "f023aab7-4bd8-42a3-9f80-7aab3d4f40b8",
-    "name": "Alternative suitable accommodation provided (Other)"
+    "name": "Alternative suitable accommodation provided - Other (inc. AP, CAS2, friends/family etc.)"
   },
   {
     "id": "edd09efb-ef83-42da-a15c-750afd057eb3",
-    "name": "Person on probation rejected placement (Out of area)"
+    "name": "Person on probation rejected placement"
   },
   {
     "id": "7c54c8f5-14df-4836-af9c-c66a6021a375",
@@ -17,10 +17,14 @@
   },
   {
     "id": "8afe2dc8-f024-4ab1-a98d-0e321e317b19",
-    "name": "Withdrawn by referrer"
+    "name": "Withdrawn by referrer (e.g. recalled, further custody, placement related risk concern)"
   },
   {
     "id": "d2a0d037-53db-4bb2-b9f7-afa07948a3f5",
     "name": "Administrative error"
+  },
+  {
+    "id": "2a7fc443-2f31-4501-90c4-435a6e8e59d3",
+    "name": "Supplier unable to accommodate (Please explain in notes)"
   }
 ]


### PR DESCRIPTION
# Context

This is the frontend counterpart to https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/573, where a new cancellation reason was added and some had changes in their wording, following an updated list provided to the CAS3 team for reasons to cancel a booking.

See [ticket #1005 on the Trello board](https://trello.com/c/KgbBdrru/1005-update-new-cancellation-reasons-provided-by-the-central-team).

# Release checklist

As part of our continuous deployment strategy we must ensure that this work is
ready to be released at any point. Before merging to `main` we must first
confirm:

## Pre merge checklist

- [ ] Have all changes to any dependencies been deployed to both `preprod` and
    `production` in a backwards compatible way? (This includes our API,
    infrastructure, third-party integrations and any secrets or environment variables)
- [ ] Has a required data migration been included in this change or been done in
    advance?

## Post merge checklist

Once we've merged we now need to release this through to production before
considering it done.

[Find the build-and-deploy job in CircleCI](https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui)
and work through the following steps:

- [ ] Has the product manager asked to provide approval for this feature?
  - [ ] Has the product manager approved?
- [ ] Manually approve release to preprod
- [ ] Verify change released to preprod
- [ ] Manually approve release to prod
- [ ] Verify change released to production

Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible.
