### PR TITLE
E2E tests read bedspace attributes from page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
@@ -12,4 +12,8 @@ export default abstract class BedspaceEditablePage extends Page {
 
     this.clickSubmit()
   }
+
+  assignCharacteristics(alias: string): void {
+    this.getCheckboxItemsAsReferenceData('Does the bedspace have any of the following attributes?', alias)
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
@@ -37,15 +37,15 @@ export default abstract class PremisesEditablePage extends Page {
     this.clickSubmit()
   }
 
-  getPdus(alias: string): void {
+  assignPdus(alias: string): void {
     this.getSelectOptionsAsReferenceData('What is the PDU?', alias)
   }
 
-  getLocalAuthorities(alias: string): void {
+  assignLocalAuthorities(alias: string): void {
     this.getSelectOptionsAsReferenceData('What is the local authority (optional)?', alias)
   }
 
-  getCharacteristics(alias: string): void {
+  assignCharacteristics(alias: string): void {
     this.getCheckboxItemsAsReferenceData('Does the property have any of the following attributes?', alias)
   }
 }

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -20,17 +20,17 @@ Given('I create a bedspace with all necessary details', () => {
   cy.get('@premises').then(premises => {
     const page = Page.verifyOnPage(BedspaceNewPage, premises)
 
-    const room = roomFactory.build({
-      id: 'unknown',
-    })
+    page.assignCharacteristics('characteristics')
 
-    const newRoom = newRoomFactory.build({
-      ...room,
-      characteristicIds: room.characteristics.map(characteristic => characteristic.id),
-    })
+    cy.then(function _() {
+      const room = roomFactory.forEnvironment(this.characteristics).build({
+        id: 'unknown',
+      })
+      const newRoom = newRoomFactory.fromRoom(room).build()
 
-    cy.wrap(room).as('room')
-    page.completeForm(newRoom)
+      cy.wrap(room).as('room')
+      page.completeForm(newRoom)
+    })
   })
 })
 
@@ -48,18 +48,18 @@ Given('I edit the bedspace details', () => {
   cy.then(function _() {
     const page = Page.verifyOnPage(BedspaceEditPage, this.premises, this.room)
 
-    const updatedRoom = roomFactory.build({
-      id: this.room.id,
-      name: this.room.name,
-    })
+    page.assignCharacteristics('characteristics')
 
-    const updateRoom = updateRoomFactory.build({
-      ...updatedRoom,
-      characteristicIds: updatedRoom.characteristics.map(characteristic => characteristic.id),
-    })
+    cy.then(function __() {
+      const updatedRoom = roomFactory.forEnvironment(this.characteristics).build({
+        id: this.room.id,
+        name: this.room.name,
+      })
+      const updateRoom = updateRoomFactory.fromRoom(updatedRoom).build()
 
-    cy.wrap(updatedRoom).as('room')
-    page.completeForm(updateRoom)
+      cy.wrap(updatedRoom).as('room')
+      page.completeForm(updateRoom)
+    })
   })
 })
 

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -58,9 +58,9 @@ Given('I view an existing active premises', () => {
 Given('I create a premises with all necessary details', () => {
   const page = Page.verifyOnPage(PremisesNewPage)
 
-  page.getPdus('pdus')
-  page.getLocalAuthorities('localAuthorities')
-  page.getCharacteristics('characteristics')
+  page.assignPdus('pdus')
+  page.assignLocalAuthorities('localAuthorities')
+  page.assignCharacteristics('characteristics')
 
   cy.then(function _() {
     const premises = premisesFactory
@@ -88,9 +88,9 @@ Given('I attempt to create a premises with required details missing', () => {
 Given('I attempt to create a premises with the PDU missing', () => {
   const page = Page.verifyOnPage(PremisesNewPage)
 
-  page.getPdus('pdus')
-  page.getLocalAuthorities('localAuthorities')
-  page.getCharacteristics('characteristics')
+  page.assignPdus('pdus')
+  page.assignLocalAuthorities('localAuthorities')
+  page.assignCharacteristics('characteristics')
 
   cy.then(function _() {
     const premises = premisesFactory
@@ -123,9 +123,9 @@ Given('I edit the premises details', () => {
   cy.get('@premises').then((premises: Premises) => {
     const page = Page.verifyOnPage(PremisesEditPage, premises)
 
-    page.getPdus('pdus')
-    page.getLocalAuthorities('localAuthorities')
-    page.getCharacteristics('characteristics')
+    page.assignPdus('pdus')
+    page.assignLocalAuthorities('localAuthorities')
+    page.assignCharacteristics('characteristics')
 
     cy.then(function _() {
       const updatedPremises = premisesFactory

--- a/server/testutils/factories/newRoom.ts
+++ b/server/testutils/factories/newRoom.ts
@@ -1,8 +1,8 @@
-import { Factory } from 'fishery'
-import { faker } from '@faker-js/faker/locale/en_GB'
 import type { NewRoom } from '@approved-premises/api'
-import referenceDataFactory from './referenceData'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
 import { unique } from '../../utils/utils'
+import referenceDataFactory from './referenceData'
 
 export default Factory.define<NewRoom>(() => ({
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,

--- a/server/testutils/factories/newRoom.ts
+++ b/server/testutils/factories/newRoom.ts
@@ -1,10 +1,20 @@
-import type { NewRoom } from '@approved-premises/api'
+import type { NewRoom, Room } from '@approved-premises/api'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
 
-export default Factory.define<NewRoom>(() => ({
+class NewRoomFactory extends Factory<NewRoom> {
+  /* istanbul ignore next */
+  fromRoom(room: Room) {
+    return this.params({
+      ...room,
+      characteristicIds: room.characteristics.map(characteristic => characteristic.id),
+    })
+  }
+}
+
+export default NewRoomFactory.define(() => ({
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   characteristicIds: unique([referenceDataFactory.characteristic('room').build()]).map(
     characteristic => characteristic.id,

--- a/server/testutils/factories/room.ts
+++ b/server/testutils/factories/room.ts
@@ -1,10 +1,10 @@
-import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
 
 import { Room } from '@approved-premises/api'
-import referenceDataFactory from './referenceData'
 import { unique } from '../../utils/utils'
 import bedFactory from './bed'
+import referenceDataFactory from './referenceData'
 
 export default Factory.define<Room>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/room.ts
+++ b/server/testutils/factories/room.ts
@@ -2,11 +2,29 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
 import { Room } from '@approved-premises/api'
+import { ReferenceData } from '../../@types/ui'
 import { unique } from '../../utils/utils'
 import bedFactory from './bed'
+import characteristicFactory from './characteristic'
 import referenceDataFactory from './referenceData'
 
-export default Factory.define<Room>(() => ({
+class RoomFactory extends Factory<Room> {
+  /* istanbul ignore next */
+  forEnvironment(characteristics: ReferenceData[]) {
+    return this.params({
+      characteristics: faker.helpers
+        .arrayElements(characteristics, faker.datatype.number({ min: 1, max: 5 }))
+        .map(characteristic =>
+          characteristicFactory.build({
+            ...characteristic,
+            modelScope: 'room',
+          }),
+        ),
+    })
+  }
+}
+
+export default RoomFactory.define(() => ({
   id: faker.datatype.uuid(),
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   characteristics: unique(

--- a/server/testutils/factories/updateRoom.ts
+++ b/server/testutils/factories/updateRoom.ts
@@ -1,10 +1,20 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
-import type { UpdateRoom } from '@approved-premises/api'
+import type { Room, UpdateRoom } from '@approved-premises/api'
 import referenceDataFactory from './referenceData'
 import { unique } from '../../utils/utils'
 
-export default Factory.define<UpdateRoom>(() => ({
+class UpdateRoomFactory extends Factory<UpdateRoom> {
+  /* istanbul ignore next */
+  fromRoom(room: Room) {
+    return this.params({
+      ...room,
+      characteristicIds: room.characteristics.map(characteristic => characteristic.id),
+    })
+  }
+}
+
+export default UpdateRoomFactory.define(() => ({
   characteristicIds: unique([referenceDataFactory.characteristic('room').build()]).map(
     characteristic => characteristic.id,
   ),


### PR DESCRIPTION
# Changes in this PR

- We update to UI E2E tests, so we no longer need to keep `characteristics.json` file synchronised with the API in order for the tests to pass. We instead derive this data from the bedspace creation and editing pages

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
