### PR TITLE
Forwards-compatibility with turnarounds API changes

### DIFF
--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -38,7 +38,7 @@ context('Booking search', () => {
     // And there are bookings of all relevant status types in the database
     const bookings = bookingSearchResultsFactory.build()
 
-    const statuses: Array<BookingSearchApiStatus> = ['provisional', 'arrived', 'departed', 'confirmed']
+    const statuses: Array<BookingSearchApiStatus> = ['provisional', 'arrived', 'departed', 'confirmed', 'closed']
 
     statuses.forEach(status => {
       cy.task('stubFindBookings', { bookings, status })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -261,4 +261,4 @@ export interface SideNavObj {
   active: boolean
 }
 
-export type BookingSearchApiStatus = 'provisional' | 'confirmed' | 'arrived' | 'departed'
+export type BookingSearchApiStatus = 'provisional' | 'confirmed' | 'arrived' | 'departed' | 'closed'

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -18,7 +18,7 @@ import {
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, reallocateErrors } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, transformErrors } from '../../../utils/validation'
 import PremisesController from './premisesController'
 
 jest.mock('../../../utils/validation')
@@ -195,7 +195,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(reallocateErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
+      expect(transformErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, paths.premises.new({}))
     })
   })
@@ -321,7 +321,7 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(reallocateErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
+      expect(transformErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -7,7 +7,7 @@ import PremisesService from '../../../services/premisesService'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, reallocateErrors } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, transformErrors } from '../../../utils/validation'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -64,7 +64,7 @@ export default class PremisesController {
         req.flash('success', 'Property created')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
-        reallocateErrors(err, 'probationDeliveryUnitId', 'pdu')
+        transformErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.new({}))
       }
     }
@@ -117,7 +117,7 @@ export default class PremisesController {
         req.flash('success', 'Property updated')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
-        reallocateErrors(err, 'probationDeliveryUnitId', 'pdu')
+        transformErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.edit({ premisesId }))
       }
     }

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -12,7 +12,14 @@ export default class BookingSearchService {
     const bookingClient = this.bookingClientFactory(callConfig)
     const bookingSummaries = await bookingClient.search(status)
 
-    return bookingSummaries.results.map(summary => {
+    const { results } = bookingSummaries
+
+    if (status === 'departed') {
+      const closedBookingSummaries = await bookingClient.search('closed')
+      results.push(...closedBookingSummaries.results)
+    }
+
+    return results.map(summary => {
       return [
         this.textValue(summary.person.name),
         this.textValue(summary.person.crn),

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -2,8 +2,8 @@ import type { BookingSearchApiStatus, TableRow } from '@approved-premises/ui'
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { CallConfig } from '../data/restClient'
-import { DateFormats } from '../utils/dateUtils'
 import paths from '../paths/temporary-accommodation/manage'
+import { DateFormats } from '../utils/dateUtils'
 
 export default class BookingSearchService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -65,6 +65,7 @@ describe('BookingService', () => {
       expect(bookingClient.create).toHaveBeenCalledWith(premisesId, {
         serviceName: 'temporary-accommodation',
         bedId,
+        enableTurnarounds: false,
         ...newBooking,
       })
       expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -6,7 +6,7 @@ import { bedFactory, bookingFactory, lostBedFactory, newBookingFactory, roomFact
 
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
-import { statusTag } from '../utils/bookingUtils'
+import { statusTag, transformApiBookingToUiBooking } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { statusTag as lostBedStatusTag } from '../utils/lostBedUtils'
 
@@ -15,6 +15,7 @@ jest.mock('../data/referenceDataClient')
 jest.mock('../utils/bookingUtils', () => ({
   ...jest.requireActual('../utils/bookingUtils'),
   statusTag: jest.fn(),
+  transformApiBookingToUiBooking: jest.fn(),
 }))
 jest.mock('../data/lostBedClient')
 jest.mock('../utils/lostBedUtils')
@@ -38,6 +39,9 @@ describe('BookingService', () => {
     jest.resetAllMocks()
     bookingClientFactory.mockReturnValue(bookingClient)
     lostBedClientFactory.mockReturnValue(lostBedClient)
+    ;(transformApiBookingToUiBooking as jest.MockedFunction<typeof transformApiBookingToUiBooking>).mockImplementation(
+      booking => booking,
+    )
   })
 
   describe('createForBedspace', () => {
@@ -63,6 +67,7 @@ describe('BookingService', () => {
         bedId,
         ...newBooking,
       })
+      expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)
     })
   })
 
@@ -272,6 +277,10 @@ describe('BookingService', () => {
 
       expect(statusTag).toHaveBeenCalledTimes(4)
       expect(lostBedStatusTag).toHaveBeenCalledTimes(4)
+
+      bookings.forEach(booking => {
+        expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)
+      })
     })
   })
 
@@ -286,6 +295,7 @@ describe('BookingService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
+      expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)
     })
   })
 })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -40,20 +40,6 @@ describe('BookingService', () => {
     lostBedClientFactory.mockReturnValue(lostBedClient)
   })
 
