### PR TITLE
Run E2E tests sequentially to avoid flakey auth failures

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,6 +44,7 @@ jobs:
           template: basic_fail_1
 
   e2e_environment_test:
+    resource_class: small
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     docker:
       - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge


### PR DESCRIPTION

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

After investigating recent flakey e2e tests[2] I could see that 2 tests were failing for auth related reasons. Firstly the user is thrown to the sign out page and secondly the user gets a not authorised error. We don't always see these and when we re-run we are usually ok. We have been toying with the idea of adding retry: 1 onto all tests.

In this case we found that there was another e2e test running[3] within the same window. Given that these tests run against the same environment and sign in with the same user, I suspect that there may be odd situations where one test signs out and the other expects them to still be signed in. This would explain the lack of pattern to the problem.

In order to solve this we use a CircleCI trick by asking it to use a small resource. Only 1 small resource can be used at a time which creates a situation where these jobs cannot be parallelised.

- When the API runs e2e tests for the frontend, it already uses this to ensure the jobs are queued[1]
- CircleCI is on the performance plan that allows this resource configuration

[1] https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/.circleci/config.yml#L18
[2] https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui/1689/workflows/732f7a22-c9e4-4692-84af-4e4ba17613b5/jobs/3667/artifacts
[3] https://app.circleci.com/pipelines/github/ministryofjustice/hmpps-temporary-accommodation-ui/1684/workflows/b6e3175d-9572-4fda-aef9-761c93dc9f36


# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
