### PR TITLE
Configure Cypress to not keep E2E tests in memory

### DIFF
--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -36,4 +36,5 @@ export default defineConfig({
     setupNodeEvents,
     supportFile: false,
   },
+  numTestsKeptInMemory: 0,
 })

--- a/script/local_e2e
+++ b/script/local_e2e
@@ -20,4 +20,4 @@ set -a
 
 set +a
 
-npx cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000"}'
+npx cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config '{"baseUrl":"http://localhost:3000", "numTestsKeptInMemory": 50}'


### PR DESCRIPTION
In our E2E test config, we set numTestsKeptInMemory to zero, to prevent our test environment running out of memory