### PR TITLE
Users can see property attributes when looking at a bedspace

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -12,6 +12,7 @@ $path: "/assets/images/"
 @import './components/_location-header'
 @import './components/_booking-info'
 @import './components/_probation-region-header'
+@import './components/_attributes-header'
 @import './local'
 
 @import './pages/temporary-accommodation/show'

--- a/assets/sass/components/_attributes-header.scss
+++ b/assets/sass/components/_attributes-header.scss
@@ -1,0 +1,7 @@
+.attributes-header {
+    margin-bottom: 2em;
+  
+    h2 {
+      @include govuk-font($size: 19, $weight: 'bold');
+    }
+  }

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -9,9 +9,12 @@ import Page from '../../page'
 export default class BedspaceShowPage extends Page {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
+  private readonly premises: Premises
+
   constructor(premises: Premises, private readonly room: Room) {
     super('View a bedspace')
 
+    this.premises = premises
     this.locationHeaderComponent = new LocationHeaderComponent({ premises })
   }
 
@@ -30,6 +33,15 @@ export default class BedspaceShowPage extends Page {
       this.room.characteristics.map(({ name }) => name),
     )
     this.shouldShowKeyAndValues('Notes', this.room.notes.split('\n'))
+  }
+
+  shouldShowPremisesAttributes(): void {
+    cy.get('.attributes-header').within(() => {
+      cy.get('h2').contains('Property attributes')
+      this.premises.characteristics?.forEach(characteristic => {
+        cy.get('h2').contains('Property attributes').siblings('ul').children().should('contain', characteristic.name)
+      })
+    })
   }
 
   shouldShowBookingDetails(booking: Booking): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -1,7 +1,7 @@
 import type { TemporaryAccommodationPremises as Premises, ProbationRegion, Room } from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
-import { pduFactory, premisesFactory } from '../../../../server/testutils/factories'
+import { characteristicFactory, pduFactory, premisesFactory } from '../../../../server/testutils/factories'
 import { statusInfo } from '../../../../server/utils/premisesUtils'
 import Page from '../../page'
 
@@ -21,6 +21,14 @@ export default class PremisesShowPage extends Page {
 
       cy.get('[data-cy-premises] h3').then(nameElement => {
         const name = nameElement.text()
+
+        const characteristics = []
+        cy.get('.govuk-summary-list__key')
+          .contains('Attributes')
+          .siblings('.govuk-summary-list__value')
+          .children()
+          .children()
+          .each($li => characteristics.push(characteristicFactory.build({ name: $li.text() })))
 
         cy.get('.govuk-summary-list__key')
           .contains('Address')
@@ -54,6 +62,7 @@ export default class PremisesShowPage extends Page {
                       status,
                       pdu: pdu.name,
                       probationDeliveryUnit: pdu,
+                      characteristics,
                     })
 
                     cy.wrap(premises).as(alias)

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -69,6 +69,7 @@ Then('I should see a confirmation for my new bedspace', () => {
     page.shouldShowBanner('Bedspace created')
 
     page.shouldShowBedspaceDetails()
+    page.shouldShowPremisesAttributes()
 
     if (this.premises.status === 'archived') {
       page.shouldShowAsArchived()
@@ -84,6 +85,7 @@ Then('I should see a confirmation for my updated bedspace', () => {
     page.shouldShowBanner('Bedspace updated')
 
     page.shouldShowBedspaceDetails()
+    page.shouldShowPremisesAttributes()
 
     if (this.premises.status === 'archived') {
       page.shouldShowAsArchived()

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -269,6 +269,7 @@ context('Bedspace', () => {
     // Then I should see the bedspace details
     page.shouldShowBedspaceDetails()
     page.shouldShowAsActive()
+    page.shouldShowPremisesAttributes()
 
     // And I should see the booking details
     bookings.forEach(booking => {
@@ -301,6 +302,7 @@ context('Bedspace', () => {
     // Then I should see the bedspace details
     page.shouldShowBedspaceDetails()
     page.shouldShowAsArchived()
+    page.shouldShowPremisesAttributes()
 
     // And I should see the booking details
     bookings.forEach(booking => {

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -6,7 +6,13 @@ import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { BookingService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
-import { premisesFactory, referenceDataFactory, roomFactory, updateRoomFactory } from '../../../testutils/factories'
+import {
+  characteristicFactory,
+  premisesFactory,
+  referenceDataFactory,
+  roomFactory,
+  updateRoomFactory,
+} from '../../../testutils/factories'
 import { bedspaceActions } from '../../../utils/bedspaceUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -246,7 +252,12 @@ describe('BedspacesController', () => {
 
   describe('show', () => {
     it('returns the bedspace details to the template', async () => {
-      const premises = premisesFactory.build()
+      const premises = premisesFactory.build({
+        characteristics: [
+          characteristicFactory.build({ name: 'b test characteristic' }),
+          characteristicFactory.build({ name: 'a test characteristic' }),
+        ],
+      })
       const room = roomFactory.build()
 
       premisesService.getPremises.mockResolvedValue(premises)
@@ -265,6 +276,7 @@ describe('BedspacesController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspaces/show', {
         premises,
+        premisesCharacteristics: ['a test characteristic', 'b test characteristic'],
         bedspace: bedspaceDetails,
         bookingTableRows,
         actions: [],

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -109,6 +109,7 @@ export default class BedspacesController {
       const { premisesId, roomId } = req.params
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
+      const premisesCharacteristics = premises.characteristics.map(item => item.name).sort((a, b) => a.localeCompare(b))
       const room = await this.bedspaceService.getRoom(callConfig, premisesId, roomId)
 
       const bedspaceDetails = await this.bedspaceService.getSingleBedspaceDetails(callConfig, premisesId, roomId)
@@ -116,6 +117,7 @@ export default class BedspacesController {
 
       return res.render('temporary-accommodation/bedspaces/show', {
         premises,
+        premisesCharacteristics,
         bedspace: bedspaceDetails,
         bookingTableRows,
         actions: bedspaceActions(premises, room),

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -39,7 +39,22 @@
     items: actions
   }) }}
 
-  {{ locationHeader({ premises: premises }) }}
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-one-third">
+      {{ locationHeader({ premises: premises }) }}
+    </div>
+    <div class="govuk-grid-column-one-third">
+      <div class="attributes-header details">
+        <h2>Property attributes</h2>
+        <ul>
+          {% for characteristic in premisesCharacteristics %}
+          <li>{{ characteristic }}</li>
+          {% endfor %}
+        </ul>
+      </div>
+    </div>
+  </div>
+
 
   <div class="edit-bar">
     <div class="edit-bar__container">
@@ -51,6 +66,7 @@
       </div>
     </div>
   </div>
+
 
   {{ govukSummaryList({
     rows: bedspace.summaryList.rows,


### PR DESCRIPTION
# Changes in this PR

Allows users to view property attributes as well as bedspace attributes when on the View a bedspace page.

## Screenshots of UI changes

### Before

![Screenshot 2023-04-28 at 11 50 58](https://user-images.githubusercontent.com/70749355/235129047-0c72cce8-bd4d-404a-ae99-435db2204acf.png)

### After

![Screenshot 2023-04-28 at 11 50 21](https://user-images.githubusercontent.com/70749355/235129086-08b25196-2b21-4c58-a995-b9a2d29498bb.png)

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
