### PR TITLE
Fix/guard against limited person details

### DIFF
--- a/server/components/bookingListing.ts
+++ b/server/components/bookingListing.ts
@@ -6,14 +6,18 @@ import { DateFormats } from '../utils/dateUtils'
 export const personSummaryListRows = (booking: Booking): SummaryList['rows'] => {
   const rows = [
     {
-      key: textValue('Date of birth'),
-      value: textValue(DateFormats.isoDateToUIDate(booking.person.dateOfBirth)),
-    },
-    {
       key: textValue('CRN'),
       value: textValue(booking.person.crn),
     },
   ] as SummaryList['rows']
+
+  if (booking.person.dateOfBirth) {
+    rows.unshift({
+      key: textValue('Date of birth'),
+      value: textValue(DateFormats.isoDateToUIDate(booking.person.dateOfBirth)),
+    })
+  }
+
   return rows
 }
 

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -22,7 +22,7 @@
         <input type="hidden" name="crn" value="{{ crn }}"/>
         <input type="hidden" name="offenceId" value="{{ offenceId }}"/>
 
-        <h1 class="govuk-heading-l">Confirm {{ person.name }}'s details</h1>
+        <h1 class="govuk-heading-l">Confirm {{ person.name | default("limited access offender") }}'s details</h1>
 
         <p>
           Taken from nDelius, <strong>{{ date }}</strong>

