### PR TITLE
Remove use of deprecated pdu field

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -46,7 +46,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
       .contains('What is the PDU?')
       .siblings('select')
       .children('option')
-      .contains(exact(this.premises.pdu))
+      .contains(exact(this.premises.probationDeliveryUnit.name))
       .should('be.selected')
 
     cy.get('legend')

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -85,7 +85,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
 
     this.getSelectInputByIdAndSelectAnEntry('localAuthorityAreaId', '')
     this.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
-    this.getSelectInputByIdAndSelectAnEntry('pdu', '')
+    this.getSelectInputByIdAndSelectAnEntry('probationDeliveryUnitId', '')
 
     cy.get('legend')
       .contains('Does the property have any of the following attributes?')

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
@@ -26,7 +26,7 @@ export default abstract class PremisesEditablePage extends Page {
     this.getSelectInputByIdAndSelectAnEntry('probationRegionId', newOrUpdatePremises.probationRegionId)
 
     this.getLabel('What is the PDU?')
-    this.getSelectInputByIdAndSelectAnEntry('pdu', newOrUpdatePremises.pdu)
+    this.getSelectInputByIdAndSelectAnEntry('probationDeliveryUnitId', newOrUpdatePremises.probationDeliveryUnitId)
 
     this.getLegend('What is the status of this property?')
     this.checkRadioByNameAndValue('status', newOrUpdatePremises.status)

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -53,6 +53,7 @@ export default class PremisesShowPage extends Page {
                       postcode: addressLines[addressLines.length - 1],
                       status,
                       pdu: pdu.name,
+                      probationDeliveryUnit: pdu,
                     })
 
                     cy.wrap(premises).as(alias)

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -78,7 +78,7 @@ export default class PremisesShowPage extends Page {
       ])
       this.shouldShowKeyAndValue('Local authority', this.premises.localAuthorityArea.name)
       this.shouldShowKeyAndValue('Probation region', this.premises.probationRegion.name)
-      this.shouldShowKeyAndValue('PDU', this.premises.pdu)
+      this.shouldShowKeyAndValue('PDU', this.premises.probationDeliveryUnit.name)
       this.shouldShowKeyAndValues(
         'Attributes',
         this.premises.characteristics.map(({ name }) => name),

--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -20,7 +20,7 @@ Given('I search for a bedspace', () => {
     const page = Page.verifyOnPage(BedspaceSearchPage)
 
     const searchParameters = bedSearchParametersFactory.build({
-      probationDeliveryUnit: this.premises.pdu,
+      probationDeliveryUnit: this.premises.probationDeliveryUnit.name,
     })
 
     page.completeForm(searchParameters)

--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -101,12 +101,12 @@ Given('I attempt to create a premises with the PDU missing', () => {
       })
 
     const newPremises = newPremisesFactory.fromPremises(premises).build({
-      pdu: '',
+      probationDeliveryUnitId: '',
     })
 
     page.completeForm(newPremises)
 
-    cy.wrap(['pdu']).as('missing')
+    cy.wrap(['probationDeliveryUnitId']).as('missing')
   })
 })
 
@@ -160,12 +160,12 @@ Given('I attempt to edit the premises to remove the PDU', () => {
     const page = Page.verifyOnPage(PremisesEditPage, this.premises)
 
     const updatePremises = updatePremisesFactory.fromPremises(this.premises).build({
-      pdu: '',
+      probationDeliveryUnitId: '',
     })
 
     page.completeForm(updatePremises)
 
-    cy.wrap(['pdu']).as('missing')
+    cy.wrap(['probationDeliveryUnitId']).as('missing')
   })
 })
 

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -193,7 +193,7 @@ context('Premises', () => {
       'town',
       'postcode',
       'probationRegionId',
-      'pdu',
+      'probationDeliveryUnitId',
       'status',
     ])
     page.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
@@ -206,7 +206,7 @@ context('Premises', () => {
       'town',
       'postcode',
       'probationRegionId',
-      'pdu',
+      'probationDeliveryUnitId',
       'status',
     ])
   })
@@ -299,13 +299,19 @@ context('Premises', () => {
     // And I clear required fields
     cy.task('stubPremisesUpdateErrors', {
       premises,
-      params: ['addressLine1', 'town', 'postcode', 'probationRegionId', 'pdu'],
+      params: ['addressLine1', 'town', 'postcode', 'probationRegionId', 'probationDeliveryUnitId'],
     })
     page.clearForm()
     page.clickSubmit()
 
     // Then I should see error messages relating to those fields
-    page.shouldShowErrorMessagesForFields(['addressLine1', 'town', 'postcode', 'probationRegionId', 'pdu'])
+    page.shouldShowErrorMessagesForFields([
+      'addressLine1',
+      'town',
+      'postcode',
+      'probationRegionId',
+      'probationDeliveryUnitId',
+    ])
   })
 
   it('should navigate back from the edit premises page to the premises show page', () => {

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -18,7 +18,7 @@ import {
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, transformErrors } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import PremisesController from './premisesController'
 
 jest.mock('../../../utils/validation')
@@ -195,7 +195,6 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(transformErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, paths.premises.new({}))
     })
   })
