### PR TITLE
Enable retries for E2E tests

### DIFF
--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -37,4 +37,5 @@ export default defineConfig({
     supportFile: false,
   },
   numTestsKeptInMemory: 0,
+  retries: 1,
 })


### PR DESCRIPTION
We are experiencing ongoing random failures of E2E tests. These do not seem to be "genuine" failures, but have causes such as the test user being logged out, premises being wiped by an API dev deploy, or the API taking longer than expected to give a response.

Given we believe these would take more time than available to address properly, we allow Cypress to retry failed tests once. The tradeoff is we risk obscuring genuine failures that may not occur on every test run, and test runs taking much longer for failures that affect the service as a whole.