### PR TITLE
Prevent person names being stored as part of submitted application

### DIFF
--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -42,7 +42,7 @@
           "id": "eligibility",
           "content": [
             {
-              "How is Edmund Kessler eligible for Temporary Accommodation (TA)?": "Moving on as homeless from an Approved Premises"
+              "How is this person eligible for Temporary Accommodation (TA)?": "Moving on as homeless from an Approved Premises"
             },
             { "Release date": "2 September 2123" },
             { "Accommodation required from date": "16 September 2123" }
@@ -141,13 +141,13 @@
           "title": "Placement considerations",
           "id": "placement-considerations",
           "content": [
-            { "Is Edmund Kessler suitable to share accommodation with others?": "Yes - Some detail" },
-            { "How you will support Edmund Kessler's placement?": "Support detail" },
+            { "Is this person suitable to share accommodation with others?": "Yes - Some detail" },
+            { "How you will support this person's placement?": "Support detail" },
             {
               "Are there any concerns or risks relating to anti-social behaviour?": "Yes - Anti-social behaviour concerns detail"
             },
             {
-              "Does Edmund Kessler have any current or previous issues with drug or alcohol misuse?": "Yes - Details of drug and alcohol misuse"
+              "Does this person have any current or previous issues with drug or alcohol misuse?": "Yes - Details of drug and alcohol misuse"
             },
             {
               "How will risk to children impact placement?": "Risk to children detail",
@@ -167,7 +167,7 @@
           "title": "Behaviour in CAS",
           "id": "behaviour-in-cas",
           "content": [
-            { "Has Edmund Kessler previously stayed in Community Accommodation Services (CAS)?": "Yes" },
+            { "Has this person previously stayed in Community Accommodation Services (CAS)?": "Yes" },
             {
               "Approved Premises (AP or CAS1)": "Approved Premises detail",
               "Temporary Accommodation, previously known as CAS3": "Temporary Accommodation detail"
@@ -194,9 +194,9 @@
               "Other": "Other needs detail"
             },
             {
-              "Will Edmund Kessler require a property with specific attributes or adaptations?": "Yes - Adaptation requirements detail"
+              "Will this person require a property with specific attributes or adaptations?": "Yes - Adaptation requirements detail"
             },
-            { "Does Edmund Kessler have any religious or cultural needs?": "Yes - Religious needs detail" }
+            { "Does this person have any religious or cultural needs?": "Yes - Religious needs detail" }
           ]
         },
         {
@@ -206,20 +206,20 @@
             { "Do you have any concerns about safeguarding and/or vulnerability?": "Yes - Concerns A, B, and C" },
             { "Details of support in the community": "Community support details" },
             { "Details of local connections": "Local connection details" },
-            { "Does Edmund Kessler have any caring responsibilities?": "Yes - Caring responsibilities X, Y, and Z" }
+            { "Does this person have any caring responsibilities?": "Yes - Caring responsibilities X, Y, and Z" }
           ]
         },
         {
           "title": "Food allergies",
           "id": "food-allergies",
           "content": [
-            { "Does Edmund Kessler have any food allergies or dietary requirements?": "Yes - Allergic to X, Y, Z" }
+            { "Does this person have any food allergies or dietary requirements?": "Yes - Allergic to X, Y, Z" }
           ]
         },
         {
           "title": "Move on plan",
           "id": "move-on-plan",
-          "content": [{ "How will you prepare Edmund Kessler for move on after placement?": "A move on plan" }]
+          "content": [{ "How will you prepare this person for move on after placement?": "A move on plan" }]
         }
       ]
     },

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.test.ts
@@ -53,7 +53,10 @@ describe('EligibilityReason', () => {
     it('returns a translated version of the response', () => {
       const page = new EligibilityReason(body, application)
 
-      expect(page.response()).toEqual({ [page.title]: 'Moving on as homeless from an Approved Premises' })
+      expect(page.response()).toEqual({
+        'How is this person eligible for Temporary Accommodation (TA)?':
+          'Moving on as homeless from an Approved Premises',
+      })
     })
   })
 })

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
@@ -27,7 +27,7 @@ export default class EligibilityReason implements TasklistPage {
   }
 
   response() {
-    return { [this.title]: eligibilityReasons[this.body.reason] }
+    return { 'How is this person eligible for Temporary Accommodation (TA)?': eligibilityReasons[this.body.reason] }
   }
 
   previous() {

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.test.ts
@@ -63,7 +63,7 @@ describe('PreviousStays', () => {
       const page = new PreviousStays(body, application)
 
       expect(page.response()).toEqual({
-        'Has John Smith previously stayed in Community Accommodation Services (CAS)?':
+        'Has this person previously stayed in Community Accommodation Services (CAS)?':
           "Yes, no, or don't know response",
       })
       expect(yesNoOrDontKnowResponse).toHaveBeenCalledWith('previousStays', body)

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
@@ -30,7 +30,10 @@ export default class PreviousStays implements TasklistPage {
 
   response() {
     return {
-      [this.questions.previousStays]: yesNoOrDontKnowResponse('previousStays', this.body),
+      'Has this person previously stayed in Community Accommodation Services (CAS)?': yesNoOrDontKnowResponse(
+        'previousStays',
+        this.body,
+      ),
     }
   }
 

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.test.ts
@@ -80,7 +80,7 @@ describe('AccommodationSharing', () => {
     it('returns a translated version of the response when the answer is yes', () => {
       const page = new AccommodationSharing(body, application)
       expect(page.response()).toEqual({
-        'Is John Smith suitable to share accommodation with others?': 'Yes - Yes detail',
+        'Is this person suitable to share accommodation with others?': 'Yes - Yes detail',
       })
     })
 
@@ -90,7 +90,7 @@ describe('AccommodationSharing', () => {
         application,
       )
       expect(page.response()).toEqual({
-        'Is John Smith suitable to share accommodation with others?': 'No - No detail',
+        'Is this person suitable to share accommodation with others?': 'No - No detail',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.ts
@@ -36,13 +36,15 @@ export default class AccommodationSharing implements TasklistPage {
   }
 
   response() {
+    const accommodationSharingQuestion = 'Is this person suitable to share accommodation with others?'
+
     if (this.body.accommodationSharing === 'yes') {
       return {
-        [this.questions.accommodationSharing]: `Yes - ${this.body.accommodationSharingYesDetail}`,
+        [accommodationSharingQuestion]: `Yes - ${this.body.accommodationSharingYesDetail}`,
       }
     }
     return {
-      [this.questions.accommodationSharing]: `No - ${this.body.accommodationSharingNoDetail}`,
+      [accommodationSharingQuestion]: `No - ${this.body.accommodationSharingNoDetail}`,
     }
   }
 

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.test.ts
@@ -50,7 +50,7 @@ describe('Cooperation', () => {
     it('returns a translated version of the response', () => {
       const page = new Cooperation(body, application)
       expect(page.response()).toEqual({
-        "How will you support John Smith's placement considering any risks to the support worker?": 'Support detail',
+        "How will you support this person's placement considering any risks to the support worker?": 'Support detail',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.ts
@@ -35,8 +35,7 @@ export default class Cooperation implements TasklistPage {
 
   response() {
     return {
-      [`How will you support ${this.application.person.name}'s placement considering any risks to the support worker?`]:
-        this.body.support,
+      [`How will you support this person's placement considering any risks to the support worker?`]: this.body.support,
     }
   }
 

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.test.ts
@@ -68,7 +68,7 @@ describe('SubstanceMisuse', () => {
 
       const page = new SubstanceMisuse(body, application)
       expect(page.response()).toEqual({
-        'Does John Smith have any current or previous issues with drug or alcohol misuse?':
+        'Does this person have any current or previous issues with drug or alcohol misuse?':
           'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('substanceMisuse', body)

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.ts
@@ -31,7 +31,10 @@ export default class SubstanceMisuse implements TasklistPage {
 
   response() {
     return {
-      [this.questions.substanceMisuse]: yesOrNoResponseWithDetail('substanceMisuse', this.body),
+      'Does this person have any current or previous issues with drug or alcohol misuse?': yesOrNoResponseWithDetail(
+        'substanceMisuse',
+        this.body,
+      ),
     }
   }
 

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.test.ts
@@ -86,7 +86,7 @@ describe('AcctAlerts', () => {
       const page = new AcctAlerts({ acctAlerts: [] }, application)
 
       expect(page.response()).toEqual({
-        'ACCT Alerts': 'No ACCT information available for John Wayne at the time of referral',
+        'ACCT Alerts': 'No ACCT information available for this person at the time of referral',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
@@ -60,7 +60,7 @@ export default class AcctAlerts implements TasklistPage {
 
     response['ACCT Alerts'] = this.body.acctAlerts.length
       ? this.body.acctAlerts.map(acctAlertResponse)
-      : `No ACCT information available for ${this.application.person.name} at the time of referral`
+      : `No ACCT information available for this person at the time of referral`
 
     return response
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.test.ts
@@ -90,7 +90,7 @@ describe('Adjudications', () => {
       const page = new Adjudications({ adjudications: [] }, application)
 
       expect(page.response()).toEqual({
-        Adjudications: 'No adjudication information available for John Wayne at the time of referral',
+        Adjudications: 'No adjudication information available for this person at the time of referral',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.ts
@@ -63,7 +63,7 @@ export default class Adjudications implements TasklistPage {
 
     response.Adjudications = this.body.adjudications.length
       ? this.body.adjudications.map(adjudicationResponse)
-      : `No adjudication information available for ${this.application.person.name} at the time of referral`
+      : `No adjudication information available for this person at the time of referral`
 
     return response
   }

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.test.ts
@@ -64,7 +64,7 @@ describe('PropertyAttributesOrAdaptations', () => {
 
       const page = new PropertyAttributesOrAdaptations(body, application)
       expect(page.response()).toEqual({
-        'Will John Smith require a property with specific attributes or adaptations?': 'Response with optional detail',
+        'Will this person require a property with specific attributes or adaptations?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('propertyAttributesOrAdaptations', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.ts
@@ -23,7 +23,10 @@ export default class PropertyAttributesOrAdaptations implements TasklistPage {
 
   response() {
     return {
-      [this.title]: yesOrNoResponseWithDetail('propertyAttributesOrAdaptations', this.body),
+      'Will this person require a property with specific attributes or adaptations?': yesOrNoResponseWithDetail(
+        'propertyAttributesOrAdaptations',
+        this.body,
+      ),
     }
   }
 

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.test.ts
@@ -57,7 +57,7 @@ describe('ReligiousOrCulturalNeeds', () => {
 
       const page = new ReligiousOrCulturalNeeds(body, application)
       expect(page.response()).toEqual({
-        'Does John Smith have any religious or cultural needs?': 'Response with optional detail',
+        'Does this person have any religious or cultural needs?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('religiousOrCulturalNeeds', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.ts
@@ -23,7 +23,10 @@ export default class ReligiousOrCulturalNeeds implements TasklistPage {
 
   response() {
     return {
-      [this.title]: yesOrNoResponseWithDetail('religiousOrCulturalNeeds', this.body),
+      'Does this person have any religious or cultural needs?': yesOrNoResponseWithDetail(
+        'religiousOrCulturalNeeds',
+        this.body,
+      ),
     }
   }
 

--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.test.ts
@@ -57,7 +57,7 @@ describe('FoodAllergies', () => {
 
       const page = new FoodAllergies(body, application)
       expect(page.response()).toEqual({
-        'Does John Smith have any food allergies or dietary requirements?': 'Response with optional detail',
+        'Does this person have any food allergies or dietary requirements?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('foodAllergies', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
@@ -26,7 +26,10 @@ export default class FoodAllergies implements TasklistPage {
 
   response() {
     return {
-      [this.questions.foodAllergies]: yesOrNoResponseWithDetail('foodAllergies', this.body),
+      'Does this person have any food allergies or dietary requirements?': yesOrNoResponseWithDetail(
+        'foodAllergies',
+        this.body,
+      ),
     }
   }
 

--- a/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.test.ts
@@ -47,7 +47,7 @@ describe('MoveOnPlan', () => {
       const page = new MoveOnPlan(body, application)
 
       expect(page.response()).toEqual({
-        'How will you prepare Some Name for move on after placement?': 'A plan',
+        'How will you prepare this person for move on after placement?': 'A plan',
       })
     })
   })

--- a/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.ts
+++ b/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.ts
@@ -19,7 +19,7 @@ export default class MoveOnPlan implements TasklistPage {
 
   response() {
     return {
-      [this.title]: this.body.plan,
+      'How will you prepare this person for move on after placement?': this.body.plan,
     }
   }
 

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.test.ts
@@ -57,7 +57,7 @@ describe('CaringResponsibilities', () => {
 
       const page = new CaringResponsibilities(body, application)
       expect(page.response()).toEqual({
-        [page.questions.caringResponsibilities]: 'Response with optional detail',
+        'Does this person have any caring responsibilities?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('caringResponsibilities', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.ts
@@ -26,7 +26,10 @@ export default class CaringResponsibilities implements TasklistPage {
 
   response() {
     return {
-      [this.questions.caringResponsibilities]: yesOrNoResponseWithDetail('caringResponsibilities', this.body),
+      'Does this person have any caring responsibilities?': yesOrNoResponseWithDetail(
+        'caringResponsibilities',
+        this.body,
+      ),
     }
   }
 


### PR DESCRIPTION
# Changes in this PR

Given the existence of LAOs, and given that a referrer may have different access rights than the assessor, we should err on the side of caution around embedding personal identifying information in the application itself. To that end, we review and modify where necessary the response() method of each of our application pages to not include the name of the person being referred. We instead use "this person", as already used on our accommodation sharing application page

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/602d2ba4-3b61-42b4-8512-5e399f86a72b)

### After
![after](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/6f1fbc34-d2cf-4064-bd2e-a32460138e97)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
