### PR TITLE
Upgrade to Node 18

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,7 +18,7 @@ parameters:
 
   node-version:
     type: string
-    default: 16.15-browsers
+    default: 18.16-browsers
 
 jobs:
   check_outdated:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:16.15-bullseye-slim as base
+FROM node:18.16-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
[Package.json](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/90e3ca41e2cf74d535f5b995fa46cc331390ec32/package.json#LL40C1-L40C1) already referenced using version 18:

```
  "engines": {
    "node": "^18",
```

Now, CircleCI and docker containers will run with version 18 in real environments. I'm not entirely sure how the two being different hasn't been a problem so far!

Here is the Docker image we were on, along with vulnerabiltiies: https://hub.docker.com/layers/library/node/16.15.1-bullseye-slim/images/sha256-c977cdcb47211ae2928552800ea7c2774bb21bda8b2ec0b0c7981d051ebdf3c3?context=explore

Here is the **new** Docker image that has various patches for high severity issues: https://hub.docker.com/layers/library/node/18.16.0-bullseye-slim/images/sha256-09714f3334c1cda4ffac832880b57fc9c72253dd365ce7fa3ff1d1705aa9435a?context=explore

We use Trivy to scan packages on CI. I've run this locally to give us confidence this actually fixes the issues:

### Old image

```
$ docker build . -t test-16
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-16
2023-05-02T15:21:08.217Z	INFO	Vulnerability scanning is enabled
2023-05-02T15:21:08.218Z	INFO	Secret scanning is enabled
2023-05-02T15:21:08.218Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-02T15:21:08.218Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-02T15:21:25.251Z	INFO	Detected OS: debian
2023-05-02T15:21:25.251Z	INFO	Detecting Debian vulnerabilities...
2023-05-02T15:21:25.267Z	INFO	Number of language-specific files: 1
2023-05-02T15:21:25.267Z	INFO	Detecting node-pkg vulnerabilities...

test-16 (debian 11.6)
=====================
Total: 3 (HIGH: 3, CRITICAL: 0)

┌──────────────┬────────────────┬──────────┬───────────────────┬────────────────────────┬────────────────────────────────────────────┐
│   Library    │ Vulnerability  │ Severity │ Installed Version │     Fixed Version      │                   Title                    │
├──────────────┼────────────────┼──────────┼───────────────────┼────────────────────────┼────────────────────────────────────────────┤
│ libtinfo6    │ CVE-2022-29458 │ HIGH     │ 6.2+20201114-2    │ 6.2+20201114-2+deb11u1 │ ncurses: segfaulting OOB read              │
│              │                │          │                   │                        │ https://avd.aquasec.com/nvd/cve-2022-29458 │
├──────────────┤                │          │                   │                        │                                            │
│ ncurses-base │                │          │                   │                        │                                            │
│              │                │          │                   │                        │                                            │
├──────────────┤                │          │                   │                        │                                            │
│ ncurses-bin  │                │          │                   │                        │                                            │
│              │                │          │                   │                        │                                            │
```

### New image

```
$ docker build . -t test-18
$ docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-18
2023-05-02T15:18:37.177Z	INFO	Vulnerability scanning is enabled
2023-05-02T15:18:37.177Z	INFO	Secret scanning is enabled
2023-05-02T15:18:37.177Z	INFO	If your scanning is slow, please try '--scanners vuln' to disable secret scanning
2023-05-02T15:18:37.177Z	INFO	Please see also https://aquasecurity.github.io/trivy/v0.41/docs/secret/scanning/#recommendation for faster secret detection
2023-05-02T15:18:53.733Z	INFO	Detected OS: debian
2023-05-02T15:18:53.733Z	INFO	Detecting Debian vulnerabilities...
2023-05-02T15:18:53.745Z	INFO	Number of language-specific files: 1
2023-05-02T15:18:53.745Z	INFO	Detecting node-pkg vulnerabilities...

test (debian 11.7)
==================
Total: 0 (HIGH: 0, CRITICAL: 0)
```

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
