### PR TITLE
Update type generation action to use an app

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -12,6 +12,12 @@ jobs:
   generate-types:
     runs-on: ubuntu-latest
     steps:
+      - name: Generate Token
+        uses: tibdex/github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.APP_PRIVATE_KEY }}
       - name: Check out code
         uses: actions/checkout@v3
       - name: Generate Types
@@ -19,7 +25,7 @@ jobs:
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@v5
         with:
-          token: ${{ secrets.OPEN_PR_ACCESS_TOKEN }}
+          token: ${{ steps.generate-token.outputs.token }}
           title: 'API model updates'
           commit-message: 'Updating hmpps-approved-premises-api models from OpenAPI specification'
           body: 'Updating hmpps-approved-premises-api models from OpenAPI specification.  This PR was created automatically from the generate-types.yml Workflow'


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

We currently use Stuart's PAT in a repository secret in this repo. The PAT token is tied to one person on the team which isn't ideal and it will eventually need to be rotated. It also means that Stuart can't approve these pull requests. Eg. https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/365

This updates the Type Generation action to use a Github App, as outlined here:

https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#authenticating-with-github-app-generated-tokens

This uses the app to generate a one-time usage token, which is more broad than the included `GITHUB_TOKEN`, so when the PR opens, the CI gets run.

Copied from https://github.com/ministryofjustice/hmpps-approved-premises-ui/commit/5b2ad74a7f12b08764698aeee9ac9ece0069b81c

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
