### PR TITLE
(1349) Assessor can make state changes to application

### DIFF
--- a/cypress_shared/pages/assess/confirm.ts
+++ b/cypress_shared/pages/assess/confirm.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class AssessmentConfirmPage extends Page {
+  constructor(title: string) {
+    super(title)
+  }
+}

--- a/cypress_shared/pages/assess/show.ts
+++ b/cypress_shared/pages/assess/show.ts
@@ -1,0 +1,10 @@
+import { TemporaryAccommodationAssessment as Assessment } from '../../../server/@types/shared'
+import { sentenceCase } from '../../../server/utils/utils'
+import Page from '../page'
+
+export default class AssessmentShowPage extends Page {
+  constructor(name: string, status: Assessment['status']) {
+    super(name)
+    cy.get('.govuk-tag').contains(sentenceCase(status as string))
+  }
+}

--- a/cypress_shared/pages/assess/show.ts
+++ b/cypress_shared/pages/assess/show.ts
@@ -7,4 +7,9 @@ export default class AssessmentShowPage extends Page {
     super(name)
     cy.get('.govuk-tag').contains(sentenceCase(status as string))
   }
+
+  clickAction(option: string) {
+    cy.get('.moj-button-menu__toggle-button').contains('Update referral status').click()
+    cy.get('.moj-button-menu__wrapper').contains(option).click()
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/assess/list.ts
+++ b/cypress_shared/pages/temporary-accommodation/assess/list.ts
@@ -1,0 +1,12 @@
+import { TemporaryAccommodationAssessment as Assessment } from '../../../../server/@types/shared'
+import Page from '../../page'
+
+export default class ListPage extends Page {
+  constructor() {
+    super('Referrals')
+  }
+
+  clickAssessment(assessment: Assessment) {
+    cy.get('a').contains(assessment.application.person.name).click()
+  }
+}

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -2,7 +2,7 @@ import type { SuperAgentRequest } from 'superagent'
 import { Assessment } from '../../server/@types/shared'
 
 import api from '../../server/paths/api'
-import { stubFor } from '../../wiremock'
+import { getMatchingRequests, stubFor } from '../../wiremock'
 
 export default {
   stubAssessments: (assessments: Array<Assessment>): SuperAgentRequest =>
@@ -29,4 +29,99 @@ export default {
         jsonBody: assessment,
       },
     }),
+  stubUnallocateAssessment: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'DELETE',
+        url: api.assessments.allocation({ id: assessment.id }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    }),
+  verifyUnallocateAssessment: async (assessmentId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'DELETE',
+        url: api.assessments.allocation({ id: assessmentId }),
+      })
+    ).body.requests,
+  stubAllocateAssessment: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: api.assessments.allocation({ id: assessment.id }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    }),
+  verifyAllocateAssessment: async (assessmentId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: api.assessments.allocation({ id: assessmentId }),
+      })
+    ).body.requests,
+  stubRejectAssessment: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: api.assessments.rejection({ id: assessment.id }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    }),
+  verifyRejectAssessment: async (assessmentId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: api.assessments.rejection({ id: assessmentId }),
+      })
+    ).body.requests,
+  stubAcceptAssessment: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: api.assessments.acceptance({ id: assessment.id }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    }),
+  verifyAcceptAssessment: async (assessmentId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: api.assessments.acceptance({ id: assessmentId }),
+      })
+    ).body.requests,
+  stubCloseAssessment: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: api.assessments.closure({ id: assessment.id }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {},
+      },
+    }),
+  verifyCloseAssessment: async (assessmentId: string) =>
+    (
+      await getMatchingRequests({
+        method: 'POST',
+        url: api.assessments.closure({ id: assessmentId }),
+      })
+    ).body.requests,
 }

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -17,4 +17,16 @@ export default {
         jsonBody: assessments,
       },
     }),
+  stubFindAssessment: (assessment: Assessment): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: api.assessments.show({ id: assessment.id }),
+      },
+      response: {
+        status: 200,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: assessment,
+      },
+    }),
 }

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -16,47 +16,49 @@ context('Apply', () => {
   })
 
   describe('Assess', () => {
-    it('I can view a list of assessments', () => {
-      // Given there are assessments in the database
-      const inProgressAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'in_review' })
-      const unallocatedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'unallocated' })
-      const readyToPlaceAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'ready_to_place' })
-      const rejectedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'rejected' })
-      const closedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'closed' })
+    describe('List assessments', () => {
+      it('I can view a list of assessments', () => {
+        // Given there are assessments in the database
+        const inProgressAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'in_review' })
+        const unallocatedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'unallocated' })
+        const readyToPlaceAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'ready_to_place' })
+        const rejectedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'rejected' })
+        const closedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'closed' })
 
-      cy.task('stubAssessments', [
-        ...inProgressAssessmentSummaries,
-        ...unallocatedAssessmentSummaries,
-        ...readyToPlaceAssessmentSummaries,
-        ...rejectedAssessmentSummaries,
-        ...closedAssessmentSummaries,
-      ])
+        cy.task('stubAssessments', [
+          ...inProgressAssessmentSummaries,
+          ...unallocatedAssessmentSummaries,
+          ...readyToPlaceAssessmentSummaries,
+          ...rejectedAssessmentSummaries,
+          ...closedAssessmentSummaries,
+        ])
 
-      // When I visit the dashboard
-      const dashboardPage = DashboardPage.visit()
+        // When I visit the dashboard
+        const dashboardPage = DashboardPage.visit()
 
-      // And I click on the "Review and assess referrals" link
-      dashboardPage.clickReviewAndAssessReferrals()
+        // And I click on the "Review and assess referrals" link
+        dashboardPage.clickReviewAndAssessReferrals()
 
-      // Then I should see the list of referrals
-      const listPage = Page.verifyOnPage(
-        ListPage,
-        unallocatedAssessmentSummaries,
-        inProgressAssessmentSummaries,
-        readyToPlaceAssessmentSummaries,
-        [...rejectedAssessmentSummaries, ...closedAssessmentSummaries],
-      )
+        // Then I should see the list of referrals
+        const listPage = Page.verifyOnPage(
+          ListPage,
+          unallocatedAssessmentSummaries,
+          inProgressAssessmentSummaries,
+          readyToPlaceAssessmentSummaries,
+          [...rejectedAssessmentSummaries, ...closedAssessmentSummaries],
+        )
 
-      // And I should see the list of referrals
-      listPage.shouldShowUnallocatedAssessments()
-      listPage.shouldShowInProgressAssessments()
-      listPage.shouldShowReadyToPlaceAssessments()
+        // And I should see the list of referrals
+        listPage.shouldShowUnallocatedAssessments()
+        listPage.shouldShowInProgressAssessments()
+        listPage.shouldShowReadyToPlaceAssessments()
 
-      // Given I click on the 'View archived assessments' link
-      listPage.clickViewArchivedReferrals()
+        // Given I click on the 'View archived assessments' link
+        listPage.clickViewArchivedReferrals()
 