-  describe('create', () => {
-    it('on success returns the booking that has been posted', async () => {
-      const booking = bookingFactory.build()
-      const newBooking = newBookingFactory.build()
-      bookingClient.create.mockResolvedValue(booking)
-
-      const postedBooking = await service.create(callConfig, premisesId, newBooking)
-      expect(postedBooking).toEqual(booking)
-
-      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(bookingClient.create).toHaveBeenCalledWith(premisesId, newBooking)
-    })
-  })
-
   describe('createForBedspace', () => {
     it('posts a new booking with a bed ID, and on success returns the created booking', async () => {
       const booking = bookingFactory.build()
@@ -77,26 +63,6 @@ describe('BookingService', () => {
         bedId,
         ...newBooking,
       })
-    })
-  })
-
-  describe('find', () => {
-    it('on success returns the booking that has been requested', async () => {
-      const arrivalDate = new Date(2022, 2, 11)
-      const departureDate = new Date(2022, 2, 12)
-
-      const booking = bookingFactory.build({
-        arrivalDate: arrivalDate.toISOString(),
-        departureDate: departureDate.toISOString(),
-      })
-
-      bookingClient.find.mockResolvedValue(booking)
-
-      const retrievedBooking = await service.find(callConfig, premisesId, booking.id)
-      expect(retrievedBooking).toEqual(booking)
-
-      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
     })
   })
 

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -17,14 +17,6 @@ export default class BookingService {
     private readonly lostBedClientFactory: RestClientBuilder<LostBedClient>,
   ) {}
 
-  async create(callConfig: CallConfig, premisesId: string, booking: NewBooking): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(callConfig)
-
-    const confirmedBooking = await bookingClient.create(premisesId, booking)
-
-    return confirmedBooking
-  }
-
   async createForBedspace(
     callConfig: CallConfig,
     premisesId: string,
@@ -40,14 +32,6 @@ export default class BookingService {
     })
 
     return confirmedBooking
