### PR TITLE
Update bedspace search E2E test

### DIFF
--- a/e2e/tests/bedspaceSearch.feature
+++ b/e2e/tests/bedspaceSearch.feature
@@ -3,7 +3,8 @@ Feature: Manage Temporary Accommodation - Bedspace Search
         Given I am logged in
 
     Scenario: Searching for a bedspace
-        Given I view an existing active premises
+        Given I'm creating a premises
+        And I create a premises with all necessary details
         And I'm creating a bedspace
         And I create a bedspace with all necessary details
         And I return to the dashboard


### PR DESCRIPTION
We update the bedspace search E2E test, as a failure to properly read the PDU of an exiting premises is leading to a later test failure