@@ -321,7 +320,6 @@ describe('PremisesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(transformErrors).toHaveBeenCalledWith(err, 'probationDeliveryUnitId', 'pdu')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -7,7 +7,7 @@ import PremisesService from '../../../services/premisesService'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, transformErrors } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -64,7 +64,6 @@ export default class PremisesController {
         req.flash('success', 'Property created')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
-        transformErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.new({}))
       }
     }
@@ -117,7 +116,6 @@ export default class PremisesController {
         req.flash('success', 'Property updated')
         res.redirect(paths.premises.show({ premisesId }))
       } catch (err) {
-        transformErrors(err, 'probationDeliveryUnitId', 'pdu')
         catchValidationErrorOrPropogate(req, res, err, paths.premises.edit({ premisesId }))
       }
     }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -93,7 +93,7 @@
     "probationRegionId": {
       "empty": "You must choose a probation region"
     },
-    "pdu": {
+    "probationDeliveryUnitId": {
       "empty": "You must choose a PDU"
     },
     "status": {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -97,11 +97,7 @@ describe('PremisesService', () => {
         localAuthorities: [localAuthority1, localAuthority2, localAuthority3],
         characteristics: [premisesCharacteristic1, premisesCharacteristic2, genericCharacteristic],
         probationRegions: [probationRegion1, probationRegion2, probationRegion3],
-        pdus: [
-          { ...pdu1, id: pdu1.name },
-          { ...pdu2, id: pdu2.name },
-          { ...pdu3, id: pdu3.name },
-        ],
+        pdus: [pdu1, pdu2, pdu3],
       })
 
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('local-authority-areas')

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -139,7 +139,7 @@ describe('PremisesService', () => {
             text: premises1.bedCount.toString(),
           },
           {
-            text: premises1.pdu,
+            text: premises1.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises1.status}</strong>`,
@@ -158,7 +158,7 @@ describe('PremisesService', () => {
             text: premises2.bedCount.toString(),
           },
           {
-            text: premises2.pdu,
+            text: premises2.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises2.status}</strong>`,
@@ -177,7 +177,7 @@ describe('PremisesService', () => {
             text: premises3.bedCount.toString(),
           },
           {
-            text: premises3.pdu,
+            text: premises3.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises3.status}</strong>`,
@@ -196,7 +196,7 @@ describe('PremisesService', () => {
             text: premises4.bedCount.toString(),
           },
           {
-            text: premises4.pdu,
+            text: premises4.probationDeliveryUnit.name,
           },
           {
             html: `<strong>${premises4.status}</strong>`,
@@ -255,6 +255,10 @@ describe('PremisesService', () => {
           name: 'A probation region',
           id: 'a-probation-region',
         }),
+        probationDeliveryUnit: pduFactory.build({
+          name: 'A probation delivery unit',
+          id: 'a-probation-delivery-unit',
+        }),
       })
 
       premisesClient.find.mockResolvedValue(premises)
@@ -265,6 +269,7 @@ describe('PremisesService', () => {
         localAuthorityAreaId: 'local-authority',
         characteristicIds: ['characteristic-a', 'characteristic-b'],
         probationRegionId: 'a-probation-region',
+        pdu: 'a-probation-delivery-unit',
       })
 
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
@@ -306,7 +311,7 @@ describe('PremisesService', () => {
         probationRegion: probationRegionFactory.build({
           name: 'A probation region',
         }),
-        pdu: 'A PDU',
+        probationDeliveryUnit: pduFactory.build({ name: 'A PDU' }),
         status: 'active',
         notes: 'Some notes',
       })

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -269,7 +269,7 @@ describe('PremisesService', () => {
         localAuthorityAreaId: 'local-authority',
         characteristicIds: ['characteristic-a', 'characteristic-b'],
         probationRegionId: 'a-probation-region',
-        pdu: 'a-probation-delivery-unit',
+        probationDeliveryUnitId: 'a-probation-delivery-unit',
       })
 
       expect(premisesClient.find).toHaveBeenCalledWith(premises.id)
@@ -398,17 +398,19 @@ describe('PremisesService', () => {
   describe('update', () => {
     it('on success updates the premises and returns the updated premises', async () => {
       const premises = premisesFactory.build()
-      const newPremises = updatePremisesFactory.build({
+      const updatePremises = updatePremisesFactory.build({
         postcode: premises.postcode,
         notes: premises.notes,
       })
       premisesClient.update.mockResolvedValue(premises)
 
-      const updatedPremises = await service.update(callConfig, premises.id, newPremises)
+      const updatedPremises = await service.update(callConfig, premises.id, updatePremises)
       expect(updatedPremises).toEqual(premises)
 
       expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(premisesClient.update).toHaveBeenCalledWith(premises.id, newPremises)
+      expect(premisesClient.update).toHaveBeenCalledWith(premises.id, {
+        ...updatePremises,
+      })
     })
   })
 })

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -56,9 +56,7 @@ export default class PremisesService {
       await referenceDataClient.getReferenceData('probation-delivery-units', {
         probationRegionId: callConfig.probationRegion.id,
       })
-    )
-      .sort((a, b) => a.name.localeCompare(b.name))
-      .map(pdu => ({ ...pdu, id: pdu.name }))
+    ).sort((a, b) => a.name.localeCompare(b.name))
 
     return { localAuthorities, characteristics, probationRegions, pdus }
   }

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -132,7 +132,7 @@ export default class PremisesService {
       localAuthorityAreaId: premises.localAuthorityArea?.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.pdu,
+      pdu: premises.probationDeliveryUnit.id,
     }
   }
 
@@ -171,7 +171,7 @@ export default class PremisesService {
         },
         {
           key: this.textValue('PDU'),
-          value: this.textValue(premises.pdu),
+          value: this.textValue(premises.probationDeliveryUnit.name),
         },
         {
           key: this.textValue('Attributes'),

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -132,7 +132,7 @@ export default class PremisesService {
       localAuthorityAreaId: premises.localAuthorityArea?.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.probationDeliveryUnit.id,
+      probationDeliveryUnitId: premises.probationDeliveryUnit.id,
     }
   }
 

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -1,6 +1,6 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
-import { NewPremises, Premises } from '../../@types/shared'
+import { NewPremises, TemporaryAccommodationPremises as Premises } from '../../@types/shared'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
 
@@ -12,6 +12,7 @@ class NewPremisesFactory extends Factory<NewPremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
+      pdu: premises.probationDeliveryUnit.id,
     })
   }
 }

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -12,7 +12,7 @@ class NewPremisesFactory extends Factory<NewPremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.probationDeliveryUnit.id,
+      probationDeliveryUnitId: premises.probationDeliveryUnit.id,
     })
   }
 }
@@ -28,7 +28,7 @@ export default NewPremisesFactory.define(() => ({
     characteristic => characteristic.id,
   ),
   probationRegionId: referenceDataFactory.probationRegion().build().id,
-  pdu: referenceDataFactory.pdu().build().id,
+  probationDeliveryUnitId: referenceDataFactory.pdu().build().id,
   status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
 }))

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -6,6 +6,7 @@ import { ReferenceData } from '../../@types/ui'
 import { unique } from '../../utils/utils'
 import characteristicFactory from './characteristic'
 import localAuthorityFactory from './localAuthority'
+import pduFactory from './pdu'
 import probationRegionFactory from './probationRegion'
 import referenceDataFactory from './referenceData'
 
@@ -29,6 +30,8 @@ class PremisesFactory extends Factory<Premises> {
     localAuthorities: ReferenceData[],
     characteristics: ReferenceData[],
   ) {
+    const pdu = pduFactory.build({ ...faker.helpers.arrayElement(pdus) })
+
     return this.params({
       probationRegion: probationRegionFactory.build({
         ...probationRegion,
@@ -36,7 +39,8 @@ class PremisesFactory extends Factory<Premises> {
       localAuthorityArea: localAuthorityFactory.build({
         ...faker.helpers.arrayElement(localAuthorities),
       }),
-      pdu: faker.helpers.arrayElement(pdus).id,
+      pdu: pdu.id,
+      probationDeliveryUnit: pdu,
       characteristics: faker.helpers
         .arrayElements(characteristics, faker.datatype.number({ min: 1, max: 5 }))
         .map(characteristic =>
@@ -49,26 +53,31 @@ class PremisesFactory extends Factory<Premises> {
   }
 }
 
-export default PremisesFactory.define(() => ({
-  id: faker.datatype.uuid(),
-  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
-  addressLine1: faker.address.streetAddress(),
-  addressLine2: faker.address.secondaryAddress(),
-  town: faker.address.cityName(),
-  postcode: faker.address.zipCode(),
-  bedCount: 50,
-  availableBedsForToday: faker.datatype.number({ min: 0, max: 50 }),
-  apAreaId: faker.random.alphaNumeric(2, { casing: 'upper' }),
-  probationRegion: referenceDataFactory.probationRegion().build(),
-  apArea: apAreaFactory.build(),
-  localAuthorityArea: referenceDataFactory.localAuthority().build(),
-  pdu: referenceDataFactory.pdu().build().id,
-  characteristics: unique(
-    referenceDataFactory.characteristic('premises').buildList(faker.datatype.number({ min: 1, max: 5 })),
-  ),
-  status: faker.helpers.arrayElement(['active', 'archived'] as const),
-  notes: faker.lorem.lines(5),
-}))
+export default PremisesFactory.define(() => {
+  const pdu = referenceDataFactory.pdu().build()
+
+  return {
+    id: faker.datatype.uuid(),
+    name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+    addressLine1: faker.address.streetAddress(),
+    addressLine2: faker.address.secondaryAddress(),
+    town: faker.address.cityName(),
+    postcode: faker.address.zipCode(),
+    bedCount: 50,
+    availableBedsForToday: faker.datatype.number({ min: 0, max: 50 }),
+    apAreaId: faker.random.alphaNumeric(2, { casing: 'upper' }),
+    probationRegion: referenceDataFactory.probationRegion().build(),
+    apArea: apAreaFactory.build(),
+    localAuthorityArea: referenceDataFactory.localAuthority().build(),
+    pdu: pdu.id,
+    probationDeliveryUnit: pdu,
+    characteristics: unique(
+      referenceDataFactory.characteristic('premises').buildList(faker.datatype.number({ min: 1, max: 5 })),
+    ),
+    status: faker.helpers.arrayElement(['active', 'archived'] as const),
+    notes: faker.lorem.lines(5),
+  }
+})
 
 const apAreaFactory = Factory.define<ApArea>(() => ({
   id: faker.datatype.uuid(),

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -12,7 +12,7 @@ class UpdatePremisesFactory extends Factory<UpdatePremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
-      pdu: premises.probationDeliveryUnit.id,
+      probationDeliveryUnitId: premises.probationDeliveryUnit.id,
     })
   }
 }
@@ -27,7 +27,7 @@ export default UpdatePremisesFactory.define(() => ({
     characteristic => characteristic.id,
   ),
   probationRegionId: referenceDataFactory.probationRegion().build().id,
-  pdu: referenceDataFactory.pdu().build().id,
+  probationDeliveryUnitId: referenceDataFactory.pdu().build().id,
   status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
 }))

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -1,4 +1,4 @@
-import type { Premises, UpdatePremises } from '@approved-premises/api'
+import type { TemporaryAccommodationPremises as Premises, UpdatePremises } from '@approved-premises/api'
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 import { unique } from '../../utils/utils'
@@ -12,6 +12,7 @@ class UpdatePremisesFactory extends Factory<UpdatePremises> {
       localAuthorityAreaId: premises.localAuthorityArea.id,
       characteristicIds: premises.characteristics.map(characteristic => characteristic.id),
       probationRegionId: premises.probationRegion.id,
+      pdu: premises.probationDeliveryUnit.id,
     })
   }
 }

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -96,8 +96,8 @@
       text: "What is the PDU?",
       classes: "govuk-label--m"
     },
-    items: convertObjectsToSelectOptions(allPdus, 'Select a PDU', 'name', 'id', 'pdu'),
-    fieldName: "pdu"
+    items: convertObjectsToSelectOptions(allPdus, 'Select a PDU', 'name', 'id', 'probationDeliveryUnitId'),
+    fieldName: "probationDeliveryUnitId"
   },
   fetchContext()
 ) }}

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -56,7 +56,10 @@ stubs.push({
   },
 })
 
-const createRequiredFields = [...getCombinations(['addressLine1', 'postcode', 'probationRegionId', 'status']), ['pdu']]
+const createRequiredFields = [
+  ...getCombinations(['addressLine1', 'postcode', 'probationRegionId', 'status']),
+  ['probationDeliveryUnitId'],
+]
 
 createRequiredFields.forEach((fields: Array<string>) => {
   stubs.push(errorStub(fields, `/premises`, 'POST'))
@@ -121,7 +124,7 @@ premises.forEach(item => {
 
   const updateRequiredFields = [
     ...getCombinations(['addressLine1', 'postcode', 'probationRegionId', 'status']),
-    ['pdu'],
+    ['probationDeliveryUnitId'],
   ]
 
   updateRequiredFields.forEach((fields: Array<string>) => {


### PR DESCRIPTION
# Changes in this PR

This PR switches to sending PDU Ids rather than PDU names, sending IDs on the probationRegionId field in `NewPremises` and `UpdatePremises`, and using the `probationDeliveryUnit` field  on `TemporaryAccommodationPremises`

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
