### PR TITLE
Bookings extensions conflicts show a more detailed error message

### DIFF
--- a/cypress_shared/components/bedspaceConflictError.ts
+++ b/cypress_shared/components/bedspaceConflictError.ts
@@ -1,0 +1,45 @@
+import type { Booking, LostBed, Premises, Room } from '@approved-premises/api'
+import errorLookups from '../../server/i18n/en/errors.json'
+import Page from '../pages/page'
+import BookingShowPage from '../pages/temporary-accommodation/manage/bookingShow'
+import LostBedShowPage from '../pages/temporary-accommodation/manage/lostBedShow'
+import Component from './component'
+
+export default class BedspaceConflictErrorComponent extends Component {
+  constructor(private readonly premises: Premises, private readonly room: Room) {
+    super()
+  }
+
+  shouldShowDateConflictErrorMessages(
+    fields: Array<string>,
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    fields.forEach(field => {
+      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
+    })
+
+    const title =
+      fields.length === 1
+        ? 'This bedspace is not available for the date entered'
+        : 'This bedspace is not available for the dates entered'
+
+    const noun = conflictingEntityType === 'booking' ? 'booking' : 'void'
+
+    const message =
+      fields.length === 1 ? `It conflicts with an existing ${noun}` : `They conflict with an existing ${noun}`
+
+    cy.get('.govuk-error-summary h2').should('contain', title)
+    cy.get('.govuk-error-summary ul').should('contain', message)
+
+    cy.get('.govuk-error-summary a').click()
+
+    if (conflictingEntityType === 'booking') {
+      Page.verifyOnPage(BookingShowPage, this.premises, this.room, conflictingEntity as Booking)
+    } else {
+      Page.verifyOnPage(LostBedShowPage, this.premises, this.room, conflictingEntity as LostBed)
+    }
+
+    cy.go('back')
+  }
+}

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -15,6 +15,10 @@ export default abstract class Page extends Component {
     cy.get('.govuk-breadcrumbs a').contains('Home').click()
   }
 
