### PR TITLE
Booking widget shows the turnaround

### DIFF
--- a/cypress_shared/components/bookingInfo.ts
+++ b/cypress_shared/components/bookingInfo.ts
@@ -1,5 +1,6 @@
 import type { Booking } from '@approved-premises/api'
-import { getLatestExtension, shortenedOrExtended } from '../../server/utils/bookingUtils'
+import { BookingStatus } from '../../server/@types/ui/index'
+import { getLatestExtension, shortenedOrExtended, statusName } from '../../server/utils/bookingUtils'
 import { DateFormats } from '../../server/utils/dateUtils'
 import Component from './component'
 
@@ -9,45 +10,60 @@ export default class BookingInfoComponent extends Component {
   }
 
   shouldShowBookingDetails(): void {
-    const { status } = this.booking
+    cy.wrap(this.booking).as('modifiedBooking')
 
-    if (status === 'provisional' || status === 'confirmed' || status === 'cancelled') {
-      this.shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-      this.shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    } else if (status === 'arrived') {
-      this.shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.booking.arrivalDate))
-      this.shouldShowKeyAndValue('Expected departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
-    } else if (status === 'departed') {
-      this.shouldShowKeyAndValue('Departure date', DateFormats.isoDateToUIDate(this.booking.departureDate))
+    if (this.booking.status === ('unknown-departed-or-closed' as BookingStatus)) {
+      cy.get('.govuk-summary-list__key')
+        .contains('Status')
+        .siblings('.govuk-summary-list__value')
+        .then(statusElement => {
+          const status = statusElement.text().trim() === statusName('closed') ? 'closed' : 'departed'
+          cy.wrap({ ...this.booking, status }).as('modifiedBooking')
+        })
     }
 
-    if (status === 'provisional') {
-      this.shouldShowKeyAndValue('Status', 'Provisional')
-    } else if (status === 'confirmed') {
-      this.shouldShowKeyAndValue('Status', 'Confirmed')
-      this.shouldShowKeyAndValues('Notes', this.booking.confirmation.notes.split('\n'))
-    } else if (status === 'cancelled') {
-      this.shouldShowKeyAndValue('Status', 'Cancelled')
-      this.shouldShowKeyAndValue('Cancellation date', DateFormats.isoDateToUIDate(this.booking.cancellation.date))
-      this.shouldShowKeyAndValue('Cancellation reason', this.booking.cancellation.reason.name)
-      this.shouldShowKeyAndValues('Notes', this.booking.cancellation.notes.split('\n'))
-    } else if (status === 'arrived') {
-      this.shouldShowKeyAndValue('Status', 'Active')
-      this.shouldShowKeyAndValues('Notes', this.booking.arrival.notes.split('\n'))
+    const { shouldShowKeyAndValue, shouldShowKeyAndValues } = this
 
-      const latestExtension = getLatestExtension(this.booking)
-      if (latestExtension) {
-        const keyText =
-          shortenedOrExtended(latestExtension) === 'shortened'
-            ? 'Notes on shortened booking'
-            : 'Notes on extended booking'
-        this.shouldShowKeyAndValues(keyText, latestExtension.notes.split('\n'))
+    cy.then(function _() {
+      const { status } = this.modifiedBooking
+
+      shouldShowKeyAndValue('Status', statusName(this.modifiedBooking.status))
+
+      if (status === 'provisional' || status === 'confirmed' || status === 'cancelled') {
+        shouldShowKeyAndValue('Start date', DateFormats.isoDateToUIDate(this.modifiedBooking.arrivalDate))
+        shouldShowKeyAndValue('End date', DateFormats.isoDateToUIDate(this.modifiedBooking.departureDate))
+      } else if (status === 'arrived') {
+        shouldShowKeyAndValue('Arrival date', DateFormats.isoDateToUIDate(this.modifiedBooking.arrivalDate))
+        shouldShowKeyAndValue(
+          'Expected departure date',
+          DateFormats.isoDateToUIDate(this.modifiedBooking.departureDate),
+        )
+      } else if (status === 'departed' || status === 'closed') {
+        shouldShowKeyAndValue('Departure date', DateFormats.isoDateToUIDate(this.modifiedBooking.departureDate))
       }
-    } else if (status === 'departed') {
-      this.shouldShowKeyAndValue('Status', 'Departed')
-      this.shouldShowKeyAndValue('Departure reason', this.booking.departure.reason.name)
-      this.shouldShowKeyAndValue('Move on category', this.booking.departure.moveOnCategory.name)
-      this.shouldShowKeyAndValues('Notes', this.booking.departure.notes.split('\n'))
-    }
+
+      if (status === 'confirmed') {
+        shouldShowKeyAndValues('Notes', this.modifiedBooking.confirmation.notes.split('\n'))
+      } else if (status === 'cancelled') {
+        shouldShowKeyAndValue('Cancellation date', DateFormats.isoDateToUIDate(this.modifiedBooking.cancellation.date))
+        shouldShowKeyAndValue('Cancellation reason', this.modifiedBooking.cancellation.reason.name)
+        shouldShowKeyAndValues('Notes', this.modifiedBooking.cancellation.notes.split('\n'))
+      } else if (status === 'arrived') {
+        shouldShowKeyAndValues('Notes', this.modifiedBooking.arrival.notes.split('\n'))
+
+        const latestExtension = getLatestExtension(this.modifiedBooking)
+        if (latestExtension) {
+          const keyText =
+            shortenedOrExtended(latestExtension) === 'shortened'
+              ? 'Notes on shortened booking'
+              : 'Notes on extended booking'
+          shouldShowKeyAndValues(keyText, latestExtension.notes.split('\n'))
+        }
+      } else if (status === 'departed' || status === 'closed') {
+        shouldShowKeyAndValue('Departure reason', this.modifiedBooking.departure.reason.name)
+        shouldShowKeyAndValue('Move on category', this.modifiedBooking.departure.moveOnCategory.name)
+        shouldShowKeyAndValues('Notes', this.modifiedBooking.departure.notes.split('\n'))
+      }
+    })
   }
 }

--- a/cypress_shared/components/bookingInfo.ts
+++ b/cypress_shared/components/bookingInfo.ts
@@ -42,6 +42,13 @@ export default class BookingInfoComponent extends Component {
         shouldShowKeyAndValue('Departure date', DateFormats.isoDateToUIDate(this.modifiedBooking.departureDate))
       }
 