-      // Then I should see the list of archived assessments
-      listPage.shouldShowArchivedAssessments()
+        // Then I should see the list of archived assessments
+        listPage.shouldShowArchivedAssessments()
+      })
     })
   })
 })

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -65,7 +65,7 @@ context('Apply', () => {
 
     describe('Show an assessment', () => {
       it('I can change the state of an assessment', () => {
-        const assessment = assessmentFactory.build({ status: 'unallocated' })
+        const assessment = assessmentFactory.build({ status: 'unallocated', decision: 'accepted' })
         const assessmentSummary = assessmentSummaryFactory.buildList(1, {
           status: 'unallocated',
           person: assessment.application.person,
@@ -84,13 +84,78 @@ context('Apply', () => {
         listPage.clickAssessment(assessment)
 
         // Then I should be taken to the referral show page
-        Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, assessment.status)
+        const assessmentPage = Page.verifyOnPage(
+          AssessmentShowPage,
+          assessment.application.person.name,
+          assessment.status,
+        )
+
         // Given I am on the referral page
         // When I click on the 'Update referral status to: In review' button
         assessmentPage.clickAction('In review')
 
         // Then I am taken to the confirmation page
-        Page.verifyOnPage(AssessmentConfirmPage, 'Mark this referral as in review')
+        const confirmationPage = Page.verifyOnPage(AssessmentConfirmPage, 'Mark this referral as in review')
+
+        // Given I confirm the action
+        // When the action is submitted
+        const updatedAssessment = { ...assessment, status: 'in_review' }
+        cy.task('stubAllocateAssessment', updatedAssessment)
+        cy.task('stubAcceptAssessment', updatedAssessment)
+        cy.task('stubCloseAssessment', updatedAssessment)
+        cy.task('stubFindAssessment', updatedAssessment)
+        confirmationPage.clickSubmit()
+
+        // I am taken to the show page and a banner is shown
+        Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, 'in_review')
+        assessmentPage.shouldShowBanner('Assessment updated status updated to "in review"')
+
+        // And the assessment is updated in the database
+        cy.task('verifyAllocateAssessment', assessment.id).then(requests => {
+          expect(requests).to.have.length(1)
+        })
+
+        // Given the assessment is in the 'in review' state
+        // When I click on the Update status to 'Ready to place' button
+        assessmentPage.clickAction('Ready to place')
+
+        // Then I am taken to the confirmation page
+        Page.verifyOnPage(AssessmentConfirmPage, 'Confirm this referral is ready to place')
+        cy.task('stubFindAssessment', { ...updatedAssessment, status: 'ready_to_place' })
+
+        // Given I confirm the action
+        // When the action is submitted
+        confirmationPage.clickSubmit()
+
+        // I am taken to the show page and a banner is shown
+        Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, 'ready_to_place')
+        assessmentPage.shouldShowBanner('Assessment updated status updated to "ready to place"')
+
+        // And the assessment is updated in the database
+        cy.task('verifyAcceptAssessment', assessment.id).then(requests => {
+          expect(requests).to.have.length(1)
+        })
+
+        // Given the assessment is in the 'ready to place' state
+        // When I click on the Update status to 'Closed' button
+        assessmentPage.clickAction('Close')
+
+        // Then I am taken to the confirmation page
+        Page.verifyOnPage(AssessmentConfirmPage, 'Archive this referral')
+        cy.task('stubFindAssessment', { ...updatedAssessment, status: 'closed' })
+
+        // Given I confirm the action
+        // When the action is submitted
+        confirmationPage.clickSubmit()
+
+        // I am taken to the show page and a banner is shown
+        Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, 'closed')
+        assessmentPage.shouldShowBanner('Assessment updated status updated to "closed"')
+
+        // And the assessment is updated in the database
+        cy.task('verifyCloseAssessment', assessment.id).then(requests => {
+          expect(requests).to.have.length(1)
+        })
       })
     })
   })

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -1,8 +1,9 @@
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
-import { assessmentSummaryFactory } from '../../../../server/testutils/factories'
+import { assessmentFactory, assessmentSummaryFactory } from '../../../../server/testutils/factories'
 import Page from '../../../../cypress_shared/pages/page'
 import ListPage from '../../../../cypress_shared/pages/assess/list'
+import AssessmentShowPage from '../../../../cypress_shared/pages/assess/show'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -58,6 +59,31 @@ context('Apply', () => {
 
         // Then I should see the list of archived assessments
         listPage.shouldShowArchivedAssessments()
+      })
+    })
+
+    describe('Show an assessment', () => {
+      it('I can change the state of an assessment', () => {
+        const assessment = assessmentFactory.build({ status: 'unallocated' })
+        const assessmentSummary = assessmentSummaryFactory.buildList(1, {
+          status: 'unallocated',
+          person: assessment.application.person,
+          id: assessment.id,
+        })
+
+        cy.task('stubAssessments', assessmentSummary)
+        cy.task('stubFindAssessment', assessment)
+
+        // Given I visit the referral list page
+        const dashboardPage = DashboardPage.visit()
+        dashboardPage.clickReviewAndAssessReferrals()
+        const listPage = Page.verifyOnPage(ListPage, assessmentSummary, [], [], [])
+
+        // When I click on the referral
+        listPage.clickAssessment(assessment)
+
+        // Then I should be taken to the referral show page
+        Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, assessment.status)
       })
     })
   })

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -4,6 +4,7 @@ import { assessmentFactory, assessmentSummaryFactory } from '../../../../server/
 import Page from '../../../../cypress_shared/pages/page'
 import ListPage from '../../../../cypress_shared/pages/assess/list'
 import AssessmentShowPage from '../../../../cypress_shared/pages/assess/show'
