### PR TITLE
Revert setting CircleCI resource_class to small

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -44,7 +44,6 @@ jobs:
           template: basic_fail_1
 
   e2e_environment_test:
-    resource_class: small
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     docker:
       - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge


### PR DESCRIPTION
This is a good candidate for the cause of our current E2E test failures, so we revert until we can investigate further.

This reverts #307 