### PR TITLE
Set up apply audit events

### DIFF
--- a/server/middleware/auditMiddleware.ts
+++ b/server/middleware/auditMiddleware.ts
@@ -7,6 +7,7 @@ export type AuditEventSpec = {
   auditEvent?: string
   auditBodyParams?: string[]
   redirectAuditEventSpecs?: RedirectAuditEventSpec[]
+  additionalMetadata?: Record<string, string>
 }
 
 type RedirectAuditEventSpec = { path: string; auditEvent: string }
@@ -30,6 +31,7 @@ export const auditMiddleware = (
       auditService,
       auditEventSpec?.auditEvent,
       auditEventSpec?.auditBodyParams,
+      auditEventSpec?.additionalMetadata,
       redirectMatchers,
     )
   }
@@ -42,6 +44,7 @@ const wrapHandler =
     auditService: AuditService,
     auditEvent: string | undefined,
     auditBodyParams: string[] | undefined,
+    additionalMetadata: Record<string, string> | undefined,
     redirectMatchers: RedirectAuditMatcher[] | undefined,
   ) =>
   async (req: Request, res: Response, next: NextFunction) => {
@@ -73,11 +76,14 @@ const wrapHandler =
     }
 
     if (auditEvent) {
-      await auditService.sendAuditMessage(auditEvent, userUuid, auditDetails(req, auditBodyParams))
+      await auditService.sendAuditMessage(auditEvent, userUuid, {
+        ...auditDetails(req, auditBodyParams),
+        ...additionalMetadata,
+      })
     }
 
     if (redirectAuditEvent) {
-      await auditService.sendAuditMessage(redirectAuditEvent, userUuid, redirectParams)
+      await auditService.sendAuditMessage(redirectAuditEvent, userUuid, { ...redirectParams, ...additionalMetadata })
     }
   }
 

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -12,8 +12,7 @@ import actions from './utils'
 export default function routes(controllers: Controllers, services: Services, router: Router): Router {
   const { pages } = Apply
   const { get, post, put } = actions(router, services.auditService)
-  const { applicationsController, pagesController, peopleController, offencesController, documentsController } =
-    controllers
+  const { applicationsController, pagesController, peopleController, offencesController } = controllers
 
   get(paths.applications.start.pattern, applicationsController.start())
   get(paths.applications.index.pattern, applicationsController.index())
@@ -25,7 +24,6 @@ export default function routes(controllers: Controllers, services: Services, rou
 
   post(paths.applications.people.find.pattern, peopleController.find())
   get(paths.applications.people.selectOffence.pattern, offencesController.selectOffence())
-  get(paths.applications.people.documents.pattern, documentsController.show())
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -14,22 +14,66 @@ export default function routes(controllers: Controllers, services: Services, rou
   const { get, post, put } = actions(router, services.auditService)
   const { applicationsController, pagesController, peopleController, offencesController } = controllers
 
-  get(paths.applications.start.pattern, applicationsController.start())
-  get(paths.applications.index.pattern, applicationsController.index())
-  get(paths.applications.new.pattern, applicationsController.new())
-  get(paths.applications.show.pattern, applicationsController.show())
-  get(paths.applications.confirm.pattern, applicationsController.confirm())
-  post(paths.applications.create.pattern, applicationsController.create())
-  post(paths.applications.submission.pattern, applicationsController.submit())
+  get(paths.applications.start.pattern, applicationsController.start(), { auditEvent: 'VIEW_APPLICATION_START' })
+  get(paths.applications.index.pattern, applicationsController.index(), { auditEvent: 'VIEW_APPLICATIONS_LIST' })
+  get(paths.applications.new.pattern, applicationsController.new(), { auditEvent: 'VIEW_APPLICATION_NEW' })
+  get(paths.applications.show.pattern, applicationsController.show(), { auditEvent: 'VIEW_APPLICATION' })
+  get(paths.applications.confirm.pattern, applicationsController.confirm(), {
+    auditEvent: 'VIEW_APPLICATION_CONFIRM',
+  })
+  post(paths.applications.create.pattern, applicationsController.create(), {
+    auditEvent: 'CREATE_APPLICATION',
+  })
+  post(paths.applications.submission.pattern, applicationsController.submit(), {
+    auditEvent: 'SUBMIT_APPLICATION',
+    redirectAuditEventSpecs: [
+      {
+        path: paths.applications.show.pattern,
+        auditEvent: 'SUBMIT_APPLICATION_FAILURE',
+      },
+      {
+        path: paths.applications.confirm.pattern,
+        auditEvent: 'SUBMIT_APPLICATION_SUCCESS',
+      },
+    ],
+  })
 
-  post(paths.applications.people.find.pattern, peopleController.find())
-  get(paths.applications.people.selectOffence.pattern, offencesController.selectOffence())
+  post(paths.applications.people.find.pattern, peopleController.find(), {
+    auditEvent: 'FIND_APPLICATION_PERSON',
+    auditBodyParams: ['crn'],
+  })
+  get(paths.applications.people.selectOffence.pattern, offencesController.selectOffence(), {
+    auditEvent: 'VIEW_APPLICATION_SELECT_OFFENCE',
+  })
 
   Object.keys(pages).forEach((taskKey: string) => {
     Object.keys(pages[taskKey]).forEach((pageKey: string) => {
       const { pattern } = paths.applications.show.path(`tasks/${taskKey}/pages/${pageKey}`)
-      get(pattern, pagesController.show(taskKey, pageKey))
-      put(pattern, pagesController.update(taskKey, pageKey))
+      get(pattern, pagesController.show(taskKey, pageKey), {
+        auditEvent: 'VIEW_APPLICATION_PAGE',
+        additionalMetadata: { task: taskKey, page: pageKey },
+      })
+      put(pattern, pagesController.update(taskKey, pageKey), {
+        auditEvent: `UPDATE_APPLICATION_PAGE`,
+        additionalMetadata: { task: taskKey, page: pageKey },
+        redirectAuditEventSpecs: [
+          {
+            // If we redirect to the same page, the user has hit an error
+            path: pattern,
+            auditEvent: 'UPDATE_APPLICATION_PAGE_FAILURE',
+          },
+          {
+            // If we redirect to the task list page, the application updated successfully
+            path: paths.applications.show.pattern,
+            auditEvent: 'UPDATE_APPLICATION_PAGE_SUCCESS',
+          },
+          {
+            // If we redirect to another application page, the application updated successfully
+            path: paths.applications.pages.show.pattern,
+            auditEvent: 'UPDATE_APPLICATION_PAGE_SUCCESS',
+          },
+        ],
+      })
     })
   })
 


### PR DESCRIPTION
# Changes in this PR

This PR sets up audit events for Apply, borrowing heavily from CAS1. Note this PR errs on the side of following CAS3 audit name conventions (VERB_CONTEXT_DETAIL[_SUCCESS || _FAILURE]), rather than copying CAS1's naming

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
