### PR TITLE
Display turnaround information on new booking page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -1,5 +1,5 @@
 import type { NewBooking } from '@approved-premises/api'
-import { Premises, Room } from '../../../../server/@types/shared'
+import { TemporaryAccommodationPremises as Premises, Room } from '../../../../server/@types/shared'
 import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -8,7 +8,7 @@ import BookingEditablePage from './bookingEditable'
 export default class BookingNewPage extends BookingEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-  constructor(premises: Premises, room: Room) {
+  constructor(private readonly premises: Premises, room: Room) {
     super('Book bedspace', premises, room)
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
@@ -34,6 +34,13 @@ export default class BookingNewPage extends BookingEditablePage {
 
   shouldShowBookingDetails(): void {
     this.locationHeaderComponent.shouldShowLocationDetails()
+
+    cy.get('p').should(
+      'contain',
+      `There will be a turnaround time of ${this.premises.turnaroundWorkingDayCount} working ${
+        this.premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'
+      } after this booking`,
+    )
   }
 
   shouldShowPrefilledBookingDetails(newBooking: NewBooking): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -1,9 +1,9 @@
 import type { NewBooking } from '@approved-premises/api'
 import { Premises, Room } from '../../../../server/@types/shared'
+import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import BookingEditablePage from './bookingEditable'
-import errorLookups from '../../../../server/i18n/en/errors.json'
 
 export default class BookingNewPage extends BookingEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent

--- a/server/views/temporary-accommodation/bookings/_editable.njk
+++ b/server/views/temporary-accommodation/bookings/_editable.njk
@@ -51,6 +51,10 @@
   )
 }}
 
+{% if not disableTurnarounds %}
+  <p>There will be a turnaround time of {{ premises.turnaroundWorkingDayCount }} working {{ 'day' if premises.turnaroundWorkingDayCount === 1 else 'days' }} after this booking</p>
+{% endif %}
+
 {{ govukButton({
   text: "Continue",
   preventDoubleClick: true


### PR DESCRIPTION
# Changes in this PR

Display turnaround information on new booking page, hidden behind the `disableTurnarouds` feature flag

## Screenshots of UI changes

### Before
![localhost_3000_properties_05d0b115-467c-483d-8482-95bbbbb0fa80_bedspaces_b0a94d0f-f408-4108-a948-74b50fc3f13f_bookings_new (1)](https://user-images.githubusercontent.com/94137563/235679277-22c0f922-9802-41c7-874b-a570711e4a29.png)

### After
![localhost_3000_properties_05d0b115-467c-483d-8482-95bbbbb0fa80_bedspaces_b0a94d0f-f408-4108-a948-74b50fc3f13f_bookings_new](https://user-images.githubusercontent.com/94137563/235679297-fa9570f1-4d71-45a1-b0e1-96a533c19f28.png)

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