+import AssessmentConfirmPage from '../../../../cypress_shared/pages/assess/confirm'
 
 context('Apply', () => {
   beforeEach(() => {
@@ -84,6 +85,12 @@ context('Apply', () => {
 
         // Then I should be taken to the referral show page
         Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, assessment.status)
+        // Given I am on the referral page
+        // When I click on the 'Update referral status to: In review' button
+        assessmentPage.clickAction('In review')
+
+        // Then I am taken to the confirmation page
+        Page.verifyOnPage(AssessmentConfirmPage, 'Mark this referral as in review')
       })
     })
   })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -6,7 +6,7 @@ import {
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysSupportingInformationQuestions,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
   Booking,
   Document,
   OASysSection,

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -7,6 +7,7 @@ import { assessmentFactory, probationRegionFactory } from '../../../testutils/fa
 import extractCallConfig from '../../../utils/restUtils'
 import AssessmentsController, { assessmentsTableHeaders, confirmationPageContent } from './assessmentsController'
 import { assessmentActions } from '../../../utils/assessmentUtils'
+import paths from '../../../paths/temporary-accommodation/manage'
 
 jest.mock('../../../utils/restUtils')
 
@@ -110,6 +111,21 @@ describe('AssessmentsController', () => {
         status,
         id: assessmentId,
       })
+    })
+  })
+
+  describe('update', () => {
+    it('calls the updateAssessmentStatus method on the service with the new status', async () => {
+      const newStatus = 'in_review'
+      const assessmentId = 'some-id'
+
+      const requestHandler = assessmentsController.update()
+      request.params = { id: assessmentId, status: newStatus }
+
+      await requestHandler(request, response, next)
+
+      expect(assessmentsService.updateAssessmentStatus).toHaveBeenCalledWith(callConfig, assessmentId, newStatus)
+      expect(response.redirect).toHaveBeenCalledWith(paths.assessments.show({ id: assessmentId }))
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -5,7 +5,7 @@ import { CallConfig } from '../../../data/restClient'
 import { AssessmentsService } from '../../../services'
 import { assessmentFactory, probationRegionFactory } from '../../../testutils/factories'
 import extractCallConfig from '../../../utils/restUtils'
-import AssessmentsController, { assessmentsTableHeaders } from './assessmentsController'
+import AssessmentsController, { assessmentsTableHeaders, confirmationPageContent } from './assessmentsController'
 import { assessmentActions } from '../../../utils/assessmentUtils'
 
 jest.mock('../../../utils/restUtils')
@@ -88,6 +88,28 @@ describe('AssessmentsController', () => {
         actions: assessmentActions(assessment),
       })
       expect(assessmentsService.findAssessment).toHaveBeenCalledWith(callConfig, assessmentId)
+    })
+  })
+
+  describe('confirm', () => {
+    it.each([
+      'null' as const,
+      'unallocated' as const,
+      'in_review' as const,
+      'ready_to_place' as const,
+      'closed' as const,
+      'rejected' as const,
+    ])('calls render with a confirmation message for the %s status', async status => {
+      const assessmentId = 'some-assessment-id'
+      const requestHandler = assessmentsController.confirm()
+      request.params = { id: assessmentId, status }
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/confirm', {
+        content: confirmationPageContent[status],
+        status,
+        id: assessmentId,
+      })
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -3,9 +3,10 @@ import type { NextFunction, Request, Response } from 'express'
 
 import { CallConfig } from '../../../data/restClient'
 import { AssessmentsService } from '../../../services'
-import { probationRegionFactory } from '../../../testutils/factories'
+import { assessmentFactory, probationRegionFactory } from '../../../testutils/factories'
 import extractCallConfig from '../../../utils/restUtils'
 import AssessmentsController, { assessmentsTableHeaders } from './assessmentsController'
+import { assessmentActions } from '../../../utils/assessmentUtils'
 
 jest.mock('../../../utils/restUtils')
 
@@ -69,6 +70,24 @@ describe('AssessmentsController', () => {
       })
 
       expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig)
+    })
+  })
+
+  describe('show', () => {
+    it('shows a readonly view of an application', async () => {
+      const assessmentId = 'some-assessment-id'
+      const assessment = assessmentFactory.build({ id: assessmentId })
+      assessmentsService.findAssessment.mockResolvedValue(assessment)
+      request.params = { id: assessmentId }
+
+      const requestHandler = assessmentsController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/show', {
+        assessment,
+        actions: assessmentActions(assessment),
+      })
+      expect(assessmentsService.findAssessment).toHaveBeenCalledWith(callConfig, assessmentId)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 import AssessmentsService from '../../../services/assessmentsService'
 import extractCallConfig from '../../../utils/restUtils'
+import { assessmentActions } from '../../../utils/assessmentUtils'
 
 export const assessmentsTableHeaders = [
   {
@@ -56,6 +57,19 @@ export default class AssessmentsController {
 
       return res.render('temporary-accommodation/assessments/archive', {
         archivedTableRows,
+      })
+    }
+  }
+
+  show(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const callConfig = extractCallConfig(req)
+
+      const assessment = await this.assessmentsService.findAssessment(callConfig, req.params.id)
+
+      return res.render('temporary-accommodation/assessments/show', {
+        assessment,
+        actions: assessmentActions(assessment),
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -1,4 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
+import { TemporaryAccommodationAssessment as Assessment } from '../../../@types/shared'
 import AssessmentsService from '../../../services/assessmentsService'
 import extractCallConfig from '../../../utils/restUtils'
 import { assessmentActions } from '../../../utils/assessmentUtils'
@@ -29,6 +30,33 @@ export const assessmentsTableHeaders = [
     },
   },
 ]
+
+export const confirmationPageContent: Record<Assessment['status'], {title: string, text: string} = {
+  in_review: {
+    title: 'Mark this referral as in review',
+    text: '<p class="govuk-body">Mark this referral as in review if you or a HPT colleague are working on this referral.</p>',
+  },
+  ready_to_place: {
+    title: 'Confirm this referral is ready to place',
+    text: `<p class="govuk-body">Mark this referral as ready to place to find a suitable bedspace.</p>
+      <p class="govuk-body">Some regions will require approval before a bedspace is booked. Other regions require an address before approvals can be given. Check with your manager if you are unsure.</p>
+      <p class="govuk-body">Once a person has been placed the referral should be archived.</p>`,
+  },
+  rejected: {
+    title: 'Confirm rejection',
+    text: `<p class="govuk-body">You will need to email the community probation practitioner to let them know their referral has been rejected.</p> 
+      <p class="govuk-body">Once a referral has been rejected it cannot be undone.</p>`,
+  },
+  closed: {
+    title: 'Archive this referral',
+    text: '<p class="govuk-body">This referral should be archived once a bedspace booking has been confirmed.</p>',
+  },
+  unallocated: {
+    title: 'Unallocate this referral',
+    text: `<p class="govuk-body">Mark this referral as unallocated if it is not being reviewed by yourself or a HPT colleague.</p>
+            <p class="govuk-body"> The referral will be updated to 'unallocated'.</p>`,
+  },
+}
 
 export default class AssessmentsController {
   constructor(private readonly assessmentsService: AssessmentsService) {}
@@ -70,6 +98,16 @@ export default class AssessmentsController {
       return res.render('temporary-accommodation/assessments/show', {
         assessment,
         actions: assessmentActions(assessment),
+      })
+    }
+  }
+
+  confirm(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      return res.render('temporary-accommodation/assessments/confirm', {
+        content: confirmationPageContent[req.params.status as string],
+        status: req.params.status,
+        id: req.params.id,
       })
     }
   }

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -6,6 +6,8 @@ import { assessmentFactory, assessmentSummaryFactory } from '../testutils/factor
 import AssessmentClient from './assessmentClient'
 import { CallConfig } from './restClient'
 
+const assessmentId = 'some-id'
+
 describe('AssessmentClient', () => {
   let fakeApprovedPremisesApi: nock.Scope
   let assessmentClient: AssessmentClient
@@ -52,6 +54,61 @@ describe('AssessmentClient', () => {
 
       const output = await assessmentClient.find(assessment.id)
       expect(output).toEqual(assessment)
+    })
+  })
+
+  describe('unallocateAssessment', () => {
+    it('deletes the allocation for the assessment', async () => {
+      fakeApprovedPremisesApi
+        .delete(paths.assessments.allocation({ id: assessmentId }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200)
+
+      await assessmentClient.unallocateAssessment(assessmentId)
+    })
+  })
+
+  describe('allocateAssessment', () => {
+    it('posts a new allocation for the assessment', async () => {
+      fakeApprovedPremisesApi
+        .post(paths.assessments.allocation({ id: assessmentId }), {})
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200)
+
+      await assessmentClient.allocateAssessment(assessmentId)
+    })
+  })
+
+  describe('rejectAssessment', () => {
+    it('posts a new rejection for the assessment', async () => {
+      fakeApprovedPremisesApi
+        .post(paths.assessments.rejection({ id: assessmentId }), { document: {}, rejectionRationale: 'default' })
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200)
+
+      await assessmentClient.rejectAssessment(assessmentId)
+    })
+  })
+
+  describe('acceptAssessment', () => {
+    it('posts a new acceptance for the assessment', async () => {
+      fakeApprovedPremisesApi
+        .post(paths.assessments.acceptance({ id: assessmentId }), { document: {} })
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200)
+
+      await assessmentClient.acceptAssessment(assessmentId)
+    })
+  })
+
+  describe('closeAssessment', () => {
+    it('posts a new closure for the assessment', async () => {
+      fakeApprovedPremisesApi
+        .post(paths.assessments.closure({ id: assessmentId }), {})
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200)
+
+      await assessmentClient.closeAssessment(assessmentId)
     })
   })
 })

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,5 +1,7 @@
 import type {
   TemporaryAccommodationAssessment as Assessment,
+  AssessmentAcceptance,
+  AssessmentRejection,
   TemporaryAccommodationAssessmentSummary as AssessmentSummary,
 } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