+  static clickBreadCrumbUp(): void {
+    cy.get('li.govuk-breadcrumbs__list-item:nth-last-child(2)').click()
+  }
+
   constructor(private readonly title: string) {
     super()
 
@@ -170,7 +174,7 @@ export default abstract class Page extends Component {
   }
 
   clickBreadCrumbUp(): void {
-    cy.get('li.govuk-breadcrumbs__list-item:nth-last-child(2)').click()
+    Page.clickBreadCrumbUp()
   }
 
   expectDownload(timeout?: number) {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -1,12 +1,14 @@
-import type { Booking, NewArrival, Premises, Room } from '@approved-premises/api'
-import errorLookups from '../../../../server/i18n/en/errors.json'
+import type { Booking, LostBed, NewArrival, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
+import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingArrivalNewPage extends Page {
+  private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
+
   private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
 
   private readonly locationHeaderComponent: LocationHeaderComponent
@@ -16,6 +18,7 @@ export default class BookingArrivalNewPage extends Page {
   constructor(premises: Premises, room: Room, private readonly booking: Booking) {
     super('Mark booking as active')
 
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room)
     this.bookingInfoComponent = new BookingInfoComponent(booking)
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
@@ -35,11 +38,15 @@ export default class BookingArrivalNewPage extends Page {
     this.shouldShowDateInputs('expectedDepartureDate', this.booking.departureDate)
   }
 
-  shouldShowDateConflictErrorMessages(): void {
-    ;['arrivalDate', 'expectedDepartureDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
-    })
+  shouldShowDateConflictErrorMessages(
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
+      ['arrivalDate', 'expectedDepartureDate'],
+      conflictingEntity,
+      conflictingEntityType,
+    )
   }
 
   completeForm(newArrival: NewArrival): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
@@ -1,13 +1,26 @@
-import type { NewBooking } from '@approved-premises/api'
+import type { Booking, LostBed, NewBooking, Premises, Room } from '@approved-premises/api'
 import errorLookups from '../../../../server/i18n/en/errors.json'
+import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import Page from '../../page'
 
 export default abstract class BookingEditablePage extends Page {
-  shouldShowDateConflictErrorMessages(): void {
-    ;['arrivalDate', 'departureDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
-    })
+  private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
+
+  constructor(title: string, premises: Premises, room: Room) {
+    super(title)
+
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room)
+  }
+
+  shouldShowDateConflictErrorMessages(
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
+      ['arrivalDate', 'departureDate'],
+      conflictingEntity,
+      conflictingEntityType,
+    )
   }
 
   shouldShowUserPermissionErrorMessage(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -1,13 +1,15 @@
-import type { Booking, NewExtension, Premises, Room } from '@approved-premises/api'
-import errorLookups from '../../../../server/i18n/en/errors.json'
+import type { Booking, LostBed, NewExtension, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { getLatestExtension } from '../../../../server/utils/bookingUtils'
+import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import PopDetailsHeaderComponent from '../../../components/popDetailsHeader'
 import Page from '../../page'
 
 export default class BookingExtensionNewPage extends Page {
+  private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
+
   private readonly popDetailsHeaderComponent: PopDetailsHeaderComponent
 
   private readonly locationHeaderComponent: LocationHeaderComponent
@@ -17,6 +19,7 @@ export default class BookingExtensionNewPage extends Page {
   constructor(premises: Premises, room: Room, private readonly booking: Booking) {
     super('Extend or shorten booking')
 
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room)
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
@@ -40,11 +43,15 @@ export default class BookingExtensionNewPage extends Page {
     }
   }
 
-  shouldShowDateConflictErrorMessages(): void {
-    ;['newDepartureDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
-    })
+  shouldShowDateConflictErrorMessages(
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
+      ['newDepartureDate'],
+      conflictingEntity,
+      conflictingEntityType,
+    )
   }
 
   completeForm(newExtension: NewExtension): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -9,7 +9,7 @@ export default class BookingNewPage extends BookingEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
   constructor(premises: Premises, room: Room) {
-    super('Book bedspace')
+    super('Book bedspace', premises, room)
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
@@ -6,8 +6,8 @@ import paths from '../../../../server/paths/temporary-accommodation/manage'
 export default class LostBedEditPage extends LostBedEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-    super('Void a bedspace')
-  constructor(private readonly premises: Premises, private readonly room: Room) {
+  constructor(premises: Premises, room: Room) {
+    super('Void a bedspace', premises, room)
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
@@ -6,15 +6,15 @@ import paths from '../../../../server/paths/temporary-accommodation/manage'
 export default class LostBedEditPage extends LostBedEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-  constructor(private readonly premises: Premises, private readonly room: Room, private readonly lostBed: LostBed) {
     super('Void a bedspace')
+  constructor(private readonly premises: Premises, private readonly room: Room) {
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
   static visit(premises: Premises, room: Room, lostBed: LostBed): LostBedEditPage {
     cy.visit(paths.lostBeds.edit({ premisesId: premises.id, roomId: room.id, lostBedId: lostBed.id }))
-    return new LostBedEditPage(premises, room, lostBed)
+    return new LostBedEditPage(premises, room)
   }
 
   shouldShowBedspaceDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
@@ -1,13 +1,25 @@
-import { NewLostBed, UpdateLostBed } from '@approved-premises/api'
+import { Booking, LostBed, NewLostBed, Premises, Room, UpdateLostBed } from '@approved-premises/api'
+import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import Page from '../../page'
-import errorLookups from '../../../../server/i18n/en/errors.json'
 
 export default abstract class LostBedEditablePage extends Page {
-  shouldShowDateConflictErrorMessages(): void {
-    ;['startDate', 'endDate'].forEach(field => {
-      cy.get('.govuk-error-summary').should('contain', errorLookups.generic[field].conflict)
-      cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
-    })
+  private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
+
+  constructor(title: string, premises: Premises, room: Room) {
+    super(title)
+
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room)
+  }
+
+  shouldShowDateConflictErrorMessages(
+    conflictingEntity: Booking | LostBed,
+    conflictingEntityType: 'booking' | 'lost-bed',
+  ): void {
+    this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
+      ['startDate', 'endDate'],
+      conflictingEntity,
+      conflictingEntityType,
+    )
   }
 
   protected completeEditableForm(newOrUpdateLostBed: NewLostBed | UpdateLostBed): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedNew.ts
@@ -6,8 +6,8 @@ import LocationHeaderComponent from '../../../components/locationHeader'
 export default class LostBedNewPage extends LostBedEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-  constructor(private readonly premises: Premises, private readonly room: Room) {
-    super('Void a bedspace')
+  constructor(premises: Premises, room: Room) {
+    super('Void a bedspace', premises, room)
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }

--- a/e2e/tests/booking.feature
+++ b/e2e/tests/booking.feature
@@ -48,6 +48,14 @@ Feature: Manage Temporary Accommodation - Booking
         And I attempt to create a booking with required details missing
         Then I should see a list of the problems encountered creating the booking
 
+    Scenario: Showing booking creation conflict errors
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I go up a breadcrumb level
+        And I'm creating a booking
+        And I attempt to create a conflicting booking
+        Then I should see errors for the conflicting booking
+
     Scenario: Showing booking cancellation errors
         Given I'm creating a booking
         And I create a booking with all necessary details

--- a/e2e/tests/lostBed.feature
+++ b/e2e/tests/lostBed.feature
@@ -14,6 +14,14 @@ Feature: Manage Temporary Accommodation - Lost beds
         Given I'm marking a bedspace as void
         And I attempt to mark a bedspace as void with required details missing
         Then I should see a list of the problems encountered voiding the bedspace
+
+    Scenario: Showing void booking creation conflict errors
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I go up a breadcrumb level
+        And I'm marking a bedspace as void
+        And I attempt to create a conflicting void booking
+        Then I should see errors for the conflicting void booking
     
     Scenario: Editing a void booking
         Given I'm marking a bedspace as void

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -16,3 +16,7 @@ Given('I am logged in', () => {
 Given('I return to the dashboard', () => {
   Page.clickDashboardLink()
 })
+
+Given('I go up a breadcrumb level', () => {
+  Page.clickBreadCrumbUp()
+})

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -64,6 +64,23 @@ Given('I attempt to create a booking with required details missing', () => {
   })
 })
 
+Given('I attempt to create a conflicting booking', () => {
+  cy.then(function _() {
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+
+    const newBooking = newBookingFactory.build({
+      ...this.booking,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
+    bookingConfirmPage.shouldShowBookingDetails()
+
+    bookingConfirmPage.clickSubmit()
+  })
+})
+
 Then('I should see a confirmation for my new booking', () => {
   cy.then(function _() {
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
@@ -100,5 +117,12 @@ Then('I should see a list of the problems encountered creating the booking', () 
   cy.then(function _() {
     const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
     page.shouldShowErrorMessagesForFields(['arrivalDate', 'departureDate'])
+  })
+})
+
+Then('I should see errors for the conflicting booking', () => {
+  cy.then(function _() {
+    const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    page.shouldShowDateConflictErrorMessages(this.booking, 'booking')
   })
 })

--- a/e2e/tests/stepDefinitions/manage/lostBed.ts
+++ b/e2e/tests/stepDefinitions/manage/lostBed.ts
@@ -125,3 +125,18 @@ Then('I should see confirmation that the void is cancelled', () => {
     lostBedShowPage.shouldShowLostBedDetails()
   })
 })
+
+Given('I attempt to create a conflicting void booking', () => {
+  cy.then(function _() {
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const newLostBed = newLostBedFactory.build({ ...this.lostBed })
+    lostBedNewPage.completeForm(newLostBed)
+  })
+})
+
+Then('I should see errors for the conflicting void booking', () => {
+  cy.then(function _() {
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    lostBedNewPage.shouldShowDateConflictErrorMessages(this.lostBed, 'lost-bed')
+  })
+})

--- a/e2e/tests/stepDefinitions/manage/lostBed.ts
+++ b/e2e/tests/stepDefinitions/manage/lostBed.ts
@@ -66,7 +66,7 @@ Given('I edit the void booking', () => {
     const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
     lostBedShowPage.clickEditVoidLink()
 
-    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room, this.lostBed)
+    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room)
     const lostBedUpdate = updateLostBedFactory.build()
     cy.wrap(lostBedUpdate).as('lostBedUpdate')
 
@@ -94,7 +94,7 @@ Given('I attempt to edit the void booking with required details missing', () => 
   cy.then(function _() {
     const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
     lostBedShowPage.clickEditVoidLink()
-    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room, this.lostBed)
+    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room)
 
     lostBedEditPage.clearForm()
     lostBedEditPage.clickSubmit()

--- a/integration_tests/mockApis/arrival.ts
+++ b/integration_tests/mockApis/arrival.ts
@@ -3,7 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type { Arrival } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
-import { errorStub } from '../../wiremock/utils'
+import { bedspaceConflictResponseBody, errorStub } from '../../wiremock/utils'
 
 export default {
   stubArrivalCreate: (args: { premisesId: string; bookingId: string; arrival: Arrival }): SuperAgentRequest =>
@@ -24,7 +24,12 @@ export default {
     params: Array<string>
   }): SuperAgentRequest =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`, 'POST')),
-  stubArrivalCreateConflictError: (args: { premisesId: string; bookingId: string }) =>
+  stubArrivalCreateConflictError: (args: {
+    premisesId: string
+    bookingId: string
+    conflictingEntityId: string
+    conflictingEntityType: 'booking' | 'lost-bed'
+  }) =>
     stubFor({
       request: {
         method: 'POST',
@@ -35,10 +40,7 @@ export default {
         headers: {
           'Content-Type': 'application/problem+json;charset=UTF-8',
         },
-        jsonBody: {
-          title: 'Conflict',
-          status: 409,
-        },
+        jsonBody: bedspaceConflictResponseBody(args.conflictingEntityId, args.conflictingEntityType),
       },
     }),
   verifyArrivalCreate: async (args: { premisesId: string; bookingId: string }) =>

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -1,7 +1,7 @@
 import type { Booking } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
-import { errorStub } from '../../wiremock/utils'
+import { bedspaceConflictResponseBody, errorStub } from '../../wiremock/utils'
 
 export default {
   stubBookingCreate: (args: { premisesId: string; booking: Booking }) =>
@@ -35,6 +35,24 @@ export default {
           title: args.errorTitle,
           status: args.errorCode,
         },
+      },
+    }),
+  stubBookingCreateConflictError: (args: {
+    premisesId: string
+    conflictingEntityId: string
+    conflictingEntityType: 'booking' | 'lost-bed'
+  }) =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: `/premises/${args.premisesId}/bookings`,
+      },
+      response: {
+        status: 409,
+        headers: {
+          'Content-Type': 'application/problem+json;charset=UTF-8',
+        },
+        jsonBody: bedspaceConflictResponseBody(args.conflictingEntityId, args.conflictingEntityType),
       },
     }),
   stubBooking: (args: { premisesId: string; booking: Booking }) =>

--- a/integration_tests/mockApis/extension.ts
+++ b/integration_tests/mockApis/extension.ts
@@ -3,7 +3,7 @@ import { SuperAgentRequest } from 'superagent'
 import type { Extension } from '@approved-premises/api'
 
 import { getMatchingRequests, stubFor } from '../../wiremock'
-import { errorStub } from '../../wiremock/utils'
+import { bedspaceConflictResponseBody, errorStub } from '../../wiremock/utils'
 
 export default {
   stubExtensionCreate: (args: { premisesId: string; bookingId: string; extension: Extension }): SuperAgentRequest =>
@@ -24,7 +24,12 @@ export default {
     params: Array<string>
   }): SuperAgentRequest =>
     stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/extensions`, 'POST')),
-  stubExtensionCreateConflictError: (args: { premisesId: string; bookingId: string }) =>
+  stubExtensionCreateConflictError: (args: {
+    premisesId: string
+    bookingId: string
+    conflictingEntityId: string
+    conflictingEntityType: 'booking' | 'lost-bed'
+  }) =>
     stubFor({
       request: {
         method: 'POST',
@@ -35,10 +40,7 @@ export default {
         headers: {
           'Content-Type': 'application/problem+json;charset=UTF-8',
         },
-        jsonBody: {
-          title: 'Conflict',
-          status: 409,
-        },
+        jsonBody: bedspaceConflictResponseBody(args.conflictingEntityId, args.conflictingEntityType),
       },
     }),
   verifyExtensionCreate: async (args: { premisesId: string; bookingId: string }) =>

--- a/integration_tests/mockApis/lostBed.ts
+++ b/integration_tests/mockApis/lostBed.ts
@@ -2,10 +2,10 @@ import { SuperAgentRequest } from 'superagent'
 
 import type { LostBed, LostBedCancellation } from '@approved-premises/api'
 
-import { getMatchingRequests, stubFor } from '../../wiremock'
-import { errorStub } from '../../wiremock/utils'
-import { lostBedReasons } from '../../wiremock/referenceDataStubs'
 import paths from '../../server/paths/api'
+import { getMatchingRequests, stubFor } from '../../wiremock'
+import { lostBedReasons } from '../../wiremock/referenceDataStubs'
+import { errorStub } from '../../wiremock/utils'
 
 export default {
   stubLostBedCreate: (args: { premisesId: string; lostBed: LostBed }): SuperAgentRequest =>

--- a/integration_tests/tests/temporary-accommodation/manage/lostBed.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/lostBed.cy.ts
@@ -291,7 +291,7 @@ context('Lost bed', () => {
     page.clickEditVoidLink()
 
     // Then I navigate to the edit void booking page
-    Page.verifyOnPage(LostBedEditPage, premises, room, lostBed)
+    Page.verifyOnPage(LostBedEditPage, premises, room)
   })
 
   it('navigates back from the update void booking page to the view void booking page', () => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -187,6 +187,11 @@ export interface ErrorsAndUserInput {
   userInput: Record<string, unknown>
 }
 
+export interface BespokeError {
+  errorTitle: string
+  errorSummary: Array<ErrorSummary>
+}
+
 export type TaskListErrors<K extends TasklistPage> = Partial<Record<keyof K['body'], unknown>>
 
 export type YesOrNo = 'yes' | 'no'

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -175,8 +175,9 @@ export interface ErrorMessages {
 }
 
 export interface ErrorSummary {
-  text: string
-  href: string
+  text?: string
+  html?: string
+  href?: string
 }
 
 export interface ErrorsAndUserInput {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -183,6 +183,7 @@ export interface ErrorSummary {
 export interface ErrorsAndUserInput {
   errors: ErrorMessages
   errorSummary: Array<ErrorSummary>
+  errorTitle?: string
   userInput: Record<string, unknown>
 }
 

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -3,9 +3,15 @@ import type { Request, RequestHandler, Response } from 'express'
 import type { NewArrival } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { ArrivalService, BedspaceService, BookingService, PremisesService } from '../../../services'
+import { generateConflictBespokeError } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import {
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  insertBespokeError,
+  insertGenericError,
+} from '../../../utils/validation'
 
 export default class ArrivalsController {
   constructor(
@@ -17,7 +23,7 @@ export default class ArrivalsController {
 
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
+      const { errors, errorSummary, errorTitle, userInput } = fetchErrorsAndUserInput(req)
       const { premisesId, roomId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
@@ -31,7 +37,8 @@ export default class ArrivalsController {
         room,
         booking,
         errors,
-        errorSummary: requestErrorSummary,
+        errorSummary,
+        errorTitle,
         ...DateFormats.isoToDateAndTimeInputs(booking.arrivalDate, 'arrivalDate'),
         ...DateFormats.isoToDateAndTimeInputs(booking.departureDate, 'expectedDepartureDate'),
         ...userInput,
@@ -57,6 +64,7 @@ export default class ArrivalsController {
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
       } catch (err) {
         if (err.status === 409) {
+          insertBespokeError(err, generateConflictBespokeError(err, premisesId, roomId, 'plural'))
           insertGenericError(err, 'arrivalDate', 'conflict')
           insertGenericError(err, 'expectedDepartureDate', 'conflict')
         }

--- a/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
@@ -1,5 +1,6 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
+import { BespokeError } from '../../../@types/ui'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { LostBedService, PremisesService } from '../../../services'
@@ -14,15 +15,22 @@ import {
   roomFactory,
   updateLostBedFactory,
 } from '../../../testutils/factories'
+import { generateConflictBespokeError } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import { allStatuses, lostBedActions } from '../../../utils/lostBedUtils'
 import extractCallConfig from '../../../utils/restUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import {
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  insertBespokeError,
+  insertGenericError,
+} from '../../../utils/validation'
 import LostBedsController from './lostBedsController'
 
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/lostBedUtils')
+jest.mock('../../../utils/bookingUtils')
 
 describe('LostBedsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -137,6 +145,14 @@ describe('LostBedsController', () => {
           throw err
         })
 
+        const bespokeError: BespokeError = {
+          errorTitle: 'some-bespoke-error',
+          errorSummary: [],
+        }
+        ;(generateConflictBespokeError as jest.MockedFunction<typeof generateConflictBespokeError>).mockReturnValue(
+          bespokeError,
+        )
+
         request.params = {
           premisesId,
           roomId,
@@ -144,6 +160,8 @@ describe('LostBedsController', () => {
 
         await requestHandler(request, response, next)
 
+        expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, roomId, 'plural')
+        expect(insertBespokeError).toHaveBeenCalledWith(err, bespokeError)
         expect(insertGenericError).toHaveBeenCalledWith(err, 'startDate', 'conflict')
         expect(insertGenericError).toHaveBeenCalledWith(err, 'endDate', 'conflict')
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
@@ -258,9 +276,18 @@ describe('LostBedsController', () => {
         lostBedService.update.mockImplementation(() => {
           throw err
         })
+        const bespokeError: BespokeError = {
+          errorTitle: 'some-bespoke-error',
+          errorSummary: [],
+        }
+        ;(generateConflictBespokeError as jest.MockedFunction<typeof generateConflictBespokeError>).mockReturnValue(
+          bespokeError,
+        )
 
         await requestHandler(request, response, next)
 
+        expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, roomId, 'plural')
+        expect(insertBespokeError).toHaveBeenCalledWith(err, bespokeError)
         expect(insertGenericError).toHaveBeenCalledWith(err, 'startDate', 'conflict')
         expect(insertGenericError).toHaveBeenCalledWith(err, 'endDate', 'conflict')
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(

--- a/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
@@ -17,7 +17,7 @@ import {
 import { DateFormats } from '../../../utils/dateUtils'
 import { allStatuses, lostBedActions } from '../../../utils/lostBedUtils'
 import extractCallConfig from '../../../utils/restUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import LostBedsController from './lostBedsController'
 
 jest.mock('../../../utils/restUtils')
@@ -109,7 +109,7 @@ describe('LostBedsController', () => {
       it('renders with errors if the API returns an error', async () => {
         const requestHandler = lostBedsController.create()
 
-        const err = { status: 409 }
+        const err = {}
         lostBedService.create.mockImplementation(() => {
           throw err
         })
@@ -144,6 +144,8 @@ describe('LostBedsController', () => {
 
         await requestHandler(request, response, next)
 
+        expect(insertGenericError).toHaveBeenCalledWith(err, 'startDate', 'conflict')
+        expect(insertGenericError).toHaveBeenCalledWith(err, 'endDate', 'conflict')
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
           request,
           response,
@@ -259,6 +261,8 @@ describe('LostBedsController', () => {
 
         await requestHandler(request, response, next)
 
+        expect(insertGenericError).toHaveBeenCalledWith(err, 'startDate', 'conflict')
+        expect(insertGenericError).toHaveBeenCalledWith(err, 'endDate', 'conflict')
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
           request,
           response,

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -18,7 +18,7 @@
     "arrivalDate": {
       "empty": "You must enter a start date",
       "invalid": "The start date is an invalid date",
-      "conflict": "An existing booking or void overlaps with these dates"
+      "conflict": "This bedspace is not available for these dates"
     },
     "date": {
       "empty": "You must enter a valid departure date",
@@ -32,13 +32,13 @@
       "empty": "You must enter an end date",
       "invalid": "The end date is an invalid date",
       "beforeBookingArrivalDate": "The end date cannot be before the start date",
-      "conflict": "An existing booking or void overlaps with these dates"
+      "conflict": "This bedspace is not available for these dates"
     },
     "expectedDepartureDate": {
       "empty": "You must enter an expected departure date",
       "invalid": "The expected departure date is an invalid date",
       "beforeBookingArrivalDate": "The departure date cannot be before the arrival date",
-      "conflict": "An existing booking or void overlaps with these dates"
+      "conflict": "This bedspace is not available for these dates"
     },
     "keyWorkerStaffId": {
       "empty": "You must choose a keyworker"
@@ -63,17 +63,17 @@
       "empty": "You must enter a new departure date",
       "invalid": "The departure date is an invalid date",
       "beforeBookingArrivalDate": "The new departure date must be after the arrival date",
-      "conflict": "An existing booking or void overlaps with these dates"
+      "conflict": "This bedspace is not available for this date"
     },
     "startDate": {
       "empty": "You must enter a start date",
       "invalid": "The start date is an invalid date",
-      "conflict": "An existing booking or void overlaps with these dates"
+      "conflict": "This bedspace is not available for these dates"
     },
     "endDate": {
       "empty": "You must enter a end date",
       "invalid": "The end date is an invalid date",
-      "conflict": "An existing booking or void overlaps with these dates",
+      "conflict": "This bedspace is not available for these dates",
       "beforeStartDate": "The end date must be before the start date"
     },
     "reason": {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -57,7 +57,7 @@ describe('catchValidationErrorOrPropogate', () => {
     }
   })
 
-  it('sets the errors and request body as flash messages and redirects back to the form', () => {
+  it('sets errors from invalid params data as flash messages and redirects back to the form', () => {
     const error = createMock<SanitisedError>({
       data: {
         'invalid-params': [
@@ -288,7 +288,7 @@ describe('insertGenericError', () => {
     })
   })
 
-  it('inserts a property error when the error data not empty', () => {
+  it('inserts a property error when the error data is not empty', () => {
     const error = {
       data: {
         'some-other-data': {},
@@ -325,7 +325,7 @@ describe('insertGenericError', () => {
   })
 })
 
-describe('reallocateError', () => {
+describe('transformErrors', () => {
   it('renames a property matching the source parameter to the destination parameter', () => {
     const error = {
       data: {

--- a/server/utils/validation.test.ts
+++ b/server/utils/validation.test.ts
@@ -1,7 +1,7 @@
 import { createMock } from '@golevelup/ts-jest'
 import { Request, Response } from 'express'
 
-import type { ErrorMessages, ErrorSummary } from '@approved-premises/ui'
+import type { BespokeError, ErrorMessages, ErrorSummary } from '@approved-premises/ui'
 import type TaskListPage from '../form-pages/tasklistPage'
 import errorLookups from '../i18n/en/errors.json'
 import { SanitisedError } from '../sanitisedError'
@@ -11,6 +11,7 @@ import {
   catchValidationErrorOrPropogate,
   clearUserInput,
   fetchErrorsAndUserInput,
+  insertBespokeError,
   insertGenericError,
   setUserInput,
   transformErrors,
@@ -361,6 +362,43 @@ describe('insertGenericError', () => {
           { propertyName: '$.someOtherProperty', errorType: 'someOtherErrorType' },
           { propertyName: '$.someProperty', errorType: 'someErrorType' },
         ],
+      },
+    })
+  })
+})
+
+describe('insertBespokeError', () => {
+  it('inserts a bespoke error when the error data is empty', () => {
+    const error = {}
+    const bespokeError: BespokeError = {
+      errorTitle: 'some-bespoke-error',
+      errorSummary: [],
+    }
+
+    insertBespokeError(error as SanitisedError, bespokeError)
+
+    expect(error).toEqual({
+      data: { bespokeError },
+    })
+  })
+
+  it('inserts a property error when the error data is not empty', () => {
+    const error = {
+      data: {
+        'some-other-data': {},
+      },
+    }
+    const bespokeError: BespokeError = {
+      errorTitle: 'some-bespoke-error',
+      errorSummary: [],
+    }
+
+    insertBespokeError(error as SanitisedError, bespokeError)
+
+    expect(error).toEqual({
+      data: {
+        bespokeError,
+        'some-other-data': {},
       },
     })
   })

--- a/server/utils/validation.ts
+++ b/server/utils/validation.ts
@@ -1,7 +1,7 @@
 import type { Request, Response } from 'express'
 import jsonpath from 'jsonpath'
 
-import type { ErrorMessage, ErrorMessages, ErrorSummary, ErrorsAndUserInput } from '@approved-premises/ui'
+import type { BespokeError, ErrorMessage, ErrorMessages, ErrorSummary, ErrorsAndUserInput } from '@approved-premises/ui'
 import errorLookup from '../i18n/en/errors.json'
 import { SanitisedError } from '../sanitisedError'
 import { TasklistAPIError, ValidationError } from './errors'
@@ -12,7 +12,7 @@ interface InvalidParams {
 }
 
 interface AnnotatedError extends Error {
-  data?: { 'invalid-params'?: Array<InvalidParams> } | Record<string, string>
+  data?: { 'invalid-params'?: Array<InvalidParams>; bespokeError?: BespokeError } | Record<string, string>
 }
 
 type ErrorContext = keyof typeof errorLookup
@@ -97,6 +97,12 @@ export const insertGenericError = (error: SanitisedError | Error, propertyName: 
   })
 
   data['invalid-params'] = invalidParams
+  ;(error as AnnotatedError).data = data
+}
+
+export const insertBespokeError = (error: SanitisedError | Error, bespokeError: BespokeError): void => {
+  const data = ('data' in error ? error.data : {}) as AnnotatedError['data']
+  data.bespokeError = bespokeError
   ;(error as AnnotatedError).data = data
 }
 

--- a/server/views/partials/showErrorSummary.njk
+++ b/server/views/partials/showErrorSummary.njk
@@ -1,10 +1,10 @@
 {% from "govuk/components/error-summary/macro.njk" import govukErrorSummary %}
 
-{% macro showErrorSummary(errorList) %}
+{% macro showErrorSummary(errorList, errorTitle) %}
 
   {% if errorList | length %}
     {{ govukErrorSummary({
-      titleText: "There is a problem",
+      titleText: errorTitle if errorTitle else "There is a problem",
       errorList: errorList
     }) }}
   {% endif %}

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -23,7 +23,7 @@
 
   <h1>Mark booking as active</h1>
 
-  {{ showErrorSummary(errorSummary) }}
+  {{ showErrorSummary(errorSummary, errorTitle) }}
 
   {{ popDetailsHeader(booking.person) }}
   {{ locationHeader({ premises: premises, room: room }) }}

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -19,7 +19,7 @@
   
   <h1>Book bedspace</h1>
 
-  {{ showErrorSummary(errorSummary) }}
+  {{ showErrorSummary(errorSummary, errorTitle) }}
 
   {{ locationHeader({ premises: premises, room: room }) }}
 

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -23,7 +23,7 @@
 
   <h1>Extend or shorten booking</h1>
 
-  {{ showErrorSummary(errorSummary) }}
+  {{ showErrorSummary(errorSummary, errorTitle) }}
 
   {{ popDetailsHeader(booking.person) }}
   {{ locationHeader({ premises: premises, room: room }) }}

--- a/server/views/temporary-accommodation/lost-beds/edit.njk
+++ b/server/views/temporary-accommodation/lost-beds/edit.njk
@@ -18,7 +18,7 @@
 
   <h1>Void a bedspace</h1>
 
-  {{ showErrorSummary(errorSummary) }}
+  {{ showErrorSummary(errorSummary, errorTitle) }}
   {{ locationHeader({ premises: premises, room: room }) }}
 
   <div class="govuk-grid-row">

--- a/server/views/temporary-accommodation/lost-beds/new.njk
+++ b/server/views/temporary-accommodation/lost-beds/new.njk
@@ -17,7 +17,7 @@
     {% include "../../_messages.njk" %}
     
     <h1>Void a bedspace</h1>
-    {{ showErrorSummary(errorSummary) }}
+    {{ showErrorSummary(errorSummary, errorTitle) }}
 
   {{ locationHeader({ premises: premises, room: room }) }}
     <div class="govuk-grid-row">

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -1,3 +1,5 @@
+import { LostBed } from '../server/@types/shared'
+
 const getCombinations = (arr: Array<string>) => {
   const result: Array<Array<string>> = []
   arr.forEach(item => {
@@ -49,4 +51,10 @@ const errorStub = (fields: Array<string>, pattern: string, method: string) => {
   }
 }
 
-export { getCombinations, errorStub }
+const bedspaceConflictResponseBody = (entityId: string | LostBed, entityType: 'booking' | 'lost-bed') => ({
+  title: 'Conflict',
+  status: 409,
+  detail: `${entityType === 'booking' ? 'Booking' : 'Lost Bed'}: ${entityId}`,
+})
+
+export { getCombinations, errorStub, bedspaceConflictResponseBody }


### PR DESCRIPTION
# Changes in this PR

This PR adds improved error messages anywhere we handle 409 conflict errors. We do this by inspecting the error message from the API, extracting the ID of the conflicting booking/lost bed, and using that to construct an error that links to the thing causing the conflict

## Screenshots of UI changes

### Before
![localhost_3000_properties_4f5ca40e-7ecb-4395-b1f9-0f26607a342c_bedspaces_737936b3-f305-4cbf-a79b-fba7ffcf08bf_bookings_new (1)](https://user-images.githubusercontent.com/94137563/233668858-33b10baa-e928-4820-a656-8558a57b5c34.png)


### After
![localhost_3000_properties_4f5ca40e-7ecb-4395-b1f9-0f26607a342c_bedspaces_737936b3-f305-4cbf-a79b-fba7ffcf08bf_bookings_new](https://user-images.githubusercontent.com/94137563/233668866-8b035c5e-bdd8-454c-96b7-54454927a83c.png)

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
