### PR TITLE
Users can change the number of days each premises needs to allow for turnaround

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -95,5 +95,6 @@ export default class PremisesEditPage extends PremisesEditablePage {
       })
 
     this.getTextInputByIdAndClear('notes')
+    this.getTextInputByIdAndClear('turnaroundWorkingDayCount')
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
@@ -34,6 +34,15 @@ export default abstract class PremisesEditablePage extends Page {
     this.getLabel('Please provide any further property details')
     this.getTextInputByIdAndEnterDetails('notes', newOrUpdatePremises.notes)
 
+    this.getLabel(
+      'Enter the number of working days required to turnaround the property. The standard turnaround time should be 2 days',
+    )
+    this.getTextInputByIdAndClear('turnaroundWorkingDayCount')
+    this.getTextInputByIdAndEnterDetails(
+      'turnaroundWorkingDayCount',
+      `${newOrUpdatePremises.turnaroundWorkingDayCount}`,
+    )
+
     this.clickSubmit()
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -85,6 +85,12 @@ export default class PremisesShowPage extends Page {
       )
       this.shouldShowKeyAndValue('Status', statusInfo(this.premises.status).name)
       this.shouldShowKeyAndValues('Notes', this.premises.notes.split('\n'))
+      this.shouldShowKeyAndValue(
+        'Expected turnaround time',
+        `${this.premises.turnaroundWorkingDayCount} working ${
+          this.premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'
+        }`,
+      )
     })
   }
 

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -168,6 +168,7 @@ context('Premises', () => {
         expect(requestBody.localAuthorityAreaId).equal(newPremises.localAuthorityAreaId)
         expect(requestBody.characteristicIds).members(newPremises.characteristicIds)
         expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(newPremises.notes)
+        expect(requestBody.turnaroundWorkingDayCount).equal(`${newPremises.turnaroundWorkingDayCount}`)
       })
 
       // And I should be redirected to the show premises page
@@ -274,6 +275,7 @@ context('Premises', () => {
         expect(requestBody.characteristicIds).members(updatePremises.characteristicIds)
         expect(requestBody.status).equal(updatePremises.status)
         expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(updatePremises.notes)
+        expect(requestBody.turnaroundWorkingDayCount).equal(`${updatePremises.turnaroundWorkingDayCount}`)
       })
 
       // And I should be redirected to the show premises page

