### PR TITLE
Set arrival date when submitting application

### DIFF
--- a/server/@types/shared/index.d.ts
+++ b/server/@types/shared/index.d.ts
@@ -34,6 +34,7 @@ export type { Assessment } from './models/Assessment';
 export type { AssessmentAcceptance } from './models/AssessmentAcceptance';
 export type { AssessmentDecision } from './models/AssessmentDecision';
 export type { AssessmentRejection } from './models/AssessmentRejection';
+export type { AssessmentSortField } from './models/AssessmentSortField';
 export type { AssessmentStatus } from './models/AssessmentStatus';
 export type { AssessmentSummary } from './models/AssessmentSummary';
 export type { AssessmentTask } from './models/AssessmentTask';

--- a/server/@types/shared/models/Assessment.ts
+++ b/server/@types/shared/models/Assessment.ts
@@ -14,7 +14,7 @@ export type Assessment = {
     schemaVersion: string;
     outdatedSchema: boolean;
     createdAt: string;
-    allocatedAt: string;
+    allocatedAt?: string;
     submittedAt?: string;
     decision?: AssessmentDecision;
     rejectionRationale?: string;

--- a/server/@types/shared/models/AssessmentSortField.ts
+++ b/server/@types/shared/models/AssessmentSortField.ts
@@ -1,0 +1,6 @@
+/* generated using openapi-typescript-codegen -- do no edit */
+/* istanbul ignore file */
+/* tslint:disable */
+/* eslint-disable */
+
+export type AssessmentSortField = 'name' | 'crn' | 'arrivalDate' | 'status' | 'createdAt';

--- a/server/@types/shared/models/SubmitTemporaryAccommodationApplication.ts
+++ b/server/@types/shared/models/SubmitTemporaryAccommodationApplication.ts
@@ -5,5 +5,7 @@
 
 import type { SubmitApplication } from './SubmitApplication';
 
-export type SubmitTemporaryAccommodationApplication = SubmitApplication;
+export type SubmitTemporaryAccommodationApplication = (SubmitApplication & {
+    arrivalDate: string;
+});
 

--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -330,6 +330,27 @@ describe('utils', () => {
     })
   })
 
+  describe('arrivalDateFromApplication', () => {
+    it('returns the arrival date when present in the application', () => {
+      const application = applicationFactory.build({
+        data: {
+          eligibility: { 'accommodation-required-from-date': { accommodationRequiredFromDate: 'Some Date' } },
+        },
+      })
+      expect(utils.arrivalDateFromApplication(application)).toEqual('Some Date')
+    })
+
+    it('throws an error when the arrival date is not known', () => {
+      const application = applicationFactory.build({
+        data: {
+          eligibility: {},
+        },
+      })
+
+      expect(() => utils.arrivalDateFromApplication(application)).toThrow(new SessionDataError('No arrival date'))
+    })
+  })
+
   describe('dateBodyProperties', () => {
     it('returns date field names for use in page body properties', () => {
       expect(utils.dateBodyProperties('someDate')).toEqual([

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -205,6 +205,18 @@ export const hasSubmittedDtr = (application: Application): boolean => {
   return dtrSubmitted === 'yes'
 }
 
+export const arrivalDateFromApplication = (application: Application): string => {
+  const dateOfArrival: string = (application.data as Record<string, unknown>)?.eligibility?.[
+    'accommodation-required-from-date'
+  ]?.accommodationRequiredFromDate
+
+  if (!dateOfArrival) {
+    throw new SessionDataError('No arrival date')
+  }
+
+  return dateOfArrival
+}
+
 export const dateBodyProperties = (root: string) => {
   return [root, `${root}-year`, `${root}-month`, `${root}-day`]
 }

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -1,3 +1,4 @@
+import applicationDataJson from '../../../cypress_shared/fixtures/applicationData.json'
 import { applicationFactory } from '../../testutils/factories'
 import { getApplicationSubmissionData, getApplicationUpdateData } from './getApplicationData'
 
@@ -14,11 +15,12 @@ describe('getApplicationUpdateData', () => {
 
 describe('getApplicationSubmissionData', () => {
   it('extracts data for submitting an application', () => {
-    const application = applicationFactory.build()
+    const application = applicationFactory.build({ data: applicationDataJson })
 
     expect(getApplicationSubmissionData(application)).toEqual({
       translatedDocument: application.document,
       type: 'CAS3',
+      arrivalDate: applicationDataJson.eligibility['accommodation-required-from-date'].accommodationRequiredFromDate,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -3,6 +3,7 @@ import {
   SubmitTemporaryAccommodationApplication as SubmitApplication,
   UpdateTemporaryAccommodationApplication as UpdateApplication,
 } from '../../@types/shared'
+import { arrivalDateFromApplication } from '../../form-pages/utils'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
@@ -15,5 +16,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
   return {
     translatedDocument: application.document,
     type: 'CAS3',
+    arrivalDate: arrivalDateFromApplication(application),
   }
 }


### PR DESCRIPTION
# Changes in this PR

An update to the `SubmitTemporaryAccommodationApplication` requires that the `arrivalDate` be set. The PR sets the arrival date from the application data, resolving a type error

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
