### PR TITLE
Update person JSON data

### DIFF
--- a/cypress_shared/fixtures/person-dev.json
+++ b/cypress_shared/fixtures/person-dev.json
@@ -7,5 +7,6 @@
   "prisonName": "Moorland (HMP & YOI)",
   "religionOrBelief": "Apostolic",
   "nationality": "British",
+  "ethnicity": "White: British/English/Welsh/Scottish/Northern Irish",
   "sex": "Male"
 }

--- a/cypress_shared/fixtures/person-local.json
+++ b/cypress_shared/fixtures/person-local.json
@@ -7,5 +7,6 @@
   "prisonName": "Leeds",
   "religionOrBelief": "",
   "nationality": "",
+  "ethnicity": "",
   "sex": "Male"
 }


### PR DESCRIPTION
Now that we display ethnicity data as part of our Apply journey, our E2E tests require we have accurate ethnicity data in our person JSON files