### PR TITLE
Update booking report form to require month and year

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingReportNew.ts
@@ -23,7 +23,17 @@ export default class BookingReportNewPage extends Page {
       .should('be.selected')
   }
 
+  completeForm(month: string, year: string): void {
+    this.getLabel('Month')
+    this.getSelectInputByIdAndSelectAnEntry('month', month)
+
+    this.getLabel('Year')
+    this.getSelectInputByIdAndSelectAnEntry('year', year)
+  }
+
   clearForm(): void {
     this.getSelectInputByIdAndSelectAnEntry('probationRegionId', '')
+    this.getSelectInputByIdAndSelectAnEntry('month', '')
+    this.getSelectInputByIdAndSelectAnEntry('year', '')
   }
 }

--- a/e2e/tests/report.feature
+++ b/e2e/tests/report.feature
@@ -9,5 +9,5 @@ Feature: Manage Temporary Accommodation - Report
 
     Scenario: Showing report download errors
         Given I'm downloading a booking report
-        And I clear the preselected probation region and attempt to download a report
+        And I clear the form and attempt to download a report
         Then I should see a list of the problems encountered downloading the report

--- a/e2e/tests/stepDefinitions/manage/bookingReport.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingReport.ts
@@ -26,21 +26,24 @@ Given('I download a report for the preselected probation region', () => {
     id: actingUserProbationRegionId,
     name: actingUserProbationRegionName,
   })
+  const month = '1'
+  const year = '2023'
 
   bookingReportPage.shouldPreselectProbationRegion(probationRegion)
+  bookingReportPage.completeForm(month, year)
   bookingReportPage.expectDownload(10000)
   bookingReportPage.clickSubmit()
 
-  cy.wrap(bookingReportForProbationRegionFilename(probationRegion)).as('filename')
+  cy.wrap(bookingReportForProbationRegionFilename(probationRegion, month, year)).as('filename')
 })
 
