### PR TITLE
Update food allergies questions with an 'I don't know' option

### DIFF
--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.test.ts
@@ -1,6 +1,6 @@
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { yesOrNoResponseWithDetail } from '../../../utils'
+import { yesNoOrDontKnowResponseWithDetail } from '../../../utils'
 import FoodAllergies from './foodAllergies'
 
 jest.mock('../../../utils')
@@ -36,6 +36,11 @@ describe('FoodAllergies', () => {
       expect(page.errors()).toEqual({})
     })
 
+    it('returns an empty object if the food allergies answer is iDontKnow', () => {
+      const page = new FoodAllergies({ foodAllergies: 'iDontKnow' }, application)
+      expect(page.errors()).toEqual({})
+    })
+
     it('returns an error if the food allergies answer not populated', () => {
       const page = new FoodAllergies({ ...body, foodAllergies: undefined }, application)
       expect(page.errors()).toEqual({
@@ -53,13 +58,13 @@ describe('FoodAllergies', () => {
 
   describe('response', () => {
     it('returns a translated version of the response', () => {
-      ;(yesOrNoResponseWithDetail as jest.Mock).mockReturnValue('Response with optional detail')
+      ;(yesNoOrDontKnowResponseWithDetail as jest.Mock).mockReturnValue('Response with optional detail')
 
       const page = new FoodAllergies(body, application)
       expect(page.response()).toEqual({
         'Does this person have any food allergies or dietary requirements?': 'Response with optional detail',
       })
-      expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('foodAllergies', body)
+      expect(yesNoOrDontKnowResponseWithDetail).toHaveBeenCalledWith('foodAllergies', body)
     })
   })
 })

--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
@@ -1,11 +1,11 @@
 import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
-import type { TaskListErrors, YesOrNoWithDetail } from '@approved-premises/ui'
+import type { TaskListErrors, YesNoOrIDKWithDetail } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { yesOrNoResponseWithDetail } from '../../../utils'
+import { yesNoOrDontKnowResponseWithDetail } from '../../../utils'
 
-type FoodAllergiesBody = YesOrNoWithDetail<'foodAllergies'>
+type FoodAllergiesBody = YesNoOrIDKWithDetail<'foodAllergies'>
 
 @Page({ name: 'food-allergies', bodyProperties: ['foodAllergies', 'foodAllergiesDetail'] })
 export default class FoodAllergies implements TasklistPage {
@@ -26,7 +26,7 @@ export default class FoodAllergies implements TasklistPage {
 
   response() {
     return {
-      'Does this person have any food allergies or dietary requirements?': yesOrNoResponseWithDetail(
+      'Does this person have any food allergies or dietary requirements?': yesNoOrDontKnowResponseWithDetail(
         'foodAllergies',
         this.body,
       ),

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -10,8 +10,8 @@
     "consent",
     "licence-conditions",
     "prison-information",
-    "approvals-for-specific-risks",
     "placement-considerations",
+    "approvals-for-specific-risks",
     "behaviour-in-cas",
     "placement-location",
     "disability-cultural-and-specific-needs",
@@ -416,27 +416,6 @@
         }
       }
     },
-    "approvals-for-specific-risks": {
-      "type": "object",
-      "properties": {
-        "approvals-for-specific-risks": {
-          "type": "object",
-          "properties": {
-            "approvals": {
-              "enum": [
-                "needsAddress",
-                "notRequired",
-                "yes"
-              ],
-              "type": "string"
-            },
-            "approvalsDetail": {
-              "type": "string"
-            }
-          }
-        }
-      }
-    },
     "placement-considerations": {
       "type": "object",
       "properties": {
@@ -539,6 +518,27 @@
               "type": "string"
             },
             "oasysCompleted": {
+              "type": "string"
+            }
+          }
+        }
+      }
+    },
+    "approvals-for-specific-risks": {
+      "type": "object",
+      "properties": {
+        "approvals-for-specific-risks": {
+          "type": "object",
+          "properties": {
+            "approvals": {
+              "enum": [
+                "needsAddress",
+                "notRequired",
+                "yes"
+              ],
+              "type": "string"
+            },
+            "approvalsDetail": {
               "type": "string"
             }
           }

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -751,6 +751,7 @@
           "properties": {
             "foodAllergies": {
               "enum": [
+                "iDontKnow",
                 "no",
                 "yes"
               ],

--- a/server/views/applications/pages/requirements-for-placement/food-allergies/food-allergies.njk
+++ b/server/views/applications/pages/requirements-for-placement/food-allergies/food-allergies.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% extends "../../layout.njk" %}
 
 {% block questions %}
@@ -7,7 +8,7 @@
     {{ page.title }}
   </h1>
 
-  {% set foodAllergiesDetailHtml %}
+  {% set foodAllergiesYesDetailHtml %}
     {{ formPageTextarea({
         fieldName: 'foodAllergiesDetail',
         label: {
@@ -15,6 +16,16 @@
           classes: "govuk-label--s"
         }
     },fetchContext()) }}
+  {% endset %}
+
+  {% set foodAllergiesIDontKnowWarningHtml %}
+    {% set warningHtml %}
+      <p class="govuk-body">If a placement is offered, you must find out whether the person has any food allergies and let the housing supplier know.</p>
+    {% endset %}
+
+    {{ govukNotificationBanner({
+      html: warningHtml
+    }) }}
   {% endset %}
 
   {{ formPageRadios({
@@ -30,12 +41,19 @@
         value: "yes",
         text: "Yes",
         conditional: {
-          html: foodAllergiesDetailHtml
+          html: foodAllergiesYesDetailHtml
         }
       },
       {
         value: "no",
         text: "No"
+      },
+      {
+        value: "iDontKnow",
+        text: "I don't know",
+        conditional: {
+          html: foodAllergiesIDontKnowWarningHtml
+        }
       }
     ]
   },fetchContext()) }}


### PR DESCRIPTION
# Changes in this PR

We update the food allergies Apply page to include an "I don't know" option

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/e3bc1136-df0c-4b3b-bca3-7df13245cfdc)

### After
![after](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/76a2b0d3-774b-4bcc-9dfa-35bab7130bfc)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
