### PR TITLE
Fix types in PremiesClient

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesList.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesList.ts
@@ -1,4 +1,7 @@
-import type { TemporaryAccommodationPremises as Premises } from '@approved-premises/api'
+import type {
+  TemporaryAccommodationPremises as Premises,
+  TemporaryAccommodationPremisesSummary as PremisesSummary,
+} from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { premisesFactory } from '../../../../server/testutils/factories'
@@ -52,7 +55,7 @@ export default class PremisesListPage extends Page {
       )
   }
 
-  shouldShowPremises(premises: Array<Premises>): void {
+  shouldShowPremises(premises: Array<PremisesSummary>): void {
     premises.forEach((item: Premises) => {
       const shortAddress = `${item.addressLine1}, ${item.postcode}`
 

--- a/integration_tests/mockApis/premises.ts
+++ b/integration_tests/mockApis/premises.ts
@@ -1,6 +1,13 @@
 import type { Response, SuperAgentRequest } from 'superagent'
 
-import type { Booking, DateCapacity, Premises, Room, StaffMember } from '@approved-premises/api'
+import type {
+  Booking,
+  DateCapacity,
+  Premises,
+  TemporaryAccommodationPremisesSummary as PremisesSummary,
+  Room,
+  StaffMember,
+} from '@approved-premises/api'
 
 import paths from '../../server/paths/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
@@ -9,7 +16,7 @@ import { errorStub } from '../../wiremock/utils'
 import bookingStubs from './booking'
 import roomStubs from './room'
 
-const stubPremises = (premises: Array<Premises>) =>
+const stubPremises = (premisesSummaries: Array<PremisesSummary>) =>
   stubFor({
     request: {
       method: 'GET',
@@ -20,7 +27,7 @@ const stubPremises = (premises: Array<Premises>) =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: premises,
+      jsonBody: premisesSummaries,
     },
   })
 

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -8,6 +8,7 @@ import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
 import {
   newPremisesFactory,
   premisesFactory,
+  premisesSummaryFactory,
   roomFactory,
   updatePremisesFactory,
 } from '../../../../server/testutils/factories'
@@ -23,8 +24,8 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    cy.task('stubPremises', premisesSummaries)
 
     // When I visit the dashboard page
     const page = DashboardPage.visit()
@@ -41,14 +42,14 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    cy.task('stubPremises', premisesSummaries)
 
     // When I visit the premises page
     const page = PremisesListPage.visit()
 
     // Then I should see all of the premises listed
-    page.shouldShowPremises(premises)
+    page.shouldShowPremises(premisesSummaries)
   })
 
   it('should navigate back from the premises list page to the dashboard', () => {
@@ -56,8 +57,8 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    cy.task('stubPremises', premisesSummaries)
 
     // When I visit the premises list page
     const page = PremisesListPage.visit()
@@ -74,8 +75,8 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    cy.task('stubPremises', premisesSummaries)
 
     // And there is reference data in the database
     cy.task('stubPremisesReferenceData')
@@ -95,18 +96,20 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
-    cy.task('stubSinglePremises', premises[0])
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    const singlePremises = premisesFactory.build({ ...premisesSummaries[0] })
+
+    cy.task('stubPremises', premisesSummaries)
+    cy.task('stubSinglePremises', singlePremises)
 
     // When I visit the premises page
     const page = PremisesListPage.visit()
 
     // Add I click the view a premises link
-    page.clickPremisesViewLink(premises[0])
+    page.clickPremisesViewLink(singlePremises)
 
     // Then I navigate to the show premises page
-    Page.verifyOnPage(PremisesShowPage, premises[0])
+    Page.verifyOnPage(PremisesShowPage, singlePremises)
   })
 
   it('should navigate to the edit premises page', () => {
@@ -217,8 +220,8 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    cy.task('stubPremises', premisesSummaries)
 
     // And there is reference data in the database
     cy.task('stubPremisesReferenceData')
@@ -382,12 +385,13 @@ context('Premises', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
-    cy.task('stubSinglePremises', premises[0])
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    const singlePremises = premisesFactory.build({ ...premisesSummaries[0] })
+    cy.task('stubPremises', premisesSummaries)
+    cy.task('stubSinglePremises', singlePremises)
 
     // When I visit the show premises page
-    const page = PremisesShowPage.visit(premises[0])
+    const page = PremisesShowPage.visit(singlePremises)
 
     // And I click the previous bread crumb
     page.clickBreadCrumbUp()

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -3,7 +3,7 @@ import Page from '../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import BookingReportNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingReportNew'
 import setupTestUser from '../../../../cypress_shared/utils/setupTestUser'
-import { premisesFactory } from '../../../../server/testutils/factories'
+import { premisesSummaryFactory } from '../../../../server/testutils/factories'
 import { bookingReportForProbationRegionFilename } from '../../../../server/utils/reportUtils'
 
 context('Report', () => {
@@ -107,8 +107,8 @@ context('Report', () => {
     cy.signIn()
 
     // And there are premises in the database
-    const premises = premisesFactory.buildList(5)
-    cy.task('stubPremises', premises)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
+    cy.task('stubPremises', premisesSummaries)
 
     // When I visit the show premises page
     cy.task('stubBookingReportReferenceData')

--- a/server/data/premisesClient.test.ts
+++ b/server/data/premisesClient.test.ts
@@ -6,6 +6,7 @@ import {
   dateCapacityFactory,
   newPremisesFactory,
   premisesFactory,
+  premisesSummaryFactory,
   staffMemberFactory,
   updatePremisesFactory,
 } from '../testutils/factories'
@@ -34,16 +35,16 @@ describe('PremisesClient', () => {
   })
 
   describe('all', () => {
-    const premises = premisesFactory.buildList(5)
+    const premisesSummaries = premisesSummaryFactory.buildList(5)
 
     it('should get all premises for the given service', async () => {
       fakeApprovedPremisesApi
         .get(paths.premises.index({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .reply(200, premises)
+        .reply(200, premisesSummaries)
 
       const output = await premisesClient.all()
-      expect(output).toEqual(premises)
+      expect(output).toEqual(premisesSummaries)
     })
   })
 

--- a/server/data/premisesClient.ts
+++ b/server/data/premisesClient.ts
@@ -2,6 +2,7 @@ import type {
   DateCapacity,
   NewPremises,
   TemporaryAccommodationPremises as Premises,
+  TemporaryAccommodationPremisesSummary as PremisesSummary,
   StaffMember,
   UpdatePremises,
 } from '@approved-premises/api'
@@ -16,8 +17,8 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async all(): Promise<Array<Premises>> {
-    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<Premises>
+  async all(): Promise<Array<PremisesSummary>> {
+    return (await this.restClient.get({ path: paths.premises.index({}) })) as Array<PremisesSummary>
   }
 
   async find(id: string): Promise<Premises> {

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -8,6 +8,7 @@ import {
   newPremisesFactory,
   pduFactory,
   premisesFactory,
+  premisesSummaryFactory,
   probationRegionFactory,
   staffMemberFactory,
   updatePremisesFactory,
@@ -115,12 +116,12 @@ describe('PremisesService', () => {
 
   describe('tableRows', () => {
     it('returns a sorted table view of the premises for Temporary Accommodation', async () => {
-      const premises1 = premisesFactory.build({ addressLine1: 'ABC', postcode: '123' })
-      const premises2 = premisesFactory.build({ addressLine1: 'GHI', postcode: '123' })
-      const premises3 = premisesFactory.build({ addressLine1: 'GHI', postcode: '456' })
-      const premises4 = premisesFactory.build({ addressLine1: 'XYZ', postcode: '123' })
+      const premisesSummary1 = premisesSummaryFactory.build({ addressLine1: 'ABC', postcode: '123' })
+      const premisesSummary2 = premisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '123' })
+      const premisesSummary3 = premisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '456' })
+      const premisesSummary4 = premisesSummaryFactory.build({ addressLine1: 'XYZ', postcode: '123' })
 
-      const premises = [premises4, premises1, premises3, premises2]
+      const premises = [premisesSummary4, premisesSummary1, premisesSummary3, premisesSummary2]
       premisesClient.all.mockResolvedValue(premises)
       ;(statusTag as jest.MockedFunction<typeof statusTag>).mockImplementation(status => `<strong>${status}</strong>`)
 
@@ -132,17 +133,17 @@ describe('PremisesService', () => {
             text: 'ABC, 123',
           },
           {
-            text: premises1.bedCount.toString(),
+            text: premisesSummary1.bedCount.toString(),
           },
           {
-            text: premises1.probationDeliveryUnit.name,
+            text: premisesSummary1.pdu,
           },
           {
-            html: `<strong>${premises1.status}</strong>`,
+            html: `<strong>${premisesSummary1.status}</strong>`,
           },
           {
             html: `<a href="${paths.premises.show({
-              premisesId: premises1.id,
+              premisesId: premisesSummary1.id,
             })}">Manage<span class="govuk-visually-hidden"> ABC, 123</span></a>`,
           },
         ],
@@ -151,17 +152,17 @@ describe('PremisesService', () => {
             text: 'GHI, 123',
           },
           {
-            text: premises2.bedCount.toString(),
+            text: premisesSummary2.bedCount.toString(),
           },
           {
-            text: premises2.probationDeliveryUnit.name,
+            text: premisesSummary2.pdu,
           },
           {
-            html: `<strong>${premises2.status}</strong>`,
+            html: `<strong>${premisesSummary2.status}</strong>`,
           },
           {
             html: `<a href="${paths.premises.show({
-              premisesId: premises2.id,
+              premisesId: premisesSummary2.id,
             })}">Manage<span class="govuk-visually-hidden"> GHI, 123</span></a>`,
           },
         ],
@@ -170,17 +171,17 @@ describe('PremisesService', () => {
             text: 'GHI, 456',
           },
           {
-            text: premises3.bedCount.toString(),
+            text: premisesSummary3.bedCount.toString(),
           },
           {
-            text: premises3.probationDeliveryUnit.name,
+            text: premisesSummary3.pdu,
           },
           {
-            html: `<strong>${premises3.status}</strong>`,
+            html: `<strong>${premisesSummary3.status}</strong>`,
           },
           {
             html: `<a href="${paths.premises.show({
-              premisesId: premises3.id,
+              premisesId: premisesSummary3.id,
             })}">Manage<span class="govuk-visually-hidden"> GHI, 456</span></a>`,
           },
         ],
@@ -189,17 +190,17 @@ describe('PremisesService', () => {
             text: 'XYZ, 123',
           },
           {
-            text: premises4.bedCount.toString(),
+            text: premisesSummary4.bedCount.toString(),
           },
           {
-            text: premises4.probationDeliveryUnit.name,
+            text: premisesSummary4.pdu,
           },
           {
-            html: `<strong>${premises4.status}</strong>`,
+            html: `<strong>${premisesSummary4.status}</strong>`,
           },
           {
             html: `<a href="${paths.premises.show({
-              premisesId: premises4.id,
+              premisesId: premisesSummary4.id,
             })}">Manage<span class="govuk-visually-hidden"> XYZ, 123</span></a>`,
           },
         ],

--- a/wiremock/stubApis.ts
+++ b/wiremock/stubApis.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-console */
 import { DeepPartial } from 'fishery'
 
-import type { ApprovedPremises } from '@approved-premises/api'
+import type { TemporaryAccommodationPremises } from '@approved-premises/api'
 import { bulkStub } from './index'
 
 import {
@@ -40,7 +40,7 @@ import { errorStub, getCombinations } from './utils'
 const stubs = []
 
 const premises = premisesJson.map(item => {
-  return premisesFactory.build({ ...(item as DeepPartial<ApprovedPremises>) })
+  return premisesFactory.build({ ...(item as DeepPartial<TemporaryAccommodationPremises>) })
 })
 
 const premisesSummaries = premisesJson.map(item => {


### PR DESCRIPTION
# Changes in this PR

Fixes the return type of PremisesClient.all()

# Release checklist

[Release process
documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually
  approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