--- a/server/config.ts
+++ b/server/config.ts
@@ -52,6 +52,7 @@ export default {
   flags: {
     oasysDisabled: process.env.OASYS_DISABLED || false,
     applyDisabled: !['local', 'dev', 'test'].includes(environment),
+    turnaroundsDisabled: !['local', 'dev', 'test'].includes(environment),
   },
   environment,
   sentry: {

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -9,6 +9,7 @@ import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { parseNaturalNumber } from '../../../utils/formUtils'
+import config from '../../../config'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -54,7 +55,9 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const newPremises: NewPremises = {
         characteristicIds: [],
-        turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
+        turnaroundWorkingDayCount: config.flags.turnaroundsDisabled
+          ? parseNaturalNumber(req.body.turnaroundWorkingDayCount)
+          : null,
         ...req.body,
       }
 
@@ -109,7 +112,9 @@ export default class PremisesController {
 
       const updatePremises: UpdatePremises = {
         characteristicIds: [],
-        turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
+        turnaroundWorkingDayCount: config.flags.turnaroundsDisabled
+          ? parseNaturalNumber(req.body.turnaroundWorkingDayCount)
+          : null,
         ...req.body,
       }
 

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -8,6 +8,7 @@ import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/
 import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { parseNaturalNumber } from '../../../utils/formUtils'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -53,6 +54,7 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const newPremises: NewPremises = {
         characteristicIds: [],
+        turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
         ...req.body,
       }
 
@@ -107,6 +109,7 @@ export default class PremisesController {
 
       const updatePremises: UpdatePremises = {
         characteristicIds: [],
+        turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
         ...req.body,
       }
 

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -98,6 +98,9 @@
     },
     "status": {
       "empty": "You must choose a status"
+    },
+    "turnaroundWorkingDayCount": {
+      "isNotAPositiveInteger": "The expected turnaround time must be a positive number"
     }
   },
   "bookingCancellation": {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -310,6 +310,7 @@ describe('PremisesService', () => {
         probationDeliveryUnit: pduFactory.build({ name: 'A PDU' }),
         status: 'active',
         notes: 'Some notes',
+        turnaroundWorkingDayCount: 2,
       })
 
       premisesClient.find.mockResolvedValue(premises)
@@ -353,6 +354,10 @@ describe('PremisesService', () => {
             {
               key: { text: 'Notes' },
               value: { html: 'Some notes' },
+            },
+            {
+              key: { text: 'Expected turnaround time' },
+              value: { text: '2 working days' },
             },
           ],
         },

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -14,6 +14,7 @@ import { CallConfig } from '../data/restClient'
 import { filterCharacteristics, formatCharacteristics } from '../utils/characteristicUtils'
 import { statusTag } from '../utils/premisesUtils'
 import { escape, formatLines } from '../utils/viewUtils'
+import config from '../config'
 
 export type PremisesReferenceData = {
   localAuthorities: Array<LocalAuthorityArea>
@@ -153,46 +154,47 @@ export default class PremisesService {
       .filter(line => line && line !== '')
       .map(line => escape(line))
 
-    return {
-      rows: [
-        {
-          key: this.textValue('Address'),
-          value: this.htmlValue(addressLines.join('<br />')),
-        },
-        {
-          key: this.textValue('Local authority'),
-          value: this.textValue(premises.localAuthorityArea?.name),
-        },
-        {
-          key: this.textValue('Probation region'),
-          value: this.textValue(premises.probationRegion.name),
-        },
-        {
-          key: this.textValue('PDU'),
-          value: this.textValue(premises.probationDeliveryUnit.name),
-        },
-        {
-          key: this.textValue('Attributes'),
-          value: formatCharacteristics(premises.characteristics),
-        },
-        {
-          key: this.textValue('Status'),
-          value: this.htmlValue(statusTag(premises.status)),
-        },
-        {
-          key: this.textValue('Notes'),
-          value: this.htmlValue(formatLines(premises.notes)),
-        },
-        {
-          key: this.textValue('Expected turnaround time'),
-          value: this.textValue(
-            `${premises.turnaroundWorkingDayCount} working ${
-              premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'
-            }`,
-          ),
-        },
-      ],
+    const rows = [
+      {
+        key: this.textValue('Address'),
+        value: this.htmlValue(addressLines.join('<br />')),
+      },
+      {
+        key: this.textValue('Local authority'),
+        value: this.textValue(premises.localAuthorityArea?.name),
+      },
+      {
+        key: this.textValue('Probation region'),
+        value: this.textValue(premises.probationRegion.name),
+      },
+      {
+        key: this.textValue('PDU'),
+        value: this.textValue(premises.probationDeliveryUnit.name),
+      },
+      {
+        key: this.textValue('Attributes'),
+        value: formatCharacteristics(premises.characteristics),
+      },
+      {
+        key: this.textValue('Status'),
+        value: this.htmlValue(statusTag(premises.status)),
+      },
+      {
+        key: this.textValue('Notes'),
+        value: this.htmlValue(formatLines(premises.notes)),
+      },
+    ]
+
+    if (!config.flags.turnaroundsDisabled) {
+      rows.push({
+        key: this.textValue('Expected turnaround time'),
+        value: this.textValue(
+          `${premises.turnaroundWorkingDayCount} working ${premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'}`,
+        ),
+      })
     }
+
+    return { rows }
   }
 
   private textValue(value: string) {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -183,6 +183,14 @@ export default class PremisesService {
           key: this.textValue('Notes'),
           value: this.htmlValue(formatLines(premises.notes)),
         },
+        {
+          key: this.textValue('Expected turnaround time'),
+          value: this.textValue(
+            `${premises.turnaroundWorkingDayCount} working ${
+              premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'
+            }`,
+          ),
+        },
       ],
     }
   }

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -34,6 +34,7 @@ import oasysSelectionFactory from './oasysSelection'
 import pduFactory from './pdu'
 import personFactory from './person'
 import premisesFactory from './premises'
+import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import probationRegionFactory from './probationRegion'
 import referenceDataFactory from './referenceData'
@@ -108,4 +109,5 @@ export {
   bookingSearchResultBedSummaryFactory,
   bookingSearchResultFactory,
   bookingSearchResultsFactory,
+  premisesSummaryFactory,
 }

--- a/server/testutils/factories/newPremises.ts
+++ b/server/testutils/factories/newPremises.ts
@@ -31,4 +31,5 @@ export default NewPremisesFactory.define(() => ({
   probationDeliveryUnitId: referenceDataFactory.pdu().build().id,
   status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
+  turnaroundWorkingDayCount: faker.datatype.number({ min: 1, max: 5 }),
 }))

--- a/server/testutils/factories/premises.ts
+++ b/server/testutils/factories/premises.ts
@@ -76,6 +76,7 @@ export default PremisesFactory.define(() => {
     ),
     status: faker.helpers.arrayElement(['active', 'archived'] as const),
     notes: faker.lorem.lines(5),
+    turnaroundWorkingDayCount: faker.datatype.number({ min: 1, max: 5 }),
   }
 })
 

--- a/server/testutils/factories/premisesSummary.ts
+++ b/server/testutils/factories/premisesSummary.ts
@@ -1,0 +1,18 @@
+/* istanbul ignore file */
+
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { Factory } from 'fishery'
+import type { TemporaryAccommodationPremisesSummary as PremisesSummary } from '@approved-premises/api'
+import referenceDataFactory from './referenceData'
+
+export default Factory.define<PremisesSummary>(() => ({
+  id: faker.datatype.uuid(),
+  name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  addressLine1: faker.address.streetAddress(),
+  addressLine2: faker.address.secondaryAddress(),
+  town: faker.address.cityName(),
+  postcode: faker.address.zipCode(),
+  bedCount: 50,
+  status: faker.helpers.arrayElement(['active', 'archived'] as const),
+  pdu: referenceDataFactory.pdu().build().id,
+}))

--- a/server/testutils/factories/updatePremises.ts
+++ b/server/testutils/factories/updatePremises.ts
@@ -30,4 +30,5 @@ export default UpdatePremisesFactory.define(() => ({
   probationDeliveryUnitId: referenceDataFactory.pdu().build().id,
   status: faker.helpers.arrayElement(['active', 'archived'] as const),
   notes: faker.lorem.lines(),
+  turnaroundWorkingDayCount: faker.datatype.number({ min: 1, max: 5 }),
 }))

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -154,4 +154,5 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('TasklistUtils', TasklistUtils)
   njkEnv.addGlobal('OasysImportUtils', OasysImportUtils)
   njkEnv.addGlobal('AttachDocumentsUtils', AttachDocumentsUtils)
+  njkEnv.addGlobal('turnaroundsDisabled', config.flags.turnaroundsDisabled)
 }

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -163,6 +163,24 @@
   }, fetchContext()
 ) }}
 