@@ -19,5 +21,37 @@ export default class AssessmentClient {
 
   async find(assessmentId: string): Promise<Assessment> {
     return (await this.restClient.get({ path: paths.assessments.show({ id: assessmentId }) })) as Assessment
+  }
+
+  async unallocateAssessment(id: string): Promise<void> {
+    await this.restClient.delete({
+      path: paths.assessments.allocation({ id }),
+    })
+  }
+
+  async allocateAssessment(id: string): Promise<void> {
+    await this.restClient.post({
+      path: paths.assessments.allocation({ id }),
+    })
+  }
+
+  async rejectAssessment(id: string): Promise<void> {
+    await this.restClient.post({
+      path: paths.assessments.rejection({ id }),
+      data: { document: {}, rejectionRationale: 'default' } as AssessmentRejection,
+    })
+  }
+
+  async acceptAssessment(id: string): Promise<void> {
+    await this.restClient.post({
+      path: paths.assessments.acceptance({ id }),
+      data: { document: {} } as AssessmentAcceptance,
+    })
+  }
+
+  async closeAssessment(id: string): Promise<void> {
+    await this.restClient.post({
+      path: paths.assessments.closure({ id }),
+    })
   }
 }

--- a/server/data/restClient.test.ts
+++ b/server/data/restClient.test.ts
@@ -137,6 +137,16 @@ describe('restClient', () => {
     })
   })
 
