### PR TITLE
Fix bedspace E2E tests

### DIFF
--- a/cypress_shared/components/bedspaceSearchResult.ts
+++ b/cypress_shared/components/bedspaceSearchResult.ts
@@ -7,28 +7,30 @@ export default class BedspaceSearchResult extends Component {
   }
 
   shouldShowResult(checkCount = true): void {
-    cy.get(`[data-cy-room-id="${this.result.room.id}"]`).within(() => {
-      cy.get('h2').should('contain', this.result.room.name)
-      if (this.result.premises.town) {
-        cy.get('h3').should(
-          'contain',
-          `${this.result.premises.addressLine1}, ${this.result.premises.town}, ${this.result.premises.postcode}`,
-        )
-      } else {
-        cy.get('h3').should('contain', `${this.result.premises.addressLine1},${this.result.premises.postcode}`)
-      }
+    cy.get('h2')
+      .contains(this.result.room.name)
+      .parents('div[data-cy-bedspace]')
+      .within(() => {
+        if (this.result.premises.town) {
+          cy.get('h3').should(
+            'contain',
+            `${this.result.premises.addressLine1}, ${this.result.premises.town}, ${this.result.premises.postcode}`,
+          )
+        } else {
+          cy.get('h3').should('contain', `${this.result.premises.addressLine1},${this.result.premises.postcode}`)
+        }
 
-      this.result.premises.characteristics.forEach(characteristic => {
-        cy.get('ul[data-cy-premises-key-characteristics] > li').should('contain', characteristic.name)
+        this.result.premises.characteristics.forEach(characteristic => {
+          cy.get('ul[data-cy-premises-key-characteristics] > li').should('contain', characteristic.name)
+        })
+
+        this.result.room.characteristics.forEach(characteristic => {
+          cy.get('ul[data-cy-bedspace-key-characteristics] > li').should('contain', characteristic.name)
+        })
+
+        if (checkCount) {
+          this.shouldShowKeyAndValue('Number of bedspaces', `${this.result.premises.bedCount}`)
+        }
       })
-
-      this.result.room.characteristics.forEach(characteristic => {
-        cy.get('ul[data-cy-bedspace-key-characteristics] > li').should('contain', characteristic.name)
-      })
-
-      if (checkCount) {
-        this.shouldShowKeyAndValue('Number of bedspaces', `${this.result.premises.bedCount}`)
-      }
-    })
   }
 }

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -85,7 +85,7 @@
 
 
         {% for result in results.results %}
-          <div data-cy-room-id="{{ result.room.id }}">
+          <div data-cy-bedspace>
             <h2 class="govuk-heading-m"><a class="govuk-link--no-underline" href="{{ paths.premises.bedspaces.show({premisesId: result.premises.id, roomId: result.room.id}) }}">{{ result.room.name }}</a></h2>
             <h3 class="govuk-heading-s">{{ PremisesUtils.shortAddress(result.premises) }}</h3>
 


### PR DESCRIPTION
We fix how we query for a particular search result in our tests so as to not depend on the ID of the bedspace room, which we do not know in our E2E tests

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
