### PR TITLE
Fully remove turnarounds feature flag

### DIFF
--- a/server/components/bookingInfo.test.ts
+++ b/server/components/bookingInfo.test.ts
@@ -1,4 +1,3 @@
-import config from '../config'
 import { bookingFactory, cancellationFactory, extensionFactory } from '../testutils/factories'
 import { getLatestExtension, shortenedOrExtended, statusTag } from '../utils/bookingUtils'
 import { formatLines } from '../utils/viewUtils'
@@ -484,121 +483,74 @@ describe('BookingInfo', () => {
       expect(formatLines).toHaveBeenCalledWith(booking.departure.notes)
     })
 
-    describe('when turnarounds are enabled', () => {
-      beforeAll(() => {
-        config.flags.turnaroundsDisabled = false
+    it('returns summary list rows containing the turnaround time when it is more than one day', () => {
+      const booking = bookingFactory.build({
+        effectiveEndDate: '2023-02-11',
+        turnaround: {
+          workingDays: 4,
+        },
       })
 
-      it('returns summary list rows containing the turnaround time when it is more than one day', () => {
-        const booking = bookingFactory.build({
-          effectiveEndDate: '2023-02-11',
-          turnaround: {
-            workingDays: 4,
+      ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+      ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+      const result = summaryListRows(booking)
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Turnaround time',
+            },
+            value: {
+              text: '4 working days',
+            },
           },
-        })
-
-        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
-        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
-
-        const result = summaryListRows(booking)
-
-        expect(result).toEqual(
-          expect.arrayContaining([
-            {
-              key: {
-                text: 'Turnaround time',
-              },
-              value: {
-                text: '4 working days',
-              },
+          {
+            key: {
+              text: 'Turnaround end date',
             },
-            {
-              key: {
-                text: 'Turnaround end date',
-              },
-              value: {
-                text: '11 February 2023',
-              },
+            value: {
+              text: '11 February 2023',
             },
-          ]),
-        )
-      })
-
-      it('returns summary list rows containing the turnaround time when it is exactly one day', () => {
-        const booking = bookingFactory.build({
-          effectiveEndDate: '2023-02-11',
-          turnaround: {
-            workingDays: 1,
           },
-        })
-
-        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
-        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
-
-        const result = summaryListRows(booking)
-
-        expect(result).toEqual(
-          expect.arrayContaining([
-            {
-              key: {
-                text: 'Turnaround time',
-              },
-              value: {
-                text: '1 working day',
-              },
-            },
-            {
-              key: {
-                text: 'Turnaround end date',
-              },
-              value: {
-                text: '11 February 2023',
-              },
-            },
-          ]),
-        )
-      })
+        ]),
+      )
     })
 
-    describe('when turnarounds are disabled', () => {
-      beforeAll(() => {
-        config.flags.turnaroundsDisabled = true
+    it('returns summary list rows containing the turnaround time when it is exactly one day', () => {
+      const booking = bookingFactory.build({
+        effectiveEndDate: '2023-02-11',
+        turnaround: {
+          workingDays: 1,
+        },
       })
 
-      it('returns summary list rows not containing the turnaround time', () => {
-        const booking = bookingFactory.build({
-          effectiveEndDate: '2023-02-11',
-          turnaround: {
-            workingDays: 4,
+      ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
+      ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
+
+      const result = summaryListRows(booking)
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          {
+            key: {
+              text: 'Turnaround time',
+            },
+            value: {
+              text: '1 working day',
+            },
           },
-        })
-
-        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockReturnValue(statusHtml)
-        ;(formatLines as jest.MockedFunction<typeof formatLines>).mockImplementation(text => text)
-
-        const result = summaryListRows(booking)
-
-        expect(result).not.toEqual(
-          expect.arrayContaining([
-            {
-              key: {
-                text: 'Turnaround time',
-              },
-              value: {
-                text: '4 working days',
-              },
+          {
+            key: {
+              text: 'Turnaround end date',
             },
-            {
-              key: {
-                text: 'Turnaround end date',
-              },
-              value: {
-                text: '11 February 2023',
-              },
+            value: {
+              text: '11 February 2023',
             },
-          ]),
-        )
-      })
+          },
+        ]),
+      )
     })
   })
 })

--- a/server/components/bookingInfo.ts
+++ b/server/components/bookingInfo.ts
@@ -1,6 +1,5 @@
 import type { Booking } from '@approved-premises/api'
 import type { SummaryList } from '@approved-premises/ui'
-import config from '../config'
 import { getLatestExtension, shortenedOrExtended, statusTag } from '../utils/bookingUtils'
 import { DateFormats } from '../utils/dateUtils'
 import { formatLines } from '../utils/viewUtils'
@@ -43,20 +42,18 @@ export default (booking: Booking): SummaryList['rows'] => {
     })
   }
 
-  if (!config.flags.turnaroundsDisabled) {
-    const days = booking.turnaround.workingDays
+  const days = booking.turnaround.workingDays
 
-    rows.push(
-      {
-        key: textValue('Turnaround time'),
-        value: textValue(`${days} working ${days === 1 ? 'day' : 'days'}`),
-      },
-      {
-        key: textValue('Turnaround end date'),
-        value: textValue(DateFormats.isoDateToUIDate(booking.effectiveEndDate || booking.departureDate)),
-      },
-    )
-  }
+  rows.push(
+    {
+      key: textValue('Turnaround time'),
+      value: textValue(`${days} working ${days === 1 ? 'day' : 'days'}`),
+    },
+    {
+      key: textValue('Turnaround end date'),
+      value: textValue(DateFormats.isoDateToUIDate(booking.effectiveEndDate || booking.departureDate)),
+    },
+  )
 
   if (status === 'confirmed') {
     rows.push({

--- a/server/config.ts
+++ b/server/config.ts
@@ -52,7 +52,6 @@ export default {
   flags: {
     oasysDisabled: process.env.OASYS_DISABLED || false,
     applyDisabled: !['local', 'dev', 'test'].includes(environment),
-    turnaroundsDisabled: false,
   },
   environment,
   sentry: {

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -9,7 +9,6 @@ import extractCallConfig from '../../../utils/restUtils'
 import filterProbationRegions from '../../../utils/userUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import { parseNaturalNumber } from '../../../utils/formUtils'
-import config from '../../../config'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService, private readonly bedspaceService: BedspaceService) {}
@@ -56,9 +55,7 @@ export default class PremisesController {
       const newPremises: NewPremises = {
         characteristicIds: [],
         ...req.body,
-        turnaroundWorkingDayCount: !config.flags.turnaroundsDisabled
-          ? parseNaturalNumber(req.body.turnaroundWorkingDayCount)
-          : null,
+        turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
       }
 
       try {
@@ -113,9 +110,7 @@ export default class PremisesController {
       const updatePremises: UpdatePremises = {
         characteristicIds: [],
         ...req.body,
-        turnaroundWorkingDayCount: !config.flags.turnaroundsDisabled
-          ? parseNaturalNumber(req.body.turnaroundWorkingDayCount)
-          : null,
+        turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
       }
 
       try {

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -6,7 +6,6 @@ import type { Controllers } from '../../controllers'
 import paths from '../../paths/temporary-accommodation/manage'
 import { Services } from '../../services'
 
-import config from '../../config'
 import actions from '../utils'
 
 export default function routes(controllers: Controllers, services: Services, router: Router): Router {
@@ -214,23 +213,21 @@ export default function routes(controllers: Controllers, services: Services, rou
     ],
   })
 
-  if (!config.flags.turnaroundsDisabled) {
-    get(paths.bookings.turnarounds.new.pattern, turnaroundsController.new(), {
-      auditEvent: 'VIEW_BOOKING_NEW_TURNAROUND',
-    })
-    post(paths.bookings.turnarounds.create.pattern, turnaroundsController.create(), {
-      redirectAuditEventSpecs: [
-        {
-          path: paths.bookings.turnarounds.new.pattern,
-          auditEvent: 'CREATE_BOOKING_TURNAROUND_FAILURE',
-        },
-        {
-          path: paths.bookings.show.pattern,
-          auditEvent: 'CREATE_BOOKING_TURNAROUND_SUCCESS',
-        },
-      ],
-    })
-  }
+  get(paths.bookings.turnarounds.new.pattern, turnaroundsController.new(), {
+    auditEvent: 'VIEW_BOOKING_NEW_TURNAROUND',
+  })
+  post(paths.bookings.turnarounds.create.pattern, turnaroundsController.create(), {
+    redirectAuditEventSpecs: [
+      {
+        path: paths.bookings.turnarounds.new.pattern,
+        auditEvent: 'CREATE_BOOKING_TURNAROUND_FAILURE',
+      },
+      {
+        path: paths.bookings.show.pattern,
+        auditEvent: 'CREATE_BOOKING_TURNAROUND_SUCCESS',
+      },
+    ],
+  })
 
   get(paths.reports.new.pattern, reportsController.new(), { auditEvent: 'VIEW_REPORT_CREATE' })
   post(paths.reports.create.pattern, reportsController.create(), {

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -4,7 +4,6 @@ import BookingService from './bookingService'
 
 import { bedFactory, bookingFactory, lostBedFactory, newBookingFactory, roomFactory } from '../testutils/factories'
 
-import config from '../config'
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
 
@@ -57,7 +56,7 @@ describe('BookingService', () => {
       expect(bookingClient.create).toHaveBeenCalledWith(premisesId, {
         serviceName: 'temporary-accommodation',
         bedId,
-        enableTurnarounds: !config.flags.turnaroundsDisabled,
+        enableTurnarounds: true,
         ...newBooking,
       })
     })

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -1,5 +1,4 @@
 import type { Booking, LostBed, NewBooking, Room } from '@approved-premises/api'
-import config from '../config'
 
 import type { LostBedClient, RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
@@ -40,7 +39,7 @@ export default class BookingService {
     const confirmedBooking = await bookingClient.create(premisesId, {
       serviceName: 'temporary-accommodation',
       bedId: room.beds[0].id,
-      enableTurnarounds: !config.flags.turnaroundsDisabled,
+      enableTurnarounds: true,
       ...booking,
     })
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -14,7 +14,6 @@ import { CallConfig } from '../data/restClient'
 import { filterCharacteristics, formatCharacteristics } from '../utils/characteristicUtils'
 import { statusTag } from '../utils/premisesUtils'
 import { escape, formatLines } from '../utils/viewUtils'
-import config from '../config'
 
 export type PremisesReferenceData = {
   localAuthorities: Array<LocalAuthorityArea>
@@ -185,14 +184,12 @@ export default class PremisesService {
       },
     ]
 
-    if (!config.flags.turnaroundsDisabled) {
-      rows.push({
-        key: this.textValue('Expected turnaround time'),
-        value: this.textValue(
-          `${premises.turnaroundWorkingDayCount} working ${premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'}`,
-        ),
-      })
-    }
+    rows.push({
+      key: this.textValue('Expected turnaround time'),
+      value: this.textValue(
+        `${premises.turnaroundWorkingDayCount} working ${premises.turnaroundWorkingDayCount === 1 ? 'day' : 'days'}`,
+      ),
+    })
 
     return { rows }
   }

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -1,4 +1,3 @@
-import config from '../config'
 import paths from '../paths/temporary-accommodation/manage'
 import { SanitisedError } from '../sanitisedError'
 import { arrivalFactory, bookingFactory, departureFactory, extensionFactory } from '../testutils/factories'
@@ -32,106 +31,88 @@ const changeTurnaroundAction = {
 
 describe('bookingUtils', () => {
   describe('bookingActions', () => {
-    describe('when turnarounds are enabled', () => {
-      beforeAll(() => {
-        config.flags.turnaroundsDisabled = false
-      })
+    it('returns a mark as confirmed action for a provisional booking', () => {
+      const booking = bookingFactory.provisional().build({ id: bookingId })
 
-      it('returns a mark as confirmed action for a provisional booking', () => {
-        const booking = bookingFactory.provisional().build({ id: bookingId })
-
-        expect(bookingActions(premisesId, roomId, booking)).toEqual([
-          {
-            text: 'Mark as confirmed',
-            classes: '',
-            href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId }),
-          },
-          cancelBookingAction,
-          changeTurnaroundAction,
-        ])
-      })
-
-      it('returns a mark as active action for a confirmed booking', () => {
-        const booking = bookingFactory.confirmed().build({ id: bookingId })
-
-        expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
-          {
-            text: 'Mark as active',
-            classes: '',
-            href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId }),
-          },
-          cancelBookingAction,
-          changeTurnaroundAction,
-        ])
-      })
-
-      it('returns mark as departed and extend actions for an arrived booking', () => {
-        const booking = bookingFactory.arrived().build({ id: bookingId })
-
-        expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
-          {
-            text: 'Mark as departed',
-            classes: 'govuk-button--secondary',
-            href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
-          },
-          {
-            text: 'Extend or shorten booking',
-            classes: 'govuk-button--secondary',
-            href: paths.bookings.extensions.new({ premisesId, roomId, bookingId: booking.id }),
-          },
-          changeTurnaroundAction,
-        ])
-      })
-
-      it('returns edit departed booking for a departed booking', () => {
-        const booking = bookingFactory.departed().build({ id: bookingId })
-
-        expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
-          {
-            text: 'Update departure details',
-            classes: 'govuk-button--secondary',
-            href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
-          },
-          changeTurnaroundAction,
-        ])
-      })
-
-      it('returns edit departed booking for a closed booking', () => {
-        const booking = bookingFactory.closed().build({ id: bookingId })
-
-        expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
-          {
-            text: 'Update departure details',
-            classes: 'govuk-button--secondary',
-            href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
-          },
-          changeTurnaroundAction,
-        ])
-      })
-
-      it('returns edit cancelled booking for a cancelled booking', () => {
-        const booking = bookingFactory.cancelled().build({ id: bookingId })
-
-        expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
-          {
-            text: 'Update cancelled booking',
-            classes: 'govuk-button--secondary',
-            href: paths.bookings.cancellations.edit({ premisesId, roomId, bookingId: booking.id }),
-          },
-        ])
-      })
+      expect(bookingActions(premisesId, roomId, booking)).toEqual([
+        {
+          text: 'Mark as confirmed',
+          classes: '',
+          href: paths.bookings.confirmations.new({ premisesId, roomId, bookingId }),
+        },
+        cancelBookingAction,
+        changeTurnaroundAction,
+      ])
     })
 
-    describe('when turnarounds are disabled', () => {
-      beforeAll(() => {
-        config.flags.turnaroundsDisabled = true
-      })
+    it('returns a mark as active action for a confirmed booking', () => {
+      const booking = bookingFactory.confirmed().build({ id: bookingId })
 
-      it('does not include a change turn around action', () => {
-        const booking = bookingFactory.departed().build({ id: bookingId })
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+        {
+          text: 'Mark as active',
+          classes: '',
+          href: paths.bookings.arrivals.new({ premisesId, roomId, bookingId }),
+        },
+        cancelBookingAction,
+        changeTurnaroundAction,
+      ])
+    })
 
-        expect(bookingActions('premisesId', 'roomId', booking)).not.toContainEqual(changeTurnaroundAction)
-      })
+    it('returns mark as departed and extend actions for an arrived booking', () => {
+      const booking = bookingFactory.arrived().build({ id: bookingId })
+
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+        {
+          text: 'Mark as departed',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.departures.new({ premisesId, roomId, bookingId: booking.id }),
+        },
+        {
+          text: 'Extend or shorten booking',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.extensions.new({ premisesId, roomId, bookingId: booking.id }),
+        },
+        changeTurnaroundAction,
+      ])
+    })
+
+    it('returns edit departed booking for a departed booking', () => {
+      const booking = bookingFactory.departed().build({ id: bookingId })
+
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+        {
+          text: 'Update departure details',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
+        },
+        changeTurnaroundAction,
+      ])
+    })
+
+    it('returns edit departed booking for a closed booking', () => {
+      const booking = bookingFactory.closed().build({ id: bookingId })
+
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+        {
+          text: 'Update departure details',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.departures.edit({ premisesId, roomId, bookingId: booking.id }),
+        },
+        changeTurnaroundAction,
+      ])
+    })
+
+    it('returns edit cancelled booking for a cancelled booking', () => {
+      const booking = bookingFactory.cancelled().build({ id: bookingId })
+
+      expect(bookingActions('premisesId', 'roomId', booking)).toEqual([
+        {
+          text: 'Update cancelled booking',
+          classes: 'govuk-button--secondary',
+          href: paths.bookings.cancellations.edit({ premisesId, roomId, bookingId: booking.id }),
+        },
+      ])
     })
   })
 

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -1,6 +1,5 @@
 import type { Booking, Cancellation, Departure, Extension } from '@approved-premises/api'
 import type { BespokeError, PageHeadingBarItem } from '@approved-premises/ui'
