### PR TITLE
Don't show check your answers in referral

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -178,6 +178,7 @@ describe('applicationUtils', () => {
           },
         ],
       })
+      expect(getSections).toHaveBeenCalledWith(application, true)
     })
   })
 

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -62,7 +62,7 @@ type TaskResponse = {
 const getResponses = (applicationOrAssessment: Application | Assessment): ApplicationOrAssessmentResponse => {
   const responses: { sections: Array<Section> } = { sections: [] }
 
-  const formSections = getSections(applicationOrAssessment)
+  const formSections = getSections(applicationOrAssessment, true)
 
   formSections.forEach(section => {
     const sectionResponses: Section = { title: section.title, tasks: [] }

--- a/server/utils/assessments/getSections.test.ts
+++ b/server/utils/assessments/getSections.test.ts
@@ -18,6 +18,11 @@ jest.mock('../../form-pages/apply', () => {
           },
         ],
       },
+      {
+        title: 'Check your answers',
+        name: 'CheckYourAnswers',
+        tasks: [],
+      },
     ],
   }
 })
@@ -57,5 +62,14 @@ describe('getSections', () => {
     const sections = getSections(assessment)
 
     expect(sections).toEqual(Assess.sections)
+  })
+
+  it('excludes the check your answers section when excludeCheckYourAnswers is set', () => {
+    ;(isAssessment as jest.MockedFunction<typeof isAssessment>).mockReturnValue(false)
+
+    const application = applicationFactory.build()
+    const sections = getSections(application, true)
+
+    expect(sections).toEqual([Apply.sections[0]])
   })
 })

--- a/server/utils/assessments/getSections.ts
+++ b/server/utils/assessments/getSections.ts
@@ -4,9 +4,15 @@ import {
 } from '../../@types/shared'
 import { FormSections } from '../../@types/ui'
 import Apply from '../../form-pages/apply'
+import CheckYourAnswers from '../../form-pages/apply/check-your-answers'
 import Assess from '../../form-pages/assess'
 import isAssessment from './isAssessment'
 
-export default (applicationOrAssessment: Application | Assessment): FormSections => {
-  return isAssessment(applicationOrAssessment) ? Assess.sections : Apply.sections
+export default (
+  applicationOrAssessment: Application | Assessment,
+  excludeCheckYourAnswers: boolean = false,
+): FormSections => {
+  const sections = isAssessment(applicationOrAssessment) ? Assess.sections : Apply.sections
+
+  return excludeCheckYourAnswers ? sections.filter(section => section.name !== CheckYourAnswers.name) : sections
 }

--- a/server/utils/reviewUtils.test.ts
+++ b/server/utils/reviewUtils.test.ts
@@ -31,11 +31,10 @@ describe('reviewSections', () => {
 
     ;(getSections as jest.MockedFunction<typeof getSections>).mockReturnValue(sections)
 
-    const nonCheckYourAnswersSections = sections.slice(0, -1)
     const result = reviewSections(application, spy)
 
-    expect(getSections).toHaveBeenCalledWith(application)
-    expect(result).toHaveLength(nonCheckYourAnswersSections.length)
+    expect(getSections).toHaveBeenCalledWith(application, true)
+    expect(result).toHaveLength(sections.length)
   })
 
   it('returns an object with the titles of each section and an object for each task', () => {
@@ -44,7 +43,7 @@ describe('reviewSections', () => {
 
     const result = reviewSections(application, spy)
 
-    expect(getSections).toHaveBeenCalledWith(application)
+    expect(getSections).toHaveBeenCalledWith(application, true)
     expect(result).toEqual([
       {
         tasks: [
@@ -56,6 +55,10 @@ describe('reviewSections', () => {
         ],
         title: 'First section',
       },
+      {
+        tasks: [],
+        title: 'Second section',
+      },
     ])
   })
 
@@ -65,7 +68,7 @@ describe('reviewSections', () => {
 
     reviewSections(application, spy)
 
-    expect(getSections).toHaveBeenCalledWith(application)
+    expect(getSections).toHaveBeenCalledWith(application, true)
     expect(spy).toHaveBeenCalledTimes(1)
     expect(spy).toHaveBeenCalledWith(
       {

--- a/server/utils/reviewUtils.ts
+++ b/server/utils/reviewUtils.ts
@@ -9,7 +9,7 @@ const reviewSections = (
   applicationOrAssessment: Application | Assessment,
   rowFunction: (task: Task, document: Application | Assessment) => Array<SummaryListItem>,
 ) => {
-  const nonCheckYourAnswersSections = getSections(applicationOrAssessment).slice(0, -1)
+  const nonCheckYourAnswersSections = getSections(applicationOrAssessment, true)
 
   return nonCheckYourAnswersSections.map(section => {
     return {


### PR DESCRIPTION
# Changes in this PR

* This PR fixes a bug where a confusing empty "check you answers" section could appear on the submitted referral

## Screenshots of UI changes

### Before
![localhost_3000_review-and-assess_297ac419-6278-4a2f-97bc-8728c3a999c6](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/4862a0b5-1316-4665-99f5-2d9bce309856)

### After
![localhost_3000_review-and-assess_2bcd6871-1bb4-4812-bc53-7c55840ed5b0](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/8bd47f67-0b80-4c1d-a7b7-bb913b45897b)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
