### PR TITLE
Change Apply url to "referrals"

### DIFF
--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -40,7 +40,7 @@ Given('I start a new application', () => {
 
 Given('I fill in and complete an application', () => {
   cy.url().then(function _(url) {
-    const id = url.match(/applications\/(.+)/)[1]
+    const id = url.match(/referrals\/(.+)/)[1]
     const application = applicationFactory.build({ ...this.application, id })
 
     const apply = new ApplyHelper(application, person, [], 'e2e')

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -13,7 +13,7 @@ import ApplyHelper from '../../../cypress_shared/helpers/apply'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import Page from '../../../cypress_shared/pages/page'
 import setupTestUser from '../../../cypress_shared/utils/setupTestUser'
-import paths from '../../../server/paths/apply'
+import paths from '../../../server/paths/api'
 import {
   activeOffenceFactory,
   applicationFactory,

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -13,6 +13,7 @@ import ApplyHelper from '../../../cypress_shared/helpers/apply'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import Page from '../../../cypress_shared/pages/page'
 import setupTestUser from '../../../cypress_shared/utils/setupTestUser'
+import paths from '../../../server/paths/apply'
 import {
   activeOffenceFactory,
   applicationFactory,
@@ -154,7 +155,7 @@ context('Apply', () => {
     cy.task('verifyApplicationSubmit', this.application.id).then(requests => {
       expect(requests).to.have.length(1)
 
-      expect(requests[0].url).to.equal(`/applications/${this.application.id}/submission`)
+      expect(requests[0].url).to.equal(paths.applications.submission({ id: this.application.id }))
     })
 
     // And I should be taken to the confirmation page

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -1,6 +1,6 @@
 import { path } from 'static-path'
 
-const applicationsPath = path('/applications')
+const applicationsPath = path('/referrals')
 const applicationPath = applicationsPath.path(':id')
 
 const pagesPath = applicationPath.path('tasks/:task/pages/:page')

--- a/server/utils/checkYourAnswersUtils.test.ts
+++ b/server/utils/checkYourAnswersUtils.test.ts
@@ -3,6 +3,7 @@ import { applicationFactory } from '../testutils/factories'
 import { forPagesInTask } from './applicationUtils'
 
 import TasklistPage from '../form-pages/tasklistPage'
+import paths from '../paths/apply'
 import {
   checkYourAnswersSections,
   embeddedSummaryListItem,
@@ -105,7 +106,7 @@ describe('checkYourAnswersUtils', () => {
           actions: {
             items: [
               {
-                href: `/applications/${application.id}/tasks/some-task/pages/some-page`,
+                href: paths.applications.pages.show({ id: application.id, task: 'some-task', page: 'some-page' }),
                 text: 'Change',
                 visuallyHiddenText: 'A question',
               },


### PR DESCRIPTION
# Changes in this PR

* The Apply journey is now reached at `<serviced domain>/referrals`, rather than `<serviced domain>/applications`

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
