### PR TITLE
Fix error checking in booking E2E tests

### DIFF
--- a/e2e/tests/stepDefinitions/manage/cancellation.ts
+++ b/e2e/tests/stepDefinitions/manage/cancellation.ts
@@ -130,7 +130,7 @@ Then('I should see the booking with the edited cancellation details', () => {
 Then('I should see a list of the problems encountered cancelling the booking', () => {
   cy.then(function _() {
     const page = Page.verifyOnPage(BookingCancellationNewPage, this.premises, this.room, this.booking)
-    page.shouldShowErrorMessagesForFields(['date'], 'bookingCancellation')
+    page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
 
     page.clickBack()
   })
@@ -139,7 +139,7 @@ Then('I should see a list of the problems encountered cancelling the booking', (
 Then('I should see a list of the problems encountered editing the cancelling booking', () => {
   cy.then(function _() {
     const page = Page.verifyOnPage(BookingCancellationEditPage, this.premises, this.room, this.booking)
-    page.shouldShowErrorMessagesForFields(['date'], 'bookingCancellation')
+    page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
 
     page.clickBack()
   })


### PR DESCRIPTION
In a previous commit we updated the signature of Page.shouldShowErrorMessagesForFields(), so we could specify the error type, but did not update its usage in our booking E2E tests, causing an E2E test failure. This fixes that failure