### PR TITLE
Reallocate errors for forward compatibility with upcoming API changes

### DIFF
--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,5 @@
-import type { ErrorMessages } from '@approved-premises/ui'
 import type { ApprovedPremisesApplication as Application, ProbationRegion } from '@approved-premises/api'
+import type { ErrorMessages } from '@approved-premises/ui'
 
 export default {}
 

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -33,6 +33,8 @@ declare module 'express' {
   type ShowRequestHandler = TypedRequestHandler<ShowParams>
 }
 
+type FlashMessage = string | ErrorMessages | Array<ErrorSummary> | Record<string, unknown>
+
 export declare global {
   namespace Express {
     interface User {
@@ -45,7 +47,8 @@ export declare global {
       verified?: boolean
       id: string
       logout(done: (err: unknown) => void): void
-      flash(type: string, message: string | ErrorMessages | Array<ErrorSummary> | Record<string, unknown>): number
+      flash(type: string, message: FlashMessage): number
+      flash(type: string): FlashMessage
     }
   }
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -181,7 +181,7 @@ export interface ErrorSummary {
 
 export interface ErrorsAndUserInput {
   errors: ErrorMessages
-  errorSummary: Array<string>
+  errorSummary: Array<ErrorSummary>
   userInput: Record<string, unknown>
 }
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -1,14 +1,14 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import TasklistService from '../../services/tasklistService'
-import ApplicationService from '../../services/applicationService'
-import { PersonService } from '../../services'
-import { fetchErrorsAndUserInput } from '../../utils/validation'
-import paths from '../../paths/apply'
-import { DateFormats } from '../../utils/dateUtils'
 import Apply from '../../form-pages/apply'
+import paths from '../../paths/apply'
+import { PersonService } from '../../services'
+import ApplicationService from '../../services/applicationService'
+import TasklistService from '../../services/tasklistService'
 import { firstPageOfApplicationJourney, getResponses, isUnapplicable } from '../../utils/applicationUtils'
+import { DateFormats } from '../../utils/dateUtils'
 import extractCallConfig from '../../utils/restUtils'
+import { fetchErrorsAndUserInput } from '../../utils/validation'
 
 export const tasklistPageHeading = 'Apply for an Approved Premises (AP) placement'
 

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -51,7 +51,7 @@ export default class ApplicationsController {
       const callConfig = extractCallConfig(req)
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const crnArr = req.flash('crn')
+      const crnArr = req.flash('crn') as string
 
       if (crnArr.length) {
         const crn = crnArr[0]

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -18,7 +18,7 @@ import {
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, reallocateErrors } from '../../../utils/validation'
 import PremisesController from './premisesController'
 
 jest.mock('../../../utils/validation')
@@ -195,6 +195,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
+      expect(reallocateErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, paths.premises.new({}))
     })
   })
@@ -320,6 +321,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
+      expect(reallocateErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -7,7 +7,7 @@ import PremisesService from '../../../services/premisesService'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, reallocateErrors } from '../../../utils/validation'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -64,6 +64,7 @@ export default class PremisesController {
         req.flash('success', 'Property created')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
+        reallocateErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.new({}))
       }
     }
@@ -116,6 +117,7 @@ export default class PremisesController {
         req.flash('success', 'Property updated')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
+        reallocateErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.edit({ premisesId }))
       }
     }

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -11,6 +11,7 @@ import {
   catchValidationErrorOrPropogate,
   fetchErrorsAndUserInput,
   insertGenericError,
+  reallocateErrors,
   setUserInput,
 } from './validation'
 
@@ -307,6 +308,52 @@ describe('insertGenericError', () => {
         'invalid-params': [
           { propertyName: '$.someOtherProperty', errorType: 'someOtherErrorType' },
           { propertyName: '$.someProperty', errorType: 'someErrorType' },
+        ],
+      },
+    })
+  })
+})
+
+describe('reallocateError', () => {
+  it('renames a property matching the source parameter to the destination parameter', () => {
+    const error = {
+      data: {
+        'invalid-params': [
+          { propertyName: '$.apiProperty', errorType: 'someErrorType' },
+          { propertyName: '$.unrelatedProperty', errorType: 'somOtherErrorType' },
+        ],
+      },
+    }
+
+    reallocateErrors(error as SanitisedError, 'apiProperty', 'uiProperty')
+
+    expect(error).toEqual({
+      data: {
+        'invalid-params': [
+          { propertyName: '$.uiProperty', errorType: 'someErrorType' },
+          { propertyName: '$.unrelatedProperty', errorType: 'somOtherErrorType' },
+        ],
+      },
+    })
+  })
+
+  it('does nothing if the desination parameter already exists', () => {
+    const error = {
+      data: {
+        'invalid-params': [
+          { propertyName: '$.apiProperty', errorType: 'someErrorType' },
+          { propertyName: '$.uiProperty', errorType: 'somOtherErrorType' },
+        ],
+      },
+    }
+
+    reallocateErrors(error as SanitisedError, 'apiProperty', 'uiProperty')
+
+    expect(error).toEqual({
+      data: {
+        'invalid-params': [
+          { propertyName: '$.apiProperty', errorType: 'someErrorType' },
+          { propertyName: '$.uiProperty', errorType: 'somOtherErrorType' },
         ],
       },
     })

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -104,7 +104,7 @@ const extractValidationErrors = (error: SanitisedError | Error, context: ErrorCo
 }
 
 export const reallocateErrors = (error: SanitisedError | Error, source: string, destination: string) => {
-  if (isAnnotedError(error)) {
+  if (isAnnotatedError(error)) {
     const invalidParams = error.data['invalid-params'] as Array<InvalidParams>
 
     if (

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -91,7 +91,7 @@ export const insertGenericError = (error: SanitisedError | Error, propertyName: 
 }
 
 const extractValidationErrors = (error: SanitisedError | Error, context: ErrorContext) => {
-  if (isAnnotedError(error)) {
+  if (isAnnotatedError(error)) {
     if (error.data['invalid-params'] && error.data['invalid-params'].length) {
       return generateErrors(error.data['invalid-params'] as Array<InvalidParams>, context)
     }
@@ -149,6 +149,6 @@ const throwUndefinedError = (message: string) => {
   throw new Error(message)
 }
 
-const isAnnotedError = (error: SanitisedError | Error): error is AnnotatedError => {
+const isAnnotatedError = (error: SanitisedError | Error): error is AnnotatedError => {
   return 'data' in error
 }


### PR DESCRIPTION
# Changes in this PR

See #259. As part of upcoming changes to how we handle PDUs, the API will look for a `probationDeliveryUnitId` field on our `NewPremises` and `UpdatePremises` objects. If this it not found, it will use the existing `pdu` field. If *both* are not found, it wil return an "empty" error against the `probationDeliveryUnitId` field field.

To ensure the UI is compatible with these changes we reallocate errors on `probationDeliveryUnitId` field to `pdu`. This can be removed once #259 is merged in

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