--- a/server/views/components/person-details/macro.njk
+++ b/server/views/components/person-details/macro.njk
@@ -2,95 +2,110 @@
 
 {% macro personDetails(person) %}
   {% set rows = ([
-    {
-      key: {
-        text: "Name"
-      },
-      value: {
-        text: person.name
+      {
+        key: {
+          text: "CRN"
+        },
+        value: {
+          text: person.crn
+        }
       }
-    },
-    {
-      key: {
-        text: "CRN"
+    ] | removeBlankSummaryListItems)
+  %}
+
+  {% if person.type !== "RestrictedPerson" %}
+    {% set rows = ([
+      {
+        key: {
+          text: "Name"
+        },
+        value: {
+          text: person.name
+        }
       },
-      value: {
-        text: person.crn
-      }
-    },
-    {
-      key: {
-        text: "Date of birth"
+      {
+        key: {
+          text: "CRN"
+        },
+        value: {
+          text: person.crn
+        }
       },
-      value: {
-        text: formatDate(person.dateOfBirth, {format: 'short'})
-      }
-    },
-    {
-      key: {
-        text: "NOMS number"
+      {
+        key: {
+          text: "Date of birth"
+        },
+        value: {
+          text: formatDate(person.dateOfBirth, {format: 'short'})
+        }
       },
-      value: {
-        text: person.nomsNumber
-      }
-    },
-    {
-      key: {
-        text: "Nationality"
+      {
+        key: {
+          text: "NOMS number"
+        },
+        value: {
+          text: person.nomsNumber
+        }
       },
-      value: {
-        text: person.nationality
-      }
-    },
-    {
-      key: {
-        text: "Religion or belief"
+      {
+        key: {
+          text: "Nationality"
+        },
+        value: {
+          text: person.nationality
+        }
       },
-      value: {
-        text: person.religionOrBelief
-      }
-    },
-    {
-      key: {
-        text: "Sex"
+      {
+        key: {
+          text: "Religion or belief"
+        },
+        value: {
+          text: person.religionOrBelief
+        }
       },
-      value: {
-        text: person.sex
-      }
-    },
-    {
-      key: {
-        text: "Ethnicity"
+      {
+        key: {
+          text: "Sex"
+        },
+        value: {
+          text: person.sex
+        }
       },
-      value: {
-        text: person.ethnicity
-      }
-    },
-    {
-      key: {
-        text: "Gender identity"
+      {
+        key: {
+          text: "Ethnicity"
+        },
+        value: {
+          text: person.ethnicity
+        }
       },
-      value: {
-        text: person.genderIdentity
-      }
-    },
-    {
-      key: {
-        text: "Status"
+      {
+        key: {
+          text: "Gender identity"
+        },
+        value: {
+          text: person.genderIdentity
+        }
       },
-      value: {
-        html: personStatusTag(person.status)
-      }
-    },
-    {
-      key: {
-        text: "Prison"
+      {
+        key: {
+          text: "Status"
+        },
+        value: {
+          html: personStatusTag(person.status)
+        }
       },
-      value: {
-        text: person.prisonName
+      {
+        key: {
+          text: "Prison"
+        },
+        value: {
+          text: person.prisonName
+        }
       }
-    }
-  ] | removeBlankSummaryListItems) %}
+    ] | removeBlankSummaryListItems) %}
+  {% endif %}
+
 
   {{ govukSummaryList({
     attributes: {

--- a/server/views/temporary-accommodation/components/booking-listing/macro.njk
+++ b/server/views/temporary-accommodation/components/booking-listing/macro.njk
@@ -19,7 +19,11 @@
   </div>
   <div class="listing-entry__content">
     <h3>
-      {{ booking.person.name }}
+      {% if booking.person.name %}
+        {{ booking.person.name }}
+      {% else %}
+        Limited access offender
+      {% endif %}
     </h3>
 
     <div class="govuk-grid-row">

--- a/server/views/temporary-accommodation/components/pop-details-header/macro.njk
+++ b/server/views/temporary-accommodation/components/pop-details-header/macro.njk
@@ -4,14 +4,24 @@
 
 <div class="pop-details-header">
   {% if person %}
-
-    {% if config.nameLink %}
-      <p><span class="govuk-!-font-weight-bold">Name:</span> <a class="govuk-link" href="{{ config.nameLink }}">{{ person.name }}</a><br />
+    {% if person.name %}
+      {% if config.nameLink %}
+        <p><span class="govuk-!-font-weight-bold">Name:</span> <a class="govuk-link" href="{{ config.nameLink }}">{{ person.name }}</a><br />
+      {% else %}
+        <p><span class="govuk-!-font-weight-bold">Name:</span> {{ person.name }}<br />
+      {% endif %}
     {% else %}
-      <p><span class="govuk-!-font-weight-bold">Name:</span> {{ person.name }}<br />
+      {% if config.nameLink %}
+        <p><span class="govuk-!-font-weight-bold"><a class="govuk-link" href="{{ config.nameLink }}">Limited access offender</a></span><br />
+      {% else %}
+        <p><span class="govuk-!-font-weight-bold">Limited access offender</span><br />
+      {% endif %}
     {% endif %}
 
-    <span class="govuk-!-font-weight-bold">Date of birth:</span> {{formatDate(person.dateOfBirth)}}<br />
+    {% if person.dateOfBirth %}
+      <span class="govuk-!-font-weight-bold">Date of birth:</span> {{formatDate(person.dateOfBirth)}}<br />
+    {% endif %}
+
     <span class="govuk-!-font-weight-bold">CRN:</span> {{ person.crn }}</p>
   {% endif %}
 </div>


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Right now if a user of CAS3 tries to view person details related to a CRN that they don't have access to (LAO) they will receive 500 errors in various places in the service. They'll be unable to create bookings or view bookings if they were created by someone else who did have access.

[The API has proposed changes to restrict person information if the logged in user shouldn't have access to a limited access offender](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/804). Instead of returning name, DOB, CRN, etc, it will now only return CRN.

These are the pages at risk of breaking badly:

1. Creating a referral when confirming the CRN
2. Viewing a full referral including CYA
3. Viewing a bedspace and all it's bookings (if one includes an LAO the page will break)
4. Viewing an individual booking
 
[CAS1 also have some more thorough changes that expect new Person types and make changes to the view by handling the different types](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/974). This is a great long term approach and we should do this too but it's unclear to me how we'll ship both sets of changes in a backwards compatible way? **A smaller set of temporary guards that work with both the new and old version of the API is needed I think - this is the intention of this pull request.**

[For testing this locally see my comment here for how I've got the API running locally in such a way that any request for person data returns the restricted set](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/804#issuecomment-1668275157).

It seems that if we continue to expect the same `Person` type back from the API despite the API now returning `FullPerson` and `RestrictedPerson` we continue to end up with a compatible object. I may have missed something fatal here in this assumption. 

Most of the view rendering continues to work except for the person's dateOfBirth, which fails when we pass `undefined` to `formatDate`, and the person's name that doesn't cause an error but does look a bit odd when it's missing. The other field like status, gender, ethnicity, all fail gracefully and are hidden when that data isn't available to present.

From here we add a few basic guards to our views to take our pages from hard failure (current behaviour) to a degraded but functional view.

Once this is merged, and perhaps a similar PR on CAS1 I believe the [API work](https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/974) could be merged in.

## Screenshots of UI changes

### Before

On each page we through a 500, in dev we can see the following:

[new referral]
![new referral](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/e8107477-7a14-429a-a628-1da03e0836e0)
[bedspace show]
![bedspace show](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/0bdcc463-8d6d-4fa7-a31b-5f1fd10a909e)
[booking show]
![booking show](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/a9354ff9-09cd-4ece-9b12-94c3ee169c89)
[confirm booking]
![confirm booking](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/aecafbc6-7f6d-43e2-a552-d83627704730)


### After
![Screenshot 2023-08-08 at 17-48-28 Temporary Accommodation - View a booking](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/a48645c4-f9f0-482b-af9d-8f9ffd5d16f3)
![Screenshot 2023-08-08 at 17-48-37 Temporary Accommodation - View a bedspace](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/03b9147d-1615-44ca-94c9-a497d74fe3cc)
![Screenshot 2023-08-08 at 17-49-12 Temporary Accommodation - Confirm undefined's details](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/60846187-4a2f-4fc6-bb35-3448d2075f63)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