-import config from '../config'
 import paths from '../paths/temporary-accommodation/manage'
 import { SanitisedError } from '../sanitisedError'
 import { DateFormats } from './dateUtils'
@@ -74,7 +73,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
       break
   }
 
-  if (!config.flags.turnaroundsDisabled && booking.status !== 'cancelled') {
+  if (booking.status !== 'cancelled') {
     items.push({
       text: 'Change turnaround time',
       classes: 'govuk-button--secondary',
@@ -106,7 +105,7 @@ export const allStatuses: Array<{ name: string; id: Booking['status']; tagClass:
     tagClass: 'govuk-tag--green',
   },
   {
-    name: config.flags.turnaroundsDisabled ? 'Departed' : 'Turnaround',
+    name: 'Turnaround',
     id: 'departed',
     tagClass: 'govuk-tag--green',
   },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -141,7 +141,6 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   })
 
   njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)
-  njkEnv.addGlobal('turnaroundsDisabled', config.flags.turnaroundsDisabled)
 
   njkEnv.addFilter('mapApiPersonRisksForUi', mapApiPersonRisksForUi)
 

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -163,8 +163,6 @@
   }, fetchContext()
 ) }}
 
-{% if not config.turnaroundsDisabled %}
-
 {{ taInput(
   {
     label: {
@@ -182,8 +180,6 @@
   },
   fetchContext()
 ) }}
-
-{% endif %}
 
 {{ govukButton({
   text: "Submit",


### PR DESCRIPTION
Now that turnarounds are in production, we have no use for this feature flag