### PR TITLE
Investigate issue with TypeScript update

### DIFF
--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -5,10 +5,10 @@
     "lib": ["es5", "dom", "es2015.promise"],
     "types": ["cypress"],
     "esModuleInterop": true,
-    "typeRoots": ["../server/@types", "../node_modules/@types"],
     "resolveJsonModule": true,
     "moduleResolution": "node",
     "baseUrl": ".",
+    "skipLibCheck": true,
     "experimentalDecorators": true,
     "paths": {
       "@approved-premises/ui": ["../server/@types/ui/index.d.ts"],


### PR DESCRIPTION
# Changes in this PR

We update our integration test tsconfig file to bring it more line line with CAS1's equivalent file, and our own main tsconfig file. This resolves an issue where on upgrading to TypeScript 5.1.3, our typecheck command appears to run out of memory checking integration tests

See https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/actions/runs/5371348478/jobs/9744052370?pr=417 for an example

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
