### PR TITLE
Standard hint text for date fields in Apply

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -4,6 +4,7 @@ import {
   DateFormats,
   InvalidDateStringError,
   dateAndTimeInputsAreValidDates,
+  dateInputHint,
   dateIsBlank,
   dateIsInFuture,
   dateIsInThePast,
@@ -272,5 +273,19 @@ describe('dateIsInTheFuture', () => {
     ;(isFuture as jest.Mock).mockReturnValue(false)
 
     expect(dateIsInFuture('2020-01-01')).toEqual(false)
+  })
+})
+
+describe('dateInputHint', () => {
+  it('returns hint text with an example past date', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2027-03-11'))
+
+    expect(dateInputHint('past')).toEqual('For example, 27 3 2026')
+  })
+
+  it('returns hint text with an example future date', () => {
+    jest.useFakeTimers().setSystemTime(new Date('2027-03-11'))
+
+    expect(dateInputHint('future')).toEqual('For example, 27 3 2028')
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -160,3 +160,9 @@ export const dateIsInFuture = (dateString: string): boolean => {
   const date = DateFormats.isoToDateObj(dateString)
   return isFuture(date)
 }
+
+export const dateInputHint = (direction: 'past' | 'future') => {
+  const year = new Date().getFullYear() + (direction === 'past' ? -1 : 1)
+
+  return `For example, 27 3 ${year}`
+}

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,7 +6,7 @@ import nunjucks from 'nunjucks'
 import * as pathModule from 'path'
 
 import type { ErrorMessages, PersonStatus } from '@approved-premises/ui'
-import { DateFormats } from './dateUtils'
+import { DateFormats, dateInputHint } from './dateUtils'
 import {
   convertObjectsToCheckboxItems,
   convertObjectsToRadioItems,
@@ -88,6 +88,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('dateFieldValues', dateFieldValues)
   njkEnv.addGlobal('formatDate', DateFormats.isoDateToUIDate)
   njkEnv.addGlobal('parseNaturalNumber', parseNaturalNumber)
+  njkEnv.addGlobal('dateInputHint', dateInputHint)
 
   njkEnv.addGlobal('dateFieldValues', function sendContextToDateFieldValues(fieldName: string, errors: ErrorMessages) {
     return dateFieldValues(fieldName, this.ctx, errors)

--- a/server/views/applications/pages/accommodation-need/eligibility/accommodation-required-from-date.njk
+++ b/server/views/applications/pages/accommodation-need/eligibility/accommodation-required-from-date.njk
@@ -9,6 +9,9 @@
 
   {{ formPageDateInput( {
     fieldName: "accommodationRequiredFromDate",
+    hint: {
+      text: dateInputHint('future')
+    },
     items: dateFieldValues('accommodationRequiredFromDate', errors)
   }, fetchContext()) }}
 

--- a/server/views/applications/pages/accommodation-need/eligibility/release-date.njk
+++ b/server/views/applications/pages/accommodation-need/eligibility/release-date.njk
@@ -7,10 +7,15 @@
     {{ page.title }}
   </h1>
 
+  {% set hintHtml %}
+    <p class="govuk-hint">This could include the release date from custody, an Approved Premises, or Bail Accommodation and Support Services</p>
+    <p class="govuk-hint">{{ dateInputHint('future') }}</p>
+  {% endset %}
+
   {{ formPageDateInput( {
     fieldName: "releaseDate",
     hint: {
-      text: "This could include the release date from custody, an Approved Premises, or Bail Accommodation and Support Services"
+      html: hintHtml
     },
     items: dateFieldValues('releaseDate', errors)
   }, fetchContext()) }}

--- a/server/views/applications/pages/referrals-and-documents/accommodation-referral-details/dtr-details.njk
+++ b/server/views/applications/pages/referrals-and-documents/accommodation-referral-details/dtr-details.njk
@@ -17,6 +17,9 @@
 
   {{ formPageDateInput( {
     fieldName: "date",
+    hint: {
+      text: dateInputHint('past')
+    },
     fieldset: {
       legend: {
         text: page.questions.date,


### PR DESCRIPTION
# Changes in this PR

* Adds (and uses in Apply) a function for generating hint text for date inputs

## Screenshots of UI changes

### Before
![localhost_3000_applications_de01549e-7e66-45d2-994a-64bdd5e48440_tasks_eligibility_pages_release-date](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/620d8e8e-89f8-4880-93e0-8bc32fee8ef1)
![localhost_3000_applications_de01549e-7e66-45d2-994a-64bdd5e48440_tasks_accommodation-referral-details_pages_dtr-details (1)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/22a57692-9a63-4b90-a502-f021b6dbacc6)

### After
![localhost_3000_applications_de01549e-7e66-45d2-994a-64bdd5e48440_tasks_eligibility_pages_release-date (1)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/a3a0ca9b-4c03-45f7-ae02-3b32f1e32921)
![localhost_3000_applications_de01549e-7e66-45d2-994a-64bdd5e48440_tasks_accommodation-referral-details_pages_dtr-details](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/12a3611b-b048-48b0-8c2c-c37bbbedbd53)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