+  describe('delete', () => {
+    it('should make a DELETE request', async () => {
+      fakeApprovedPremisesApi.delete(`/some/path`).reply(200)
+
+      await restClient.delete({ path: '/some/path' })
+
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
   describe('pipe', () => {
     it('should make a GET request and pipe the response, using the specified filename', async () => {
       const data = 'some-data'

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -1,18 +1,18 @@
 /* istanbul ignore file */
 
-import { ApprovedPremisesAssessment, TemporaryAccommodationApplication } from '@approved-premises/api'
+import { TemporaryAccommodationApplication, TemporaryAccommodationAssessment } from '@approved-premises/api'
 import type { DataServices, PageResponse, TaskListErrors } from '@approved-premises/ui'
 import { CallConfig } from '../data/restClient'
 
 export interface TasklistPageInterface {
   new (
     body: Record<string, unknown>,
-    document?: TemporaryAccommodationApplication | ApprovedPremisesAssessment,
+    document?: TemporaryAccommodationApplication | TemporaryAccommodationAssessment,
     previousPage?: string,
   ): TasklistPage
   initialize?(
     body: Record<string, unknown>,
-    document: TemporaryAccommodationApplication | ApprovedPremisesAssessment,
+    document: TemporaryAccommodationApplication | TemporaryAccommodationAssessment,
     callConfig: CallConfig,
     dataServices: DataServices,
   ): Promise<TasklistPage>

--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -1,6 +1,6 @@
 import {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '@approved-premises/api'
 import type { Task, TaskStatus } from '@approved-premises/ui'
 import { TasklistPageInterface } from '../tasklistPage'

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -11,7 +11,7 @@ import type {
 import {
   Adjudication,
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment,
+  TemporaryAccommodationAssessment as Assessment,
   PersonAcctAlert,
   PersonRisks,
 } from '../../@types/shared'
@@ -128,10 +128,7 @@ export const getTaskName = <T>(page: T) => {
   return Reflect.getMetadata('page:task', page)
 }
 
-export const updateAssessmentData = (
-  page: TasklistPage,
-  assessment: ApprovedPremisesAssessment,
-): ApprovedPremisesAssessment => {
+export const updateAssessmentData = (page: TasklistPage, assessment: Assessment): Assessment => {
   const pageName = getPageName(page.constructor)
   const taskName = getTaskName(page.constructor)
 
@@ -144,7 +141,7 @@ export const updateAssessmentData = (
 
 export function getBody(
   Page: TasklistPageInterface,
-  application: Application | ApprovedPremisesAssessment,
+  application: Application | Assessment,
   request: Request,
   userInput: Record<string, unknown>,
 ) {
@@ -157,10 +154,7 @@ export function getBody(
   return getPageDataFromApplication(Page, application)
 }
 
-export function getPageDataFromApplication(
-  Page: TasklistPageInterface,
-  application: Application | ApprovedPremisesAssessment,
-) {
+export function getPageDataFromApplication(Page: TasklistPageInterface, application: Application | Assessment) {
   const pageName = getPageName(Page)
   const taskName = getTaskName(Page)
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -19,8 +19,10 @@ const searchBookingsPath = bookingsPath.path('search')
 const assessPaths = {
   assessments: path('/assessments'),
   singleAssessment: path('/assessments/:id'),
-  acceptance: path('/assessments/:id/acceptance'),
+  allocation: path('/tasks/assessment/:id/allocations'),
   rejection: path('/assessments/:id/rejection'),
+  acceptance: path('/assessments/:id/acceptance'),
+  closure: path('/assessments/:id/closure'),
 }
 
 const clarificationNotePaths = {
@@ -116,8 +118,10 @@ export default {
     index: assessPaths.assessments,
     show: assessPaths.singleAssessment,
     update: assessPaths.singleAssessment,
-    acceptance: assessPaths.acceptance,
+    allocation: assessPaths.allocation,
     rejection: assessPaths.rejection,
+    acceptance: assessPaths.acceptance,
+    closure: assessPaths.closure,
     clarificationNotes: {
       create: clarificationNotePaths.notes,
       update: clarificationNotePaths.notes.path(':clarificationNoteId'),

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -25,6 +25,7 @@ const singleLostBedPath = lostBedsPath.path(':lostBedId')
 const reportsPath = temporaryAccommodationPath.path('reports')
 
 const assessmentsPath = temporaryAccommodationPath.path('review-and-assess')
+const assessmentPath = assessmentsPath.path(':id')
 
 const paths = {
   dashboard: {
@@ -113,6 +114,7 @@ const paths = {
     index: assessmentsPath,
     archive: assessmentsPath.path('archive'),
     show: assessmentsPath.path(':id'),
+    confirm: assessmentPath.path(':status'),
   },
 }
 

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -115,6 +115,7 @@ const paths = {
     archive: assessmentsPath.path('archive'),
     show: assessmentsPath.path(':id'),
     confirm: assessmentPath.path(':status'),
+    update: assessmentPath.path(':status'),
   },
 }
 

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -304,6 +304,9 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.assessments.show.pattern, assessmentsController.show(), {
     auditEvent: 'VIEW_ASSESSMENT',
   })
+  get(paths.assessments.confirm.pattern, assessmentsController.confirm(), {
+    auditEvent: 'VIEW_ASSESSMENT_STATUS_CHANGE_CONFIRM',
+  })
 
   return router
 }

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -308,5 +308,15 @@ export default function routes(controllers: Controllers, services: Services, rou
     auditEvent: 'VIEW_ASSESSMENT_STATUS_CHANGE_CONFIRM',
   })
 
+  put(paths.assessments.update.pattern, assessmentsController.update(), {
+    auditEvent: 'UPDATE_ASSESSMENT',
+    redirectAuditEventSpecs: [
+      {
+        path: paths.assessments.show.pattern,
+        auditEvent: 'UPDATE_ASSESSMENT_SUCCESS',
+      },
+    ],
+  })
+
   return router
 }

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -301,6 +301,9 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.assessments.archive.pattern, assessmentsController.archive(), {
     auditEvent: 'VIEW_ARCHIVE_ASSESSMENTS_LIST',
   })
+  get(paths.assessments.show.pattern, assessmentsController.show(), {
+    auditEvent: 'VIEW_ASSESSMENT',
+  })
 
   return router
 }

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -7,6 +7,8 @@ import AssessmentsService from './assessmentsService'
 jest.mock('../data/assessmentClient')
 jest.mock('../utils/assessmentUtils')
 
+const assessmentId = 'some-id'
+
 describe('AssessmentsService', () => {
   const assessmentClient = new AssessmentClient(null) as jest.Mocked<AssessmentClient>
 
@@ -101,7 +103,6 @@ describe('AssessmentsService', () => {
   describe('findAssessment', () => {
     it('calls the find method on the assessment client and returns the result', async () => {
       const assessment = assessmentFactory.build()
-      const assessmentId = 'some-id'
 
       assessmentClient.find.mockResolvedValue(assessment)
 
@@ -109,6 +110,43 @@ describe('AssessmentsService', () => {
 
       expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
       expect(assessmentClient.find).toHaveBeenCalledWith(assessmentId)
+    })
+  })
+
+  describe('updateAssessment', () => {
+    it("calls the unallocateAssessment method on the client when the new status is 'unallocated'", async () => {
+      await service.updateAssessmentStatus(callConfig, assessmentId, 'unallocated')
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.unallocateAssessment).toHaveBeenCalledWith(assessmentId)
+    })
+
+    it("calls the allocateAssessment method on the client when the new status is 'in_review'", async () => {
+      await service.updateAssessmentStatus(callConfig, assessmentId, 'in_review')
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.allocateAssessment).toHaveBeenCalledWith(assessmentId)
+    })
+
+    it("calls the rejectAssessment method on the client when the new status is 'rejected'", async () => {
+      await service.updateAssessmentStatus(callConfig, assessmentId, 'rejected')
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId)
+    })
+
+    it("calls the acceptAssessment method on the client when the new status is 'ready_to_place'", async () => {
+      await service.updateAssessmentStatus(callConfig, assessmentId, 'ready_to_place')
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.acceptAssessment).toHaveBeenCalledWith(assessmentId)
+    })
+
+    it("calls the closeAssessment method on the client when the new status is 'closed'", async () => {
+      await service.updateAssessmentStatus(callConfig, assessmentId, 'closed')
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.closeAssessment).toHaveBeenCalledWith(assessmentId)
     })
   })
 })

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -1,6 +1,6 @@
 import AssessmentClient from '../data/assessmentClient'
 import { CallConfig } from '../data/restClient'
-import { assessmentSummaryFactory } from '../testutils/factories'
+import { assessmentFactory, assessmentSummaryFactory } from '../testutils/factories'
 import { assessmentTableRows } from '../utils/assessmentUtils'
 import AssessmentsService from './assessmentsService'
 
@@ -95,6 +95,20 @@ describe('AssessmentsService', () => {
       archivedAssessments.forEach(archivedAssessment =>
         expect(assessmentTableRows).toHaveBeenCalledWith(archivedAssessment, true),
       )
+    })
+  })
+
+  describe('findAssessment', () => {
+    it('calls the find method on the assessment client and returns the result', async () => {
+      const assessment = assessmentFactory.build()
+      const assessmentId = 'some-id'
+
+      assessmentClient.find.mockResolvedValue(assessment)
+
+      expect(await service.findAssessment(callConfig, assessmentId)).toEqual(assessment)
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.find).toHaveBeenCalledWith(assessmentId)
     })
   })
 })

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -1,4 +1,5 @@
 import type { TableRow } from '@approved-premises/ui'
+import type { TemporaryAccommodationAssessment as Assessment } from '../@types/shared'
 import type { AssessmentClient, RestClientBuilder } from '../data'
 import { CallConfig } from '../data/restClient'
 import { assessmentTableRows } from '../utils/assessmentUtils'
@@ -46,5 +47,11 @@ export default class AssessmentsService {
     )
 
     return result
+  }
+
+  findAssessment(callConfig: CallConfig, assessmentId: string): Promise<Assessment> {
+    const assessmentClient = this.assessmentClientFactory(callConfig)
+
+    return assessmentClient.find(assessmentId)
   }
 }

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -1,8 +1,12 @@
 import type { TableRow } from '@approved-premises/ui'
-import type { TemporaryAccommodationAssessment as Assessment } from '../@types/shared'
+import type {
+  TemporaryAccommodationAssessment as Assessment,
+  TemporaryAccommodationAssessmentStatus as AssessmentStatus,
+} from '../@types/shared'
 import type { AssessmentClient, RestClientBuilder } from '../data'
 import { CallConfig } from '../data/restClient'
 import { assessmentTableRows } from '../utils/assessmentUtils'
+import { assertUnreachable } from '../utils/utils'
 
 export default class AssessmentsService {
   constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
@@ -53,5 +57,30 @@ export default class AssessmentsService {
     const assessmentClient = this.assessmentClientFactory(callConfig)
 
     return assessmentClient.find(assessmentId)
+  }
+
+  async updateAssessmentStatus(callConfig: CallConfig, assessmentId: string, status: AssessmentStatus): Promise<void> {
+    const assessmentClient = this.assessmentClientFactory(callConfig)
+
+    switch (status) {
+      case 'unallocated':
+        await assessmentClient.unallocateAssessment(assessmentId)
+        break
+      case 'in_review':
+        await assessmentClient.allocateAssessment(assessmentId)
+        break
+      case 'rejected':
+        await assessmentClient.rejectAssessment(assessmentId)
+        break
+      case 'ready_to_place':
+        await assessmentClient.acceptAssessment(assessmentId)
+        break
+      case 'closed':
+        await assessmentClient.closeAssessment(assessmentId)
+        break
+
+      default:
+        assertUnreachable(status)
+    }
   }
 }

--- a/server/services/tasklistService.ts
+++ b/server/services/tasklistService.ts
@@ -1,6 +1,6 @@
 import {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '@approved-premises/api'
 import { FormSections, Task, TaskStatus, TaskWithStatus } from '@approved-premises/ui'
 import getTaskStatus from '../form-pages/utils/getTaskStatus'

--- a/server/testutils/factories/assessment.ts
+++ b/server/testutils/factories/assessment.ts
@@ -2,13 +2,13 @@
 
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
-import type { ApprovedPremisesAssessment } from '@approved-premises/api'
+import type { TemporaryAccommodationAssessment as Assessment } from '@approved-premises/api'
 
 import { DateFormats } from '../../utils/dateUtils'
 import { fakeObject } from '../utils'
 import applicationFactory from './application'
 
-class AssessmentFactory extends Factory<ApprovedPremisesAssessment> {
+class AssessmentFactory extends Factory<Assessment> {
   createdXDaysAgo(days: number) {
     const today = new Date()
     return this.params({
@@ -37,4 +37,11 @@ export default AssessmentFactory.define(() => ({
   clarificationNotes: [],
   rejectionRationale: faker.lorem.sentence(),
   service: 'CAS3',
+  status: faker.helpers.arrayElement([
+    'unallocated' as const,
+    'in_review' as const,
+    'ready_to_place' as const,
+    'closed' as const,
+    'rejected' as const,
+  ]),
 }))

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -14,6 +14,7 @@ import {
   getResponses,
   getSectionAndTask,
   getStatus,
+  retrieveQuestionResponseFromApplication,
 } from './applicationUtils'
 import getSections from './assessments/getSections'
 import { SessionDataError, UnknownPageError, UnknownTaskError } from './errors'
@@ -394,6 +395,42 @@ describe('applicationUtils', () => {
       const application = applicationFactory.build()
 
       expect(firstPageOfApplicationJourney(application)).toEqual(paths.applications.show({ id: application.id }))
+    })
+  })
+
+  describe('retrieveQuestionResponseFromApplication', () => {
+    it("throws a SessionDataError if the property doesn't exist", () => {
+      const application = applicationFactory.build()
+      expect(() => retrieveQuestionResponseFromApplication(application, 'basic-information', '')).toThrow(
+        SessionDataError,
+      )
+    })
+
+    it('returns the property if it does exist and a question is not provided', () => {
+      const application = applicationFactory.build({
+        data: {
+          'basic-information': { 'my-page': { myPage: 'no' } },
+        },
+      })
+
+      const questionResponse = retrieveQuestionResponseFromApplication(application, 'basic-information', 'myPage')
+      expect(questionResponse).toBe('no')
+    })
+
+    it('returns the property if it does exist and a question is provided', () => {
+      const application = applicationFactory.build({
+        data: {
+          'basic-information': { 'my-page': { questionResponse: 'no' } },
+        },
+      })
+
+      const questionResponse = retrieveQuestionResponseFromApplication(
+        application,
+        'basic-information',
+        'myPage',
+        'questionResponse',
+      )
+      expect(questionResponse).toBe('no')
     })
   })
 })

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -1,6 +1,6 @@
 import type {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '@approved-premises/api'
 import type { FormSection, PageResponse, TableRow, Task } from '@approved-premises/ui'
 import Apply from '../form-pages/apply'

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -11,6 +11,7 @@ import getSections from './assessments/getSections'
 import isAssessment from './assessments/isAssessment'
 import { DateFormats } from './dateUtils'
 import { SessionDataError, UnknownPageError, UnknownTaskError } from './errors'
+import { kebabCase } from './utils'
 
 const dashboardTableRows = (applications: Array<Application>): Array<TableRow> => {
   return applications.map(application => {
@@ -175,6 +176,27 @@ const firstPageOfApplicationJourney = (application: Application) => {
   return paths.applications.show({ id: application.id })
 }
 
+/**
+ * Retrieves response for a given question from the application object.
+ * @param application the application to fetch the response from.
+ * @param task the task to retrieve the response for.
+ * @param page the page that we need the response for in camelCase.
+ * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
+ * @returns the response for the given task/page/question.
+ */
+const retrieveQuestionResponseFromApplication = <T>(
+  application: Application,
+  task: string,
+  page: string,
+  question?: string,
+) => {
+  try {
+    return application.data[task][kebabCase(page)][question || page] as T
+  } catch (e) {
+    throw new SessionDataError(`Question ${question} was not found in the session`)
+  }
+}
+
 export {
   getResponses,
   forPagesInTask,
@@ -184,4 +206,5 @@ export {
   dashboardTableRows,
   firstPageOfApplicationJourney,
   getStatus,
+  retrieveQuestionResponseFromApplication,
 }

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -1,6 +1,6 @@
 import paths from '../paths/temporary-accommodation/manage'
-import { assessmentSummaryFactory, personFactory } from '../testutils/factories'
-import { assessmentTableRows, statusName, statusTag } from './assessmentUtils'
+import { assessmentFactory, assessmentSummaryFactory, personFactory } from '../testutils/factories'
+import { assessmentActions, assessmentTableRows, statusName, statusTag } from './assessmentUtils'
 
 describe('assessmentUtils', () => {
   describe('statusTag', () => {
@@ -68,6 +68,113 @@ describe('assessmentUtils', () => {
             'data-sort-value': 'Unallocated',
           },
           html: '<strong class="govuk-tag govuk-tag--grey">Unallocated</strong>',
+        },
+      ])
+    })
+  })
+
+  describe('assessmentActions', () => {
+    it('returns the "reject" and "in_review" actions for an assessment with a status of "unallocated"', () => {
+      const assessment = assessmentFactory.build({
+        status: 'unallocated',
+      })
+
+      const result = assessmentActions(assessment)
+
+      expect(result).toEqual([
+        {
+          text: 'In review',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'in_review' }),
+        },
+        {
+          text: 'Reject',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
+        },
+      ])
+    })
+
+    it('returns the "unallocated", "ready_to_place" and "rejected" actions for an assessment with a status of "in_review"', () => {
+      const assessment = assessmentFactory.build({
+        status: 'in_review',
+      })
+
+      const result = assessmentActions(assessment)
+
+      expect(result).toEqual([
+        {
+          text: 'Ready to place',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'ready_to_place' }),
+        },
+        {
+          text: 'Unallocated',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'unallocated' }),
+        },
+        {
+          text: 'Reject',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
+        },
+      ])
+    })
+
+    it('returns the "closed", "in_review" and "reject" actions for an assessment with a status of "ready_to_place"', () => {
+      const assessment = assessmentFactory.build({
+        status: 'ready_to_place',
+      })
+
+      const result = assessmentActions(assessment)
+
+      expect(result).toEqual([
+        {
+          text: 'Close',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'closed' }),
+        },
+        {
+          text: 'In review',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'in_review' }),
+        },
+        {
+          text: 'Reject',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
+        },
+      ])
+    })
+
+    it('returns the "ready_to_place" action for an assessment with a status of "closed"', () => {
+      const assessment = assessmentFactory.build({
+        status: 'closed',
+      })
+
+      const result = assessmentActions(assessment)
+
+      expect(result).toEqual([
+        {
+          text: 'Ready to place',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'ready_to_place' }),
+        },
+      ])
+    })
+
+    it('returns the "unallocated" action for an assessment with a status of "rejected"', () => {
+      const assessment = assessmentFactory.build({
+        status: 'rejected',
+      })
+
+      const result = assessmentActions(assessment)
+
+      expect(result).toEqual([
+        {
+          text: 'Unallocated',
+          classes: 'govuk-button--secondary',
+          href: paths.assessments.confirm({ id: assessment.id, status: 'unallocated' }),
         },
       ])
     })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -1,4 +1,7 @@
-import { TemporaryAccommodationAssessmentSummary as AssessmentSummary } from '@approved-premises/api'
+import {
+  TemporaryAccommodationAssessment as Assessment,
+  TemporaryAccommodationAssessmentSummary as AssessmentSummary,
+} from '@approved-premises/api'
 import { TableRow } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from './dateUtils'
@@ -79,4 +82,62 @@ const dateValue = (date: string) => {
       'data-sort-value': date,
     },
   }
