### PR TITLE
Hide submitted application from referrer

### DIFF
--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -4,17 +4,14 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 import Page from '../page'
 
 export default class ListPage extends Page {
-  constructor(
-    private readonly inProgressApplications: Array<Application>,
-    private readonly submittedApplications: Array<Application>,
-  ) {
+  constructor(private readonly inProgressApplications: Array<Application>) {
     super('Temporary Accommodation (TA) referrals')
   }
 
-  static visit(inProgressApplications: Array<Application>, submittedApplications: Array<Application>): ListPage {
+  static visit(inProgressApplications: Array<Application>): ListPage {
     cy.visit(paths.applications.index.pattern)
 
-    return new ListPage(inProgressApplications, submittedApplications)
+    return new ListPage(inProgressApplications)
   }
 
   clickApplication(application: Application) {
@@ -25,19 +22,13 @@ export default class ListPage extends Page {
     this.shouldShowApplications(this.inProgressApplications, 'in-progress', 'In Progress')
   }
 
-  shouldShowSubmittedApplications(): void {
-    this.shouldShowApplications(this.submittedApplications, 'applications-submitted', 'Submitted')
-  }
-
   clickSubmit() {
     cy.get('.govuk-button').click()
   }
 
-  clickSubmittedTab() {
-    cy.get('a').contains('Submitted').click()
-  }
-
   private shouldShowApplications(applications: Array<Application>, containerId: string, status: string): void {
+    cy.get(`#${containerId}`).find('tbody>tr').should('have.length', applications.length)
+
     applications.forEach(application => {
       const releaseDate = application.data['basic-information']?.['release-date']?.releaseDate
 

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -56,7 +56,7 @@ Then('I should see a confirmation of the application', () => {
   confirmationPage.clickBackToDashboard()
 
   cy.then(function _() {
-    const listPage = Page.verifyOnPage(ListPage, [this.application], [], [])
-    listPage.shouldShowSubmittedApplications()
+    const listPage = Page.verifyOnPage(ListPage, [])
+    listPage.shouldShowInProgressApplications()
   })
 })

--- a/integration_tests/support/index.ts
+++ b/integration_tests/support/index.ts
@@ -1,1 +1,5 @@
 import './commands'
+
+Cypress.Keyboard.defaults({
+  keystrokeDelay: 0,
+})

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -180,7 +180,7 @@ context('Apply', () => {
     confirmationPage.clickBackToDashboard()
 
     // Then I am taken back to the dashboard
-    Page.verifyOnPage(ListPage, applications, [])
+    Page.verifyOnPage(ListPage, applications)
   })
 
   it('shows an error if the application is submitted without checking the confirm checkbox', function test() {
@@ -191,7 +191,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([this.application], [])
+    const listPage = ListPage.visit([this.application])
 
     // And I click on the application
     listPage.clickApplication(this.application)
@@ -213,7 +213,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([application], [])
+    const listPage = ListPage.visit([application])
 
     // And I click on the application
     listPage.clickApplication(application)
@@ -231,7 +231,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([this.application], [])
+    const listPage = ListPage.visit([this.application])
 
     // And I click on the application
     listPage.clickApplication(this.application)
@@ -270,7 +270,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([this.application], [])
+    const listPage = ListPage.visit([this.application])
 
     // And I click on the application
     listPage.clickApplication(this.application)

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -21,16 +21,10 @@ context('Applications dashboard', () => {
     cy.signIn()
 
     // When I visit the Previous Applications page
-    const page = ListPage.visit(inProgressApplications, submittedApplications)
+    const page = ListPage.visit(inProgressApplications)
 
     // Then I should see all of the in progress applications
     page.shouldShowInProgressApplications()
-
-    // And I click on the submitted tab
-    page.clickSubmittedTab()
-
-    // Then I should see the applications that have been submitted
-    page.shouldShowSubmittedApplications()
 
     // And I the button should take me to the application start page
     page.clickSubmit()

--- a/integration_tests/tests/landing.cy.ts
+++ b/integration_tests/tests/landing.cy.ts
@@ -27,7 +27,7 @@ context('Landing', () => {
     cy.signIn()
 
     // I am redirected to the application listing page
-    Page.verifyOnPage(ListPage, [], [])
+    Page.verifyOnPage(ListPage, [])
   })
 
   it('signs-out a user who is not an assessor or a referrer', () => {

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -71,7 +71,6 @@ describe('ApplicationService', () => {
 
       expect(result).toEqual({
         inProgress: inProgressApplications,
-        submitted: submittedApplications,
       })
 
       expect(applicationClientFactory).toHaveBeenCalledWith(callConfig)

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -35,17 +35,15 @@ export default class ApplicationService {
     const allApplications = await applicationClient.all()
     const result = {
       inProgress: [],
-      submitted: [],
     } as GroupedApplications
 
     await Promise.all(
       allApplications.map(async application => {
         switch (application.status) {
-          case 'submitted':
-            result.submitted.push(application)
+          case 'inProgress':
+            result.inProgress.push(application)
             break
           default:
-            result.inProgress.push(application)
             break
         }
       }),

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -11,41 +11,41 @@
 
 {% block content %}
 
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-full">
 
-            <h1 class="govuk-heading-l">Temporary Accommodation (TA) referrals</h1>
+      <h1 class="govuk-heading-l">Temporary Accommodation (TA) referrals</h1>
 
-            {{ govukTabs({
-                items: [
-                    {
-                        label: "In Progress",
-                        id: "in-progress",
-                        panel: {
-                            html: applicationsTable("Referrals", dashboardTableRows(applications.inProgress))
-                        }
-                    },
-                    {
-                        label: "Submitted",
-                        id: "applications-submitted",
-                        panel: {
-                            html: applicationsTable("Referrals", dashboardTableRows(applications.submitted))
-                        }
-                    }
-                ]
-            }) }}
+      {{ govukTabs({
+        items: [
+          {
+            label: "In Progress",
+            id: "in-progress",
+            panel: {
+              html: applicationsTable("Referrals", dashboardTableRows(applications.inProgress))
+            }
+          },
+          {
+            label: "Submitted",
+            id: "applications-submitted",
+            panel: {
+              html: applicationsTable("Referrals", dashboardTableRows(applications.submitted))
+            }
+          }
+        ]
+      }) }}
 
-        </div>
-
-        <div class="govuk-grid-column-two-thirds">
-            <h2 class="govuk-heading-m">Start a new referral</h2>
-            <p>Start a new referral for Temporary Accommodation below.</p>
-
-            {{ govukButton({
-                text: "Start now",
-                href: paths.applications.start()
-            }) }}
-        </div>
     </div>
+
+    <div class="govuk-grid-column-two-thirds">
+      <h2 class="govuk-heading-m">Start a new referral</h2>
+      <p class="govuk-body">Start a new referral for Temporary Accommodation below.</p>
+
+      {{ govukButton({
+        text: "Start now",
+        href: paths.applications.start()
+      }) }}
+    </div>
+  </div>
 </div>
 {% endblock %}

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -24,13 +24,6 @@
             panel: {
               html: applicationsTable("Referrals", dashboardTableRows(applications.inProgress))
             }
-          },
-          {
-            label: "Submitted",
-            id: "applications-submitted",
-            panel: {
-              html: applicationsTable("Referrals", dashboardTableRows(applications.submitted))
-            }
           }
         ]
       }) }}


### PR DESCRIPTION
# Changes in this PR

This PR removes the "submitted" tab from the applications dashboard seen by a referrer. This is a quick change to prevent possible confusion for our tests, as currently it leads users back to the task listing for a submitted application

Despite there now only being one tab, I've left the tab interface in place. When I tried removing the tab interface, it lost any communication that users would only see in progress applications on this screen

## Screenshots of UI changes

### Before
![localhost_3000_referrals (1)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/72f0facb-cece-44ea-b85b-49f764bc13df)

### After
![localhost_3000_referrals](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/7362e7c0-23b9-479c-99b1-fe9fa7eacc9f)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
