### PR TITLE
A user can also link to a referral as part of creating a provisional booking

### DIFF
--- a/cypress_shared/components/popDetailsHeader.ts
+++ b/cypress_shared/components/popDetailsHeader.ts
@@ -14,4 +14,8 @@ export default class PopDetailsHeaderComponent extends Component {
       cy.get('p').should('contain', `Date of birth: ${DateFormats.isoDateToUIDate(this.person.dateOfBirth)}`)
     })
   }
+
+  shouldHaveNameLink(path: string): void {
+    cy.get('a').contains(this.person.name).should('have.attr', 'href', path)
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment.ts
@@ -1,0 +1,48 @@
+import type { AssessmentSummary } from '@approved-premises/api'
+import { assessmentSummaryFactory } from '../../../../server/testutils/factories'
+import { noAssessmentId } from '../../../../server/utils/bookingUtils'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+import Page from '../../page'
+
+export default class BookingSelectAssessmentPage extends Page {
+  constructor(private readonly assessmentSummaries: Array<AssessmentSummary>) {
+    super(assessmentSummaries.length ? 'Confirm which referral this booking is for' : 'No referrals found')
+  }
+
+  static assignAssessmentSummaries(alias: string): void {
+    cy.get('h1').then(titleElement => {
+      if (Cypress.$(titleElement).text() === 'No referrals found') {
+        cy.wrap([]).as(alias)
+      } else {
+        cy.get('.govuk-radios')
+          .children('.govuk-radios__item')
+          .then(elements => {
+            const assessmentSummaries = elements.toArray().map(element =>
+              assessmentSummaryFactory.build({
+                id: Cypress.$(element).children('input').attr('value'),
+                status: 'ready_to_place',
+              }),
+            )
+            cy.wrap(assessmentSummaries.slice(0, -1)).as(alias)
+          })
+      }
+    })
+  }
+
+  shouldDisplayAssessments(): void {
+    this.assessmentSummaries.forEach((assessmentSummary: AssessmentSummary) => {
+      cy.get(`input[name="assessmentId"][value="${assessmentSummary.id}"]`)
+        .siblings('label')
+        .eq(0)
+        .contains(DateFormats.isoDateToUIDate(assessmentSummary.createdAt, { format: 'short' }))
+    })
+  }
+
+  selectAssessment(assessmentSummary: AssessmentSummary): void {
+    this.checkRadioByNameAndValue('assessmentId', assessmentSummary.id)
+  }
+
+  selectNoAssessment(): void {
+    this.checkRadioByNameAndValue('assessmentId', noAssessmentId)
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -13,7 +13,11 @@ export default class BookingShowPage extends Page {
 
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(premises: Premises, room: Room, booking: Booking) {
+  constructor(
+    premises: Premises,
+    room: Room,
+    private readonly booking: Booking,
+  ) {
     super('View a booking')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
@@ -66,6 +70,10 @@ export default class BookingShowPage extends Page {
     this.popDetailsHeaderComponent.shouldShowPopDetails()
     this.locationHeaderComponent.shouldShowLocationDetails()
     this.bookingInfoComponent.shouldShowBookingDetails()
+
+    if (this.booking.assessmentId) {
+      this.popDetailsHeaderComponent.shouldHaveNameLink(paths.assessments.show({ id: this.booking.assessmentId }))
+    }
   }
 
   private clickAction(action: string) {

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -81,14 +81,6 @@ Given('I attempt to create a booking with required details missing', () => {
     const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
     bookingNewPage.enterCrn(person.crn)
     bookingNewPage.clickSubmit()
-
-    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessment, [])
-    bookingSelectAssessmentPage.clickSubmit()
-
-    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
-    bookingConfirmPage.shouldShowBookingDetails()
-
-    bookingConfirmPage.clickSubmit()
   })
 })
 

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -6,6 +6,7 @@ import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommo
 import BookingConfirmPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirm'
 import BookingHistoryPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingHistory'
 import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
+import BookingSelectAssessment from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment'
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import {
   bookingFactory,
@@ -50,16 +51,27 @@ Given('I create a booking with all necessary details', () => {
         effectiveEndDate: 'unknown',
         turnaroundStartDate: 'unknown',
       })
+      booking.assessmentId = undefined
 
       bookingNewPage.completeForm(newBooking)
 
-      const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
-      bookingConfirmPage.shouldShowBookingDetails()
+      BookingSelectAssessment.assignAssessmentSummaries('assessments')
 
-      bookingConfirmPage.clickSubmit()
+      cy.get('@assessments').then(assessments => {
+        const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessment, assessments)
+        if (assessments.length) {
+          bookingSelectAssessmentPage.selectNoAssessment()
+        }
+        bookingSelectAssessmentPage.clickSubmit()
 
-      cy.wrap(booking).as('booking')
-      this.historicBookings.push(booking)
+        const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
+        bookingConfirmPage.shouldShowBookingDetails()
+
+        bookingConfirmPage.clickSubmit()
+
+        cy.wrap(booking).as('booking')
+        this.historicBookings.push(booking)
+      })
     })
   })
 })
