### PR TITLE
Dev environment automatically checks for very new node versions

### DIFF
--- a/script/bootstrap
+++ b/script/bootstrap
@@ -3,6 +3,18 @@
 # script/bootstrap: Resolve all dependencies that the application requires to
 #                   run.
 
+# INFO: node-build doesn't always have the latest version so we have to build it
+# Here we follow the process laid out in the node-build-update-defs readme.
+function update_node_build {
+  if ! brew list node-build-update-defs >/dev/null 2>&1; then
+    brew install nodenv/nodenv/node-build-update-defs
+  fi
+
+  export NODE_BUILD_DEFINITIONS="/usr/local/opt/node-build-update-defs/share/node-build"
+
+  nodenv update-version-defs
+}
+
 set -e
 
 cd "$(dirname "$0")/.."
@@ -11,7 +23,10 @@ script/utils/launch-docker.sh
 
 echo "==> Installing application dependencies..."
 
+update_node_build
+
 nodenv install --skip-existing
+
 npm install
 
 script/utils/start-backing-services.sh


### PR DESCRIPTION
We found that Renovate proposed we update node 1 minor version from 18.15.0 to 18.16.0. 4 days later the latest version of node-build failed to contain this new version which was eventually added[1]. This meant that attempts to run `script/setup` failed due to node 18.16.0 not being available local and attempts to install it failed since it wasn't an available version, at least via node-build.

CAS1 linked us to this nodenv package[2] that seems to account for this situation and allows our machine to build new definitions without delay.

We want Renovate to keep proposeing minor and patch updates quickly in order to keep the service secure. This means that we need to accound for the fact that our local environments may again fall behind. Given  the `script/setup` is run after new updates (and we advise returning devs to run it) and that has a dependant `script/bootstrap` script, this seems like the best place to do it.

NB. The package advises the installation via github. This assumes we can always trust the contents of this github repository which cannot be guaranteed. Alternatively we could make this a manual part of the set up process. Given this is just to support dev tooling it feels reasonable. Thoughts?

[1] https://github.com/nodenv/node-build/blob/master/share/node-build/18.16.0
[2] https://github.com/nodenv/node-build-update-defs.git