-Given('I clear the preselected probation region and attempt to download a report', () => {
+Given('I clear the form and attempt to download a report', () => {
   const bookingReportPage = Page.verifyOnPage(BookingReportNewPage)
 
   bookingReportPage.clearForm()
   bookingReportPage.clickSubmit()
 
-  cy.wrap(['probationRegionId']).as('missing')
+  cy.wrap(['probationRegionId', 'month', 'year']).as('missing')
 })
 
 Then('I should download a booking report', () => {

--- a/integration_tests/mockApis/report.ts
+++ b/integration_tests/mockApis/report.ts
@@ -17,7 +17,7 @@ export default {
         body: data,
       },
     }),
-  stubBookingReportError: (args: { data: string; probationRegionId: string }) =>
+  stubBookingReportError: (args: { data: string; probationRegionId: string; month: string; year: string }) =>
     stubFor({
       request: {
         method: 'GET',
@@ -26,6 +26,12 @@ export default {
           probationRegionId: {
             equalTo: args.probationRegionId,
           },
+          month: {
+            equalTo: args.month,
+          },
+          year: {
+            equalTo: args.year,
+          },
         },
       },
       response: {
@@ -33,7 +39,7 @@ export default {
         body: args.data,
       },
     }),
-  stubBookingReportForRegion: (args: { data: string; probationRegionId: string }) =>
+  stubBookingReportForRegion: (args: { data: string; probationRegionId: string; month: string; year: string }) =>
     stubFor({
       request: {
         method: 'GET',
@@ -59,14 +65,20 @@ export default {
         url: api.reports.bookings({}),
       })
     ).body.requests,
-  verifyBookingReportForRegion: async (probationRegionId: string) =>
+  verifyBookingReportForRegion: async (args: { probationRegionId: string; month: string; year: string }) =>
     (
       await getMatchingRequests({
         method: 'GET',
         urlPath: api.reports.bookings({}),
         queryParameters: {
           probationRegionId: {
-            equalTo: probationRegionId,
+            equalTo: args.probationRegionId,
+          },
+          month: {
+            equalTo: args.month,
+          },
+          year: {
+            equalTo: args.year,
           },
         },
       })

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -41,7 +41,17 @@ context('Report', () => {
     // And I fill out the form
     cy.then(function _() {
       const probationRegion = this.actingUserProbationRegion
-      cy.task('stubBookingReportError', { data: 'some-data', probationRegionId: probationRegion.id })
+      const month = '3'
+      const year = '2023'
+
+      page.completeForm(month, year)
+
+      cy.task('stubBookingReportError', {
+        data: 'some-data',
+        probationRegionId: probationRegion.id,
+        month,
+        year,
+      })
     })
 
     page.expectDownload()
@@ -64,20 +74,24 @@ context('Report', () => {
 
       // And when I fill out the form
       const probationRegion = this.actingUserProbationRegion
+      const month = '3'
+      const year = '2023'
 
-      cy.task('stubBookingReportForRegion', { data: 'some-data', probationRegionId: probationRegion.id })
+      page.completeForm(month, year)
+
+      cy.task('stubBookingReportForRegion', { data: 'some-data', probationRegionId: probationRegion.id, month, year })
       page.expectDownload()
       page.clickSubmit()
 
       // Then a report should have been requested from the API
-      cy.task('verifyBookingReportForRegion', probationRegion.id).then(requests => {
+      cy.task('verifyBookingReportForRegion', { probationRegionId: probationRegion.id, month, year }).then(requests => {
         expect(requests).to.have.length(1)
       })
 
       // And the report should be downloded
       const filePath = path.join(
         Cypress.config('downloadsFolder'),
-        bookingReportForProbationRegionFilename(probationRegion),
+        bookingReportForProbationRegionFilename(probationRegion, month, year),
       )
 
       cy.readFile(filePath).then(file => {
@@ -86,7 +100,7 @@ context('Report', () => {
     })
   })
 
-  it('should show an error when the user does not select a probation region', () => {
+  it('should show an error when the user does not select required fields', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -99,7 +113,7 @@ context('Report', () => {
     page.clickSubmit()
 
     // Then I should see an messages relating to the probation region
-    page.shouldShowErrorMessagesForFields(['probationRegionId'])
+    page.shouldShowErrorMessagesForFields(['probationRegionId', 'month', 'year'])
   })
 
   it('navigates back from the booking report page to the dashboard page', () => {

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -33,14 +33,18 @@ describe('ReportClient', () => {
     it('pipes all bookings to an express response', async () => {
       const data = 'some-data'
 
+      const year = '2023'
+      const month = '3'
+
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .query({ year, month })
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
 
-      await reportClient.bookings(response, 'some-filename')
+      await reportClient.bookings(response, 'some-filename', month, year)
 
       expect(response.write).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
       expect(response.set).toHaveBeenCalledWith({
@@ -54,14 +58,18 @@ describe('ReportClient', () => {
     it('pipes all bookings to an express response', async () => {
       const data = 'some-data'
 
+      const year = '2024'
+      const month = '0'
+
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .query({ year, month })
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
 
-      await reportClient.bookings(response, 'some-filename')
+      await reportClient.bookings(response, 'some-filename', month, year)
 
       expect(response.write).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
       expect(response.set).toHaveBeenCalledWith({
@@ -76,16 +84,18 @@ describe('ReportClient', () => {
       const probationRegion = probationRegionFactory.build()
 
       const data = 'some-data'
+      const year = '2020'
+      const month = '1'
 
       fakeApprovedPremisesApi
         .get(paths.reports.bookings({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .query({ probationRegionId: probationRegion.id })
+        .query({ probationRegionId: probationRegion.id, year, month })
         .reply(200, data, { 'content-type': 'some-content-type' })
 
       const response = createMock<Response>()
 
-      await reportClient.bookingsForProbationRegion(response, 'some-filename', probationRegion.id)
+      await reportClient.bookingsForProbationRegion(response, 'some-filename', probationRegion.id, month, year)
 
       expect(response.write).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
       expect(response.set).toHaveBeenCalledWith({

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -10,11 +10,25 @@ export default class ReportClient {
     this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async bookings(response: Response, filename: string): Promise<void> {
-    await this.restClient.pipe(response, { path: paths.reports.bookings({}), filename })
+  async bookings(response: Response, filename: string, month: string, year: string): Promise<void> {
+    await this.restClient.pipe(response, {
+      path: paths.reports.bookings({}),
+      query: { year, month },
+      filename,
+    })
   }
 
-  async bookingsForProbationRegion(response: Response, filename: string, probationRegionId: string): Promise<void> {
-    await this.restClient.pipe(response, { path: paths.reports.bookings({}), query: { probationRegionId }, filename })
+  async bookingsForProbationRegion(
+    response: Response,
+    filename: string,
+    probationRegionId: string,
+    month: string,
+    year: string,
+  ): Promise<void> {
+    await this.restClient.pipe(response, {
+      path: paths.reports.bookings({}),
+      query: { probationRegionId, year, month },
+      filename,
+    })
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -109,6 +109,12 @@
       "expectedNumber": "You must enter a turnaround time in days",
       "isNotAPositiveInteger": "You must enter a turnaround time of at least one day",
       "conflict": "This bedspace is not available for this turnaround time"
+    },
+    "month": {
+      "empty": "You must choose a month"
+    },
+    "year": {
+      "empty": "You must choose a year"
     }
   },
   "bookingCancellation": {

--- a/server/services/bookingReportService.test.ts
+++ b/server/services/bookingReportService.test.ts
@@ -32,12 +32,14 @@ describe('BookingReportService', () => {
     it('pipes all bookings to an express response, for download as a file', async () => {
       const response = createMock<Response>()
       ;(bookingReportFilename as jest.MockedFunction<typeof bookingReportFilename>).mockReturnValue('some-filename')
+      const month = '1'
+      const year = '2023'
 
-      await service.pipeBookings(callConfig, response)
+      await service.pipeBookings(callConfig, response, month, year)
 
       expect(ReportClientFactory).toHaveBeenCalledWith(callConfig)
       expect(bookingReportFilename).toHaveBeenCalled()
-      expect(reportClient.bookings).toHaveBeenCalledWith(response, 'some-filename')
+      expect(reportClient.bookings).toHaveBeenCalledWith(response, 'some-filename', month, year)
     })
   })
 
@@ -49,15 +51,19 @@ describe('BookingReportService', () => {
       ;(
         bookingReportForProbationRegionFilename as jest.MockedFunction<typeof bookingReportForProbationRegionFilename>
       ).mockReturnValue('some-filename')
+      const month = '1'
+      const year = '2023'
 
-      await service.pipeBookingsForProbationRegion(callConfig, response, probationRegions[0].id)
+      await service.pipeBookingsForProbationRegion(callConfig, response, probationRegions[0].id, month, year)
 
       expect(ReportClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(bookingReportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0])
+      expect(bookingReportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0], month, year)
       expect(reportClient.bookingsForProbationRegion).toHaveBeenCalledWith(
         response,
         'some-filename',
         probationRegions[0].id,
+        month,
+        year,
       )
     })
   })

--- a/server/services/bookingReportService.ts
+++ b/server/services/bookingReportService.ts
@@ -15,18 +15,20 @@ export default class BookingReportService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async pipeBookings(callConfig: CallConfig, response: Response): Promise<void> {
+  async pipeBookings(callConfig: CallConfig, response: Response, month: string, year: string): Promise<void> {
     const reportClient = this.reportClientFactory(callConfig)
 
     const filename = bookingReportFilename()
 
-    await reportClient.bookings(response, filename)
+    await reportClient.bookings(response, filename, month, year)
   }
 
   async pipeBookingsForProbationRegion(
     callConfig: CallConfig,
     response: Response,
     probationRegionId: string,
+    month: string,
+    year: string,
   ): Promise<void> {
     const reportClient = this.reportClientFactory(callConfig)
 
@@ -34,9 +36,9 @@ export default class BookingReportService {
       region => region.id === probationRegionId,
     )
 
-    const filename = bookingReportForProbationRegionFilename(probationRegion)
+    const filename = bookingReportForProbationRegionFilename(probationRegion, month, year)
 
-    await reportClient.bookingsForProbationRegion(response, filename, probationRegionId)
+    await reportClient.bookingsForProbationRegion(response, filename, probationRegionId, month, year)
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<BookingReportReferenceData> {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,5 +1,11 @@
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { DateFormats, InvalidDateStringError, dateAndTimeInputsAreValidDates, dateIsBlank } from './dateUtils'
+import {
+  DateFormats,
+  InvalidDateStringError,
+  dateAndTimeInputsAreValidDates,
+  dateIsBlank,
+  getYearsSince,
+} from './dateUtils'
 
 describe('DateFormats', () => {
   describe('dateObjToIsoDate', () => {
@@ -222,5 +228,15 @@ describe('dateIsBlank', () => {
     }
 
     expect(dateIsBlank(date)).toEqual(true)
+  })
+})
+
+describe('getYearsSince', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2027-01-01'))
+
+  it('returns correct years array', () => {
+    const years = [{ year: '2023' }, { year: '2024' }, { year: '2025' }, { year: '2026' }, { year: '2027' }]
+
+    expect(getYearsSince(2023)).toEqual(years)
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -125,3 +125,27 @@ export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): 
 }
 
 export class InvalidDateStringError extends Error {}
+
+export const monthsArr = [
+  { name: 'January', value: '1' },
+  { name: 'February', value: '2' },
+  { name: 'March', value: '3' },
+  { name: 'April', value: '4' },
+  { name: 'May', value: '5' },
+  { name: 'June', value: '6' },
+  { name: 'July', value: '7' },
+  { name: 'August', value: '8' },
+  { name: 'September', value: '9' },
+  { name: 'October', value: '10' },
+  { name: 'November', value: '11' },
+  { name: 'December', value: '12' },
+]
+
+export const getYearsSince = (startYear: number): Array<{ year: string }> => {
+  let years = []
+  const thisYear = new Date().getFullYear()
+  while (startYear <= thisYear) {
+    years.push({ year: (startYear++).toString() })
+  }
+  return years
+}

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -1,6 +1,8 @@
 import { probationRegionFactory } from '../testutils/factories'
 import { bookingReportFilename, bookingReportForProbationRegionFilename } from './reportUtils'
 
+jest.mock('./validation')
+
 describe('reportUtils', () => {
   describe('bookingReportFilename', () => {
     it('returns a filename with the current date', () => {
@@ -17,11 +19,12 @@ describe('reportUtils', () => {
       const probationRegion = probationRegionFactory.build({
         name: 'Kent, Surrey & Sussex',
       })
-      jest.useFakeTimers().setSystemTime(new Date(2023, 2, 14))
+      const month = '3'
+      const year = '2023'
 
-      const result = bookingReportForProbationRegionFilename(probationRegion)
+      const result = bookingReportForProbationRegionFilename(probationRegion, month, year)
 
-      expect(result).toEqual('bookings-kent-surrey-sussex-14-mar-23.xlsx')
+      expect(result).toEqual('bookings-kent-surrey-sussex-march-2023.xlsx')
     })
   })
 })

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -1,5 +1,5 @@
 import { ProbationRegion } from '@approved-premises/api'
-import { DateFormats } from './dateUtils'
+import { DateFormats, monthsArr } from './dateUtils'
 
 const permittedFilenameCharacters = 'abcdefghijklmnopqrstuvwxyz01234567890 '
 
@@ -11,11 +11,16 @@ export const bookingReportFilename = () => {
   return `${filterFilename(concatenatedName)}.xlsx`
 }
 
-export const bookingReportForProbationRegionFilename = (probationRegion: ProbationRegion) => {
-  const date = DateFormats.dateObjtoUIDate(new Date(), { format: 'short' })
+export const bookingReportForProbationRegionFilename = (
+  probationRegion: ProbationRegion,
+  month: string,
+  year: string,
+) => {
   const regionName = probationRegion.name
 
-  const concatenatedName = `bookings ${regionName} ${date}`
+  const monthName = monthsArr.find(monthObj => monthObj.value === month).name
+
+  const concatenatedName = `bookings ${regionName} ${monthName} ${year}`
 
   return `${filterFilename(concatenatedName)}.xlsx`
 }

--- a/server/views/temporary-accommodation/reports/bookings/new.njk
+++ b/server/views/temporary-accommodation/reports/bookings/new.njk
@@ -34,6 +34,39 @@
           fetchContext()
         ) }}
 
+        <div class="govuk-grid-row">
+           <div class="govuk-grid-column-one-third">
+
+              {{ taSelect(
+                {
+                  label: {
+                    text: "Month",
+                    classes: "govuk-label--s"
+                  },
+                  items: convertObjectsToSelectOptions(months, 'Choose month', 'name', 'value', 'month'),
+                  fieldName: "month"
+                },
+                fetchContext()
+              ) }}
+
+           </div>
+           <div class="govuk-grid-column-one-third govuk-!-margin-left-5">
+
+            {{ taSelect(
+              {
+                label: {
+                  text: "Year",
+                  classes: "govuk-label--s"
+                },
+                items: convertObjectsToSelectOptions(years, 'Choose year', 'year', 'year', 'year'),
+                fieldName: "year"
+              },
+              fetchContext()
+            ) }}
+
+           </div>
+        </div>
+
         {{ govukButton({
           text: "Download report"
         }) }}


### PR DESCRIPTION
# Changes in this PR

This PR requires users to specify a month and year before downloading a booking report. Because of the existing method being used to pipe the response directly from the API, it is not practical to check for API errors, so we are validating the form input in the UI.

## Screenshots of UI changes

### Before

![Screenshot 2023-05-10 at 11 13 41](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/70749355/9aa5e128-56d7-488c-9b80-b633a5bc21d2)

### After

![Screenshot 2023-05-10 at 11 12 47](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/70749355/84a2890a-6f93-4c1f-b1c9-5ecba956faee)

![Screenshot 2023-05-10 at 11 13 01](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/70749355/68aa4c9b-c385-4ada-ae17-1026e7a7ecc7)


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
