### PR TITLE
Always create an active premises in E2E tests

### DIFF
--- a/e2e/tests/bedspaceSearch.feature
+++ b/e2e/tests/bedspaceSearch.feature
@@ -4,7 +4,7 @@ Feature: Manage Temporary Accommodation - Bedspace Search
 
     Scenario: Searching for a bedspace
         Given I'm creating a premises
-        And I create a premises with all necessary details
+        And I create an active premises with all necessary details
         And I'm creating a bedspace
         And I create a bedspace with all necessary details
         And I return to the dashboard

--- a/e2e/tests/premises.feature
+++ b/e2e/tests/premises.feature
@@ -8,7 +8,7 @@ Feature: Manage Temporary Accommodation - Premises
 
     Scenario: Creating a premises
         Given I'm creating a premises
-        And I create a premises with all necessary details
+        And I create an active premises with all necessary details
         Then I should see a confirmation for my new premises
 
     Scenario: Showing premises creation errors
@@ -20,14 +20,14 @@ Feature: Manage Temporary Accommodation - Premises
 
     Scenario: Editing a premises
         Given I'm creating a premises
-        And I create a premises with all necessary details
+        And I create an active premises with all necessary details
         And I'm editing the premises
         And I edit the premises details
         Then I should see a confirmation for my updated premises
 
     Scenario: Showing premises editing errors
         Given I'm creating a premises
-        And I create a premises with all necessary details
+        And I create an active premises with all necessary details
         And I'm editing the premises
         And I attempt to edit the premises to remove required details
         Then I should see a list of the problems encountered updating the premises

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -55,7 +55,7 @@ Given('I view an existing active premises', () => {
   })
 })
 
-Given('I create a premises with all necessary details', () => {
+Given('I create an active premises with all necessary details', () => {
   const page = Page.verifyOnPage(PremisesNewPage)
 
   page.assignPdus('pdus')
@@ -65,6 +65,7 @@ Given('I create a premises with all necessary details', () => {
   cy.then(function _() {
     const premises = premisesFactory
       .forEnvironment(actingUserProbationRegion, this.pdus, this.localAuthorities, this.characteristics)
+      .active()
       .build({
         id: 'unknown',
       })


### PR DESCRIPTION
We change our step definition so when creating a premises in our E2E tests, it will always be active. Creating premises as inactive was causing later test failures