@@ -69,6 +81,9 @@ Given('I attempt to create a booking with required details missing', () => {
     const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
     bookingNewPage.enterCrn(person.crn)
     bookingNewPage.clickSubmit()
+
+    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessment, [])
+    bookingSelectAssessmentPage.clickSubmit()
 
     const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
     bookingConfirmPage.shouldShowBookingDetails()
@@ -87,10 +102,21 @@ Given('I attempt to create a conflicting booking', () => {
 
     bookingNewPage.completeForm(newBooking)
 
-    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
-    bookingConfirmPage.shouldShowBookingDetails()
+    BookingSelectAssessment.assignAssessmentSummaries('assessments')
 
-    bookingConfirmPage.clickSubmit()
+    cy.get('@assessments').then(assessments => {
+      const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessment, assessments)
+      if (assessments.length) {
+        bookingSelectAssessmentPage.selectNoAssessment()
+      }
+      bookingSelectAssessmentPage.clickSubmit()
+      bookingSelectAssessmentPage.clickSubmit()
+
+      const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
+      bookingConfirmPage.shouldShowBookingDetails()
+
+      bookingConfirmPage.clickSubmit()
+    })
   })
 })
 

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -1,15 +1,15 @@
 import type { SuperAgentRequest } from 'superagent'
-import { Assessment } from '../../server/@types/shared'
+import { Assessment, AssessmentSummary } from '../../server/@types/shared'
 
 import api from '../../server/paths/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 
 export default {
-  stubAssessments: (assessments: Array<Assessment>): SuperAgentRequest =>
+  stubAssessments: (assessments: Array<AssessmentSummary>): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'GET',
-        url: api.assessments.index({}),
+        urlPath: api.assessments.index({}),
       },
       response: {
         status: 200,

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -237,9 +237,13 @@ context('Booking', () => {
     // When I visit the new booking page
     const bookingNewPage = BookingNewPage.visit(premises, room)
 
-    // And I enter a CRN that is not found in the API
-    bookingNewPage.enterCrn(person.crn)
-    bookingNewPage.clickSubmit()
+    // And when I fill out the form with a CRN that is not found in the API
+    const booking = bookingFactory.build({ person })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+    bookingNewPage.completeForm(newBooking)
 
     // Then I should see the relevant error message
     const page = Page.verifyOnPage(BookingNewPage, premises, room)
@@ -266,25 +270,11 @@ context('Booking', () => {
     const bookingNewPage = BookingNewPage.visit(premises, room)
 
     // And I miss required fields
-    bookingNewPage.enterCrn(person.crn)
     bookingNewPage.clickSubmit()
-
-    // And I select no assessment
-    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
-    bookingSelectAssessmentPage.clickSubmit()
-
-    // And I confirm the booking
-    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, room, person)
-
-    cy.task('stubBookingCreateErrors', {
-      premisesId: premises.id,
-      params: ['arrivalDate', 'departureDate'],
-    })
-    bookingConfirmPage.clickSubmit()
 
     // Then I should see error messages relating to those fields
     const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
-    returnedBookingNewPage.shouldShowErrorMessagesForFields(['arrivalDate', 'departureDate'])
+    returnedBookingNewPage.shouldShowErrorMessagesForFields(['crn', 'arrivalDate', 'departureDate'])
   })
 
   it('shows errors when the API returns a 409 Conflict error', () => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -99,11 +99,15 @@ export interface TableRow {
   [index: number]: TableCell
 }
 
-export interface RadioItem {
-  text: string
-  value: string
-  checked?: boolean
-}
+export type RadioItem =
+  | {
+      text: string
+      value: string
+      checked?: boolean
+    }
+  | {
+      divider: string
+    }
 
 export type CheckBoxItem =
   | {

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -1,18 +1,26 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import { BespokeError } from '../../../@types/ui'
+import config from '../../../config'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BookingService, PersonService, PremisesService } from '../../../services'
+import { AssessmentsService, BookingService, PersonService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
 import {
+  assessmentSummaryFactory,
   bookingFactory,
   newBookingFactory,
   personFactory,
   premisesFactory,
   roomFactory,
 } from '../../../testutils/factories'
-import { bookingActions, deriveBookingHistory, generateConflictBespokeError } from '../../../utils/bookingUtils'
+import {
+  assessmentRadioItems,
+  bookingActions,
+  deriveBookingHistory,
+  generateConflictBespokeError,
+  noAssessmentId,
+} from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { appendQueryString } from '../../../utils/utils'
@@ -34,6 +42,8 @@ describe('BookingsController', () => {
   const premisesId = 'premisesId'
   const roomId = 'roomId'
   const backLink = 'some-back-link'
+  const assessmentId = 'some-assessment-id'
+  const radioItems = [{ text: 'Some text', value: 'some-value' }]
 
   let request: Request
 
@@ -44,12 +54,20 @@ describe('BookingsController', () => {
   const bedspaceService = createMock<BedspaceService>({})
   const bookingService = createMock<BookingService>({})
   const personService = createMock<PersonService>({})
+  const assessmentService = createMock<AssessmentsService>({})
 
-  const bookingsController = new BookingsController(premisesService, bedspaceService, bookingService, personService)
+  const bookingsController = new BookingsController(
+    premisesService,
+    bedspaceService,
+    bookingService,
+    personService,
+    assessmentService,
+  )
 
   beforeEach(() => {
     request = createMock<Request>()
     ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+    config.flags.applyDisabled = false
   })
 
   describe('new', () => {
@@ -86,6 +104,188 @@ describe('BookingsController', () => {
     })
   })
 
+  describe('selectAssessment', () => {
+    it('renders the select assessment page', async () => {
+      const newBooking = newBookingFactory.build()
+      const person = personFactory.build()
+      const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      personService.findByCrn.mockResolvedValue(person)
+      assessmentService.getReadyToPlaceForCrn.mockResolvedValue(assessmentSummaries)
+      ;(assessmentRadioItems as jest.MockedFunction<typeof assessmentRadioItems>).mockReturnValue(radioItems)
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.selectAssessment()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+
+      await requestHandler(request, response, next)
+
+      expect(assessmentService.getReadyToPlaceForCrn).toHaveBeenCalledWith(callConfig, newBooking.crn)
+      expect(personService.findByCrn).toHaveBeenCalledWith(callConfig, newBooking.crn)
+      expect(assessmentRadioItems).toHaveBeenCalledWith(assessmentSummaries)
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, roomId }), request.query)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/selectAssessment', {
+        premisesId,
+        roomId,
+        assessmentRadioItems: radioItems,
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        errors: {},
+        errorSummary: [],
+        backLink,
+      })
+    })
+
+    it('renders the select with a "no assessment" assessment ID if there are no assessments for the given CRN', async () => {
+      const newBooking = newBookingFactory.build()
+      const person = personFactory.build()
+      const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+
+      config.flags.applyDisabled = true
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      personService.findByCrn.mockResolvedValue(person)
+      assessmentService.getReadyToPlaceForCrn.mockResolvedValue(assessmentSummaries)
+      ;(assessmentRadioItems as jest.MockedFunction<typeof assessmentRadioItems>).mockReturnValue(radioItems)
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.selectAssessment()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/selectAssessment', {
+        premisesId,
+        roomId,
+        assessmentRadioItems: radioItems,
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        forceAssessmentId: noAssessmentId,
+        errors: {},
+        errorSummary: [],
+        backLink,
+      })
+    })
+
+    it('renders the select with a "no assessment" assessment ID if the Apply feature is disabled', async () => {
+      const newBooking = newBookingFactory.build()
+      const person = personFactory.build()
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      personService.findByCrn.mockResolvedValue(person)
+      assessmentService.getReadyToPlaceForCrn.mockResolvedValue([])
+      ;(assessmentRadioItems as jest.MockedFunction<typeof assessmentRadioItems>).mockReturnValue(radioItems)
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.selectAssessment()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/selectAssessment', {
+        premisesId,
+        roomId,
+        assessmentRadioItems: radioItems,
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        forceAssessmentId: noAssessmentId,
+        errors: {},
+        errorSummary: [],
+        backLink,
+      })
+    })
+
+    it('renders with an error if the API returns a 404 person not found status', async () => {
+      const newBooking = newBookingFactory.build()
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      const err = { status: 404 }
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.selectAssessment()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+
+      await requestHandler(request, response, next)
+
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, roomId }), request.query)
+      expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'doesNotExist')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
+    })
+
+    it('renders with an error if the API returns a 403 forbidden status', async () => {
+      const newBooking = newBookingFactory.build()
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      const err = { status: 403 }
+      personService.findByCrn.mockImplementation(() => {
+        throw err
+      })
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.selectAssessment()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+
+      await requestHandler(request, response, next)
+
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, roomId }), request.query)
+      expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'userPermission')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
+    })
+  })
+
   describe('confirm', () => {
     it('renders the confirmation page', async () => {
       const newBooking = newBookingFactory.build()
@@ -101,6 +301,7 @@ describe('BookingsController', () => {
         crn: newBooking.crn,
         ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
         ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        assessmentId,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
@@ -115,7 +316,7 @@ describe('BookingsController', () => {
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premisesId)
       expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premisesId, roomId)
       expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId: premises.id, roomId: room.id }),
+        paths.bookings.selectAssessment({ premisesId: premises.id, roomId: room.id }),
         request.query,
       )
 
@@ -126,6 +327,7 @@ describe('BookingsController', () => {
         crn: newBooking.crn,
         ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
         ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        assessmentId,
         backLink,
       })
     })
@@ -133,6 +335,7 @@ describe('BookingsController', () => {
     it('renders with an error if the API returns a 404 person not found status', async () => {
       request.query = {
         crn: 'some-crn',
+        assessmentId,
       }
 
       const requestHandler = bookingsController.confirm()
@@ -162,6 +365,7 @@ describe('BookingsController', () => {
     it('renders with an error if the API returns a 403 forbidden status', async () => {
       request.query = {
         crn: 'some-crn',
+        assessmentId,
       }
 
       const requestHandler = bookingsController.confirm()
@@ -187,6 +391,44 @@ describe('BookingsController', () => {
       expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'userPermission')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
     })
+
+    it('renders with an error if no assessment ID is provided', async () => {
+      const newBooking = newBookingFactory.build()
+      const premises = premisesFactory.build()
+      const room = roomFactory.build()
+      const person = personFactory.build()
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      premisesService.getPremises.mockResolvedValue(premises)
+      bedspaceService.getRoom.mockResolvedValue(room)
+      personService.findByCrn.mockResolvedValue(person)
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.confirm()
+
+      await requestHandler(request, response, next)
+
+      expect(appendQueryString).toHaveBeenCalledWith(
+        paths.bookings.selectAssessment({ premisesId: premises.id, roomId: room.id }),
+        request.query,
+      )
+      expect(appendQueryString).not.toHaveBeenCalledWith(
+        paths.bookings.new({ premisesId: premises.id, roomId: room.id }),
+        request.query,
+      )
+
+      expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'assessmentId', 'empty')
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, new Error(), backLink)
+    })
   })
 
   describe('create', () => {
@@ -208,6 +450,7 @@ describe('BookingsController', () => {
         ...newBooking,
         ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
         ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        assessmentId,
       }
 
       bedspaceService.getRoom.mockResolvedValue(room)
@@ -219,7 +462,44 @@ describe('BookingsController', () => {
         callConfig,
         premisesId,
         room,
-        expect.objectContaining(newBooking),
+        expect.objectContaining({ ...newBooking, assessmentId }),
+      )
+
+      expect(request.flash).toHaveBeenCalledWith('success', 'Booking created')
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, roomId, bookingId: booking.id }))
+    })
+
+    it('creates a booking without an assessment ID if the given assessment ID is the known "no assessment" ID', async () => {
+      const requestHandler = bookingsController.create()
+
+      const room = roomFactory.build()
+
+      const booking = bookingFactory.build()
+      const newBooking = newBookingFactory.build({
+        ...booking,
+      })
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.body = {
+        ...newBooking,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+        assessmentId: noAssessmentId,
+      }
+
+      bedspaceService.getRoom.mockResolvedValue(room)
+      bookingService.createForBedspace.mockResolvedValue(booking)
+
+      await requestHandler(request, response, next)
+
+      expect(bookingService.createForBedspace).toHaveBeenCalledWith(
+        callConfig,
+        premisesId,
+        room,
+        expect.not.objectContaining({ assessmentId: noAssessmentId }),
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking created')

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -30,6 +30,7 @@ export const controllers = (services: Services) => {
     services.bedspaceService,
     services.bookingService,
     services.personService,
+    services.assessmentsService,
   )
 
   const confirmationsController = new ConfirmationsController(

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,5 +1,6 @@
 import nock from 'nock'
 
+import { TemporaryAccommodationAssessmentStatus as AssessmentStatus } from '../@types/shared'
 import config from '../config'
 import paths from '../paths/api'
 import { assessmentFactory, assessmentSummaryFactory } from '../testutils/factories'
@@ -39,6 +40,22 @@ describe('AssessmentClient', () => {
         .reply(200, assessmentSummaries)
 
       const output = await assessmentClient.all()
+      expect(output).toEqual(assessmentSummaries)
+    })
+  })
+
+  describe('readyToPlaceForCrn', () => {
+    it('should get all ready to place assessments for the given CRN', async () => {
+      const crn = 'some-crn'
+      const status = 'ready_to_place' as AssessmentStatus
+      const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+
+      fakeApprovedPremisesApi
+        .get(`${paths.assessments.index({})}?crn=${crn}&statuses=${status}`)
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, assessmentSummaries)
+
+      const output = await assessmentClient.readyToPlaceForCrn(crn)
       expect(output).toEqual(assessmentSummaries)
     })
   })

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -6,6 +6,7 @@ import type {
 } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
+import { appendQueryString } from '../utils/utils'
 import RestClient, { CallConfig } from './restClient'
 
 export default class AssessmentClient {
@@ -17,6 +18,14 @@ export default class AssessmentClient {
 
   async all(): Promise<Array<AssessmentSummary>> {
     return (await this.restClient.get({ path: paths.assessments.index.pattern })) as Array<AssessmentSummary>
+  }
+
+  async readyToPlaceForCrn(crn: string): Promise<Array<AssessmentSummary>> {
+    const status: AssessmentSummary['status'] = 'ready_to_place'
+
+    return (await this.restClient.get({
+      path: appendQueryString(paths.assessments.index.pattern, { crn: crn.trim(), statuses: status }),
+    })) as Array<AssessmentSummary>
   }
 
   async find(assessmentId: string): Promise<Assessment> {

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -20,7 +20,7 @@ import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import type { BookingSearchResults } from 'server/@types/shared/models/BookingSearchResults'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
-import { createQueryString } from '../utils/utils'
+import { appendQueryString } from '../utils/utils'
 import RestClient, { CallConfig } from './restClient'
 
 export default class BookingClient {
@@ -123,9 +123,7 @@ export default class BookingClient {
   }
 
   async search(status: BookingSearchApiStatus): Promise<BookingSearchResults> {
-    const queryString: string = createQueryString({ status })
-
-    const path = `${paths.bookings.search({ status })}${queryString ? `?${queryString}` : ''}`
+    const path = appendQueryString(paths.bookings.search({ status }), { status })
 
     const response = await this.restClient.get({ path })
 

--- a/server/data/personClient.ts
+++ b/server/data/personClient.ts
@@ -15,7 +15,7 @@ import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 import RestClient, { CallConfig } from './restClient'
 
-import { createQueryString } from '../utils/utils'
+import { appendQueryString } from '../utils/utils'
 import oasysStubs from './stubs/oasysStubs.json'
 
 export default class PersonClient {
@@ -77,9 +77,9 @@ export default class PersonClient {
     if (config.flags.oasysDisabled) {
       response = oasysStubs as OASysSections
     } else {
-      const queryString: string = createQueryString({ 'selected-sections': selectedSections })
-
-      const path = `${paths.people.oasys.sections({ crn: crn.trim() })}${queryString ? `?${queryString}` : ''}`
+      const path = appendQueryString(paths.people.oasys.sections({ crn: crn.trim() }), {
+        'selected-sections': selectedSections,
+      })
 
       response = (await this.restClient.get({ path })) as OASysSections
     }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -115,6 +115,9 @@
     },
     "year": {
       "empty": "You must choose a year"
+    },
+    "assessmentId": {
+      "empty": "You must select an assessment, or select 'Book this bedspace without linking a referral'"
     }
   },
   "bookingCancellation": {

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -48,6 +48,7 @@ const paths = {
   },
   bookings: {
     new: bookingsPath.path('new'),
+    selectAssessment: bookingsPath.path('select-assessment'),
     confirm: bookingsPath.path('confirm'),
     create: bookingsPath,
     show: singleBookingPath,

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -91,6 +91,9 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.bookings.confirm.pattern, bookingsController.confirm(), {
     auditEvent: 'VIEW_BOOKING_CONFIRM',
   })
+  get(paths.bookings.selectAssessment.pattern, bookingsController.selectAssessment(), {
+    auditEvent: 'VIEW_BOOKING_SELECT_ASSESSMENT',
+  })
   post(paths.bookings.create.pattern, bookingsController.create(), {
     redirectAuditEventSpecs: [
       {

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -88,7 +88,7 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.premises.bedspaces.show.pattern, bedspacesController.show(), { auditEvent: 'VIEW_BEDSPACE' })
 
   get(paths.bookings.new.pattern, bookingsController.new(), { auditEvent: 'VIEW_BOOKING_CREATE' })
-  post(paths.bookings.confirm.pattern, bookingsController.confirm(), {
+  get(paths.bookings.confirm.pattern, bookingsController.confirm(), {
     auditEvent: 'VIEW_BOOKING_CONFIRM',
   })
   post(paths.bookings.create.pattern, bookingsController.create(), {

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -149,4 +149,19 @@ describe('AssessmentsService', () => {
       expect(assessmentClient.closeAssessment).toHaveBeenCalledWith(assessmentId)
     })
   })
+
+  describe('getReadyToPlaceForCrn', () => {
+    it('returns ready to place assessment summaries for the given CRN', async () => {
+      const crn = 'some-crn'
+
+      const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+      assessmentClient.readyToPlaceForCrn.mockResolvedValue(assessmentSummaries)
+
+      const result = await service.getReadyToPlaceForCrn(callConfig, crn)
+
+      expect(result).toEqual(assessmentSummaries)
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.readyToPlaceForCrn).toHaveBeenCalledWith(crn)
+    })
+  })
 })

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -3,6 +3,7 @@ import type {
   TemporaryAccommodationAssessment as Assessment,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
 } from '../@types/shared'
+import { AssessmentSummary } from '../@types/shared'
 import type { AssessmentClient, RestClientBuilder } from '../data'
 import { CallConfig } from '../data/restClient'
 import { assessmentTableRows } from '../utils/assessmentUtils'
@@ -82,5 +83,10 @@ export default class AssessmentsService {
       default:
         assertUnreachable(status)
     }
+  }
+
+  async getReadyToPlaceForCrn(callConfig: CallConfig, crn: string): Promise<Array<AssessmentSummary>> {
+    const assessmentClient = this.assessmentClientFactory(callConfig)
+    return assessmentClient.readyToPlaceForCrn(crn)
   }
 }

--- a/server/testutils/factories/booking.ts
+++ b/server/testutils/factories/booking.ts
@@ -126,5 +126,6 @@ export default BookingFactory.define(() => {
     turnarounds,
     serviceName: 'temporary-accommodation' as const,
     createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
+    assessmentId: faker.string.uuid(),
   }
 })

--- a/server/testutils/factories/newBooking.ts
+++ b/server/testutils/factories/newBooking.ts
@@ -15,6 +15,7 @@ export default Factory.define<NewBooking>(() => {
     arrivalDate: DateFormats.dateObjToIsoDate(arrivalDate),
     departureDate: DateFormats.dateObjToIsoDate(departureDate),
     bedId: faker.string.uuid(),
+    assessmentId: faker.string.uuid(),
     serviceName: 'temporary-accommodation',
   }
 })

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -1,7 +1,15 @@
 import paths from '../paths/temporary-accommodation/manage'
 import { SanitisedError } from '../sanitisedError'
-import { arrivalFactory, bookingFactory, departureFactory, extensionFactory } from '../testutils/factories'
 import {
+  arrivalFactory,
+  assessmentSummaryFactory,
+  bookingFactory,
+  departureFactory,
+  extensionFactory,
+  personFactory,
+} from '../testutils/factories'
+import {
+  assessmentRadioItems,
   bookingActions,
   deriveBookingHistory,
   generateConflictBespokeError,
@@ -510,6 +518,101 @@ describe('bookingUtils', () => {
           },
         ],
       })
+    })
+  })
+
+  describe('assessmentRadioItems', () => {
+    it('returns a single "no assessment" option when given an empty list of assessment summaries', () => {
+      expect(assessmentRadioItems([])).toEqual([
+        {
+          text: 'Book this bedspace without linking a referral',
+          value: 'no-assessment',
+        },
+      ])
+    })
+
+    it('returns a radio item for each asssessment summary, plus a "no assessment" option when given a non-empty list of assessment summaries', () => {
+      const person = personFactory.build({
+        name: 'John Smith',
+        crn: 'ABC123',
+      })
+
+      const assessmentSummary1 = assessmentSummaryFactory.build({
+        person,
+        createdAt: '2023-05-01',
+      })
+
+      const assessmentSummary2 = assessmentSummaryFactory.build({
+        person,
+        createdAt: '2023-04-01',
+      })
+
+      const assessmentSummary3 = assessmentSummaryFactory.build({
+        person,
+        createdAt: '2023-03-01',
+      })
+
+      expect(assessmentRadioItems([assessmentSummary2, assessmentSummary1, assessmentSummary3])).toEqual([
+        {
+          text: 'John Smith, CRN ABC123, referral submitted 1 May 23',
+          value: assessmentSummary1.id,
+        },
+        {
+          text: 'John Smith, CRN ABC123, referral submitted 1 Apr 23',
+          value: assessmentSummary2.id,
+        },
+        {
+          text: 'John Smith, CRN ABC123, referral submitted 1 Mar 23',
+          value: assessmentSummary3.id,
+        },
+        { divider: 'or' },
+        {
+          text: 'Book this bedspace without linking a referral',
+          value: 'no-assessment',
+        },
+      ])
+    })
+
+    it('returns a radio item for each asssessment summary when the person is a LAO', () => {
+      const person = personFactory.build({
+        crn: 'ABC123',
+      })
+      person.name = undefined
+
+      const assessmentSummary1 = assessmentSummaryFactory.build({
+        person,
+        createdAt: '2023-05-01',
+      })
+
+      const assessmentSummary2 = assessmentSummaryFactory.build({
+        person,
+        createdAt: '2023-04-01',
+      })
+
+      const assessmentSummary3 = assessmentSummaryFactory.build({
+        person,
+        createdAt: '2023-03-01',
+      })
+
+      expect(assessmentRadioItems([assessmentSummary2, assessmentSummary1, assessmentSummary3])).toEqual([
+        {
+          text: 'CRN ABC123, referral submitted 1 May 23',
+          value: assessmentSummary1.id,
+        },
+        {
+          text: 'CRN ABC123, referral submitted 1 Apr 23',
+          value: assessmentSummary2.id,
+        },
+        {
+          text: 'CRN ABC123, referral submitted 1 Mar 23',
+          value: assessmentSummary3.id,
+        },
+        { divider: 'or' },
+        {
+          text: 'Book this bedspace without linking a referral',
+          value: 'no-assessment',
+        },
+      ])
     })
   })
 })

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -1,6 +1,7 @@
 import type { SummaryListItem } from '@approved-premises/ui'
 import { risksFactory } from '../testutils/factories'
 import {
+  appendQueryString,
   camelCase,
   convertToTitleCase,
   exact,
@@ -209,6 +210,18 @@ describe('unique', () => {
 
       expect(regExp.exec(evilString)).toBeTruthy()
       expect(regExp.exec(evilString.replace('$', '£'))).toBeFalsy()
+    })
+  })
+
+  describe('appendQueryString', () => {
+    it('appends a query string to a given path', () => {
+      expect(
+        appendQueryString('/some/path', { userId: 'some-user', bookingId: 'some-booking', num: 4, string: '&foo=bar' }),
+      ).toEqual('/some/path?userId=some-user&bookingId=some-booking&num=4&string=%26foo%3Dbar')
+    })
+
+    it('leaves the string unmodified when the provided data is empty', () => {
+      expect(appendQueryString('/some/path', {})).toEqual('/some/path')
     })
   })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -96,7 +96,7 @@ export const exact = (text: string) => new RegExp(`^${escapeRegExp(text)}$`)
 
 export const createQueryString = (
   params: Record<string, unknown> | string,
-  options: IStringifyOptions = { encode: false, indices: false },
+  options: IStringifyOptions = { encode: true, indices: false },
 ): string => {
   return qs.stringify(params, options)
 }