+}
+
+export const assessmentActions = (assessment: Assessment) => {
+  const items = []
+
+  const actions = {
+    unallocated: {
+      text: 'Unallocated',
+      classes: 'govuk-button--secondary',
+      href: paths.assessments.update({ id: assessment.id, status: 'unallocated' }),
+    },
+    inReview: {
+      text: 'In review',
+      classes: 'govuk-button--secondary',
+      href: paths.assessments.update({ id: assessment.id, status: 'in_review' }),
+    },
+    reject: {
+      text: 'Reject',
+      classes: 'govuk-button--secondary',
+      href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
+    },
+    readyToPlace: {
+      text: 'Ready to place',
+      classes: 'govuk-button--secondary',
+      href: paths.assessments.confirm({ id: assessment.id, status: 'ready_to_place' }),
+    },
+    close: {
+      text: 'Close',
+      classes: 'govuk-button--secondary',
+      href: paths.assessments.confirm({ id: assessment.id, status: 'closed' }),
+    },
+  }
+
+  switch (assessment.status) {
+    case 'unallocated':
+      items.push(actions.inReview, actions.reject)
+      break
+    case 'in_review':
+      items.push(actions.readyToPlace, actions.unallocated, actions.reject)
+      break
+    case 'ready_to_place':
+      items.push(actions.close, actions.inReview, actions.reject)
+      break
+    case 'rejected':
+      items.push(actions.unallocated)
+      break
+    case 'closed':
+      items.push(actions.readyToPlace)
+      break
+    default:
+      break
+  }
+
+  if (items.length === 0) {
+    return null
+  }
+
+  return items
 }

