### PR TITLE
Add sentence expiry and release type screens within sentence information task

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -58,7 +58,8 @@
             "printWidth": 120,
             "semi": false
           }
-        ]
+        ],
+        "no-underscore-dangle": ["error", { "allowAfterThis": true }]
       }
     }
   ],

--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -2,6 +2,31 @@
   "sentence-information": {
     "sentence-type": {
       "sentenceType": "communityOrder"
+    },
+    "sentence-expiry": {
+      "sentenceExpiryDate": "2124-01-19",
+      "sentenceExpiryDate-year": "2124",
+      "sentenceExpiryDate-month": "1",
+      "sentenceExpiryDate-day": "19"
+    },
+    "release-type": {
+      "releaseTypes": ["licence", "pss"],
+      "licenceStartDate": "2024-01-19",
+      "licenceStartDate-year": "2024",
+      "licenceStartDate-month": "1",
+      "licenceStartDate-day": "19",
+      "licenceEndDate": "2024-07-09",
+      "licenceEndDate-year": "2024",
+      "licenceEndDate-month": "7",
+      "licenceEndDate-day": "9",
+      "pssStartDate": "2122-04-01",
+      "pssStartDate-year": "2122",
+      "pssStartDate-month": "4",
+      "pssStartDate-day": "1",
+      "pssEndDate": "2122-07-18",
+      "pssEndDate-year": "2122",
+      "pssEndDate-month": "7",
+      "pssEndDate-day": "18"
     }
   },
   "contact-details": {

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -45,11 +45,13 @@ import {
   PropertySharingPage,
   ReferralHistoryDetailsPage,
   ReleaseDatePage,
+  ReleaseTypePage,
   ReligiousOrCulturalNeedsPage,
   RiskManagementPlanPage,
   RiskToSelfPage,
   RoshSummaryPage,
   SafeguardingAndVulnerabilityPage,
+  SentenceExpiryPage,
   SentenceTypePage,
   StartPage,
   SupportInTheCommunityPage,
@@ -279,13 +281,21 @@ export default class ApplyHelper {
   completeSentenceInformation() {
     // Given I click the sentence information task
     cy.get('[data-cy-task-name="sentence-information"]').click()
-    const sentenceTypePage = new SentenceTypePage(this.application)
 
     // When I complete the form
+    const sentenceTypePage = new SentenceTypePage(this.application)
     sentenceTypePage.completeForm()
     sentenceTypePage.clickSubmit()
 
-    this.pages.sentenceInformation = [sentenceTypePage]
+    const sentenceExpiryPage = new SentenceExpiryPage(this.application)
+    sentenceExpiryPage.completeForm()
+    sentenceExpiryPage.clickSubmit()
+
+    const releaseTypePage = new ReleaseTypePage(this.application)
+    releaseTypePage.completeForm()
+    releaseTypePage.clickSubmit()
+
+    this.pages.sentenceInformation = [sentenceTypePage, sentenceExpiryPage, releaseTypePage]
 
     // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(TaskListPage)

--- a/cypress_shared/pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/cypress_shared/pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -1,0 +1,29 @@
+import type { TemporaryAccommodationApplication } from '@approved-premises/api'
+import paths from '../../../../../server/paths/apply'
+import ApplyPage from '../../applyPage'
+
+export default class ReleaseTypePage extends ApplyPage {
+  constructor(application: TemporaryAccommodationApplication) {
+    super(
+      'What is the release type?',
+      application,
+      'sentence-information',
+      'release-type',
+      paths.applications.pages.show({ id: application.id, task: 'sentence-information', page: 'sentence-expiry' }),
+    )
+  }
+
+  completeForm() {
+    this.checkCheckboxesFromPageBody('releaseTypes')
+
+    if ((this.tasklistPage.body.releaseTypes as Array<string>).includes('licence')) {
+      this.completeDateInputsFromPageBody('licenceStartDate')
+      this.completeDateInputsFromPageBody('licenceEndDate')
+    }
+
+    if ((this.tasklistPage.body.releaseTypes as Array<string>).includes('pss')) {
+      this.completeDateInputsFromPageBody('pssStartDate')
+      this.completeDateInputsFromPageBody('pssEndDate')
+    }
+  }
+}

--- a/cypress_shared/pages/apply/accommodation-need/sentence-information/sentenceExpiry.ts
+++ b/cypress_shared/pages/apply/accommodation-need/sentence-information/sentenceExpiry.ts
@@ -1,0 +1,19 @@
+import type { TemporaryAccommodationApplication } from '@approved-premises/api'
+import paths from '../../../../../server/paths/apply'
+import ApplyPage from '../../applyPage'
+
+export default class SentenceExpiryPage extends ApplyPage {
+  constructor(application: TemporaryAccommodationApplication) {
+    super(
+      'Sentence expiry date',
+      application,
+      'sentence-information',
+      'sentence-expiry',
+      paths.applications.pages.show({ id: application.id, task: 'sentence-information', page: 'sentence-type' }),
+    )
+  }
+
+  completeForm() {
+    this.completeDateInputsFromPageBody('sentenceExpiryDate')
+  }
+}

--- a/cypress_shared/pages/apply/check-your-answers/check-your-answers/checkYourAnswersPage.ts
+++ b/cypress_shared/pages/apply/check-your-answers/check-your-answers/checkYourAnswersPage.ts
@@ -104,7 +104,9 @@ export default class CheckYourAnswersPage extends ApplyPage {
           const value = responses[key] as string | Array<Record<string, unknown>>
 
           if (typeof value === 'string') {
-            this.assertDefinition(key, responses[key] as string)
+            ;(responses[key] as string).split('\n').forEach(line => {
+              this.assertDefinition(key, line)
+            })
           } else {
             cy.get('dt')
               .contains(key)

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -8,6 +8,7 @@ import ProbationPractitionerPage from './accommodation-need/contact-details/prob
 import AccommodationRequiredFromDatePage from './accommodation-need/eligibility/accommodationRequiredFromDate'
 import EligibilityReasonPage from './accommodation-need/eligibility/eligibilityReason'
 import ReleaseDatePage from './accommodation-need/eligibility/releaseDate'
+import SentenceExpiryPage from './accommodation-need/sentence-information/sentenceExpiry'
 import SentenceTypePage from './accommodation-need/sentence-information/sentenceType'
 import CheckYourAnswersPage from './check-your-answers/check-your-answers/checkYourAnswersPage'
 import ConfirmDetailsPage from './confirmDetails'
@@ -51,6 +52,7 @@ export {
   SubmissionConfirmation,
   TaskListPage,
   SentenceTypePage,
+  SentenceExpiryPage,
   ProbationPractitionerPage,
   BackupContactPage,
   PractitionerPduPage,

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -8,6 +8,7 @@ import ProbationPractitionerPage from './accommodation-need/contact-details/prob
 import AccommodationRequiredFromDatePage from './accommodation-need/eligibility/accommodationRequiredFromDate'
 import EligibilityReasonPage from './accommodation-need/eligibility/eligibilityReason'
 import ReleaseDatePage from './accommodation-need/eligibility/releaseDate'
+import ReleaseTypePage from './accommodation-need/sentence-information/releaseType'
 import SentenceExpiryPage from './accommodation-need/sentence-information/sentenceExpiry'
 import SentenceTypePage from './accommodation-need/sentence-information/sentenceType'
 import CheckYourAnswersPage from './check-your-answers/check-your-answers/checkYourAnswersPage'
@@ -53,6 +54,7 @@ export {
   TaskListPage,
   SentenceTypePage,
   SentenceExpiryPage,
+  ReleaseTypePage,
   ProbationPractitionerPage,
   BackupContactPage,
   PractitionerPduPage,

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -23,14 +23,16 @@ export default class BedspaceSearchController {
       const { pdus: allPdus } = await this.searchService.getReferenceData(callConfig)
 
       const query = Object.keys(req.query).length ? (req.query as BedspaceSearchQuery) : undefined
+
       let results: BedSearchResults
+      let startDate: string
 
       try {
         if (query) {
-          const { startDate } = DateFormats.dateAndTimeInputsToIsoString(
+          startDate = DateFormats.dateAndTimeInputsToIsoString(
             query as ObjectWithDateParts<'startDate'>,
             'startDate',
-          )
+          ).startDate
 
           const durationDays = parseNaturalNumber(query.durationDays)
 
@@ -44,6 +46,7 @@ export default class BedspaceSearchController {
         res.render('temporary-accommodation/bedspace-search/index', {
           allPdus,
           results,
+          startDate,
           errors,
           errorSummary,
           ...query,

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.test.ts
@@ -1,11 +1,24 @@
 import { applicationFactory } from '../../../../testutils/factories'
-import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import AccommodationRequiredFromDate from './accommodationRequiredFromDate'
 
-jest.mock('../../../../utils/dateUtils')
+jest.mock('../../../../utils/dateUtils', () => {
+  const module = jest.requireActual('../../../../utils/dateUtils')
 
-const body = { accommodationRequiredFromDate: '2024-04-11' as const }
+  return {
+    ...module,
+    dateIsBlank: jest.fn(),
+    dateAndTimeInputsAreValidDates: jest.fn(),
+    dateIsInThePast: jest.fn(),
+  }
+})
+
+const body = {
+  'accommodationRequiredFromDate-year': '2024',
+  'accommodationRequiredFromDate-month': '4',
+  'accommodationRequiredFromDate-day': '11',
+}
 
 describe('AccommodationRequiredFromDate', () => {
   const application = applicationFactory.build()
@@ -14,7 +27,10 @@ describe('AccommodationRequiredFromDate', () => {
     it('sets the body', () => {
       const page = new AccommodationRequiredFromDate(body, application)
 
-      expect(page.body).toEqual(body)
+      expect(page.body).toEqual({
+        ...body,
+        accommodationRequiredFromDate: '2024-04-11',
+      })
     })
   })
 
@@ -67,12 +83,8 @@ describe('AccommodationRequiredFromDate', () => {
 
   describe('response', () => {
     it('returns a translated version of the response', () => {
-      ;(DateFormats.isoDateToUIDate as jest.Mock).mockReturnValue('11 April 2024')
-
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.response()).toEqual({ 'Accommodation required from date': '11 April 2024' })
-
-      expect(DateFormats.isoDateToUIDate).toHaveBeenCalledWith('2024-04-11')
     })
   })
 })

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
@@ -2,18 +2,14 @@ import { TemporaryAccommodationApplication as Application } from '@approved-prem
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import TasklistPage from '../../../tasklistPage'
+import { dateBodyProperties } from '../../../utils'
 import { Page } from '../../../utils/decorators'
 
 type AccommodationRequiredFromDateBody = ObjectWithDateParts<'accommodationRequiredFromDate'>
 
 @Page({
   name: 'accommodation-required-from-date',
-  bodyProperties: [
-    'accommodationRequiredFromDate',
-    'accommodationRequiredFromDate-year',
-    'accommodationRequiredFromDate-month',
-    'accommodationRequiredFromDate-day',
-  ],
+  bodyProperties: dateBodyProperties('accommodationRequiredFromDate'),
 })
 export default class AccommodationRequiredFromDate implements TasklistPage {
   title = 'What date is accommodation required from?'

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
@@ -35,12 +35,7 @@ export default class AccommodationRequiredFromDate implements TasklistPage {
 
     if (dateIsBlank(this.body, 'accommodationRequiredFromDate')) {
       errors.accommodationRequiredFromDate = 'You must specify the date accommodation is required from'
-    } else if (
-      !dateAndTimeInputsAreValidDates(
-        this.body as ObjectWithDateParts<'accommodationRequiredFromDate'>,
-        'accommodationRequiredFromDate',
-      )
-    ) {
+    } else if (!dateAndTimeInputsAreValidDates(this.body, 'accommodationRequiredFromDate')) {
       errors.accommodationRequiredFromDate = 'You must specify a valid date accommodation is required from'
     } else if (dateIsInThePast(this.body.accommodationRequiredFromDate)) {
       errors.accommodationRequiredFromDate = 'The date accommodation is required from must not be in the past'

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
@@ -33,7 +33,7 @@ export default class AccommodationRequiredFromDate implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (dateIsBlank(this.body)) {
+    if (dateIsBlank(this.body, 'accommodationRequiredFromDate')) {
       errors.accommodationRequiredFromDate = 'You must specify the date accommodation is required from'
     } else if (
       !dateAndTimeInputsAreValidDates(

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
@@ -14,7 +14,18 @@ type AccommodationRequiredFromDateBody = ObjectWithDateParts<'accommodationRequi
 export default class AccommodationRequiredFromDate implements TasklistPage {
   title = 'What date is accommodation required from?'
 
-  constructor(readonly body: Partial<AccommodationRequiredFromDateBody>, readonly application: Application) {}
+  constructor(private _body: Partial<AccommodationRequiredFromDateBody>, readonly application: Application) {}
+
+  public set body(value: Partial<AccommodationRequiredFromDateBody>) {
+    this._body = {
+      ...value,
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'accommodationRequiredFromDate'),
+    }
+  }
+
+  public get body(): Partial<AccommodationRequiredFromDateBody> {
+    return this._body
+  }
 
   response() {
     return {

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
@@ -1,11 +1,20 @@
 import { applicationFactory } from '../../../../testutils/factories'
-import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import ReleaseDate from './releaseDate'
 
-jest.mock('../../../../utils/dateUtils')
+jest.mock('../../../../utils/dateUtils', () => {
+  const module = jest.requireActual('../../../../utils/dateUtils')
 
-const body = { releaseDate: '2024-04-11' as const }
+  return {
+    ...module,
+    dateIsBlank: jest.fn(),
+    dateAndTimeInputsAreValidDates: jest.fn(),
+    dateIsInThePast: jest.fn(),
+  }
+})
+
+const body = { 'releaseDate-year': '2024', 'releaseDate-month': '4', 'releaseDate-day': '11' }
 
 describe('ReleaseDate', () => {
   const application = applicationFactory.build()
@@ -14,7 +23,10 @@ describe('ReleaseDate', () => {
     it('sets the body', () => {
       const page = new ReleaseDate(body, application)
 
-      expect(page.body).toEqual(body)
+      expect(page.body).toEqual({
+        ...body,
+        releaseDate: '2024-04-11',
+      })
     })
   })
 
@@ -61,12 +73,8 @@ describe('ReleaseDate', () => {
 
   describe('response', () => {
     it('returns a translated version of the response', () => {
-      ;(DateFormats.isoDateToUIDate as jest.Mock).mockReturnValue('11 April 2024')
-
       const page = new ReleaseDate(body, application)
       expect(page.response()).toEqual({ 'Release date': '11 April 2024' })
-
-      expect(DateFormats.isoDateToUIDate).toHaveBeenCalledWith('2024-04-11')
     })
   })
 })

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -37,7 +37,7 @@ export default class ReleaseDate implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (dateIsBlank(this.body)) {
+    if (dateIsBlank(this.body, 'releaseDate')) {
       errors.releaseDate = 'You must specify the release date'
     } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'releaseDate'>, 'releaseDate')) {
       errors.releaseDate = 'You must specify a valid release date'

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -39,7 +39,7 @@ export default class ReleaseDate implements TasklistPage {
 
     if (dateIsBlank(this.body, 'releaseDate')) {
       errors.releaseDate = 'You must specify the release date'
-    } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'releaseDate'>, 'releaseDate')) {
+    } else if (!dateAndTimeInputsAreValidDates(this.body, 'releaseDate')) {
       errors.releaseDate = 'You must specify a valid release date'
     } else if (dateIsInThePast(this.body.releaseDate)) {
       errors.releaseDate = 'The release date must not be in the past'

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -2,13 +2,14 @@ import { TemporaryAccommodationApplication as Application } from '@approved-prem
 import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
 import TasklistPage from '../../../tasklistPage'
+import { dateBodyProperties } from '../../../utils'
 import { Page } from '../../../utils/decorators'
 
 type ReleaseDateBody = ObjectWithDateParts<'releaseDate'>
 
 @Page({
   name: 'release-date',
-  bodyProperties: ['releaseDate', 'releaseDate-year', 'releaseDate-month', 'releaseDate-day'],
+  bodyProperties: dateBodyProperties('releaseDate'),
 })
 export default class ReleaseDate implements TasklistPage {
   title: string

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -14,10 +14,21 @@ type ReleaseDateBody = ObjectWithDateParts<'releaseDate'>
 export default class ReleaseDate implements TasklistPage {
   title: string
 
-  constructor(readonly body: Partial<ReleaseDateBody>, readonly application: Application) {
+  constructor(private _body: Partial<ReleaseDateBody>, readonly application: Application) {
     const { name } = application.person
 
     this.title = `What is ${name}'s release date?`
+  }
+
+  public set body(value: Partial<ReleaseDateBody>) {
+    this._body = {
+      ...value,
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'releaseDate'),
+    }
+  }
+
+  public get body(): Partial<ReleaseDateBody> {
+    return this._body
   }
 
   response() {

--- a/server/form-pages/apply/accommodation-need/sentence-information/index.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/index.ts
@@ -1,12 +1,14 @@
 /* istanbul ignore file */
 
 import { Task } from '../../../utils/decorators'
+import ReleaseType from './releaseType'
+import SentenceExpiry from './sentenceExpiry'
 import SentenceType from './sentenceType'
 
 @Task({
   name: 'Sentence information',
   actionText: 'Add sentence information',
   slug: 'sentence-information',
-  pages: [SentenceType],
+  pages: [SentenceType, SentenceExpiry, ReleaseType],
 })
 export default class SentenceInformation {}

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
@@ -1,0 +1,164 @@
+import { applicationFactory } from '../../../../testutils/factories'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import ReleaseType from './releaseType'
+
+jest.mock('../../../../utils/dateUtils', () => {
+  const module = jest.requireActual('../../../../utils/dateUtils')
+
+  return {
+    ...module,
+    dateIsBlank: jest.fn(),
+    dateAndTimeInputsAreValidDates: jest.fn(),
+  }
+})
+
+const body = {
+  releaseTypes: ['licence' as const, 'pss' as const],
+  'licenceStartDate-year': '2024',
+  'licenceStartDate-month': '1',
+  'licenceStartDate-day': '19',
+  'licenceEndDate-year': '2024',
+  'licenceEndDate-month': '7',
+  'licenceEndDate-day': '9',
+  'pssStartDate-year': '2122',
+  'pssStartDate-month': '4',
+  'pssStartDate-day': '1',
+  'pssEndDate-year': '2122',
+  'pssEndDate-month': '7',
+  'pssEndDate-day': '18',
+}
+
+describe('SentenceExpiry', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('sets the body', () => {
+      const page = new ReleaseType(body, application)
+
+      expect(page.body).toEqual({
+        ...body,
+        licenceStartDate: '2024-01-19',
+        licenceEndDate: '2024-07-09',
+        pssStartDate: '2122-04-01',
+        pssEndDate: '2122-07-18',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new ReleaseType({}, application), 'sentence-expiry')
+  itShouldHaveNextValue(new ReleaseType({}, application), '')
+
+  describe('errors', () => {
+    it('returns an empty object if the all fields are populated', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new ReleaseType(body, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('returns an empty object if the licence release type is specified and only the licence dates are specified', () => {
+      ;(dateIsBlank as jest.MockedFunction<typeof dateIsBlank>).mockImplementation(
+        (_, field) => !(field as string).startsWith('licence'),
+      )
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new ReleaseType({ ...body, releaseTypes: ['licence'] }, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('returns an empty object if the PSS release type is specified and only the PSS dates are specified', () => {
+      ;(dateIsBlank as jest.MockedFunction<typeof dateIsBlank>).mockImplementation(
+        (_, field) => !(field as string).startsWith('pss'),
+      )
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new ReleaseType({ ...body, releaseTypes: ['pss'] }, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('returns errors if the licence release type is specified and the licence dates are blank', () => {
+      ;(dateIsBlank as jest.MockedFunction<typeof dateIsBlank>).mockImplementation((_, field) =>
+        (field as string).startsWith('licence'),
+      )
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new ReleaseType(body, application)
+      expect(page.errors()).toEqual({
+        licenceStartDate: 'You must specify the licence start date',
+        licenceEndDate: 'You must specify the licence end date',
+      })
+    })
+
+    it('returns errors if the licence release type is specified and the licence dates are invalid', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(
+        dateAndTimeInputsAreValidDates as jest.MockedFunction<typeof dateAndTimeInputsAreValidDates>
+      ).mockImplementation((_, field) => !(field as string).startsWith('licence'))
+
+      const page = new ReleaseType(body, application)
+      expect(page.errors()).toEqual({
+        licenceStartDate: 'You must specify a valid licence start date',
+        licenceEndDate: 'You must specify a valid licence end date',
+      })
+    })
+
+    it('returns errors if the PSS release type is specified and the PSS dates are blank', () => {
+      ;(dateIsBlank as jest.MockedFunction<typeof dateIsBlank>).mockImplementation((_, field) =>
+        (field as string).startsWith('pss'),
+      )
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new ReleaseType(body, application)
+      expect(page.errors()).toEqual({
+        pssStartDate: 'You must specify the PSS start date',
+        pssEndDate: 'You must specify the PSS end date',
+      })
+    })
+
+    it('returns errors if the PSS release type is specified and the PSS dates are invalid', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(
+        dateAndTimeInputsAreValidDates as jest.MockedFunction<typeof dateAndTimeInputsAreValidDates>
+      ).mockImplementation((_, field) => !(field as string).startsWith('pss'))
+
+      const page = new ReleaseType(body, application)
+      expect(page.errors()).toEqual({
+        pssStartDate: 'You must specify a valid PSS start date',
+        pssEndDate: 'You must specify a valid PSS end date',
+      })
+    })
+  })
+
+  describe('response', () => {
+    it('returns a translated version of the response when both release types are selected', () => {
+      const page = new ReleaseType(body, application)
+      expect(page.response()).toEqual({
+        'What is the release type?': 'Licence\nPost sentence supervision (PSS)',
+        'Licence start date': '19 January 2024',
+        'Licence end date': '9 July 2024',
+        'PSS start date': '1 April 2122',
+        'PSS end date': '18 July 2122',
+      })
+    })
+
+    it('returns a translated version of the response when the licence release type is selected', () => {
+      const page = new ReleaseType({ ...body, releaseTypes: ['licence'] }, application)
+      expect(page.response()).toEqual({
+        'What is the release type?': 'Licence',
+        'Licence start date': '19 January 2024',
+        'Licence end date': '9 July 2024',
+      })
+    })
+
+    it('returns a translated version of the response when the PSS release type is selected', () => {
+      const page = new ReleaseType({ ...body, releaseTypes: ['pss'] }, application)
+      expect(page.response()).toEqual({
+        'What is the release type?': 'Post sentence supervision (PSS)',
+        'PSS start date': '1 April 2122',
+        'PSS end date': '18 July 2122',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -1,0 +1,110 @@
+import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
+import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
+import { Page } from '../../../utils/decorators'
+
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import TasklistPage from '../../../tasklistPage'
+import { dateBodyProperties } from '../../../utils'
+
+type ReleaseTypeBody = {
+  releaseTypes: Array<'licence' | 'pss'>
+} & ObjectWithDateParts<'licenceStartDate'> &
+  ObjectWithDateParts<'licenceEndDate'> &
+  ObjectWithDateParts<'pssStartDate'> &
+  ObjectWithDateParts<'pssEndDate'>
+
+@Page({
+  name: 'release-type',
+  bodyProperties: [
+    'releaseTypes',
+    ...dateBodyProperties('licenceStartDate'),
+    ...dateBodyProperties('licenceEndDate'),
+    ...dateBodyProperties('pssStartDate'),
+    ...dateBodyProperties('pssEndDate'),
+  ],
+})
+export default class ReleaseType implements TasklistPage {
+  title = 'What is the release type?'
+
+  constructor(private _body: Partial<ReleaseTypeBody>, readonly application: Application) {}
+
+  public set body(value: Partial<ReleaseTypeBody>) {
+    this._body = {
+      ...value,
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'licenceStartDate'),
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'licenceEndDate'),
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'pssStartDate'),
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'pssEndDate'),
+    }
+  }
+
+  public get body(): Partial<ReleaseTypeBody> {
+    return this._body
+  }
+
+  response() {
+    const response = {
+      [this.title]: this.body.releaseTypes
+        .map(releaseType => (releaseType === 'licence' ? 'Licence' : 'Post sentence supervision (PSS)'))
+        .join('\n'),
+    }
+
+    if (this.body.releaseTypes.includes('licence')) {
+      response['Licence start date'] = DateFormats.isoDateToUIDate(this.body.licenceStartDate)
+      response['Licence end date'] = DateFormats.isoDateToUIDate(this.body.licenceEndDate)
+    }
+
+    if (this.body.releaseTypes.includes('pss')) {
+      response['PSS start date'] = DateFormats.isoDateToUIDate(this.body.pssStartDate)
+      response['PSS end date'] = DateFormats.isoDateToUIDate(this.body.pssEndDate)
+    }
+
+    return response
+  }
+
+  previous() {
+    return 'sentence-expiry'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.releaseTypes?.length) {
+      errors.releaseTypes = 'You must specify the licence start date'
+    }
+
+    if (this.body.releaseTypes.includes('licence')) {
+      if (dateIsBlank(this.body, 'licenceStartDate')) {
+        errors.licenceStartDate = 'You must specify the licence start date'
+      } else if (!dateAndTimeInputsAreValidDates(this.body, 'licenceStartDate')) {
+        errors.licenceStartDate = 'You must specify a valid licence start date'
+      }
+
+      if (dateIsBlank(this.body, 'licenceEndDate')) {
+        errors.licenceEndDate = 'You must specify the licence end date'
+      } else if (!dateAndTimeInputsAreValidDates(this.body, 'licenceEndDate')) {
+        errors.licenceEndDate = 'You must specify a valid licence end date'
+      }
+    }
+
+    if (this.body.releaseTypes.includes('pss')) {
+      if (dateIsBlank(this.body, 'pssStartDate')) {
+        errors.pssStartDate = 'You must specify the PSS start date'
+      } else if (!dateAndTimeInputsAreValidDates(this.body, 'pssStartDate')) {
+        errors.pssStartDate = 'You must specify a valid PSS start date'
+      }
+
+      if (dateIsBlank(this.body, 'pssEndDate')) {
+        errors.pssEndDate = 'You must specify the PSS end date'
+      } else if (!dateAndTimeInputsAreValidDates(this.body, 'pssEndDate')) {
+        errors.pssEndDate = 'You must specify a valid PSS end date'
+      }
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceExpiry.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceExpiry.test.ts
@@ -1,0 +1,67 @@
+import { applicationFactory } from '../../../../testutils/factories'
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import SentenceExpiry from './sentenceExpiry'
+
+jest.mock('../../../../utils/dateUtils', () => {
+  const module = jest.requireActual('../../../../utils/dateUtils')
+
+  return {
+    ...module,
+    dateIsBlank: jest.fn(),
+    dateAndTimeInputsAreValidDates: jest.fn(),
+  }
+})
+
+const body = { 'sentenceExpiryDate-year': '2024', 'sentenceExpiryDate-month': '4', 'sentenceExpiryDate-day': '11' }
+
+describe('SentenceExpiry', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('sets the body', () => {
+      const page = new SentenceExpiry(body, application)
+
+      expect(page.body).toEqual({
+        ...body,
+        sentenceExpiryDate: '2024-04-11',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new SentenceExpiry({}, application), 'sentence-type')
+  itShouldHaveNextValue(new SentenceExpiry({}, application), 'release-type')
+
+  describe('errors', () => {
+    it('should return an empty object if the release date is specified', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new SentenceExpiry(body, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('should return an error if the date is not populated', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(true)
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+
+      const page = new SentenceExpiry(body, application)
+      expect(page.errors()).toEqual({ sentenceExpiryDate: 'You must specify the sentence expiry date' })
+    })
+
+    it('should return an error if the date is invalid', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(false)
+
+      const page = new SentenceExpiry(body, application)
+      expect(page.errors()).toEqual({ sentenceExpiryDate: 'You must specify a valid sentence expiry date' })
+    })
+  })
+
+  describe('response', () => {
+    it('returns a translated version of the response', () => {
+      const page = new SentenceExpiry(body, application)
+      expect(page.response()).toEqual({ 'Sentence expiry date': '11 April 2024' })
+    })
+  })
+})

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceExpiry.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceExpiry.ts
@@ -1,0 +1,54 @@
+import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
+import type { ObjectWithDateParts, TaskListErrors } from '@approved-premises/ui'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import TasklistPage from '../../../tasklistPage'
+import { dateBodyProperties } from '../../../utils'
+import { Page } from '../../../utils/decorators'
+
+type SentenceExpiryBody = ObjectWithDateParts<'sentenceExpiryDate'>
+
+@Page({ name: 'sentence-expiry', bodyProperties: dateBodyProperties('sentenceExpiryDate') })
+export default class SentenceExpiry implements TasklistPage {
+  title: string
+
+  constructor(private _body: Partial<SentenceExpiryBody>, readonly application: Application) {
+    this.title = 'Sentence expiry date'
+  }
+
+  public set body(value: Partial<SentenceExpiryBody>) {
+    this._body = {
+      ...value,
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'sentenceExpiryDate'),
+    }
+  }
+
+  public get body(): Partial<SentenceExpiryBody> {
+    return this._body
+  }
+
+  response() {
+    return {
+      [this.title]: DateFormats.isoDateToUIDate(this.body.sentenceExpiryDate),
+    }
+  }
+
+  previous() {
+    return 'sentence-type'
+  }
+
+  next() {
+    return 'release-type'
+  }
+
+  errors() {
+    const errors: TaskListErrors<this> = {}
+
+    if (dateIsBlank(this.body, 'sentenceExpiryDate')) {
+      errors.sentenceExpiryDate = 'You must specify the sentence expiry date'
+    } else if (!dateAndTimeInputsAreValidDates(this.body, 'sentenceExpiryDate')) {
+      errors.sentenceExpiryDate = 'You must specify a valid sentence expiry date'
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.test.ts
@@ -14,8 +14,8 @@ describe('SentenceType', () => {
     })
   })
 
+  itShouldHavePreviousValue(new SentenceType({}, application), 'dashboard')
   itShouldHaveNextValue(new SentenceType({}, application), '')
-  itShouldHavePreviousValue(new SentenceType({}, application), '')
 
   describe('errors', () => {
     it('should return an empty object if the sentence type is populated', () => {

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.test.ts
@@ -15,7 +15,7 @@ describe('SentenceType', () => {
   })
 
   itShouldHavePreviousValue(new SentenceType({}, application), 'dashboard')
-  itShouldHaveNextValue(new SentenceType({}, application), '')
+  itShouldHaveNextValue(new SentenceType({}, application), 'sentence-expiry')
 
   describe('errors', () => {
     it('should return an empty object if the sentence type is populated', () => {

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.ts
@@ -27,7 +27,7 @@ export default class SentenceType implements TasklistPage {
   }
 
   previous() {
-    return ''
+    return 'dashboard'
   }
 
   next() {

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.ts
@@ -31,7 +31,7 @@ export default class SentenceType implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'sentence-expiry'
   }
 
   errors() {

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.test.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.test.ts
@@ -1,11 +1,20 @@
 import { applicationFactory } from '../../../../testutils/factories'
-import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInFuture } from '../../../../utils/dateUtils'
+import { dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInFuture } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import DtrDetails from './dtrDetails'
 
-jest.mock('../../../../utils/dateUtils')
+jest.mock('../../../../utils/dateUtils', () => {
+  const module = jest.requireActual('../../../../utils/dateUtils')
 
-const body = { reference: 'ABC123', date: '2022-07-23' }
+  return {
+    ...module,
+    dateIsBlank: jest.fn(),
+    dateAndTimeInputsAreValidDates: jest.fn(),
+    dateIsInFuture: jest.fn(),
+  }
+})
+
+const body = { reference: 'ABC123', 'date-year': '2022', 'date-month': '7', 'date-day': '23' }
 
 describe('DtrDetails', () => {
   const application = applicationFactory.build()
@@ -14,7 +23,10 @@ describe('DtrDetails', () => {
     it('sets the body', () => {
       const page = new DtrDetails(body, application)
 
-      expect(page.body).toEqual(body)
+      expect(page.body).toEqual({
+        ...body,
+        date: '2022-07-23',
+      })
     })
   })
 
@@ -78,12 +90,10 @@ describe('DtrDetails', () => {
 
   describe('response', () => {
     it('returns a translated version of the response', () => {
-      ;(DateFormats.isoDateToUIDate as jest.Mock).mockReturnValue('23 July 2023')
-
       const page = new DtrDetails(body, application)
       expect(page.response()).toEqual({
         'DTR / NOP reference number': 'ABC123',
-        'Date DTR / NOP was submitted': '23 July 2023',
+        'Date DTR / NOP was submitted': '23 July 2022',
       })
     })
   })

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
@@ -45,7 +45,7 @@ export default class DtrDetails implements TasklistPage {
 
     if (dateIsBlank(this.body, 'date')) {
       errors.date = 'You must specify the date DTR / NOP was submitted'
-    } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'date'>, 'date')) {
+    } else if (!dateAndTimeInputsAreValidDates(this.body, 'date')) {
       errors.date = 'You must specify a valid date DTR / NOP was submitted'
     } else if (dateIsInFuture(this.body.date)) {
       errors.date = 'The date DTR / NOP was submitted must not be in the future'

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
@@ -4,12 +4,13 @@ import { Page } from '../../../utils/decorators'
 
 import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInFuture } from '../../../../utils/dateUtils'
 import TasklistPage from '../../../tasklistPage'
+import { dateBodyProperties } from '../../../utils'
 
 type DtrDetailsBody = {
   reference: string
 } & ObjectWithDateParts<'date'>
 
-@Page({ name: 'dtr-details', bodyProperties: ['reference', 'date', 'date-year', 'date-month', 'date-day'] })
+@Page({ name: 'dtr-details', bodyProperties: ['reference', ...dateBodyProperties('date')] })
 export default class DtrDetails implements TasklistPage {
   title = 'Provide further details'
 

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
@@ -43,7 +43,7 @@ export default class DtrDetails implements TasklistPage {
       errors.reference = 'You must specify the DTR / NOP reference number'
     }
 
-    if (dateIsBlank(this.body)) {
+    if (dateIsBlank(this.body, 'date')) {
       errors.date = 'You must specify the date DTR / NOP was submitted'
     } else if (!dateAndTimeInputsAreValidDates(this.body as ObjectWithDateParts<'date'>, 'date')) {
       errors.date = 'You must specify a valid date DTR / NOP was submitted'

--- a/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/referrals-and-documents/accommodation-referral-details/dtrDetails.ts
@@ -19,7 +19,18 @@ export default class DtrDetails implements TasklistPage {
     date: 'Date DTR / NOP was submitted',
   }
 
-  constructor(readonly body: Partial<DtrDetailsBody>, readonly application: Application) {}
+  constructor(private _body: Partial<DtrDetailsBody>, readonly application: Application) {}
+
+  public set body(value: Partial<DtrDetailsBody>) {
+    this._body = {
+      ...value,
+      ...DateFormats.dateAndTimeInputsToIsoString(value, 'date'),
+    }
+  }
+
+  public get body(): Partial<DtrDetailsBody> {
+    return this._body
+  }
 
   response() {
     return {

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -40,6 +40,101 @@
               "type": "string"
             }
           }
+        },
+        "sentence-expiry": {
+          "type": "object",
+          "properties": {
+            "sentenceExpiryDate-year": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-month": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-day": {
+              "type": "string"
+            },
+            "sentenceExpiryDate-time": {
+              "type": "string"
+            },
+            "sentenceExpiryDate": {
+              "type": "string"
+            }
+          }
+        },
+        "release-type": {
+          "type": "object",
+          "properties": {
+            "releaseTypes": {
+              "type": "array",
+              "items": {
+                "enum": [
+                  "licence",
+                  "pss"
+                ],
+                "type": "string"
+              }
+            },
+            "licenceStartDate-year": {
+              "type": "string"
+            },
+            "licenceStartDate-month": {
+              "type": "string"
+            },
+            "licenceStartDate-day": {
+              "type": "string"
+            },
+            "licenceStartDate-time": {
+              "type": "string"
+            },
+            "licenceStartDate": {
+              "type": "string"
+            },
+            "licenceEndDate-year": {
+              "type": "string"
+            },
+            "licenceEndDate-month": {
+              "type": "string"
+            },
+            "licenceEndDate-day": {
+              "type": "string"
+            },
+            "licenceEndDate-time": {
+              "type": "string"
+            },
+            "licenceEndDate": {
+              "type": "string"
+            },
+            "pssStartDate-year": {
+              "type": "string"
+            },
+            "pssStartDate-month": {
+              "type": "string"
+            },
+            "pssStartDate-day": {
+              "type": "string"
+            },
+            "pssStartDate-time": {
+              "type": "string"
+            },
+            "pssStartDate": {
+              "type": "string"
+            },
+            "pssEndDate-year": {
+              "type": "string"
+            },
+            "pssEndDate-month": {
+              "type": "string"
+            },
+            "pssEndDate-day": {
+              "type": "string"
+            },
+            "pssEndDate-time": {
+              "type": "string"
+            },
+            "pssEndDate": {
+              "type": "string"
+            }
+          }
         }
       }
     },

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -320,4 +320,15 @@ describe('utils', () => {
       expect(() => utils.hasSubmittedDtr(application)).toThrow(new SessionDataError('No DTR submitted value'))
     })
   })
+
+  describe('dateBodyProperties', () => {
+    it('returns date field names for use in page body properties', () => {
+      expect(utils.dateBodyProperties('someDate')).toEqual([
+        'someDate',
+        'someDate-year',
+        'someDate-month',
+        'someDate-day',
+      ])
+    })
+  })
 })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -163,3 +163,7 @@ export const hasSubmittedDtr = (application: Application): boolean => {
 
   return dtrSubmitted === 'yes'
 }
+
+export const dateBodyProperties = (root: string) => {
+  return [root, `${root}-year`, `${root}-month`, `${root}-day`]
+}

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -224,7 +224,7 @@ describe('dateIsBlank', () => {
       'field-year': '2022',
     }
 
-    expect(dateIsBlank(date)).toEqual(false)
+    expect(dateIsBlank(date, 'field')).toEqual(false)
   })
 
   it('returns true if the date is blank', () => {
@@ -234,7 +234,20 @@ describe('dateIsBlank', () => {
       'field-year': '',
     }
 
-    expect(dateIsBlank(date)).toEqual(true)
+    expect(dateIsBlank(date, 'field')).toEqual(true)
+  })
+
+  it('ignores irrelevant fields', () => {
+    const date: ObjectWithDateParts<'field'> & ObjectWithDateParts<'otherField'> = {
+      'field-day': '12',
+      'field-month': '1',
+      'field-year': '2022',
+      'otherField-day': undefined,
+      'otherField-month': undefined,
+      'otherField-year': undefined,
+    }
+
+    expect(dateIsBlank(date, 'field')).toEqual(false)
   })
 })
 

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -120,9 +120,11 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   return true
 }
 
-export const dateIsBlank = <T = ObjectWithDateParts<string | number>>(body: T): boolean => {
-  const fields = Object.keys(body).filter(key => key.match(/-[year|month|day]/)) as Array<keyof T>
-  return fields.every(field => !body[field])
+export const dateIsBlank = <K extends string | number>(
+  dateInputObj: Partial<ObjectWithDateParts<K>>,
+  key: K,
+): boolean => {
+  return !['year' as const, 'month' as const, 'day' as const].every(part => !!dateInputObj[`${key}-${part}`])
 }
 
 export class InvalidDateStringError extends Error {}

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -67,7 +67,7 @@ export class DateFormats {
    * @returns an ISO8601 date string.
    */
   static dateAndTimeInputsToIsoString<K extends string | number>(
-    dateInputObj: ObjectWithDateParts<K>,
+    dateInputObj: Partial<ObjectWithDateParts<K>>,
     key: K,
     options: { representation: 'auto' | 'complete' } = { representation: 'auto' },
   ) {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -71,25 +71,36 @@ export class DateFormats {
     key: K,
     options: { representation: 'auto' | 'complete' } = { representation: 'auto' },
   ) {
-    const day = `0${dateInputObj[`${key}-day`]}`.slice(-2)
-    const month = `0${dateInputObj[`${key}-month`]}`.slice(-2)
-    const year = dateInputObj[`${key}-year`]
-    const time = dateInputObj[`${key}-time`]
+    const yearKey = `${key}-year`
+    const monthKey = `${key}-month`
+    const dayKey = `${key}-day`
+    const timeKey = `${key}-time`
 
-    const o: { [P in K]?: string } = dateInputObj
+    const year = dateInputObj[yearKey] as string
+    const month = `0${dateInputObj[monthKey]}`.slice(-2)
+    const day = `0${dateInputObj[dayKey]}`.slice(-2)
+    const time = dateInputObj[timeKey] as string
+
+    let date: string
     if (day && month && year) {
       if (time) {
-        o[key] = `${year}-${month}-${day}T${time}:00.000Z`
+        date = `${year}-${month}-${day}T${time}:00.000Z`
       } else if (options.representation === 'complete') {
-        o[key] = `${year}-${month}-${day}T00:00:00.000Z`
+        date = `${year}-${month}-${day}T00:00:00.000Z`
       } else {
-        o[key] = `${year}-${month}-${day}`
+        date = `${year}-${month}-${day}`
       }
     } else {
-      o[key] = undefined
+      date = undefined
     }
 
-    return dateInputObj
+    return {
+      [yearKey]: dateInputObj[yearKey],
+      [monthKey]: dateInputObj[monthKey],
+      [dayKey]: dateInputObj[dayKey],
+      [timeKey]: time,
+      [key]: date,
+    } as ObjectWithDateParts<K>
   }
 
   static isoToDateAndTimeInputs<K extends string | number>(isoDate: string, key: K): ObjectWithDateParts<K> {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -104,7 +104,7 @@ export class DateFormats {
 }
 
 export const dateAndTimeInputsAreValidDates = <K extends string | number>(
-  dateInputObj: ObjectWithDateParts<K>,
+  dateInputObj: Partial<ObjectWithDateParts<K>>,
   key: K,
 ): boolean => {
   const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)

--- a/server/views/applications/pages/accommodation-need/sentence-information/release-type.njk
+++ b/server/views/applications/pages/accommodation-need/sentence-information/release-type.njk
@@ -1,0 +1,98 @@
+ {% extends "../../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">{{ task.title }}</span>
+    {{ page.title }}
+  </h1>
+
+  {% set licenceConditionalHtml %}
+    {{ formPageDateInput( {
+      fieldName: "licenceStartDate",
+      fieldset: {
+        legend: {
+          text: "Start date",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: dateInputHint('future')
+      },
+      items: dateFieldValues("licenceStartDate", errors)
+    }, fetchContext()) }}
+
+    {{ formPageDateInput( {
+      fieldName: "licenceEndDate",
+      fieldset: {
+        legend: {
+          text: "End date",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: dateInputHint('future')
+      },
+      items: dateFieldValues("licenceEndDate", errors)
+    }, fetchContext()) }}
+  {% endset %}
+
+
+  {% set pssConditionalHtml %}
+    {{ formPageDateInput( {
+      fieldName: "pssStartDate",
+      fieldset: {
+        legend: {
+          text: "Start date",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: dateInputHint('future')
+      },
+      items: dateFieldValues("pssStartDate", errors)
+    }, fetchContext()) }}
+
+    {{ formPageDateInput( {
+      fieldName: "pssEndDate",
+      fieldset: {
+        legend: {
+          text: "End date",
+          classes: "govuk-fieldset__legend--m"
+        }
+      },
+      hint: {
+        text: dateInputHint('future')
+      },
+      items: dateFieldValues("pssEndDate", errors)
+    }, fetchContext()) }}
+  {% endset %}
+
+
+  {{ formPageCheckboxes({
+    fieldName: "releaseTypes",
+    fieldset: {
+      legend: {
+        text: "Select all that apply",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        value: "licence",
+        text: "Licence",
+        conditional: {
+          html: licenceConditionalHtml
+        }
+      },
+      {
+        value: "pss",
+        text: "Post sentence supervision (PSS)",
+        conditional: {
+          html: pssConditionalHtml
+        }
+      }
+    ]
+  }, fetchContext()) }}
+
+{% endblock %}

--- a/server/views/applications/pages/accommodation-need/sentence-information/sentence-expiry.njk
+++ b/server/views/applications/pages/accommodation-need/sentence-information/sentence-expiry.njk
@@ -1,0 +1,18 @@
+{% extends "../../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">{{ task.title }}</span>
+    {{ page.title }}
+  </h1>
+
+  {{ formPageDateInput( {
+    fieldName: "sentenceExpiryDate",
+    hint: {
+      text: dateInputHint('future')
+    },
+    items: dateFieldValues('sentenceExpiryDate', errors)
+  }, fetchContext()) }}
+
+{% endblock %}


### PR DESCRIPTION
# Changes in this PR

This adds two new screens to the sentence information task. The screens themselves are reasonably straightforward, though there is a lot of groundwork first to support a page containing multiple date fields

## Screenshots of UI changes
![localhost_3000_applications_1149c179-d1aa-4eeb-b10c-2d07acba071d_tasks_sentence-information_pages_sentence-expiry](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/d167a69a-3bc8-442a-b4fa-435a022cbc9d)
![localhost_3000_applications_1149c179-d1aa-4eeb-b10c-2d07acba071d_tasks_sentence-information_pages_sentence-expiry (1)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/c79a4cb2-e411-4623-b58c-c37ea6109295)
![localhost_3000_applications_1149c179-d1aa-4eeb-b10c-2d07acba071d_tasks_sentence-information_pages_release-type](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/53bcbcc6-8e45-46e0-a5a0-98ffc6308faf)
![localhost_3000_applications_1149c179-d1aa-4eeb-b10c-2d07acba071d_tasks_sentence-information_pages_release-type (1)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/b2827332-4d74-47d5-a3c2-258d9977fa07)
![localhost_3000_applications_1149c179-d1aa-4eeb-b10c-2d07acba071d_tasks_check-your-answers_pages_review](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/3f7be75a-43f3-4d4a-8fb8-e4013c2ebef9)


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
