### PR TITLE
Disable API retries for PUT/POST

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -17,6 +17,8 @@ generic-service:
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
     AUDIT_LOG_ERRORS: 'true'
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -14,6 +14,8 @@ generic-service:
     INGRESS_URL: 'https://temporary-accommodation-preprod.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-preprod.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-preprod.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -14,6 +14,8 @@ generic-service:
     INGRESS_URL: 'https://temporary-accommodation.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -16,6 +16,8 @@ generic-service:
     INGRESS_URL: 'https://temporary-accommodation-test.hmpps.service.justice.gov.uk'
     HMPPS_AUTH_URL: 'https://sign-in-dev.hmpps.service.justice.gov.uk/auth'
     TOKEN_VERIFICATION_API_URL: 'https://token-verification-api-dev.prison.service.justice.gov.uk'
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE: 30000
+    COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE: 30000
 
   allowlist: null
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -93,10 +93,10 @@ export default {
     approvedPremises: {
       url: get('APPROVED_PREMISES_API_URL', 'http://localhost:9092', requiredInProduction),
       timeout: {
-        response: 10000,
-        deadline: 10000,
+        response: Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 10000)),
+        deadline: Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_DEADLINE', 10000)),
       },
-      agent: new AgentConfig(10000),
+      agent: new AgentConfig(Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 10000))),
       serviceName: 'temporary-accommodation',
     },
     audit: {

--- a/server/data/restClient.ts
+++ b/server/data/restClient.ts
@@ -203,10 +203,6 @@ export default class RestClient {
         .send(this.prepareDataForTransport(data))
         .agent(this.agent)
         .use(restClientMetricsMiddleware)
-        .retry(2, (err, res) => {
-          if (err) logger.info(`Retry handler found API error with ${err.code} ${err.message}`)
-          return undefined // retry handler only for logging retries, not to influence retry logic
-        })
         .auth(this.token, { type: 'bearer' })
         .set({ ...this.defaultHeaders, ...headers })
         .responseType(responseType)


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Following on with CAS1’s finding that this can create up to 3 duplicate records in the case of API failures[1].

We introduce the COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE environment variable in the same way as CAS1. Right now they are all configured the same however we may want to refine this in future.

Increasing the timeout to the API to 30 seconds creates enough space for the API (who also has a 10 second timeout) to gracefully recover from a timeout to the integration service. Perhaps this should be 15-20 seconds as 30 seems a long time but I'm taking the steer from CAS1. What do we think?

[1] https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/981

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