+      const days = this.modifiedBooking.turnaround.workingDays
+      shouldShowKeyAndValue('Turnaround time', `${days} working ${days === 1 ? 'day' : 'days'}`)
+
+      if (this.modifiedBooking.effectiveEndDate !== 'unknown') {
+        shouldShowKeyAndValue('Turnaround end date', DateFormats.isoDateToUIDate(this.modifiedBooking.effectiveEndDate))
+      }
+
       if (status === 'confirmed') {
         shouldShowKeyAndValues('Notes', this.modifiedBooking.confirmation.notes.split('\n'))
       } else if (status === 'cancelled') {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -68,9 +68,12 @@ export default class BedspaceShowPage extends Page {
           cy.get('td')
             .eq(1)
             .contains(DateFormats.isoDateToUIDate(this.modifiedBooking.arrivalDate, { format: 'short' }))
-          cy.get('td')
-            .eq(2)
-            .contains(DateFormats.isoDateToUIDate(this.modifiedBooking.departureDate, { format: 'short' }))
+
+          if (this.modifiedBooking.effectiveEndDate !== 'unknown') {
+            cy.get('td')
+              .eq(2)
+              .contains(DateFormats.isoDateToUIDate(this.modifiedBooking.effectiveEndDate, { format: 'short' }))
+          }
 
           cy.get('td').eq(3).contains(statusName(status))
           cy.get('td').eq(4).contains('View')

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit.ts
@@ -13,7 +13,7 @@ export default class BookingDepartureEditPage extends BookingDepartureEditablePa
   private readonly bookingInfoComponent: BookingInfoComponent
 
   constructor(premises: Premises, room: Room, private readonly booking: Booking) {
-    super('Update departed booking')
+    super('Update departure details')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -19,6 +19,15 @@ export default class BookingNewPage extends BookingEditablePage {
     return new BookingNewPage(premises, room)
   }
 
+  assignTurnaroundDays(alias: string): void {
+    cy.get('p')
+      .contains(this.turnaroundText())
+      .then(element => {
+        const days = Number.parseInt(element.text().match(/\d+/)[0], 10)
+        cy.wrap(days).as(alias)
+      })
+  }
+
   completeForm(newBooking: NewBooking): void {
     super.completeEditableForm(newBooking)
   }
@@ -35,12 +44,7 @@ export default class BookingNewPage extends BookingEditablePage {
   shouldShowBookingDetails(): void {
     this.locationHeaderComponent.shouldShowLocationDetails()
 
-    cy.get('p').should(
-      'contain',
-      `There will be a turnaround time of ${this.premises.turnaroundWorkingDayCount} working ${
-        this.premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'
-      } after this booking`,
-    )
+    cy.get('p').should('contain', this.turnaroundText())
   }
 
   shouldShowPrefilledBookingDetails(newBooking: NewBooking): void {
@@ -48,5 +52,11 @@ export default class BookingNewPage extends BookingEditablePage {
     this.shouldShowDateInputs('departureDate', newBooking.departureDate)
 
     cy.get('#crn').should('have.value', newBooking.crn)
+  }
+
+  private turnaroundText(): string {
+    return `There will be a turnaround time of ${this.premises.turnaroundWorkingDayCount} working ${
+      this.premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'
+    } after this booking`
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -39,7 +39,7 @@ export default class BookingShowPage extends Page {
   }
 
   clickEditDepartedBookingButton(): void {
-    this.clickAction('Update departed booking')
+    this.clickAction('Update departure details')
   }
 
   clickExtendBookingButton(): void {

--- a/e2e/tests/booking.feature
+++ b/e2e/tests/booking.feature
@@ -43,6 +43,12 @@ Feature: Manage Temporary Accommodation - Booking
         Then I should see the booking with the edited departure details
         And I should see previous booking states in the booking history
 
+    Scenario: Editing a booking's turnaround time
+        Given I'm creating a booking
+        And I create a booking with all necessary details
+        And I edit the booking's turnaround time
+        Then I should see the booking with the edited turnaround time
+
     Scenario: Showing booking creation errors
         Given I'm creating a booking
         And I attempt to create a booking with required details missing

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -37,6 +37,8 @@ Given('I create a booking with all necessary details', () => {
     const booking = bookingFactory.provisional().build({
       ...newBooking,
       person,
+      effectiveEndDate: 'unknown',
+      turnaroundStartDate: 'unknown',
     })
 
     bookingNewPage.completeForm(newBooking)

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -7,6 +7,7 @@ import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import { bookingFactory, departureFactory, newDepartureFactory } from '../../../../server/testutils/factories'
 import { DateFormats } from '../../../../server/utils/dateUtils'
+import { BookingStatus } from '../../../../server/@types/ui/index'
 
 Given('I mark the booking as departed', () => {
   cy.then(function _() {
@@ -70,6 +71,7 @@ Given('I edit the departed booking', () => {
       ...this.booking,
       departureDate: newDeparture.dateTime,
       departure,
+      status: 'unknown-departed-or-closed' as BookingStatus,
     })
 
     cy.wrap(departedBooking).as('booking')

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -107,7 +107,7 @@ Then('I should see the booking with the departed status', () => {
 Then('I should see the booking with the edited departure details', () => {
   cy.then(function _() {
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
-    bookingShowPage.shouldShowBanner('Departed booking updated')
+    bookingShowPage.shouldShowBanner('Departure details changed')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()

--- a/e2e/tests/stepDefinitions/manage/turnaround.ts
+++ b/e2e/tests/stepDefinitions/manage/turnaround.ts
@@ -1,0 +1,36 @@
+import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import BookingTurnaroundNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingTurnaroundNew'
+import { bookingFactory, newTurnaroundFactory, turnaroundFactory } from '../../../../server/testutils/factories'
+
+Given("I edit the booking's turnaround time", () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.clickChangeTurnaround()
+
+    const newTurnaround = newTurnaroundFactory.build()
+    const turnaround = turnaroundFactory.build({
+      ...newTurnaround,
+    })
+
+    const bookingTurnaroundNewPage = Page.verifyOnPage(BookingTurnaroundNewPage, this.premises, this.room, this.booking)
+    bookingTurnaroundNewPage.shouldShowBookingDetails()
+    bookingTurnaroundNewPage.completeForm(newTurnaround)
+
+    const updatedBooking = bookingFactory.build({
+      ...this.booking,
+      turnaround,
+    })
+
+    cy.wrap(updatedBooking).as('booking')
+  })
+})
+
+Then('I should see the booking with the edited turnaround time', () => {
+  cy.then(function _() {
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    bookingShowPage.shouldShowBanner('Turnaround time changed')
+    bookingShowPage.shouldShowBookingDetails()
+  })
+})

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -170,7 +170,7 @@ context('Booking departure', () => {
 
     // And I should be redirected to the show booking page
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    bookingShowPage.shouldShowBanner('Departed booking updated')
+    bookingShowPage.shouldShowBanner('Departure details changed')
   })
 
   it('shows errors when the API returns an error when editing a departed booking', () => {

--- a/server/components/bookingInfo.test.ts
+++ b/server/components/bookingInfo.test.ts
@@ -1,3 +1,4 @@
+import config from '../config'
 import { bookingFactory, cancellationFactory, extensionFactory } from '../testutils/factories'
 import { getLatestExtension, shortenedOrExtended, statusTag } from '../utils/bookingUtils'
 import { formatLines } from '../utils/viewUtils'
@@ -20,32 +21,34 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Start date',
+            },
+            value: {
+              text: '21 March 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Start date',
+          {
+            key: {
+              text: 'End date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-          value: {
-            text: '21 March 2022',
-          },
-        },
-        {
-          key: {
-            text: 'End date',
-          },
-          value: {
-            text: '7 January 2023',
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('provisional')
     })
@@ -61,40 +64,42 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Start date',
+            },
+            value: {
+              text: '21 March 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Start date',
+          {
+            key: {
+              text: 'End date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-          value: {
-            text: '21 March 2022',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.confirmation.notes,
+            },
           },
-        },
-        {
-          key: {
-            text: 'End date',
-          },
-          value: {
-            text: '7 January 2023',
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.confirmation.notes,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('confirmed')
       expect(formatLines).toHaveBeenCalledWith(booking.confirmation.notes)
@@ -114,56 +119,58 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Start date',
+            },
+            value: {
+              text: '21 March 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Start date',
+          {
+            key: {
+              text: 'End date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-          value: {
-            text: '21 March 2022',
+          {
+            key: {
+              text: 'Cancellation date',
+            },
+            value: {
+              text: '14 May 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'End date',
+          {
+            key: {
+              text: 'Cancellation reason',
+            },
+            value: {
+              text: booking.cancellation.reason.name,
+            },
           },
-          value: {
-            text: '7 January 2023',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.cancellation.notes,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Cancellation date',
-          },
-          value: {
-            text: '14 May 2022',
-          },
-        },
-        {
-          key: {
-            text: 'Cancellation reason',
-          },
-          value: {
-            text: booking.cancellation.reason.name,
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.cancellation.notes,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('cancelled')
       expect(formatLines).toHaveBeenCalledWith(booking.cancellation.notes)
@@ -180,40 +187,42 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Arrival date',
+            },
+            value: {
+              text: '21 March 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Arrival date',
+          {
+            key: {
+              text: 'Expected departure date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-          value: {
-            text: '21 March 2022',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.arrival.notes,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Expected departure date',
-          },
-          value: {
-            text: '7 January 2023',
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.arrival.notes,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('arrived')
       expect(formatLines).toHaveBeenCalledWith(booking.arrival.notes)
@@ -235,48 +244,50 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Arrival date',
+            },
+            value: {
+              text: '21 March 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Arrival date',
+          {
+            key: {
+              text: 'Expected departure date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-          value: {
-            text: '21 March 2022',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.arrival.notes,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Expected departure date',
+          {
+            key: {
+              text: 'Notes on extended booking',
+            },
+            value: {
+              html: `${booking.extensions[0].notes}`,
+            },
           },
-          value: {
-            text: '7 January 2023',
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.arrival.notes,
-          },
-        },
-        {
-          key: {
-            text: 'Notes on extended booking',
-          },
-          value: {
-            html: `${booking.extensions[0].notes}`,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('arrived')
       expect(formatLines).toHaveBeenCalledWith(booking.arrival.notes)
@@ -301,48 +312,50 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Arrival date',
+            },
+            value: {
+              text: '21 March 2022',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Arrival date',
+          {
+            key: {
+              text: 'Expected departure date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-          value: {
-            text: '21 March 2022',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.arrival.notes,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Expected departure date',
+          {
+            key: {
+              text: 'Notes on shortened booking',
+            },
+            value: {
+              html: `${booking.extensions[0].notes}`,
+            },
           },
-          value: {
-            text: '7 January 2023',
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.arrival.notes,
-          },
-        },
-        {
-          key: {
-            text: 'Notes on shortened booking',
-          },
-          value: {
-            html: `${booking.extensions[0].notes}`,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('arrived')
       expect(formatLines).toHaveBeenCalledWith(booking.arrival.notes)
@@ -362,48 +375,50 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Departure date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Departure date',
+          {
+            key: {
+              text: 'Departure reason',
+            },
+            value: {
+              text: booking.departure.reason.name,
+            },
           },
-          value: {
-            text: '7 January 2023',
+          {
+            key: {
+              text: 'Move on category',
+            },
+            value: {
+              text: booking.departure.moveOnCategory.name,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Departure reason',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.departure.notes,
+            },
           },
-          value: {
-            text: booking.departure.reason.name,
-          },
-        },
-        {
-          key: {
-            text: 'Move on category',
-          },
-          value: {
-            text: booking.departure.moveOnCategory.name,
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.departure.notes,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('departed')
       expect(formatLines).toHaveBeenCalledWith(booking.departure.notes)
@@ -420,51 +435,170 @@ describe('BookingInfo', () => {
 
       const result = summaryListRows(booking)
 
-      expect(result).toEqual([
-        {
-          key: {
-            text: 'Status',
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Status',
+            },
+            value: {
+              html: statusHtml,
+            },
           },
-          value: {
-            html: statusHtml,
+          {
+            key: {
+              text: 'Departure date',
+            },
+            value: {
+              text: '7 January 2023',
+            },
           },
-        },
-        {
-          key: {
-            text: 'Departure date',
+          {
+            key: {
+              text: 'Departure reason',
+            },
+            value: {
+              text: booking.departure.reason.name,
+            },
           },
-          value: {
-            text: '7 January 2023',
+          {
+            key: {
+              text: 'Move on category',
+            },
+            value: {
+              text: booking.departure.moveOnCategory.name,
+            },
           },
-        },
-        {
-          key: {
-            text: 'Departure reason',
+          {
+            key: {
+              text: 'Notes',
+            },
+            value: {
+              html: booking.departure.notes,
+            },
           },
-          value: {
-            text: booking.departure.reason.name,
-          },
-        },
-        {
-          key: {
-            text: 'Move on category',
-          },
-          value: {
-            text: booking.departure.moveOnCategory.name,
-          },
-        },
-        {
-          key: {
-            text: 'Notes',
-          },
-          value: {
-            html: booking.departure.notes,
-          },
-        },
-      ])
+        ]),
+      )
 
       expect(statusTag).toHaveBeenCalledWith('closed')
       expect(formatLines).toHaveBeenCalledWith(booking.departure.notes)
+    })
+
+    describe('when turnarounds are enabled', () => {
+      beforeAll(() => {
+        config.flags.turnaroundsDisabled = false
+      })
+
+      it('returns summary list rows containing the turnaround time when it is more than one day', () => {
+        const booking = bookingFactory.build({
+          effectiveEndDate: '2023-02-11',
+          turnaround: {
+            workingDays: 4,
+          },
+        })
+
+        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+        const result = summaryListRows(booking)
+
+        expect(result).toEqual(
+          expect.arrayContaining([
+            {
+              key: {
+                text: 'Turnaround time',
+              },
+              value: {
+                text: '4 working days',
+              },
+            },
+            {
+              key: {
+                text: 'Turnaround end date',
+              },
+              value: {
+                text: '11 February 2023',
+              },
+            },
+          ]),
+        )
+      })
+
+      it('returns summary list rows containing the turnaround time when it is exactly one day', () => {
+        const booking = bookingFactory.build({
+          effectiveEndDate: '2023-02-11',
+          turnaround: {
+            workingDays: 1,
+          },
+        })
+
+        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+        const result = summaryListRows(booking)
+
+        expect(result).toEqual(
+          expect.arrayContaining([
+            {
+              key: {
+                text: 'Turnaround time',
+              },
+              value: {
+                text: '1 working day',
+              },
+            },
+            {
+              key: {
+                text: 'Turnaround end date',
+              },
+              value: {
+                text: '11 February 2023',
+              },
+            },
+          ]),
+        )
+      })
+    })
+
+    describe('when turnarounds are disabled', () => {
+      beforeAll(() => {
+        config.flags.turnaroundsDisabled = true
+      })
+
+      it('returns summary list rows not containing the turnaround time', () => {
+        const booking = bookingFactory.build({
+          effectiveEndDate: '2023-02-11',
+          turnaround: {
+            workingDays: 4,
+          },
+        })
+
+        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+        const result = summaryListRows(booking)
+
+        expect(result).not.toEqual(
+          expect.arrayContaining([
+            {
+              key: {
+                text: 'Turnaround time',
+              },
+              value: {
+                text: '4 working days',
+              },
+            },
+            {
+              key: {
+                text: 'Turnaround end date',
+              },
+              value: {
+                text: '11 February 2023',
+              },
+            },
+          ]),
+        )
+      })
     })
   })
 })

--- a/server/components/bookingInfo.test.ts
+++ b/server/components/bookingInfo.test.ts
@@ -408,5 +408,63 @@ describe('BookingInfo', () => {
       expect(statusTag).toHaveBeenCalledWith('departed')
       expect(formatLines).toHaveBeenCalledWith(booking.departure.notes)
     })
+
+    it('returns summary list rows for a closed booking', () => {
+      const booking = bookingFactory.closed().build({
+        arrivalDate: '2022-03-21',
+        departureDate: '2023-01-07T00:00:00.000Z',
+      })
+
+      ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+      ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+      const result = summaryListRows(booking)
+
+      expect(result).toEqual([
+        {
+          key: {
+            text: 'Status',
+          },
+          value: {
+            html: statusHtml,
+          },
+        },
+        {
+          key: {
+            text: 'Departure date',
+          },
+          value: {
+            text: '7 January 2023',
+          },
+        },
+        {
+          key: {
+            text: 'Departure reason',
+          },
+          value: {
+            text: booking.departure.reason.name,
+          },
+        },
+        {
+          key: {
+            text: 'Move on category',
+          },
+          value: {
+            text: booking.departure.moveOnCategory.name,
+          },
+        },
+        {
+          key: {
+            text: 'Notes',
+          },
+          value: {
+            html: booking.departure.notes,
+          },
+        },
+      ])
+
+      expect(statusTag).toHaveBeenCalledWith('closed')
+      expect(formatLines).toHaveBeenCalledWith(booking.departure.notes)
+    })
   })
 })

--- a/server/components/bookingInfo.test.ts
+++ b/server/components/bookingInfo.test.ts
@@ -10,7 +10,7 @@ describe('BookingInfo', () => {
   const statusHtml = '<strong>Some status</strong>'
 
   describe('summaryListRows', () => {
-    it('returns summary list rows for a provisional booking', async () => {
+    it('returns summary list rows for a provisional booking', () => {
       const booking = bookingFactory.provisional().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07',
@@ -18,7 +18,7 @@ describe('BookingInfo', () => {
 
       ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
 
-      const result = await summaryListRows(booking)
+      const result = summaryListRows(booking)
 
       expect(result).toEqual([
         {
@@ -50,7 +50,7 @@ describe('BookingInfo', () => {
       expect(statusTag).toHaveBeenCalledWith('provisional')
     })
 
-    it('returns summary list rows for a confirmed booking', async () => {
+    it('returns summary list rows for a confirmed booking', () => {
       const booking = bookingFactory.confirmed().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07',
@@ -100,7 +100,7 @@ describe('BookingInfo', () => {
       expect(formatLines).toHaveBeenCalledWith(booking.confirmation.notes)
     })
 
-    it('returns summary list rows for a cancelled booking', async () => {
+    it('returns summary list rows for a cancelled booking', () => {
       const booking = bookingFactory.cancelled().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07',
@@ -169,7 +169,7 @@ describe('BookingInfo', () => {
       expect(formatLines).toHaveBeenCalledWith(booking.cancellation.notes)
     })
 
-    it('returns summary list rows for an arrived booking', async () => {
+    it('returns summary list rows for an arrived booking', () => {
       const booking = bookingFactory.arrived().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07',
@@ -219,7 +219,7 @@ describe('BookingInfo', () => {
       expect(formatLines).toHaveBeenCalledWith(booking.arrival.notes)
     })
 
-    it('returns summary list rows for an arrived and extended booking', async () => {
+    it('returns summary list rows for an arrived and extended booking', () => {
       const booking = bookingFactory.arrived().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07',
@@ -285,7 +285,7 @@ describe('BookingInfo', () => {
       expect(shortenedOrExtended).toHaveBeenCalledWith(booking.extensions[0])
     })
 
-    it('returns summary list rows for an arrived and shortended booking', async () => {
+    it('returns summary list rows for an arrived and shortended booking', () => {
       const booking = bookingFactory.arrived().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07',
@@ -351,7 +351,7 @@ describe('BookingInfo', () => {
       expect(shortenedOrExtended).toHaveBeenCalledWith(booking.extensions[0])
     })
 
-    it('returns summary list rows for a departed booking', async () => {
+    it('returns summary list rows for a departed booking', () => {
       const booking = bookingFactory.departed().build({
         arrivalDate: '2022-03-21',
         departureDate: '2023-01-07T00:00:00.000Z',

--- a/server/components/bookingInfo.ts
+++ b/server/components/bookingInfo.ts
@@ -35,7 +35,7 @@ export default (booking: Booking): SummaryList['rows'] => {
         value: textValue(DateFormats.isoDateToUIDate(departureDate)),
       },
     )
-  } else if (status === 'departed') {
+  } else if (status === 'departed' || status === 'closed') {
     rows.push({
       key: textValue('Departure date'),
       value: textValue(DateFormats.isoDateToUIDate(departureDate)),
@@ -81,7 +81,7 @@ export default (booking: Booking): SummaryList['rows'] => {
         value: htmlValue(formatLines(latestExtension.notes)),
       })
     }
-  } else if (status === 'departed') {
+  } else if (status === 'departed' || status === 'closed') {
     rows.push(
       {
         key: textValue('Departure reason'),

--- a/server/components/bookingInfo.ts
+++ b/server/components/bookingInfo.ts
@@ -1,5 +1,6 @@
 import type { Booking } from '@approved-premises/api'
 import type { SummaryList } from '@approved-premises/ui'
+import config from '../config'
 import { getLatestExtension, shortenedOrExtended, statusTag } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { formatLines } from '../utils/viewUtils'
@@ -40,6 +41,21 @@ export default (booking: Booking): SummaryList['rows'] => {
       key: textValue('Departure date'),
       value: textValue(DateFormats.isoDateToUIDate(departureDate)),
     })
+  }
+
+  if (!config.flags.turnaroundsDisabled) {
+    const days = booking.turnaround.workingDays
+
+    rows.push(
+      {
+        key: textValue('Turnaround time'),
+        value: textValue(`${days} working ${days === 1 ? 'day' : 'days'}`),
+      },
+      {
+        key: textValue('Turnaround end date'),
+        value: textValue(DateFormats.isoDateToUIDate(booking.effectiveEndDate || booking.departureDate)),
+      },
+    )
   }
 
   if (status === 'confirmed') {

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -230,7 +230,7 @@ describe('DeparturesController', () => {
         expect.objectContaining(newDeparture),
       )
 
-      expect(request.flash).toHaveBeenCalledWith('success', 'Departed booking updated')
+      expect(request.flash).toHaveBeenCalledWith('success', 'Departure details changed')
       expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId }))
     })
 

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -106,7 +106,7 @@ export default class DeparturesController {
       try {
         await this.departureService.createDeparture(callConfig, premisesId, bookingId, newDeparture)
 
-        req.flash('success', 'Departed booking updated')
+        req.flash('success', 'Departure details changed')
         res.redirect(paths.bookings.show({ premisesId, roomId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -14,11 +14,6 @@ export default class BookingSearchService {
 
     const { results } = bookingSummaries
 
-    if (status === 'departed') {
-      const closedBookingSummaries = await bookingClient.search('closed')
-      results.push(...closedBookingSummaries.results)
-    }
-
     return results.map(summary => {
       return [
         this.textValue(summary.person.name),

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -6,7 +6,7 @@ import { bedFactory, bookingFactory, lostBedFactory, newBookingFactory, roomFact
 
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
-import { statusTag, transformApiBookingToUiBooking } from '../utils/bookingUtils'
+import { statusTag } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { statusTag as lostBedStatusTag } from '../utils/lostBedUtils'
 import config from '../config'
@@ -16,7 +16,6 @@ jest.mock('../data/referenceDataClient')
 jest.mock('../utils/bookingUtils', () => ({
   ...jest.requireActual('../utils/bookingUtils'),
   statusTag: jest.fn(),
-  transformApiBookingToUiBooking: jest.fn(),
 }))
 jest.mock('../data/lostBedClient')
 jest.mock('../utils/lostBedUtils')
@@ -40,9 +39,6 @@ describe('BookingService', () => {
     jest.resetAllMocks()
     bookingClientFactory.mockReturnValue(bookingClient)
     lostBedClientFactory.mockReturnValue(lostBedClient)
-    ;(transformApiBookingToUiBooking as jest.MockedFunction<typeof transformApiBookingToUiBooking>).mockImplementation(
-      booking => booking,
-    )
   })
 
   describe('createForBedspace', () => {
@@ -69,7 +65,6 @@ describe('BookingService', () => {
         enableTurnarounds: !config.flags.turnaroundsDisabled,
         ...newBooking,
       })
-      expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)
     })
   })
 
@@ -279,10 +274,6 @@ describe('BookingService', () => {
 
       expect(statusTag).toHaveBeenCalledTimes(4)
       expect(lostBedStatusTag).toHaveBeenCalledTimes(4)
-
-      bookings.forEach(booking => {
-        expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)
-      })
     })
   })
 
@@ -297,7 +288,6 @@ describe('BookingService', () => {
 
       expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingClient.find).toHaveBeenCalledWith(premisesId, booking.id)
-      expect(transformApiBookingToUiBooking).toHaveBeenCalledWith(booking)
     })
   })
 })

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -4,12 +4,12 @@ import BookingService from './bookingService'
 
 import { bedFactory, bookingFactory, lostBedFactory, newBookingFactory, roomFactory } from '../testutils/factories'
 
+import config from '../config'
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
 import { statusTag } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { statusTag as lostBedStatusTag } from '../utils/lostBedUtils'
-import config from '../config'
 
 jest.mock('../data/bookingClient')
 jest.mock('../data/referenceDataClient')
@@ -69,211 +69,320 @@ describe('BookingService', () => {
   })
 
   describe('getTableRowsForBedspace', () => {
-    it('returns a sorted table view of the bookings for the given room', async () => {
-      const booking1 = bookingFactory.provisional().build({
-        bed: bedFactory.build({ id: bedId }),
-        arrivalDate: '2023-07-01',
-      })
-      const booking2 = bookingFactory.confirmed().build({
-        bed: bedFactory.build({ id: bedId }),
-        arrivalDate: '2022-11-14',
-      })
-      const booking3 = bookingFactory.arrived().build({
-        bed: bedFactory.build({ id: bedId }),
-        arrivalDate: '2022-04-19',
-      })
-      const booking4 = bookingFactory.departed().build({
-        bed: bedFactory.build({ id: bedId }),
-        arrivalDate: '2022-01-03',
+    describe('when turnarounds are enabled', () => {
+      beforeAll(() => {
+        config.flags.turnaroundsDisabled = false
       })
 
-      const otherBedBooking = bookingFactory.build({
-        bed: bedFactory.build({ id: 'other-bed-id' }),
+      it('returns a sorted table view of the bookings for the given room, using the effective end date for each booking', async () => {
+        const booking1 = bookingFactory.provisional().build({
+          bed: bedFactory.build({ id: bedId }),
+          arrivalDate: '2023-07-01',
+        })
+        const booking2 = bookingFactory.confirmed().build({
+          bed: bedFactory.build({ id: bedId }),
+          arrivalDate: '2022-11-14',
+        })
+        const booking3 = bookingFactory.arrived().build({
+          bed: bedFactory.build({ id: bedId }),
+          arrivalDate: '2022-04-19',
+        })
+        const booking4 = bookingFactory.departed().build({
+          bed: bedFactory.build({ id: bedId }),
+          arrivalDate: '2022-01-03',
+        })
+
+        const otherBedBooking = bookingFactory.build({
+          bed: bedFactory.build({ id: 'other-bed-id' }),
+        })
+
+        const lostBed1 = lostBedFactory.build({
+          bedId,
+          startDate: '2023-04-07',
+          status: 'active',
+        })
+
+        const lostBed2 = lostBedFactory.build({
+          bedId,
+          startDate: '2022-10-07',
+          status: 'active',
+        })
+
+        const lostBed3 = lostBedFactory.build({
+          bedId,
+          startDate: '2023-01-07',
+          status: 'cancelled',
+        })
+
+        const otherLostBed = lostBedFactory.past().build({
+          bedId: 'other-bed-id',
+        })
+
+        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+        ;(lostBedStatusTag as jest.MockedFunction<typeof lostBedStatusTag>).mockReturnValue(statusHtml)
+
+        const bookings = [booking2, booking1, booking4, booking3, otherBedBooking]
+        bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)
+
+        const lostBeds = [lostBed1, lostBed2, lostBed3, otherLostBed]
+        lostBedClient.allLostBedsForPremisesId.mockResolvedValue(lostBeds)
+
+        const room = roomFactory.build({
+          beds: [
+            bedFactory.build({
+              id: bedId,
+            }),
+          ],
+        })
+
+        const rows = await service.getTableRowsForBedspace(callConfig, premisesId, room)
+
+        expect(rows).toEqual([
+          [
+            {
+              text: booking1.person.crn,
+            },
+            {
+              text: '1 Jul 23',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(booking1.effectiveEndDate, { format: 'short' }),
+            },
+            {
+              html: statusHtml,
+            },
+            {
+              html: `<a href="${paths.bookings.show({
+                premisesId,
+                roomId: room.id,
+                bookingId: booking1.id,
+              })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+                booking1.person.crn
+              }</span></a>`,
+            },
+          ],
+          [
+            {
+              text: '-',
+            },
+            {
+              text: '7 Apr 23',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(lostBed1.endDate, { format: 'short' }),
+            },
+            {
+              html: lostBedStatusTag(lostBed1.status, 'bookingsAndVoids'),
+            },
+            {
+              html: `<a href="${paths.lostBeds.show({
+                premisesId,
+                roomId: room.id,
+                lostBedId: lostBed1.id,
+              })}">View<span class="govuk-visually-hidden"> void booking</span></a>`,
+            },
+          ],
+          [
+            {
+              text: booking2.person.crn,
+            },
+            {
+              text: '14 Nov 22',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(booking2.effectiveEndDate, { format: 'short' }),
+            },
+            {
+              html: statusHtml,
+            },
+            {
+              html: `<a href="${paths.bookings.show({
+                premisesId,
+                roomId: room.id,
+                bookingId: booking2.id,
+              })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+                booking2.person.crn
+              }</span></a>`,
+            },
+          ],
+          [
+            {
+              text: '-',
+            },
+            {
+              text: '7 Oct 22',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(lostBed2.endDate, { format: 'short' }),
+            },
+            {
+              html: lostBedStatusTag(lostBed2.status, 'bookingsAndVoids'),
+            },
+            {
+              html: `<a href="${paths.lostBeds.show({
+                premisesId,
+                roomId: room.id,
+                lostBedId: lostBed2.id,
+              })}">View<span class="govuk-visually-hidden"> void booking</span></a>`,
+            },
+          ],
+          [
+            {
+              text: booking3.person.crn,
+            },
+            {
+              text: '19 Apr 22',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(booking3.effectiveEndDate, { format: 'short' }),
+            },
+            {
+              html: statusHtml,
+            },
+            {
+              html: `<a href="${paths.bookings.show({
+                premisesId,
+                roomId: room.id,
+                bookingId: booking3.id,
+              })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+                booking3.person.crn
+              }</span></a>`,
+            },
+          ],
+          [
+            {
+              text: booking4.person.crn,
+            },
+            {
+              text: '3 Jan 22',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(booking4.effectiveEndDate, { format: 'short' }),
+            },
+            {
+              html: statusHtml,
+            },
+            {
+              html: `<a href="${paths.bookings.show({
+                premisesId,
+                roomId: room.id,
+                bookingId: booking4.id,
+              })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+                booking4.person.crn
+              }</span></a>`,
+            },
+          ],
+        ])
+
+        expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
+        expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
+
+        expect(statusTag).toHaveBeenCalledTimes(4)
+        expect(lostBedStatusTag).toHaveBeenCalledTimes(4)
       })
 
-      const lostBed1 = lostBedFactory.build({
-        bedId,
-        startDate: '2023-04-07',
-        status: 'active',
+      it('uses the departure date where no effective end date is given', async () => {
+        const booking = bookingFactory.provisional().build({
+          bed: bedFactory.build({ id: bedId }),
+          arrivalDate: '2023-07-01',
+        })
+
+        delete booking.effectiveEndDate
+        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+
+        bookingClient.allBookingsForPremisesId.mockResolvedValue([booking])
+        lostBedClient.allLostBedsForPremisesId.mockResolvedValue([])
+
+        const room = roomFactory.build({
+          beds: [
+            bedFactory.build({
+              id: bedId,
+            }),
+          ],
+        })
+
+        const rows = await service.getTableRowsForBedspace(callConfig, premisesId, room)
+
+        expect(rows).toEqual([
+          [
+            {
+              text: booking.person.crn,
+            },
+            {
+              text: '1 Jul 23',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(booking.departureDate, { format: 'short' }),
+            },
+            {
+              html: statusHtml,
+            },
+            {
+              html: `<a href="${paths.bookings.show({
+                premisesId,
+                roomId: room.id,
+                bookingId: booking.id,
+              })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+                booking.person.crn
+              }</span></a>`,
+            },
+          ],
+        ])
+      })
+    })
+
+    describe('when turnarounds are disabled', () => {
+      beforeAll(() => {
+        config.flags.turnaroundsDisabled = true
       })
 
-      const lostBed2 = lostBedFactory.build({
-        bedId,
-        startDate: '2022-10-07',
-        status: 'active',
+      it('uses the departure date for each booking', async () => {
+        const booking = bookingFactory.provisional().build({
+          bed: bedFactory.build({ id: bedId }),
+          arrivalDate: '2023-07-01',
+        })
+
+        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+
+        bookingClient.allBookingsForPremisesId.mockResolvedValue([booking])
+        lostBedClient.allLostBedsForPremisesId.mockResolvedValue([])
+
+        const room = roomFactory.build({
+          beds: [
+            bedFactory.build({
+              id: bedId,
+            }),
+          ],
+        })
+
+        const rows = await service.getTableRowsForBedspace(callConfig, premisesId, room)
+
+        expect(rows).toEqual([
+          [
+            {
+              text: booking.person.crn,
+            },
+            {
+              text: '1 Jul 23',
+            },
+            {
+              text: DateFormats.isoDateToUIDate(booking.departureDate, { format: 'short' }),
+            },
+            {
+              html: statusHtml,
+            },
+            {
+              html: `<a href="${paths.bookings.show({
+                premisesId,
+                roomId: room.id,
+                bookingId: booking.id,
+              })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
+                booking.person.crn
+              }</span></a>`,
+            },
+          ],
+        ])
       })
-
-      const lostBed3 = lostBedFactory.build({
-        bedId,
-        startDate: '2023-01-07',
-        status: 'cancelled',
-      })
-
-      const otherLostBed = lostBedFactory.past().build({
-        bedId: 'other-bed-id',
-      })
-
-      ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
-      ;(lostBedStatusTag as jest.MockedFunction<typeof lostBedStatusTag>).mockReturnValue(statusHtml)
-
-      const bookings = [booking2, booking1, booking4, booking3, otherBedBooking]
-      bookingClient.allBookingsForPremisesId.mockResolvedValue(bookings)
-
-      const lostBeds = [lostBed1, lostBed2, lostBed3, otherLostBed]
-      lostBedClient.allLostBedsForPremisesId.mockResolvedValue(lostBeds)
-
-      const room = roomFactory.build({
-        beds: [
-          bedFactory.build({
-            id: bedId,
-          }),
-        ],
-      })
-
-      const rows = await service.getTableRowsForBedspace(callConfig, premisesId, room)
-
-      expect(rows).toEqual([
-        [
-          {
-            text: booking1.person.crn,
-          },
-          {
-            text: '1 Jul 23',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(booking1.departureDate, { format: 'short' }),
-          },
-          {
-            html: statusHtml,
-          },
-          {
-            html: `<a href="${paths.bookings.show({
-              premisesId,
-              roomId: room.id,
-              bookingId: booking1.id,
-            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
-              booking1.person.crn
-            }</span></a>`,
-          },
-        ],
-        [
-          {
-            text: '-',
-          },
-          {
-            text: '7 Apr 23',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(lostBed1.endDate, { format: 'short' }),
-          },
-          {
-            html: lostBedStatusTag(lostBed1.status, 'bookingsAndVoids'),
-          },
-          {
-            html: `<a href="${paths.lostBeds.show({
-              premisesId,
-              roomId: room.id,
-              lostBedId: lostBed1.id,
-            })}">View<span class="govuk-visually-hidden"> void booking</span></a>`,
-          },
-        ],
-        [
-          {
-            text: booking2.person.crn,
-          },
-          {
-            text: '14 Nov 22',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(booking2.departureDate, { format: 'short' }),
-          },
-          {
-            html: statusHtml,
-          },
-          {
-            html: `<a href="${paths.bookings.show({
-              premisesId,
-              roomId: room.id,
-              bookingId: booking2.id,
-            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
-              booking2.person.crn
-            }</span></a>`,
-          },
-        ],
-        [
-          {
-            text: '-',
-          },
-          {
-            text: '7 Oct 22',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(lostBed2.endDate, { format: 'short' }),
-          },
-          {
-            html: lostBedStatusTag(lostBed2.status, 'bookingsAndVoids'),
-          },
-          {
-            html: `<a href="${paths.lostBeds.show({
-              premisesId,
-              roomId: room.id,
-              lostBedId: lostBed2.id,
-            })}">View<span class="govuk-visually-hidden"> void booking</span></a>`,
-          },
-        ],
-        [
-          {
-            text: booking3.person.crn,
-          },
-          {
-            text: '19 Apr 22',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(booking3.departureDate, { format: 'short' }),
-          },
-          {
-            html: statusHtml,
-          },
-          {
-            html: `<a href="${paths.bookings.show({
-              premisesId,
-              roomId: room.id,
-              bookingId: booking3.id,
-            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
-              booking3.person.crn
-            }</span></a>`,
-          },
-        ],
-        [
-          {
-            text: booking4.person.crn,
-          },
-          {
-            text: '3 Jan 22',
-          },
-          {
-            text: DateFormats.isoDateToUIDate(booking4.departureDate, { format: 'short' }),
-          },
-          {
-            html: statusHtml,
-          },
-          {
-            html: `<a href="${paths.bookings.show({
-              premisesId,
-              roomId: room.id,
-              bookingId: booking4.id,
-            })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
-              booking4.person.crn
-            }</span></a>`,
-          },
-        ],
-      ])
-
-      expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(bookingClient.allBookingsForPremisesId).toHaveBeenCalledWith(premisesId)
-
-      expect(statusTag).toHaveBeenCalledTimes(4)
-      expect(lostBedStatusTag).toHaveBeenCalledTimes(4)
     })
   })
 

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -6,7 +6,7 @@ import type { LostBedClient, RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
-import { statusTag, transformApiBookingToUiBooking } from '../utils/bookingUtils'
+import { statusTag } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { statusTag as lostBedStatusTag } from '../utils/lostBedUtils'
 
@@ -33,14 +33,12 @@ export default class BookingService {
       ...booking,
     })
 
-    return transformApiBookingToUiBooking(confirmedBooking)
+    return confirmedBooking
   }
 
   async getTableRowsForBedspace(callConfig: CallConfig, premisesId: string, room: Room): Promise<Array<TableRow>> {
     const bookingClient = this.bookingClientFactory(callConfig)
-    const bookings = (await bookingClient.allBookingsForPremisesId(premisesId)).map(booking =>
-      transformApiBookingToUiBooking(booking),
-    )
+    const bookings = await bookingClient.allBookingsForPremisesId(premisesId)
 
     const lostBedClient = this.lostBedClientFactory(callConfig)
     const lostBeds = await (
@@ -98,7 +96,7 @@ export default class BookingService {
     const bookingClient = this.bookingClientFactory(callConfig)
     const booking = await bookingClient.find(premisesId, bookingId)
 
-    return transformApiBookingToUiBooking(booking)
+    return booking
   }
 
   private textValue(value: string) {

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -54,7 +54,14 @@ export default class BookingService {
         rows: [
           this.textValue(b.person.crn),
           this.textValue(DateFormats.isoDateToUIDate(b.arrivalDate, { format: 'short' })),
-          this.textValue(DateFormats.isoDateToUIDate(b.departureDate, { format: 'short' })),
+          this.textValue(
+            DateFormats.isoDateToUIDate(
+              config.flags.turnaroundsDisabled ? b.departureDate : b.effectiveEndDate || b.departureDate,
+              {
+                format: 'short',
+              },
+            ),
+          ),
           this.htmlValue(statusTag(b.status)),
           this.htmlValue(
             `<a href="${paths.bookings.show({

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -97,6 +97,19 @@ describe('bookingUtils', () => {
         ])
       })
 
+      it('returns edit departed booking for a closed booking', () => {
+        const booking = bookingFactory.closed().build({ id: bookingId })
+
+        expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+          {
+            text: 'Update departed booking',
+            classes: 'govuk-button--secondary',
+            href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
+          },
+          changeTurnaroundAction,
+        ])
+      })
+
       it('returns edit cancelled booking for a cancelled booking', () => {
         const booking = bookingFactory.cancelled().build({ id: bookingId })
 

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -88,7 +88,7 @@ describe('bookingUtils', () => {
 
         expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
           {
-            text: 'Update departed booking',
+            text: 'Update departure details',
             classes: 'govuk-button--secondary',
             href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
           },
@@ -101,7 +101,7 @@ describe('bookingUtils', () => {
 
         expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
           {
-            text: 'Update departed booking',
+            text: 'Update departure details',
             classes: 'govuk-button--secondary',
             href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
           },

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -9,6 +9,7 @@ import {
   generateTurnaroundConflictBespokeError,
   getLatestExtension,
   shortenedOrExtended,
+  statusName,
   statusTag,
   transformApiBookingToUiBooking,
 } from './bookingUtils'
@@ -125,6 +126,12 @@ describe('bookingUtils', () => {
   describe('statusTag', () => {
     it('returns the HTML formatted display name of a given status', () => {
       expect(statusTag('confirmed')).toEqual('<strong class="govuk-tag govuk-tag--purple">Confirmed</strong>')
+    })
+  })
+
+  describe('statusName', () => {
+    it('returns display name of a given status', () => {
+      expect(statusName('confirmed')).toEqual('Confirmed')
     })
   })
 

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -11,7 +11,6 @@ import {
   shortenedOrExtended,
   statusName,
   statusTag,
-  transformApiBookingToUiBooking,
 } from './bookingUtils'
 
 const premisesId = 'premisesId'
@@ -421,26 +420,6 @@ describe('bookingUtils', () => {
       })
 
       expect(shortenedOrExtended(extension)).toEqual('extended')
-    })
-  })
-
-  describe('transformApiBookingToUiBooking', () => {
-    it('transforms a closed booking to a departed booking', () => {
-      const booking = bookingFactory.closed().build()
-      const bookingCopy = { ...booking }
-
-      const result = transformApiBookingToUiBooking(booking)
-
-      expect(result).toEqual({ ...bookingCopy, status: 'departed' })
-    })
-
-    it('leaves non-closed bookings unchanged', () => {
-      const booking = bookingFactory.arrived().build()
-      const bookingCopy = { ...booking }
-
-      const result = transformApiBookingToUiBooking(booking)
-
-      expect(result).toEqual(bookingCopy)
     })
   })
 

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -104,8 +104,13 @@ export const allStatuses: Array<{ name: string; id: Booking['status']; tagClass:
     tagClass: 'govuk-tag--green',
   },
   {
-    name: 'Departed',
+    name: config.flags.turnaroundsDisabled ? 'Departed' : 'Turnaround',
     id: 'departed',
+    tagClass: 'govuk-tag--red',
+  },
+  {
+    name: 'Departed',
+    id: 'closed',
     tagClass: 'govuk-tag--red',
   },
   {

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -58,7 +58,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
     case 'departed':
     case 'closed':
       items.push({
-        text: 'Update departed booking',
+        text: 'Update departure details',
         classes: 'govuk-button--secondary',
         href: paths.bookings.departures.edit({ premisesId, roomId, bookingId }),
       })

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -120,6 +120,11 @@ export const statusTag = (statusId: Booking['status']) => {
   return `<strong class="govuk-tag ${status.tagClass}">${status.name}</strong>`
 }
 
+export const statusName = (statusId: Booking['status']) => {
+  const status = allStatuses.find(({ id }) => id === statusId)
+  return status.name
+}
+
 export const getLatestExtension = (booking: Booking) => {
   return booking.extensions.reduce((latestExtension, testExtension) => {
     const latestTime = DateFormats.isoToDateObj(latestExtension.createdAt).getTime()

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -171,13 +171,6 @@ export const shortenedOrExtended = (extension: Extension): 'shortened' | 'extend
   return previousDepartureDate.getTime() > newDepartureDate.getTime() ? 'shortened' : 'extended'
 }
 
-export const transformApiBookingToUiBooking = (booking: Booking): Booking => {
-  if (booking.status === 'closed') {
-    return { ...booking, status: 'departed' }
-  }
-  return booking
-}
-
 export const generateConflictBespokeError = (
   err: SanitisedError,
   premisesId: string,

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -144,8 +144,9 @@ export const deriveBookingHistory = (booking: Booking) => {
   const departures = [...booking.departures].sort(compareBookingState)
   const cancellations = [...booking.cancellations].sort(compareBookingState)
 
-  const bookingWithSortedExensions = {
+  const bookingWithSortedExensions: Booking = {
     ...booking,
+    status: booking.status === 'closed' ? 'departed' : booking.status,
     extensions,
     departures,
     cancellations,

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -12,11 +12,12 @@ type ParsedConflictError = {
 
 export function bookingActions(premisesId: string, roomId: string, booking: Booking): Array<PageHeadingBarItem> {
   const items = []
+  const bookingId = booking.id
 
   const cancelAction = {
     text: 'Cancel booking',
     classes: 'govuk-button--secondary',
-    href: paths.bookings.cancellations.new({ premisesId, roomId, bookingId: booking.id }),
+    href: paths.bookings.cancellations.new({ premisesId, roomId, bookingId }),
   }
 
   switch (booking.status) {
@@ -25,7 +26,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
         {
           text: 'Mark as confirmed',
           classes: '',
-          href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId: booking.id }),
+          href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId }),
         },
         cancelAction,
       )
@@ -35,7 +36,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
         {
           text: 'Mark as active',
           classes: '',
-          href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId: booking.id }),
+          href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId }),
         },
         cancelAction,
       )
@@ -45,27 +46,28 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
         {
           text: 'Mark as departed',
           classes: 'govuk-button--secondary',
-          href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
+          href: paths.bookings.departures.new({ premisesId, roomId, bookingId }),
         },
         {
           text: 'Extend or shorten booking',
           classes: 'govuk-button--secondary',
-          href: paths.bookings.extensions.new({ premisesId, roomId, bookingId: booking.id }),
+          href: paths.bookings.extensions.new({ premisesId, roomId, bookingId }),
         },
       )
       break
     case 'departed':
+    case 'closed':
       items.push({
         text: 'Update departed booking',
         classes: 'govuk-button--secondary',
-        href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
+        href: paths.bookings.departures.edit({ premisesId, roomId, bookingId }),
       })
       break
     case 'cancelled':
       items.push({
         text: 'Update cancelled booking',
         classes: 'govuk-button--secondary',
-        href: paths.bookings.cancellations.edit({ premisesId, roomId, bookingId: booking.id }),
+        href: paths.bookings.cancellations.edit({ premisesId, roomId, bookingId }),
       })
       break
     default:

--- a/server/views/temporary-accommodation/departures/edit.njk
+++ b/server/views/temporary-accommodation/departures/edit.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - EdUpdateit departed booking" %}
+{% set pageTitle = applicationName + " - Update departure details" %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
@@ -18,7 +18,7 @@
 
   {% include "../../_messages.njk" %}
 
-  <h1>Update departed booking</h1>
+  <h1>Update departure details</h1>
 
   {{ showErrorSummary(errorSummary) }}
 

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -164,6 +164,7 @@ premises.forEach(item => {
     bedspaceBookingFactory.confirmed().buildList(rand()),
     bedspaceBookingFactory.arrived().buildList(rand()),
     bedspaceBookingFactory.departed().buildList(rand()),
+    bedspaceBookingFactory.closed().buildList(rand()),
     bedspaceBookingFactory.cancelled().buildList(rand()),
   ].flat()
 


### PR DESCRIPTION
# Changes in this PR

This PR updates the app to properly show closed bookings, and to show the turnaround time for bookings. With the exception of some small text changes, this feature is hidden behind the `disbaledTurnarounds` feature flag

## Screenshots of UI changes

### Before
![localhost_3000_properties_d86befab-2bef-4e89-b540-16986cbf7dbc_bedspaces_16e112dc-ccf5-4c48-8c51-8f1ff5f60a91_bookings_33c778a9-d941-4c64-88ad-d343314b357c (1)](https://user-images.githubusercontent.com/94137563/235668420-e0858115-2a37-425e-b187-f10b66d12204.png)

### After
![localhost_3000_properties_d86befab-2bef-4e89-b540-16986cbf7dbc_bedspaces_16e112dc-ccf5-4c48-8c51-8f1ff5f60a91_bookings_33c778a9-d941-4c64-88ad-d343314b357c](https://user-images.githubusercontent.com/94137563/235668405-0c1dd1fc-ad74-4a3f-8d02-ce928148e1b7.png)

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
