### PR TITLE
Repair E2E test 'env' flag in config.yml

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -64,14 +64,7 @@ jobs:
           name: E2E Check - << parameters.environment >>
           command: |
             npm run test:e2e:ci --\
-              --env "\
-                assessor_username=${CYPRESS_ASSESSOR_USERNAME_<< parameters.environment >>},\
-                assessor_password=${CYPRESS_ASSESSOR_PASSWORD_<< parameters.environment >>},\
-                referrer_username=${CYPRESS_REFERRER_USERNAME_<< parameters.environment >>},\
-                referrer_password=${CYPRESS_REFERRER_PASSWORD_<< parameters.environment >>},\
-                acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},\
-                acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},\
-                environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"\
+              --env "assessor_username=${CYPRESS_ASSESSOR_USERNAME_<< parameters.environment >>},assessor_password=${CYPRESS_ASSESSOR_PASSWORD_<< parameters.environment >>},referrer_username=${CYPRESS_REFERRER_USERNAME_<< parameters.environment >>},referrer_password=${CYPRESS_REFERRER_PASSWORD_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"\
               --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots


### PR DESCRIPTION
We attempted to split this across multiple lines for readability. Sadly this does seem to need to be a single line without any spaces