### PR TITLE
Fix spelling of "specifiy" across Apply feature

### DIFF
--- a/server/form-pages/apply/placement-considerations/placement-location/alternativePdu.test.ts
+++ b/server/form-pages/apply/placement-considerations/placement-location/alternativePdu.test.ts
@@ -35,7 +35,7 @@ describe('AlternativePdu', () => {
     it('returns an error if the alternative PDU answer not populated', () => {
       const page = new AlternativePdu({ ...body, alternativePdu: undefined }, application)
       expect(page.errors()).toEqual({
-        alternativePdu: 'You must specifiy if placement is required in an alternative PDU',
+        alternativePdu: 'You must specify if placement is required in an alternative PDU',
       })
     })
 

--- a/server/form-pages/apply/placement-considerations/placement-location/alternativePdu.ts
+++ b/server/form-pages/apply/placement-considerations/placement-location/alternativePdu.ts
@@ -31,7 +31,7 @@ export default class AlternativePdu implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.alternativePdu) {
-      errors.alternativePdu = 'You must specifiy if placement is required in an alternative PDU'
+      errors.alternativePdu = 'You must specify if placement is required in an alternative PDU'
     }
 
     if (this.body.alternativePdu === 'yes' && !this.body.alternativePduDetail) {

--- a/server/form-pages/apply/placement-considerations/requirements-for-placement/foodAllergies.test.ts
+++ b/server/form-pages/apply/placement-considerations/requirements-for-placement/foodAllergies.test.ts
@@ -39,7 +39,7 @@ describe('FoodAllergies', () => {
     it('returns an error if the food allergies answer not populated', () => {
       const page = new FoodAllergies({ ...body, foodAllergies: undefined }, application)
       expect(page.errors()).toEqual({
-        foodAllergies: 'You must specifiy if John Smith has any food allergies or dietary requirements',
+        foodAllergies: 'You must specify if John Smith has any food allergies or dietary requirements',
       })
     })
 

--- a/server/form-pages/apply/placement-considerations/requirements-for-placement/foodAllergies.ts
+++ b/server/form-pages/apply/placement-considerations/requirements-for-placement/foodAllergies.ts
@@ -39,7 +39,7 @@ export default class FoodAllergies implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.foodAllergies) {
-      errors.foodAllergies = `You must specifiy if ${this.application.person.name} has any food allergies or dietary requirements`
+      errors.foodAllergies = `You must specify if ${this.application.person.name} has any food allergies or dietary requirements`
     }
 
     if (this.body.foodAllergies === 'yes' && !this.body.foodAllergiesDetail) {

--- a/server/form-pages/apply/placement-considerations/requirements-for-placement/propertySharing.test.ts
+++ b/server/form-pages/apply/placement-considerations/requirements-for-placement/propertySharing.test.ts
@@ -39,7 +39,7 @@ describe('PropertySharing', () => {
     it('returns an error if the property sharing answer not populated', () => {
       const page = new PropertySharing({ ...body, propertySharing: undefined }, application)
       expect(page.errors()).toEqual({
-        propertySharing: 'You must specifiy if John Smith would be able to share accommodation with others',
+        propertySharing: 'You must specify if John Smith would be able to share accommodation with others',
       })
     })
 

--- a/server/form-pages/apply/placement-considerations/requirements-for-placement/propertySharing.ts
+++ b/server/form-pages/apply/placement-considerations/requirements-for-placement/propertySharing.ts
@@ -39,7 +39,7 @@ export default class PropertySharing implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.propertySharing) {
-      errors.propertySharing = `You must specifiy if ${this.application.person.name} would be able to share accommodation with others`
+      errors.propertySharing = `You must specify if ${this.application.person.name} would be able to share accommodation with others`
     }
 
     if (this.body.propertySharing === 'yes' && !this.body.propertySharingDetail) {

--- a/server/form-pages/apply/placement-considerations/safeguarding-and-support/caringResponsibilities.test.ts
+++ b/server/form-pages/apply/placement-considerations/safeguarding-and-support/caringResponsibilities.test.ts
@@ -39,7 +39,7 @@ describe('CaringResponsibilities', () => {
     it('returns an error if the caring responsibilities answer not populated', () => {
       const page = new CaringResponsibilities({ ...body, caringResponsibilities: undefined }, application)
       expect(page.errors()).toEqual({
-        caringResponsibilities: `You must specifiy if John Smith has any caring responsibilities`,
+        caringResponsibilities: `You must specify if John Smith has any caring responsibilities`,
       })
     })
 

--- a/server/form-pages/apply/placement-considerations/safeguarding-and-support/caringResponsibilities.ts
+++ b/server/form-pages/apply/placement-considerations/safeguarding-and-support/caringResponsibilities.ts
@@ -39,7 +39,7 @@ export default class CaringResponsibilities implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.caringResponsibilities) {
-      errors.caringResponsibilities = `You must specifiy if ${this.application.person.name} has any caring responsibilities`
+      errors.caringResponsibilities = `You must specify if ${this.application.person.name} has any caring responsibilities`
     }
 
     if (this.body.caringResponsibilities === 'yes' && !this.body.caringResponsibilitiesDetail) {

--- a/server/form-pages/apply/placement-considerations/safeguarding-and-support/safeguardingAndVulnerability.test.ts
+++ b/server/form-pages/apply/placement-considerations/safeguarding-and-support/safeguardingAndVulnerability.test.ts
@@ -35,7 +35,7 @@ describe('SafeguardingAndVulnerability', () => {
     it('returns an error if the concerns answer not populated', () => {
       const page = new SafeguardingAndVulnerability({ ...body, concerns: undefined }, application)
       expect(page.errors()).toEqual({
-        concerns: 'You must specifiy if you have any concerns about safeguarding and/or vulnerability',
+        concerns: 'You must specify if you have any concerns about safeguarding and/or vulnerability',
       })
     })
 

--- a/server/form-pages/apply/placement-considerations/safeguarding-and-support/safeguardingAndVulnerability.ts
+++ b/server/form-pages/apply/placement-considerations/safeguarding-and-support/safeguardingAndVulnerability.ts
@@ -35,7 +35,7 @@ export default class SafeguardingAndVulnerability implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.concerns) {
-      errors.concerns = 'You must specifiy if you have any concerns about safeguarding and/or vulnerability'
+      errors.concerns = 'You must specify if you have any concerns about safeguarding and/or vulnerability'
     }
 
     if (this.body.concerns === 'yes' && !this.body.concernsDetail) {

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/otherAccommodationOptions.test.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/otherAccommodationOptions.test.ts
@@ -35,7 +35,7 @@ describe('OtherAccommodationOptions', () => {
     it('returns an error if the other options answer not populated', () => {
       const page = new OtherAccommodationOptions({ ...body, otherOptions: undefined }, application)
       expect(page.errors()).toEqual({
-        otherOptions: 'You must specifiy if other accommodation options have been considered',
+        otherOptions: 'You must specify if other accommodation options have been considered',
       })
     })
 

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/otherAccommodationOptions.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/otherAccommodationOptions.ts
@@ -31,7 +31,7 @@ export default class OtherAccommodationOptions implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.otherOptions) {
-      errors.otherOptions = 'You must specifiy if other accommodation options have been considered'
+      errors.otherOptions = 'You must specify if other accommodation options have been considered'
     }
 
     if (this.body.otherOptions === 'yes' && !this.body.otherOptionsDetail) {


### PR DESCRIPTION
We correct the spelling of "specify" across the Apply feature, which had been persistently misspelled as "specifiy"

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