-  }
-
-  async find(callConfig: CallConfig, premisesId: string, bookingId: string): Promise<Booking> {
-    const bookingClient = this.bookingClientFactory(callConfig)
-
-    const booking = await bookingClient.find(premisesId, bookingId)
-
-    return booking
   }
 
   async getTableRowsForBedspace(callConfig: CallConfig, premisesId: string, room: Room): Promise<Array<TableRow>> {

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -28,6 +28,7 @@ export default class BookingService {
     const confirmedBooking = await bookingClient.create(premisesId, {
       serviceName: 'temporary-accommodation',
       bedId: room.beds[0].id,
+      enableTurnarounds: false,
       ...booking,
     })
 

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -5,7 +5,7 @@ import type { LostBedClient, RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
-import { statusTag } from '../utils/bookingUtils'
+import { statusTag, transformApiBookingToUiBooking } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { statusTag as lostBedStatusTag } from '../utils/lostBedUtils'
 
@@ -31,12 +31,14 @@ export default class BookingService {
       ...booking,
     })
 
-    return confirmedBooking
+    return transformApiBookingToUiBooking(confirmedBooking)
   }
 
   async getTableRowsForBedspace(callConfig: CallConfig, premisesId: string, room: Room): Promise<Array<TableRow>> {
     const bookingClient = this.bookingClientFactory(callConfig)
-    const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
+    const bookings = (await bookingClient.allBookingsForPremisesId(premisesId)).map(booking =>
+      transformApiBookingToUiBooking(booking),
+    )
 
     const lostBedClient = this.lostBedClientFactory(callConfig)
     const lostBeds = await (
@@ -94,7 +96,7 @@ export default class BookingService {
     const bookingClient = this.bookingClientFactory(callConfig)
     const booking = await bookingClient.find(premisesId, bookingId)
 
-    return booking
+    return transformApiBookingToUiBooking(booking)
   }
 
   private textValue(value: string) {

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -59,6 +59,12 @@ class BookingFactory extends Factory<Booking> {
     })
   }
 
+  closed() {
+    return this.departed().params({
+      status: 'closed',
+    })
+  }
+
   cancelled(source: 'provisional' | 'confirmed' = 'provisional') {
     const cancellation = cancellationFactory.build()
 

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -6,6 +6,7 @@ import {
   getLatestExtension,
   shortenedOrExtended,
   statusTag,
+  transformApiBookingToUiBooking,
 } from './bookingUtils'
 
 const premisesId = 'premisesId'
@@ -368,6 +369,26 @@ describe('bookingUtils', () => {
       })
 
       expect(shortenedOrExtended(extension)).toEqual('extended')
+    })
+  })
+
+  describe('transformApiBookingToUiBooking', () => {
+    it('transforms a closed booking to a departed booking', () => {
+      const booking = bookingFactory.closed().build()
+      const bookingCopy = { ...booking }
+
+      const result = transformApiBookingToUiBooking(booking)
+
+      expect(result).toEqual({ ...bookingCopy, status: 'departed' })
+    })
+
+    it('leaves non-closed bookings unchanged', () => {
+      const booking = bookingFactory.arrived().build()
+      const bookingCopy = { ...booking }
+
+      const result = transformApiBookingToUiBooking(booking)
+
+      expect(result).toEqual(bookingCopy)
     })
   })
 })

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -143,6 +143,13 @@ export const shortenedOrExtended = (extension: Extension): 'shortened' | 'extend
   return previousDepartureDate.getTime() > newDepartureDate.getTime() ? 'shortened' : 'extended'
 }
 
+export const transformApiBookingToUiBooking = (booking: Booking): Booking => {
+  if (booking.status === 'closed') {
+    return { ...booking, status: 'departed' }
+  }
+  return booking
+}
+
 const getUpdatedAt = (booking: Booking): string => {
   if (booking.status === 'departed') {
     return booking.departure.createdAt

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -12,8 +12,8 @@ import {
   clearUserInput,
   fetchErrorsAndUserInput,
   insertGenericError,
-  reallocateErrors,
   setUserInput,
+  transformErrors,
 } from './validation'
 
 jest.mock('../i18n/en/errors.json', () => {
@@ -336,7 +336,7 @@ describe('reallocateError', () => {
       },
     }
 
-    reallocateErrors(error as SanitisedError, 'apiProperty', 'uiProperty')
+    transformErrors(error as SanitisedError, 'apiProperty', 'uiProperty')
 
     expect(error).toEqual({
       data: {
@@ -358,7 +358,7 @@ describe('reallocateError', () => {
       },
     }
 
-    reallocateErrors(error as SanitisedError, 'apiProperty', 'uiProperty')
+    transformErrors(error as SanitisedError, 'apiProperty', 'uiProperty')
 
     expect(error).toEqual({
       data: {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -107,7 +107,7 @@ const extractValidationErrors = (error: SanitisedError | Error, context: ErrorCo
   throw error
 }
 
-export const reallocateErrors = (error: SanitisedError | Error, source: string, destination: string) => {
+export const transformErrors = (error: SanitisedError | Error, source: string, destination: string) => {
   if (isAnnotatedError(error)) {
     const invalidParams = error.data['invalid-params'] as Array<InvalidParams>
 


### PR DESCRIPTION
# Changes in this PR

This PR makes changes to allow API features for turnarounds to be developed, without affecting the UI. Specifically:
- We transform any 'closed' bookings coming from the API to 'departed' bookings
- When the user searches for 'departed' bookings, the UI also searches for 'closed' bookings

This allows the API to make a distinction between closed and departed bookings, without this difference yet being exposed to the user

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