@@ -104,4 +104,14 @@ export const createQueryString = (
 /* istanbul ignore next */
 export const assertUnreachable = (_: never) => {
   throw new Error('Unreachable code reached')
+}
+
+export const appendQueryString = (
+  path: string,
+  params: Record<string, unknown>,
+  options: IStringifyOptions = { encode: true, indices: false },
+): string => {
+  const queryString = createQueryString(params, options)
+
+  return `${path}${queryString ? `?${queryString}` : ''}`
 }

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -13,7 +13,7 @@
 
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.new({ premisesId: premises.id, roomId: room.id })
+    href: backLink
   }) }}
   
   <h1>Confirm CRN</h1>
@@ -28,15 +28,24 @@
       <form action="{{ paths.bookings.create({ premisesId: premises.id, roomId: room.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
-        <input type="hidden" name="crn" value="{{ person.crn }}"/>
-        <input type="hidden" name="arrivalDate" value="{{ arrivalDate }}"/>
-        <input type="hidden" name="departureDate" value="{{ departureDate }}"/>
+        {% set context = fetchContext() %}
+
+        <input type="hidden" name="crn" value="{{ crn }}"/>
+
+        <input type="hidden" name="arrivalDate-day" value="{{ context['arrivalDate-day'] }}"/>
+        <input type="hidden" name="arrivalDate-month" value="{{ context['arrivalDate-month'] }}"/>
+        <input type="hidden" name="arrivalDate-year" value="{{ context['arrivalDate-year'] }}"/>
+        <input type="hidden" name="departureDate-day" value="{{ context['departureDate-day'] }}"/>
+        <input type="hidden" name="departureDate-month" value="{{ context['departureDate-month'] }}"/>
+        <input type="hidden" name="departureDate-year" value="{{ context['departureDate-year'] }}"/>
+
+        <input type="hidden" name="assessmentId" value="{{ assessmentId }}"/>
 
         <div class="govuk-button-group">
           {{ govukButton({
             text: "Back",
             classes: "govuk-button--secondary",
-            href: paths.bookings.new({ premisesId: premises.id, roomId: room.id })
+            href: backLink
           }) }}
           {{ govukButton({
             text: "Submit",

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -25,9 +25,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.confirm({ premisesId: premises.id, roomId: room.id }) }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-      
+      <form action="{{ paths.bookings.selectAssessment({ premisesId: premises.id, roomId: room.id }) }}" method="get">      
         {% include "./_editable.njk" %}  
       </form>
     </div>
@@ -37,6 +35,6 @@
 
 {% block extraScripts %}
 
-<script type="text/javascript"  nonce="{{ cspNonce }}" src="/assets/js/booking-date-hint.js"></script>
+<script type="text/javascript" nonce="{{ cspNonce }}" src="/assets/js/booking-date-hint.js"></script>
 
 {% endblock %}

--- a/server/views/temporary-accommodation/bookings/selectAssessment.njk
+++ b/server/views/temporary-accommodation/bookings/selectAssessment.njk
@@ -1,0 +1,97 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../components/ta-radios/macro.njk" import taRadios %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = applicationName + " - Book bedspace" %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block content %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: backLink
+  }) }}
+
+  {% if applyDisabled %}
+    <h1 class="govuk-heading-l">Book bedspace for a person referred through nDelius</h1>
+  {% elif forceAssessmentId %}
+    <h1 class="govuk-heading-l">No referrals found</h1>
+  {% else %}
+    <h1 class="govuk-heading-l">Confirm which referral this booking is for</h1>
+  {% endif %}
+
+  {{ showErrorSummary(errorSummary, errorTitle) }}
+  
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.bookings.confirm({ premisesId: premisesId, roomId: roomId }) }}" method="get">
+
+        {% set context = fetchContext() %}
+
+        <input type="hidden" name="crn" value="{{ crn }}"/>
+
+        <input type="hidden" name="arrivalDate-day" value="{{ context['arrivalDate-day'] }}"/>
+        <input type="hidden" name="arrivalDate-month" value="{{ context['arrivalDate-month'] }}"/>
+        <input type="hidden" name="arrivalDate-year" value="{{ context['arrivalDate-year'] }}"/>
+        <input type="hidden" name="departureDate-day" value="{{ context['departureDate-day'] }}"/>
+        <input type="hidden" name="departureDate-month" value="{{ context['departureDate-month'] }}"/>
+        <input type="hidden" name="departureDate-year" value="{{ context['departureDate-year'] }}"/>
+
+        {% set bookingWithoutReferralGuidance %}
+          {% set detailsHtml %}
+            <p class="govuk-body">Choosing this option will impact the management information (MI) data for your region. Bookings will not be associated with a specific referral.</p>
+            <p class="govuk-body">This option should only be used where a referral could not be submitted through the Temporary Accommodation service. For example, in Wales where the referral process is different.</p>
+          {% endset %}
+
+          {{ govukDetails({
+            summaryText: "Booking a bedspace without linking a referral",
+            html: detailsHtml
+          }) }}
+        {% endset %}
+        
+        {% if applyDisabled %}
+          <p class="govuk-body">Book this bedspace for a person who has been referred to Temporary Accommodation (formerly CAS3) through nDelius.</p>
+
+          <h2 class="govuk-heading-m">Digital referrals</h1>
+          <p class="govuk-body">We are working on creating a digital referral for the Temporary Accommodation service. Is it not currently available in your region.</p>
+          <p class="govuk-body">In the future you will be able to link this booking to a digital referral.</p>
+
+          <input type="hidden" name="assessmentId" value="{{ forceAssessmentId }}"/>
+        {% elif forceAssessmentId %}
+          <p class="govuk-body">There are no referrals for this person that are ready to place.</p>
+          <p class="govuk-body">Check the list of <a class="govuk-link" href="{{ paths.assessments.index({}) }}">submitted referrals</a> to see if there is a referral for this person that should be marked as ready to place.</p>
+
+          <h2 class="govuk-heading-m">Book without linking a referral</h1>
+          <p class="govuk-body">You can continue to book this bedspace without linking a referral.</p>
+          
+          <input type="hidden" name="assessmentId" value="{{ forceAssessmentId }}"/>
+
+          {{ bookingWithoutReferralGuidance | safe }}
+        {% else %}
+          <p class="govuk-body">If the correct referral is not appearing in this list check that it has been marked as 'ready to place'.</p>
+          {{ taRadios(
+            {
+              items: assessmentRadioItems,
+              value: assessmentId,
+              fieldName: "assessmentId"
+            }, context
+          ) }}
+
+          {{ bookingWithoutReferralGuidance | safe }}
+        {% endif %}
+
+        <div class="govuk-button-group">
+          {{ govukButton({
+            text: "Continue",
+            preventDoubleClick: true
+          }) }}
+        </div>
+      </form>
+    </div>
+  </div>
+
+{% endblock %}

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -30,7 +30,7 @@
     items: actions
   }) }}
 