+{{ taInput(
+  {
+    label: {
+      text: "Enter the number of working days required to turnaround the property. The standard turnaround time should be 2 days",
+      classes: "govuk-label--m"
+    },
+    classes: "govuk-input--width-3",
+    fieldName: "turnaroundWorkingDayCount",
+    hint: {
+      text: "Weekends and bank holidays will be automatically added to the turnaround time"
+    },
+    suffix: {
+    text: "working days"
+    }
+  },
+  fetchContext()
+) }}
+
 {{ govukButton({
   text: "Submit",
   preventDoubleClick: true

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -163,6 +163,8 @@
   }, fetchContext()
 ) }}
 
+{% if not config.turnaroundsDisabled %}
+
 {{ taInput(
   {
     label: {
@@ -180,6 +182,8 @@
   },
   fetchContext()
 ) }}
+
+{% endif %}
 
 {{ govukButton({
   text: "Submit",

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -11,6 +11,7 @@ import {
   dateCapacityFactory,
   lostBedFactory,
   premisesFactory,
+  premisesSummaryFactory,
   staffMemberFactory,
 } from '../server/testutils/factories'
 import premisesJson from './stubs/premises.json'
@@ -42,17 +43,21 @@ const premises = premisesJson.map(item => {
   return premisesFactory.build({ ...(item as DeepPartial<ApprovedPremises>) })
 })
 
+const premisesSummaries = premisesJson.map(item => {
+  return premisesSummaryFactory.build({ ...item })
+})
+
 stubs.push({
   request: {
     method: 'GET',
-    urlPath: '/premises',
+    urlPath: '/premises/summary',
   },
   response: {
     status: 200,
     headers: {
       'Content-Type': 'application/json;charset=UTF-8',
     },
-    jsonBody: premises,
+    jsonBody: premisesSummaries,
   },
 })
 


### PR DESCRIPTION
# Changes in this PR

This PR allows users to set, update and view the turnaround time for a premises. For now the changes are hidden behind a feature flag in prod, whilst we await full support for turnaround features in the UI and API.

I have also added the new premises summary endpoint to Wiremock, and created a premises summary factory, to allow continued local development against Wiremock.

## Screenshots of UI changes

### Before

![Screenshot 2023-05-03 at 10 35 50](https://user-images.githubusercontent.com/70749355/235881973-86f64490-87d0-4e15-aa84-af4d900df7b9.png)

![Screenshot 2023-05-03 at 10 38 20](https://user-images.githubusercontent.com/70749355/235882205-a7890d77-e17a-45a6-9b7a-758b45cd2e5d.png)

### After

![Screenshot 2023-05-03 at 10 35 32](https://user-images.githubusercontent.com/70749355/235881998-cb8624ab-2c98-4e81-b5ee-acf9c264c865.png)

![Screenshot 2023-05-03 at 10 37 57](https://user-images.githubusercontent.com/70749355/235882124-9ca8499e-c665-49cd-a82a-6a1c71a183e8.png)

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
