### PR TITLE
Update error handling on release type Apply page

### DIFF
--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
@@ -129,6 +129,20 @@ describe('SentenceExpiry', () => {
         pssEndDate: 'You must specify a valid PSS end date',
       })
     })
+
+    it('returns an error if release types are not specified', () => {
+      const page = new ReleaseType({}, application)
+      expect(page.errors()).toEqual({
+        releaseTypes: 'You must specify the release types',
+      })
+    })
+
+    it('returns an error if release types are empty', () => {
+      const page = new ReleaseType({ releaseTypes: [] }, application)
+      expect(page.errors()).toEqual({
+        releaseTypes: 'You must specify the release types',
+      })
+    })
   })
 
   describe('response', () => {

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -74,10 +74,10 @@ export default class ReleaseType implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.releaseTypes?.length) {
-      errors.releaseTypes = 'You must specify the licence start date'
+      errors.releaseTypes = 'You must specify the release types'
     }
 
-    if (this.body.releaseTypes.includes('licence')) {
+    if (this.body.releaseTypes?.includes('licence')) {
       if (dateIsBlank(this.body, 'licenceStartDate')) {
         errors.licenceStartDate = 'You must specify the licence start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body, 'licenceStartDate')) {
@@ -91,7 +91,7 @@ export default class ReleaseType implements TasklistPage {
       }
     }
 
-    if (this.body.releaseTypes.includes('pss')) {
+    if (this.body.releaseTypes?.includes('pss')) {
       if (dateIsBlank(this.body, 'pssStartDate')) {
         errors.pssStartDate = 'You must specify the PSS start date'
       } else if (!dateAndTimeInputsAreValidDates(this.body, 'pssStartDate')) {


### PR DESCRIPTION
We update the error handing on the release type Apply page to handle the case where the submitted releaseType array is undefined. Previously, the user would see a server error if they did not select either of the release types

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
