### PR TITLE
Set flash messages on res.locals

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -51,8 +51,8 @@ export default function createApp(controllers: Controllers, services: Services):
   app.use(setUpCurrentUser(services))
   nunjucksSetup(app, path)
   app.use((req, res, next) => {
-    res.app.locals.infoMessages = req.flash('info')
-    res.app.locals.successMessages = req.flash('success')
+    res.locals.infoMessages = req.flash('info')
+    res.locals.successMessages = req.flash('success')
     return next()
   })
 


### PR DESCRIPTION
We update `app.ts` so that flash messages are set on res.locals rather than res.app.locals. This ensures their scope is a single request, rather than the application as a whole. This fixes a likely culprit for our E2E tests sometimes failing due to flash messages not appearing

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
