### PR TITLE
Move next button on placement considerations Apply pages

### DIFF
--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/accommodation-sharing.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/accommodation-sharing.njk
@@ -5,7 +5,7 @@
 {% from "../../../../components/riskWidgets/risk-flag-widget/macro.njk" import riskFlagWidget %}
 {% extends "../../layout.njk" %}
 
-{% set buttonText = "Next" %}
+{% set disableButton = true %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% block questions %}
@@ -92,6 +92,10 @@
         html: detailsHtml
       }) }}
 
+      {{ govukButton({
+        text: "Next",
+        preventDoubleClick: true
+      }) }}
     </div>
     <div class="govuk-grid-column-one-third">
       {{ roshWidget(page.risks.roshRisks) }}

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/anti-social-behaviour.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/anti-social-behaviour.njk
@@ -4,7 +4,7 @@
 {% from "../../../../components/riskWidgets/risk-flag-widget/macro.njk" import riskFlagWidget %}
 {% extends "../../layout.njk" %}
 
-{% set buttonText = "Next" %}
+{% set disableButton = true %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% block questions %}
@@ -60,6 +60,11 @@
       {{ govukDetails({
         summaryText: "Guidance on anti-social behaviour",
         html: detailsHtml
+      }) }}
+
+      {{ govukButton({
+        text: "Next",
+        preventDoubleClick: true
       }) }}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/cooperation.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/cooperation.njk
@@ -5,7 +5,7 @@
 {% from "../../../../components/riskWidgets/risk-flag-widget/macro.njk" import riskFlagWidget %}
 {% extends "../../layout.njk" %}
 
-{% set buttonText = "Next" %}
+{% set disableButton = true %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% block questions %}
@@ -30,6 +30,11 @@
             classes: "govuk-label--m"
           }
       }, fetchContext()) }}
+
+      {{ govukButton({
+        text: "Next",
+        preventDoubleClick: true
+      }) }}
     </div>
     <div class="govuk-grid-column-one-third">
       {{ roshWidget(page.risks.roshRisks) }}

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/risk-management-plan.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/risk-management-plan.njk
@@ -5,6 +5,8 @@
 {% from "../../../../components/riskWidgets/risk-flag-widget/macro.njk" import riskFlagWidget %}
 {% extends "../../layout.njk" %}
 
+{% set disableButton = true %}
+
 {% set columnClasses = "govuk-grid-column-full" %}
 {% block questions %}
 
@@ -53,6 +55,11 @@
           classes: "govuk-label--m"
         }
       }, fetchContext()) }}
+
+      {{ govukButton({
+        text: "Save and continue",
+        preventDoubleClick: true
+      }) }}
     </div>
     <div class="govuk-grid-column-one-third">
       {{ roshWidget(page.risks.roshRisks) }}

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/rosh-level.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/rosh-level.njk
@@ -4,7 +4,7 @@
 {% from "../../../../components/riskWidgets/risk-flag-widget/macro.njk" import riskFlagWidget %}
 {% extends "../../layout.njk" %}
 
-{% set buttonText = "Next" %}
+{% set disableButton = true %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% block questions %}
@@ -88,6 +88,11 @@
           html: riskToStaffHintHtml
         }
       }, fetchContext()) }}
+
+      {{ govukButton({
+        text: "Next",
+        preventDoubleClick: true
+      }) }}
     </div>
     <div class="govuk-grid-column-one-third">
       {{ roshWidget(page.risks.roshRisks) }}

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/substance-misuse.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/substance-misuse.njk
@@ -4,7 +4,7 @@
 {% from "../../../../components/riskWidgets/risk-flag-widget/macro.njk" import riskFlagWidget %}
 {% extends "../../layout.njk" %}
 
-{% set buttonText = "Next" %}
+{% set disableButton = true %}
 
 {% set columnClasses = "govuk-grid-column-full" %}
 {% block questions %}
@@ -61,6 +61,11 @@
       {{ govukDetails({
         summaryText: "Guidance on drug or alcohol misuse",
         html: detailsHtml
+      }) }}
+
+      {{ govukButton({
+        text: "Next",
+        preventDoubleClick: true
       }) }}
     </div>
     <div class="govuk-grid-column-one-third">

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -42,10 +42,12 @@
 
         {% block questions %}{% endblock %}
 
-        {{ govukButton({
-          text: buttonText if buttonText else "Save and continue",
-          preventDoubleClick: true
-        }) }}
+        {% if not disableButton %}
+          {{ govukButton({
+            text: buttonText if buttonText else "Save and continue",
+            preventDoubleClick: true
+          }) }}
+        {% endif %}
       </form>
     </div>
   </div>


### PR DESCRIPTION
# Changes in this PR

* This PR moves the "Next" button in each of the placement considerations Apply pages to avoid the button appearing away from the main page content, below the OASys risk sidebar

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/63ed96bd-211f-48ea-a8ac-f61d23cafb42)

### After
![after](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/852d0b8c-e8aa-476d-a26a-ada501b70975)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