--- a/server/utils/assessments/getSections.ts
+++ b/server/utils/assessments/getSections.ts
@@ -1,6 +1,6 @@
 import {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '../../@types/shared'
 import { FormSections } from '../../@types/ui'
 import Apply from '../../form-pages/apply'

--- a/server/utils/assessments/isAssessment.ts
+++ b/server/utils/assessments/isAssessment.ts
@@ -1,6 +1,6 @@
 import {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '../../@types/shared'
 
 export default (applicationOrAssessment: Application | Assessment): applicationOrAssessment is Assessment => {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -14,7 +14,8 @@ import {
   dateFieldValues,
   parseNaturalNumber,
 } from './formUtils'
-import { statusTag } from './personUtils'
+import { statusTag as personStatusTag } from './personUtils'
+import { statusTag as assessmentStatusTag } from './assessmentUtils'
 import { initialiseName, mapApiPersonRisksForUi, removeBlankSummaryListItems, sentenceCase } from './utils'
 
 import { dashboardTableRows } from './applicationUtils'
@@ -33,6 +34,7 @@ import applyPaths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
 import { checkYourAnswersSections } from './checkYourAnswersUtils'
+import { TemporaryAccommodationAssessment } from '../@types/shared'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -132,7 +134,10 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
     },
   )
 
-  njkEnv.addGlobal('statusTag', (status: PersonStatus) => markAsSafe(statusTag(status)))
+  njkEnv.addGlobal('personStatusTag', (status: PersonStatus) => markAsSafe(personStatusTag(status)))
+  njkEnv.addGlobal('assessmentStatusTag', (status: TemporaryAccommodationAssessment['status']) =>
+    markAsSafe(assessmentStatusTag(status)),
+  )
 
   njkEnv.addGlobal('mergeObjects', (obj1: Record<string, unknown>, obj2: Record<string, unknown>) => {
     return { ...obj1, ...obj2 }

--- a/server/utils/reviewUtils.ts
+++ b/server/utils/reviewUtils.ts
@@ -1,6 +1,6 @@
 import {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '../@types/shared'
 import { SummaryListItem, Task } from '../@types/ui'
 import getSections from './assessments/getSections'

--- a/server/utils/taskListUtils.ts
+++ b/server/utils/taskListUtils.ts
@@ -1,7 +1,7 @@
 import type { TaskWithStatus } from '@approved-premises/ui'
 import {
   TemporaryAccommodationApplication as Application,
-  ApprovedPremisesAssessment as Assessment,
+  TemporaryAccommodationAssessment as Assessment,
 } from '../@types/shared'
 import applyPaths from '../paths/apply'
 import assessPaths from '../paths/assess'

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,6 +1,5 @@
 import type { SummaryListItem } from '@approved-premises/ui'
-import { applicationFactory, risksFactory } from '../testutils/factories'
-import { SessionDataError } from './errors'
+import { risksFactory } from '../testutils/factories'
 import {
   camelCase,
   convertToTitleCase,
@@ -11,7 +10,6 @@ import {
   mapApiPersonRisksForUi,
   pascalCase,
   removeBlankSummaryListItems,
-  retrieveQuestionResponseFromApplication,
   sentenceCase,
   unique,
 } from './utils'
@@ -72,42 +70,6 @@ describe('initialise name', () => {
     ['Double barrelled', 'Robert-John Smith-Jones-Wilson', 'R. Smith-Jones-Wilson'],
   ])('%s initialiseName(%s, %s)', (_: string, a: string, expected: string) => {
     expect(initialiseName(a)).toEqual(expected)
-  })
-})
-
-describe('retrieveQuestionResponseFromApplication', () => {
-  it("throws a SessionDataError if the property doesn't exist", () => {
-    const application = applicationFactory.build()
-    expect(() => retrieveQuestionResponseFromApplication(application, 'basic-information', '')).toThrow(
-      SessionDataError,
-    )
-  })
-
-  it('returns the property if it does exist and a question is not provided', () => {
-    const application = applicationFactory.build({
-      data: {
-        'basic-information': { 'my-page': { myPage: 'no' } },
-      },
-    })
-
-    const questionResponse = retrieveQuestionResponseFromApplication(application, 'basic-information', 'myPage')
-    expect(questionResponse).toBe('no')
-  })
-
-  it('returns the property if it does exist and a question is provided', () => {
-    const application = applicationFactory.build({
-      data: {
-        'basic-information': { 'my-page': { questionResponse: 'no' } },
-      },
-    })
-
-    const questionResponse = retrieveQuestionResponseFromApplication(
-      application,
-      'basic-information',
-      'myPage',
-      'questionResponse',
-    )
-    expect(questionResponse).toBe('no')
   })
 })
 

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -2,10 +2,8 @@ import Case from 'case'
 
 import escapeRegExp from 'lodash.escaperegexp'
 import qs, { IStringifyOptions } from 'qs'
-import type { PersonRisks, TemporaryAccommodationApplication } from '@approved-premises/api'
+import type { PersonRisks } from '@approved-premises/api'
 import type { PersonRisksUI, SummaryListItem } from '@approved-premises/ui'
-
-import { SessionDataError } from './errors'
 
 /* istanbul ignore next */
 const properCase = (word: string): string =>
@@ -66,27 +64,6 @@ export const pascalCase = (string: string) => camelCase(string).replace(/\w/, s 
 export const sentenceCase = (string: string) => Case.sentence(string)
 
 export const lowerCase = (string: string) => Case.lower(string)
-
-/**
- * Retrieves response for a given question from the application object.
- * @param application the application to fetch the response from.
- * @param task the task to retrieve the response for.
- * @param page the page that we need the response for in camelCase.
- * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
- * @returns the response for the given task/page/question.
- */
-export const retrieveQuestionResponseFromApplication = <T>(
-  application: TemporaryAccommodationApplication,
-  task: string,
-  page: string,
-  question?: string,
-) => {
-  try {
-    return application.data[task][kebabCase(page)][question || page] as T
-  } catch (e) {
-    throw new SessionDataError(`Question ${question} was not found in the session`)
-  }
-}
 
 /**
  * Removes any items in an array of summary list items that are blank or undefined

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -123,3 +123,8 @@ export const createQueryString = (
 ): string => {
   return qs.stringify(params, options)
 }
+
+/* istanbul ignore next */
+export const assertUnreachable = (_: never) => {
+  throw new Error('Unreachable code reached')
+}

--- a/server/views/components/person-details/macro.njk
+++ b/server/views/components/person-details/macro.njk
@@ -79,7 +79,7 @@
         text: "Status"
       },
       value: {
-        html: statusTag(person.status)
+        html: personStatusTag(person.status)
       }
     },
     {

--- a/server/views/temporary-accommodation/assessments/confirm.njk
+++ b/server/views/temporary-accommodation/assessments/confirm.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - confirmation" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.assessments.show({ id: id })
+  }) }}
+
+  <h1 class="govuk-heading-l">{{content.title}}</h1>
+  {{content.text | safe}}
+
+  <form action="{{ paths.assessments.update({id: id, status: status}) }}?_method=PUT" method="post">
+    <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+    {{ 
+      govukButton({
+          text: "Confirm",
+          preventDoubleClick: true
+        }) 
+    }}
+
+  </form>
+{% endblock %}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/badge/macro.njk" import mojBadge %}
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
 {% extends "../../partials/layout.njk" %}
 
 {% set pageTitle = applicationName + " - Referrals" %}