-  {{ popDetailsHeader(booking.person) }}
+  {{ popDetailsHeader(booking.person, { nameLink: paths.assessments.show({ id: booking.assessmentId }) if booking.assessmentId else "" }) }}
   {{ locationHeader({ room: room, premises: premises }) }}
 
   {{ bookingInfo(booking, paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })) }}

--- a/server/views/temporary-accommodation/components/pop-details-header/macro.njk
+++ b/server/views/temporary-accommodation/components/pop-details-header/macro.njk
@@ -1,10 +1,16 @@
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 
-{% macro popDetailsHeader(person) %}
+{% macro popDetailsHeader(person, config) %}
 
 <div class="pop-details-header">
   {% if person %}
-    <p><span class="govuk-!-font-weight-bold">Name:</span> {{ person.name }}<br />
+
+    {% if config.nameLink %}
+      <p><span class="govuk-!-font-weight-bold">Name:</span> <a class="govuk-link" href="{{ config.nameLink }}">{{ person.name }}</a><br />
+    {% else %}
+      <p><span class="govuk-!-font-weight-bold">Name:</span> {{ person.name }}<br />
+    {% endif %}
+
     <span class="govuk-!-font-weight-bold">Date of birth:</span> {{formatDate(person.dateOfBirth)}}<br />
     <span class="govuk-!-font-weight-bold">CRN:</span> {{ person.crn }}</p>
   {% endif %}

