### PR TITLE
Fix E2E tests trying to submit twice on same page

### DIFF
--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -102,7 +102,6 @@ Given('I attempt to create a conflicting booking', () => {
         bookingSelectAssessmentPage.selectNoAssessment()
       }
       bookingSelectAssessmentPage.clickSubmit()
-      bookingSelectAssessmentPage.clickSubmit()
 
       const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
       bookingConfirmPage.shouldShowBookingDetails()


### PR DESCRIPTION
# Changes in this PR

Fix an error where our E2E tests try to submit on the select assessment page twice, causing a test failure

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
