### PR TITLE
Clear user input on booking creation success

### DIFF
--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -9,6 +9,7 @@ import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import {
   catchValidationErrorOrPropogate,
+  clearUserInput,
   fetchErrorsAndUserInput,
   insertGenericError,
   setUserInput,
@@ -99,6 +100,8 @@ export default class BookingsController {
         const booking = await this.bookingsService.createForBedspace(callConfig, premisesId, room, newBooking)
 
         req.flash('success', 'Booking created')
+        clearUserInput(req)
+
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId: booking.id }))
       } catch (err) {
         if (err.status === 409) {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -9,6 +9,7 @@ import { TasklistAPIError, ValidationError } from './errors'
 import {
   catchAPIErrorOrPropogate,
   catchValidationErrorOrPropogate,
+  clearUserInput,
   fetchErrorsAndUserInput,
   insertGenericError,
   reallocateErrors,
@@ -262,6 +263,16 @@ describe('setUserInput', () => {
 
     expect(request.flash).toHaveBeenCalledWith('userInput', request.query)
   })
+})
+
+describe('clearUserInput', () => {
+  const request = createMock<Request>({})
+
+  request.flash('userInput', 'text')
+
+  clearUserInput(request)
+
+  expect(request.flash).toHaveBeenCalledWith('userInput', null)
 })
 
 describe('insertGenericError', () => {

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -61,6 +61,10 @@ export const setUserInput = (request: Request, source: 'get' | 'post' = 'post'):
   request.flash('userInput', source === 'post' ? request.body : request.query)
 }
 
+export const clearUserInput = (request: Request): void => {
+  request.flash('userInput', null)
+}
+
 export const errorSummary = (field: string, text: string): ErrorSummary => {
   return {
     text,


### PR DESCRIPTION
# Changes in this PR

This PR fixes [a bug](https://trello.com/c/Shy1z6nu/1046-after-successfully-creating-a-booking-when-next-creating-a-booking-the-form-is-prepopulated-with-the-previous-bookings-details) in which after a booking is successfully created, the booking data persists when the user navigates to the create booking page, and prepopulates the form.

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