--- a/wiremock/assessmentStubs.ts
+++ b/wiremock/assessmentStubs.ts
@@ -7,7 +7,7 @@ const assessmentStubs = [
   {
     request: {
       method: 'GET',
-      url: paths.assessments.index({}),
+      urlPathPattern: paths.assessments.index({}),
     },
     response: {
       status: 200,


### PR DESCRIPTION
# Changes in this PR

This PR adds a new screen as part of the booking creation journey to allow the user to associate a booking with an assessment

Where a booking is associated with an assessment, we link back to the assessment from the booking page

## To note
- This cannot be merged until API changes are made - awaiting support for linking bookings to assessments, and filtering assessments from the API by CRN
- This feature suggests a rethink of how we approach E2E tests, which is out of scope for now. See [this ticket](https://trello.com/c/bPFBAWyf/1440-receive-and-place-e2e-testing)
- This feature relies on the `applyDisabled` flag, which [this ticket](https://trello.com/c/PBk6dQWJ/1361-only-expected-regions-can-interact-with-referrals) will likely remove in favour of per-region filtering. Will need to co-ordinate these two changes
- The Figma designs show the name of the referral submitter in the referral list. We do not currently get this data from the API. This is covered by [these](https://trello.com/c/C6cxR1z9/1443-display-referrer-name-in-referral-list-when-creating-a-booking) [tickets](https://trello.com/c/Pb7gAP75/1442-include-referrer-name-when-returning-a-list-of-assessmentsummarys)

## Screenshots of UI changes

#### Select assessment
![select](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/0a83fd57-9d15-4921-aa3a-56a0953c3d0e)

#### Select assessment with error
![select](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/b2c48e6c-1994-4e21-b1c6-9cbdeb68bd86)

#### Select assessment with no assessments
![select no referrals](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/4ed94221-5540-480b-a2fc-b815f9642983)

#### Select assessments when feature is not enabled for this region
![select apply disabled](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/8bac4ea7-1e34-43b6-a56b-ba74a786f7be)

#### Booking with assessment link
![booking-with-link](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/760ca663-5a32-4dba-b3a6-bcab8d5c981f)


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