@@ -48,6 +50,8 @@
 {% endset %}
 
 {% block content %}
+  {{ breadCrumb('Referrals', []) }}
+
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
       <h1 class="govuk-heading-l">Referrals</h1>

--- a/server/views/temporary-accommodation/assessments/show.njk
+++ b/server/views/temporary-accommodation/assessments/show.njk
@@ -1,0 +1,31 @@
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - " + assessment.application.person.name + " referral" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+  {{ breadCrumb(assessment.application.person.name, [
+    {title: 'Referrals', href: paths.assessments.index()}
+  ]) }}
+
+  {% include "../../_messages.njk" %}
+
+  {{
+    mojIdentityBar({
+      title: {
+        html: "<span><h1>" + assessment.application.person.name + "</h1>" + assessmentStatusTag(assessment.status) + "</span>"
+      },
+      menus: [{items: actions}]
+    })
+  }}
+
+{% endblock %}
+
+{% block extraScripts %}
+  <script type="text/javascript" nonce="{{ cspNonce }}">
+    new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Update referral status", menuClasses: "moj-button-menu__wrapper--right"});
+  </script>
+{% endblock %}

--- a/wiremock/assessmentStubs.ts
+++ b/wiremock/assessmentStubs.ts
@@ -1,7 +1,9 @@
 import paths from '../server/paths/api'
-import { assessmentSummaryFactory } from '../server/testutils/factories'
+import { assessmentFactory, assessmentSummaryFactory } from '../server/testutils/factories'
 
 const assessmentSummaries = assessmentSummaryFactory.buildList(20)
+
+const assessment = assessmentFactory.build()
 
 const assessmentStubs = [
   {
@@ -13,6 +15,17 @@ const assessmentStubs = [
       status: 200,
       headers: { 'Content-Type': 'application/json;charset=UTF-8' },
       jsonBody: assessmentSummaries,
+    },
+  },
+  {
+    request: {
+      method: 'GET',
+      url: paths.assessments.show({ id: assessment.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: assessment,
     },
   },
 ]

--- a/wiremock/assessmentStubs.ts
+++ b/wiremock/assessmentStubs.ts
@@ -28,6 +28,61 @@ const assessmentStubs = [
       jsonBody: assessment,
     },
   },
+  {
+    request: {
+      method: 'DELETE',
+      url: paths.assessments.allocation({ id: assessment.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {},
+    },
+  },
+  {
+    request: {
+      method: 'POST',
+      url: paths.assessments.allocation({ id: assessment.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {},
+    },
+  },
+  {
+    request: {
+      method: 'POST',
+      url: paths.assessments.rejection({ id: assessment.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {},
+    },
+  },
+  {
+    request: {
+      method: 'POST',
+      url: paths.assessments.acceptance({ id: assessment.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {},
+    },
+  },
+  {
+    request: {
+      method: 'POST',
+      url: paths.assessments.closure({ id: assessment.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {},
+    },
+  },
 ]
 
 export default assessmentStubs


### PR DESCRIPTION
# Context
An assessment needs to be able to move between the states outlined in this diagram (with the adjustment that from the rejected state we can only transition to unallocated).
![image](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/44123869/1bdf6659-823f-482e-a24d-d93591a4a9e0)

In order to do this we need to:
- be able to 'show' an assessment
- be able to update the state to one of the viable states, given the state we're in 
- confirm this transition
- perform it
- show the user confirmation that the assessment has been updated

This work builds on the the `feature/1346-an-assessor-can-see-an-application-listing-page-from-the-dashboard` branch which should be merged first

[Trello card](https://trello.com/c/ZI5W46gr/1349-an-assessor-can-make-state-changes-to-an-application)

# Changes in this PR
- We update the Assessments used throughout the application to the correct domain: `TemporaryAccommodationAssessment`
- We add a temporary type for the `TemporaryAccommodationAssessment` with the desired statuses as this has not yet been added in the [api spec](https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/resources/static/api.yml). This will need to be deleted once the spec is correct
- We add the 'find' method to the assessment service
- We add some utils for generating the 'status' badge and 'actions' menu on the assessments/show view
- We add the 'show' view 
- We add the confirm view
- We add the client, service and controller methods to update the assessment
- We extend the intergration tests

## Screenshots of UI changes

![Apply -- Assess -- I can change the state of the referral from unallocated to in review (2)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/44123869/5402a1f9-6283-4a24-8602-2afbe9bd5446)
![confirm-in-review (11)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/44123869/244c9848-60ef-44bd-aee6-4878cca1d2e3)
![confirm-ready-to-place](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/44123869/67d8ae58-7940-46c8-a06a-381a6f406a09)
![confirm-close](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/44123869/163c7549-495a-41cf-9f7e-bc156f81dc45)
![show-with-banner](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/44123869/a7af5d81-e568-4d7f-8183-c59f65257947)





# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
