### PR TITLE
A user can place a referral and is taken to the Find a Bedspace journey and it remembers the referral data

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -14,6 +14,7 @@ $path: "/assets/images/"
 @import './components/_listing-entry'
 @import './components/_probation-region-header'
 @import './components/_attributes-header'
+@import './components/_place-context-header'
 @import './local'
 
 @import './pages/temporary-accommodation/show'

--- a/assets/sass/components/_place-context-header.scss
+++ b/assets/sass/components/_place-context-header.scss
@@ -1,0 +1,19 @@
+.place-context-header {
+  background-color:  govuk-colour("light-grey");
+  padding: govuk-spacing(3);
+  border-left: $govuk-border-width solid govuk-colour("blue");
+  margin-bottom: govuk-spacing(3);
+}
+
+.place-context-header__attribute-container {
+  > div {
+    display: inline;
+    padding-right: govuk-spacing(2);
+    margin-right: govuk-spacing(2);
+    border-right: 1px solid govuk-colour("black");
+
+    &:last-child {
+      border-right: 0;
+    }
+  }
+}

--- a/cypress_shared/components/placeContextHeader.ts
+++ b/cypress_shared/components/placeContextHeader.ts
@@ -1,0 +1,30 @@
+import { PlaceContext } from '../../server/@types/ui'
+import { DateFormats } from '../../server/utils/dateUtils'
+import Component from './component'
+
+export default class PlaceContextHeaderComponent extends Component {
+  constructor(private readonly placeContext: PlaceContext) {
+    super()
+  }
+
+  shouldShowPlaceContextDetails(): void {
+    cy.get('.place-context-header').within(() => {
+      const { person } = this.placeContext.assessment.application
+
+      cy.root().should('contain', person.name)
+      cy.root().should(
+        'contain',
+        `Date of birth: ${DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' })}`,
+      )
+      cy.root().should('contain', `Sex: ${person.sex}`)
+
+      if (person.genderIdentity) {
+        cy.root().should('contain', `Gender identity: ${person.genderIdentity}`)
+      } else {
+        cy.root().should('not.contain', `Gender identity`)
+      }
+
+      cy.root().should('contain', `CRN: ${person.crn}`)
+    })
+  }
+}

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -1,0 +1,72 @@
+import { BedSearchResults, Premises, Room } from '../../server/@types/shared'
+import { PlaceContext } from '../../server/@types/ui'
+import {
+  bedSearchParametersFactory,
+  bedSearchResultFactory,
+  bedSearchResultsFactory,
+} from '../../server/testutils/factories'
+import AssessmentShowPage from '../pages/assess/show'
+import Page from '../pages/page'
+import BedspaceSearchPage from '../pages/temporary-accommodation/manage/bedspaceSearch'
+
+export default class PlaceHelper {
+  private readonly bedSearchResults: BedSearchResults
+
+  constructor(
+    private readonly placeContext: PlaceContext,
+    private readonly premises: Premises,
+    private readonly room: Room,
+  ) {
+    this.bedSearchResults = bedSearchResultsFactory.build({
+      results: [bedSearchResultFactory.forBedspace(this.premises, this.room).build()],
+    })
+  }
+
+  setupStubs() {
+    cy.task('stubBedspaceSearchReferenceData')
+    cy.task('stubFindAssessment', this.placeContext.assessment)
+    cy.task('stubBedSearch', this.bedSearchResults)
+  }
+
+  startPlace() {
+    AssessmentShowPage.visit(this.placeContext.assessment)
+  }
+
+  progressPlace() {
+    this.assessmentToBedspaceSearch()
+    this.bedspaceSearchToSearchResults()
+  }
+
+  private assessmentToBedspaceSearch() {
+    // Given I am viewing a ready to place assessment
+    const assessmentShowPage = Page.verifyOnPage(AssessmentShowPage, this.placeContext.assessment)
+
+    // When I click "Place referral"
+    assessmentShowPage.clickAction('Place referral')
+
+    // I am taken to the bedspace search page
+    const bedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage)
+
+    // And the place context header is visible
+    bedspaceSearchPage.shouldShowPlaceContextHeader(this.placeContext)
+
+    // And the start date is prefilled
+    bedspaceSearchPage.shouldShowPrefilledStartDate(this.placeContext.assessment.application.arrivalDate)
+  }
+
+  private bedspaceSearchToSearchResults() {
+    // Given I am viewing the bedspace search page
+    const bedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage)
+
+    // When I fill out the form
+    const searchParameters = bedSearchParametersFactory.build()
+    bedspaceSearchPage.completeForm(searchParameters)
+    bedspaceSearchPage.clickSubmit()
+
+    // I am taken to the search results page
+    const resultsBedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage, this.bedSearchResults)
+
+    // And the place context header is visible
+    resultsBedspaceSearchPage.shouldShowPlaceContextHeader(this.placeContext)
+  }
+}

--- a/cypress_shared/pages/assess/show.ts
+++ b/cypress_shared/pages/assess/show.ts
@@ -1,6 +1,6 @@
 import { TemporaryAccommodationAssessment as Assessment } from '../../../server/@types/shared'
-import { sentenceCase } from '../../../server/utils/utils'
 import type { Section } from '../../../server/utils/applicationUtils'
+import { sentenceCase } from '../../../server/utils/utils'
 import Page from '../page'
 
 export default class AssessmentShowPage extends Page {

--- a/cypress_shared/pages/assess/show.ts
+++ b/cypress_shared/pages/assess/show.ts
@@ -17,7 +17,7 @@ export default class AssessmentShowPage extends Page {
 
   clickAction(option: string) {
     cy.get('.moj-button-menu__toggle-button').contains('Update referral status').click()
-    cy.get('.moj-button-menu__wrapper').contains(option).click()
+    cy.get('.moj-button-menu__wrapper').contains(option).invoke('removeAttr', 'target').click()
   }
 
   shouldShowAssessment(applicationTranslatedDocument: Record<'sections', Array<Section>>) {

--- a/cypress_shared/pages/assess/show.ts
+++ b/cypress_shared/pages/assess/show.ts
@@ -1,12 +1,18 @@
 import { TemporaryAccommodationAssessment as Assessment } from '../../../server/@types/shared'
+import paths from '../../../server/paths/temporary-accommodation/manage'
 import type { Section } from '../../../server/utils/applicationUtils'
 import { sentenceCase } from '../../../server/utils/utils'
 import Page from '../page'
 
 export default class AssessmentShowPage extends Page {
-  constructor(name: string, status: Assessment['status']) {
-    super(name)
-    cy.get('.govuk-tag').contains(sentenceCase(status as string))
+  constructor(assessment: Assessment) {
+    super(assessment.application.person.name)
+    cy.get('.govuk-tag').contains(sentenceCase(assessment.status as string))
+  }
+
+  static visit(assessment: Assessment): AssessmentShowPage {
+    cy.visit(paths.assessments.show({ id: assessment.id }))
+    return new AssessmentShowPage(assessment)
   }
 
   clickAction(option: string) {

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,8 +1,9 @@
-import { PersonRisksUI, ReferenceData } from '../../server/@types/ui'
+import { PersonRisksUI, PlaceContext, ReferenceData } from '../../server/@types/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
 import { exact } from '../../server/utils/utils'
 import Component from '../components/component'
+import PlaceContextHeaderComponent from '../components/placeContextHeader'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -250,6 +251,11 @@ export default abstract class Page extends Component {
     cy.get(`[data-cy-check-your-answers-section="${taskName}"]`).within(() => {
       cy.get('.box-title').should('contain', taskTitle)
     })
+  }
+
+  shouldShowPlaceContextHeader(placeContext: PlaceContext) {
+    const component = new PlaceContextHeaderComponent(placeContext)
+    component.shouldShowPlaceContextDetails()
   }
 
   getSelectOptionsAsReferenceData(label: string, alias: string): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -46,6 +46,10 @@ export default class BedspaceSearchPage extends Page {
     this.shouldShowSelectInputByLabel('Probation Delivery Unit (PDU)', searchParameters.probationDeliveryUnit)
   }
 
+  shouldShowPrefilledStartDate(startDate: string) {
+    this.shouldShowDateInputsByLegend('Available from', startDate)
+  }
+
   completeForm(searchParameters: BedSearchParameters) {
     this.completeDateInputsByLegend('Available from', searchParameters.startDate)
     this.completeTextInputByLabel('Number of days available', `${searchParameters.durationDays}`)

--- a/integration_tests/tests/place/place.cy.ts
+++ b/integration_tests/tests/place/place.cy.ts
@@ -1,0 +1,28 @@
+import PlaceHelper from '../../../cypress_shared/helpers/place'
+import { setupTestUser } from '../../../cypress_shared/utils/setupTestUser'
+import { placeContextFactory, premisesFactory, roomFactory } from '../../../server/testutils/factories'
+
+context('Place', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    setupTestUser('assessor')
+  })
+
+  it('allows the user progress along the "place" joureny', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    const premises = premisesFactory.build()
+    const room = roomFactory.build()
+
+    const placeContext = placeContextFactory.build()
+    const placeHelper = new PlaceHelper(placeContext, premises, room)
+    placeHelper.setupStubs()
+
+    // And I am at the start of the "place" journey
+    placeHelper.startPlace()
+
+    // I can progress along the "place" journey
+    placeHelper.progressPlace()
+  })
+})

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -86,11 +86,7 @@ context('Apply', () => {
           listPage.clickAssessment(assessment)
 
           // Then I should be taken to the referral show page
-          const assessmentPage = Page.verifyOnPage(
-            AssessmentShowPage,
-            assessment.application.person.name,
-            assessment.status,
-          )
+          const assessmentPage = Page.verifyOnPage(AssessmentShowPage, assessment)
           // And I can view an assessment
           assessmentPage.shouldShowAssessment(applicationTranslatedDocument)
 
@@ -111,7 +107,7 @@ context('Apply', () => {
           confirmationPage.clickSubmit()
 
           // I am taken to the show page and a banner is shown
-          Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, 'in_review')
+          Page.verifyOnPage(AssessmentShowPage, { ...assessment, status: 'in_review' })
           assessmentPage.shouldShowBanner('Assessment updated status updated to "in review"')
 
           // And the assessment is updated in the database
@@ -132,7 +128,7 @@ context('Apply', () => {
           confirmationPage.clickSubmit()
 
           // I am taken to the show page and a banner is shown
-          Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, 'ready_to_place')
+          Page.verifyOnPage(AssessmentShowPage, { ...assessment, status: 'ready_to_place' })
           assessmentPage.shouldShowBanner('Assessment updated status updated to "ready to place"')
 
           // And the assessment is updated in the database
@@ -153,7 +149,7 @@ context('Apply', () => {
           confirmationPage.clickSubmit()
 
           // I am taken to the show page and a banner is shown
-          Page.verifyOnPage(AssessmentShowPage, assessment.application.person.name, 'closed')
+          Page.verifyOnPage(AssessmentShowPage, { ...assessment, status: 'closed' })
           assessmentPage.shouldShowBanner('Assessment updated status updated to "closed"')
 
           // And the assessment is updated in the database

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,5 @@
 import type { TemporaryAccommodationApplication as Application, ProbationRegion } from '@approved-premises/api'
-import type { ErrorMessages } from '@approved-premises/ui'
+import type { ErrorMessages, PlaceContext } from '@approved-premises/ui'
 
 export default {}
 
@@ -12,6 +12,12 @@ declare module 'express-session' {
     previousPage: string
     probationRegion: ProbationRegion
     userDetails: UserDetails
+  }
+}
+
+declare module 'express-serve-static-core' {
+  interface Locals {
+    placeContext: PlaceContext
   }
 }
 

--- a/server/@types/shared/models/Application.ts
+++ b/server/@types/shared/models/Application.ts
@@ -10,5 +10,6 @@ export type Application = {
     id: string;
     person: Person;
     createdAt: string;
+    arrivalDate: string;
 };
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -273,3 +273,7 @@ export interface OasysPage extends TasklistPage {
   risks: PersonRisksUI
   oasysSuccess: boolean
 }
+
+export type PlaceContext = {
+  assessment: Assessment
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,6 +1,7 @@
 import {
   Adjudication,
   Application,
+  TemporaryAccommodationApplicationSummary as ApplicationSummary,
   ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
@@ -237,8 +238,8 @@ export interface GroupedAssessments {
 }
 
 export interface GroupedApplications {
-  inProgress: Array<Application>
-  submitted: Array<Application>
+  inProgress: Array<ApplicationSummary>
+  submitted: Array<ApplicationSummary>
 }
 
 export interface ApplicationWithRisks extends Application {

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -3,10 +3,10 @@ import {
   TemporaryAccommodationAssessment as Assessment,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
 } from '../../../@types/shared'
-import AssessmentsService from '../../../services/assessmentsService'
-import extractCallConfig from '../../../utils/restUtils'
-import { assessmentActions, statusName } from '../../../utils/assessmentUtils'
 import paths from '../../../paths/temporary-accommodation/manage'
+import AssessmentsService from '../../../services/assessmentsService'
+import { assessmentActions, statusName } from '../../../utils/assessmentUtils'
+import extractCallConfig from '../../../utils/restUtils'
 import { lowerCase } from '../../../utils/utils'
 
 export const assessmentsTableHeaders = [

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
@@ -2,15 +2,23 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
+import { AssessmentsService } from '../../../services'
 import BedspaceSearchService from '../../../services/bedspaceSearchService'
-import { bedSearchParametersFactory, bedSearchResultsFactory, referenceDataFactory } from '../../../testutils/factories'
+import {
+  bedSearchParametersFactory,
+  bedSearchResultsFactory,
+  placeContextFactory,
+  referenceDataFactory,
+} from '../../../testutils/factories'
 import { DateFormats } from '../../../utils/dateUtils'
+import { addPlaceContext, preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, setUserInput } from '../../../utils/validation'
 import BedspaceSearchController from './bedspaceSearchController'
 
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/placeUtils')
 
 describe('BedspaceSearchController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -25,8 +33,9 @@ describe('BedspaceSearchController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const bedspaceSearchService = createMock<BedspaceSearchService>({})
+  const assessmentService = createMock<AssessmentsService>({})
 
-  const bedspaceSearchController = new BedspaceSearchController(bedspaceSearchService)
+  const bedspaceSearchController = new BedspaceSearchController(bedspaceSearchService, assessmentService)
 
   beforeEach(() => {
     request = createMock<Request>()
@@ -35,7 +44,9 @@ describe('BedspaceSearchController', () => {
 
   describe('index', () => {
     it('renders the search page when not given a search query', async () => {
-      request.query = {}
+      request.query = {
+        'other-parameter': 'other-data',
+      }
 
       bedspaceSearchService.getReferenceData.mockResolvedValue(referenceData)
 
@@ -46,6 +57,7 @@ describe('BedspaceSearchController', () => {
 
       expect(bedspaceSearchService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(bedspaceSearchService.search).not.toHaveBeenCalled()
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspace-search/index', {
         allPdus: referenceData.pdus,
@@ -75,6 +87,7 @@ describe('BedspaceSearchController', () => {
 
       expect(bedspaceSearchService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(bedspaceSearchService.search).toHaveBeenCalledWith(callConfig, expect.objectContaining(searchParameters))
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspace-search/index', {
         allPdus: referenceData.pdus,
@@ -87,6 +100,7 @@ describe('BedspaceSearchController', () => {
 
     it('renders with errors if the API returns an error', async () => {
       const searchParameters = bedSearchParametersFactory.build()
+      const placeContext = placeContextFactory.build()
 
       request.query = {
         ...searchParameters,
@@ -103,18 +117,22 @@ describe('BedspaceSearchController', () => {
 
       const requestHandler = bedspaceSearchController.index()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+      ;(preservePlaceContext as jest.MockedFunction<typeof preservePlaceContext>).mockResolvedValue(placeContext)
+      ;(addPlaceContext as jest.MockedFunction<typeof addPlaceContext>).mockReturnValue('/path/with/place/context')
 
       await requestHandler(request, response, next)
 
       expect(bedspaceSearchService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(bedspaceSearchService.search).toHaveBeenCalledWith(callConfig, expect.objectContaining(searchParameters))
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
+      expect(addPlaceContext).toHaveBeenCalledWith(paths.bedspaces.search({}), placeContext)
 
       expect(setUserInput).toHaveBeenCalledWith(request.query, 'get')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,
         err,
-        paths.bedspaces.search({}),
+        '/path/with/place/context',
         'bedspaceSearch',
       )
     })

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -32,6 +32,11 @@ export default class BedspaceSearchController {
       const query =
         (req.query as BedspaceSearchQuery).durationDays !== undefined ? (req.query as BedspaceSearchQuery) : undefined
 
+      const placeContextArrivalDate = placeContext?.assessment.application.arrivalDate
+      const startDatePrefill = placeContextArrivalDate
+        ? DateFormats.isoToDateAndTimeInputs(placeContextArrivalDate, 'startDate')
+        : {}
+
       let results: BedSearchResults
       let startDate: string
 
@@ -57,6 +62,7 @@ export default class BedspaceSearchController {
           startDate,
           errors,
           errorSummary,
+          ...startDatePrefill,
           ...query,
           ...userInput,
         })

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -4,7 +4,7 @@ import type { NextFunction, Request, Response } from 'express'
 import { ErrorsAndUserInput, SummaryListItem } from '../../../@types/ui'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BookingService, PremisesService } from '../../../services'
+import { AssessmentsService, BookingService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
 import { ListingEntry } from '../../../services/bookingService'
 import {
@@ -39,7 +39,13 @@ describe('BedspacesController', () => {
   const premisesService = createMock<PremisesService>({})
   const bedspaceService = createMock<BedspaceService>({})
   const bookingService = createMock<BookingService>({})
-  const bedspacesController = new BedspacesController(premisesService, bedspaceService, bookingService)
+  const assessmentService = createMock<AssessmentsService>({})
+  const bedspacesController = new BedspacesController(
+    premisesService,
+    bedspaceService,
+    bookingService,
+    assessmentService,
+  )
 
   beforeEach(() => {
     request = createMock<Request>()

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
+import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import { appendQueryString } from '../../../utils/utils'
 import {
   catchValidationErrorOrPropogate,
@@ -21,7 +22,6 @@ import {
   insertBespokeError,
   insertGenericError,
 } from '../../../utils/validation'
-import { isApplyEnabledForUser } from '../../../utils/userUtils'
 
 export default class BookingsController {
   constructor(

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -221,7 +221,7 @@ export default class BookingsController {
           req,
           res,
           err,
-          appendQueryString(paths.bookings.new({ premisesId, roomId }), req.body),
+          appendQueryString(paths.bookings.new({ premisesId, roomId }), { ...req.body, _csrf: undefined }),
         )
       }
     }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -78,7 +78,10 @@ export const controllers = (services: Services) => {
     services.bedspaceService,
   )
 
-  const bedspaceSearchController = new BedspaceSearchController(services.bedspaceSearchService)
+  const bedspaceSearchController = new BedspaceSearchController(
+    services.bedspaceSearchService,
+    services.assessmentsService,
+  )
   const bookingSearchController = new BookingSearchController(services.bookingSearchService)
 
   const assessmentsController = new AssessmentsController(services.assessmentsService)

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -24,6 +24,7 @@ export const controllers = (services: Services) => {
     services.premisesService,
     services.bedspaceService,
     services.bookingService,
+    services.assessmentsService,
   )
   const bookingsController = new BookingsController(
     services.premisesService,

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -4,11 +4,11 @@ import type { NewPremises, UpdatePremises } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import BedspaceService from '../../../services/bedspaceService'
 import PremisesService from '../../../services/premisesService'
+import { parseNaturalNumber } from '../../../utils/formUtils'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { filterProbationRegions } from '../../../utils/userUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
-import { parseNaturalNumber } from '../../../utils/formUtils'
 
 export default class PremisesController {
   constructor(

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -1,6 +1,7 @@
 import type {
   Arrival,
   Booking,
+  BookingSearchResults,
   Cancellation,
   Confirmation,
   Departure,
@@ -17,7 +18,6 @@ import type {
   Turnaround,
 } from '@approved-premises/api'
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
-import type { BookingSearchResults } from 'server/@types/shared/models/BookingSearchResults'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 import { appendQueryString } from '../utils/utils'

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -56,4 +56,5 @@ export default ApplicationFactory.define(() => ({
   risks: risksFactory.build(),
   status: 'inProgress' as const,
   type: 'CAS3',
+  arrivalDate: DateFormats.dateObjToIsoDate(faker.date.past()),
 }))

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -3,6 +3,7 @@ import { Factory } from 'fishery'
 
 import type { OASysSection, TemporaryAccommodationApplication } from '@approved-premises/api'
 
+import applicationTranslatedDocument from '../../../cypress_shared/fixtures/applicationTranslatedDocument.json'
 import { DateFormats } from '../../utils/dateUtils'
 import { fakeObject } from '../utils'
 import personFactory from './person'
@@ -51,7 +52,7 @@ export default ApplicationFactory.define(() => ({
   createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
   submittedAt: DateFormats.dateObjToIsoDate(faker.date.past()),
   data: {},
-  document: {},
+  document: applicationTranslatedDocument,
   outdatedSchema: faker.datatype.boolean(),
   risks: risksFactory.build(),
   status: 'inProgress' as const,

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -46,6 +46,7 @@ import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import oasysSelectionFactory from './oasysSelection'
 import pduFactory from './pdu'
 import personFactory from './person'
+import placeContextFactory from './placeContext'
 import premisesFactory from './premises'
 import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
@@ -111,6 +112,7 @@ export {
   oasysSelectionFactory,
   pduFactory,
   personFactory,
+  placeContextFactory,
   premisesFactory,
   premisesSummaryFactory,
   prisonCaseNotesFactory,

--- a/server/testutils/factories/placeContext.ts
+++ b/server/testutils/factories/placeContext.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { PlaceContext } from '../../@types/ui'
+import assessmentFactory from './assessment'
+
+export default Factory.define<PlaceContext>(() => ({
+  assessment: assessmentFactory.build({
+    status: 'ready_to_place',
+  }),
+}))

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -1,6 +1,9 @@
 import paths from '../paths/temporary-accommodation/manage'
-import { assessmentFactory, assessmentSummaryFactory, personFactory } from '../testutils/factories'
+import { assessmentFactory, assessmentSummaryFactory, personFactory, placeContextFactory } from '../testutils/factories'
 import { assessmentActions, assessmentTableRows, statusName, statusTag } from './assessmentUtils'
+import { addPlaceContext, createPlaceContext } from './placeUtils'
+
+jest.mock('./placeUtils')
 
 describe('assessmentUtils', () => {
   describe('statusTag', () => {
@@ -131,6 +134,11 @@ describe('assessmentUtils', () => {
         status: 'ready_to_place',
       })
 
+      const placeContext = placeContextFactory.build()
+
+      ;(createPlaceContext as jest.MockedFunction<typeof createPlaceContext>).mockReturnValue(placeContext)
+      ;(addPlaceContext as jest.MockedFunction<typeof addPlaceContext>).mockReturnValue('/path/with/place/context')
+
       const result = assessmentActions(assessment)
 
       expect(result).toEqual([
@@ -154,11 +162,14 @@ describe('assessmentUtils', () => {
         },
         {
           classes: 'govuk-button--secondary',
-          href: paths.bedspaces.search({}),
+          href: '/path/with/place/context',
           text: 'Place referral',
           newTab: true,
         },
       ])
+
+      expect(createPlaceContext).toHaveBeenCalledWith(assessment)
+      expect(addPlaceContext).toHaveBeenCalledWith(paths.bedspaces.search({}), placeContext)
     })
 
     it('returns the "ready_to_place" action for an assessment with a status of "closed"', () => {

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -5,6 +5,7 @@ import {
 import { TableRow } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from './dateUtils'
+import { addPlaceContext, createPlaceContext } from './placeUtils'
 
 export const allStatuses: Array<{ name: string; id: AssessmentSummary['status']; tagClass: string }> = [
   {
@@ -120,7 +121,7 @@ export const assessmentActions = (assessment: Assessment) => {
     },
     findABedspace: {
       classes: 'govuk-button--secondary',
-      href: paths.bedspaces.search({}),
+      href: addPlaceContext(paths.bedspaces.search({}), createPlaceContext(assessment)),
       text: 'Place referral',
       newTab: true,
     },

--- a/server/utils/bedspaceUtils.test.ts
+++ b/server/utils/bedspaceUtils.test.ts
@@ -10,7 +10,7 @@ describe('bedspaceUtils', () => {
       })
       const room = roomFactory.build()
 
-      expect(bedspaceActions(premises, room)).toEqual([
+      expect(bedspaceActions(premises, room, undefined)).toEqual([
         {
           text: 'Book bedspace',
           classes: 'govuk-button--secondary',
@@ -30,7 +30,7 @@ describe('bedspaceUtils', () => {
       })
       const room = roomFactory.build()
 
-      expect(bedspaceActions(premises, room)).toEqual(null)
+      expect(bedspaceActions(premises, room, undefined)).toEqual(null)
     })
   })
 })

--- a/server/utils/bedspaceUtils.ts
+++ b/server/utils/bedspaceUtils.ts
@@ -1,8 +1,9 @@
 import { Premises, Room } from '../@types/shared'
-import { PageHeadingBarItem } from '../@types/ui'
+import { PageHeadingBarItem, PlaceContext } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
+import { addPlaceContext } from './placeUtils'
 
-export function bedspaceActions(premises: Premises, room: Room): Array<PageHeadingBarItem> {
+export function bedspaceActions(premises: Premises, room: Room, placeContext: PlaceContext): Array<PageHeadingBarItem> {
   if (premises.status === 'archived') {
     return null
   }
@@ -10,7 +11,7 @@ export function bedspaceActions(premises: Premises, room: Room): Array<PageHeadi
     {
       text: 'Book bedspace',
       classes: 'govuk-button--secondary',
-      href: paths.bookings.new({ premisesId: premises.id, roomId: room.id }),
+      href: addPlaceContext(paths.bookings.new({ premisesId: premises.id, roomId: room.id }), placeContext),
     },
   ]
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -37,6 +37,7 @@ import applyPaths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
 import { checkYourAnswersSections } from './checkYourAnswersUtils'
+import { addPlaceContext } from './placeUtils'
 
 const production = process.env.NODE_ENV === 'production'
 
@@ -147,6 +148,10 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('fetchContext', function fetchContext() {
     return this.ctx
+  })
+
+  njkEnv.addGlobal('addPlaceContext', function _(link: string) {
+    return addPlaceContext(link, this.ctx.placeContext)
   })
 
   njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -6,6 +6,7 @@ import express from 'express'
 import nunjucks from 'nunjucks'
 
 import type { ErrorMessages, PersonStatus } from '@approved-premises/ui'
+import { statusTag as assessmentStatusTag } from './assessmentUtils'
 import { DateFormats, dateInputHint } from './dateUtils'
 import {
   convertObjectsToCheckboxItems,
@@ -15,7 +16,6 @@ import {
   parseNaturalNumber,
 } from './formUtils'
 import { statusTag as personStatusTag } from './personUtils'
-import { statusTag as assessmentStatusTag } from './assessmentUtils'
 import { initialiseName, mapApiPersonRisksForUi, removeBlankSummaryListItems, sentenceCase } from './utils'
 
 import { dashboardTableRows, taskResponsesToSummaryListRowItems } from './applicationUtils'
@@ -27,6 +27,7 @@ import * as PhaseBannerUtils from './phaseBannerUtils'
 import * as TasklistUtils from './taskListUtils'
 import * as PremisesUtils from './premisesUtils'
 
+import { TemporaryAccommodationAssessment } from '../@types/shared'
 import bookingSummaryListRows from '../components/bookingInfo'
 import * as BookingListing from '../components/bookingListing'
 import lostBedSummaryListRows from '../components/lostBedInfo'
@@ -36,7 +37,6 @@ import applyPaths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
 import { checkYourAnswersSections } from './checkYourAnswersUtils'
-import { TemporaryAccommodationAssessment } from '../@types/shared'
 
 const production = process.env.NODE_ENV === 'production'
 

--- a/server/utils/placeUtils.test.ts
+++ b/server/utils/placeUtils.test.ts
@@ -1,0 +1,41 @@
+import { assessmentFactory, placeContextFactory } from '../testutils/factories'
+import { addPlaceContext, createPlaceContext } from './placeUtils'
+import { appendQueryString } from './utils'
+
+jest.mock('./utils')
+
+describe('placeUtils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('createPlaceContext', () => {
+    it('returns a PlaceContext type object', () => {
+      const assessment = assessmentFactory.build()
+
+      expect(createPlaceContext(assessment)).toEqual({ assessment })
+    })
+  })
+
+  describe('addPlaceContext', () => {
+    it('returns a path with a reference to the given place context', () => {
+      const placeContext = placeContextFactory.build({
+        assessment: assessmentFactory.build({
+          id: 'some-id',
+        }),
+      })
+
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockImplementation(
+        path => `${path}?some-query-string`,
+      )
+
+      expect(addPlaceContext('/some/path', placeContext)).toEqual('/some/path?some-query-string')
+      expect(appendQueryString).toHaveBeenCalledWith('/some/path', { placeContextAssessmentId: 'some-id' })
+    })
+
+    it('returns the original path if the place context is undefinded', () => {
+      expect(addPlaceContext('/some/path', undefined)).toEqual('/some/path')
+      expect(appendQueryString).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/utils/placeUtils.test.ts
+++ b/server/utils/placeUtils.test.ts
@@ -1,8 +1,14 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Request, Response } from 'express'
+import { CallConfig } from '../data/restClient'
+import type { AssessmentsService } from '../services'
 import { assessmentFactory, placeContextFactory } from '../testutils/factories'
-import { addPlaceContext, createPlaceContext } from './placeUtils'
+import { addPlaceContext, createPlaceContext, preservePlaceContext } from './placeUtils'
+import extractCallConfig from './restUtils'
 import { appendQueryString } from './utils'
 
 jest.mock('./utils')
+jest.mock('./restUtils')
 
 describe('placeUtils', () => {
   beforeEach(() => {
@@ -36,6 +42,72 @@ describe('placeUtils', () => {
     it('returns the original path if the place context is undefinded', () => {
       expect(addPlaceContext('/some/path', undefined)).toEqual('/some/path')
       expect(appendQueryString).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('preservePlaceContext', () => {
+    it('uses the assessment service to set and return place context data', async () => {
+      const callConfig = { token: 'some-call-config-token' } as CallConfig
+
+      ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+
+      const assessmentService = createMock<AssessmentsService>()
+
+      const assessment = assessmentFactory.build()
+      assessmentService.findAssessment.mockResolvedValue(assessment)
+
+      const req = createMock<Request>({
+        query: { placeContextAssessmentId: 'some-assessment-id' },
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual({ assessment })
+      expect(res.locals.placeContext).toEqual({ assessment })
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(callConfig, 'some-assessment-id')
+    })
+
+    it('returns undefined when the assessment service throws an error', async () => {
+      const callConfig = { token: 'some-call-config-token' } as CallConfig
+
+      ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+
+      const assessmentService = createMock<AssessmentsService>()
+
+      assessmentService.findAssessment.mockRejectedValue(new Error())
+
+      const req = createMock<Request>({
+        query: { placeContextAssessmentId: 'some-assessment-id' },
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual(undefined)
+      expect(res.locals.placeContext).toEqual(undefined)
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(callConfig, 'some-assessment-id')
+    })
+
+    it('does nothing when the place context assessment ID is not set in the query parameters', async () => {
+      const assessmentService = createMock<AssessmentsService>()
+
+      const req = createMock<Request>({
+        query: {},
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual(undefined)
+      expect(res.locals.placeContext).toEqual(undefined)
+      expect(assessmentService.findAssessment).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -1,5 +1,8 @@
+import { Request, Response } from 'express'
 import { TemporaryAccommodationAssessment as Assessment } from '../@types/shared'
 import { PlaceContext } from '../@types/ui'
+import type { AssessmentsService } from '../services'
+import extractCallConfig from './restUtils'
 import { appendQueryString } from './utils'
 
 export const createPlaceContext = (assessment: Assessment) => {
@@ -12,3 +15,28 @@ export const addPlaceContext = (path: string, placeContext: PlaceContext) => {
   }
   return path
 }
+
+export const preservePlaceContext = async (
+  req: Request,
+  res: Response,
+  assessmentService: AssessmentsService,
+): Promise<PlaceContext> => {
+  if (req.query.placeContextAssessmentId) {
+    let assessment: Assessment
+
+    try {
+      assessment = await assessmentService.findAssessment(
+        extractCallConfig(req),
+        req.query.placeContextAssessmentId as string,
+      )
+    } catch (err) {
+      return undefined
+    }
+
+    res.locals.placeContext = { assessment }
+    return { assessment }
+  }
+
+  return undefined
+}
+

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -1,0 +1,14 @@
+import { TemporaryAccommodationAssessment as Assessment } from '../@types/shared'
+import { PlaceContext } from '../@types/ui'
+import { appendQueryString } from './utils'
+
+export const createPlaceContext = (assessment: Assessment) => {
+  return { assessment }
+}
+
+export const addPlaceContext = (path: string, placeContext: PlaceContext) => {
+  if (placeContext) {
+    return appendQueryString(path, { placeContextAssessmentId: placeContext.assessment.id })
+  }
+  return path
+}

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -224,4 +224,10 @@ describe('unique', () => {
       expect(appendQueryString('/some/path', {})).toEqual('/some/path')
     })
   })
+
+  it('appends a query string to a path that already contais a query string', () => {
+    expect(appendQueryString('/some/path?userId=some-user', { bookingId: 'some-booking' })).toEqual(
+      '/some/path?userId=some-user&bookingId=some-booking',
+    )
+  })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -113,5 +113,8 @@ export const appendQueryString = (
 ): string => {
   const queryString = createQueryString(params, options)
 
+  if (path.includes('?')) {
+    return `${path}${queryString ? `&${queryString}` : ''}`
+  }
   return `${path}${queryString ? `?${queryString}` : ''}`
 }

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -6,6 +6,8 @@
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
+{% from "../components/place-context-value/macro.njk" import placeContextValue %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -14,6 +16,7 @@
 
 {% block beforeContent %}
   {{ breadCrumb('Find a bedspace', []) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -22,6 +25,9 @@
   <h1 class="govuk-heading-l">Search for available bedspaces</h1>
   <form action="{{ paths.bedspaces.search({}) }}" method="get">
     {{ showErrorSummary(errorSummary) }}
+
+    {{ placeContextValue(placeContext) }}
+
 
     {{ taDateInput(
       {
@@ -87,7 +93,9 @@
 
         {% for result in results.results %}
           <div data-cy-bedspace>
-            <h2 class="govuk-heading-m"><a class="govuk-link--no-underline" href="{{ paths.premises.bedspaces.show({premisesId: result.premises.id, roomId: result.room.id}) }}">{{ result.room.name }}</a></h2>
+            <h2 class="govuk-heading-m">
+              <a class="govuk-link--no-underline" href="{{ addPlaceContext(paths.premises.bedspaces.show({premisesId: result.premises.id, roomId: result.room.id})) }}">{{ result.room.name }}</a>
+            </h2>
             <h3 class="govuk-heading-s">{{ PremisesUtils.shortAddress(result.premises) }}</h3>
 
             {% set keyCharacteristicsHtml %}

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -6,6 +6,7 @@
 {% from "../components/location-header/macro.njk" import locationHeader %}
 {% from "../components/booking-listing/macro.njk" import bookingListing %}
 {% from "../components/lost-bed-listing/macro.njk" import lostBedListing %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -16,8 +17,9 @@
 {% block beforeContent %}
   {{ breadCrumb('View a bedspace', [
     {title: 'List of properties', href: paths.premises.index()},
-    {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })}
+    {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -80,9 +82,9 @@
 
   {% for listingEntry in listingEntries %}
     {% if listingEntry.type === 'booking'%}
-      {{ bookingListing(listingEntry.body, listingEntry.path) }}
+      {{ bookingListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
     {% elif listingEntry.type === 'lost-bed' %}
-      {{ lostBedListing(listingEntry.body, listingEntry.path) }}
+      {{ lostBedListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
     {% endif %}
   {% endfor %}
 

--- a/server/views/temporary-accommodation/components/place-context-header/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-header/macro.njk
@@ -1,0 +1,24 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro placeContextHeader(placeContext) %}
+
+  {% if placeContext %}
+    <div class="place-context-header">
+      <strong class="govuk-heading-s govuk-!-margin-bottom-2">Person to place</strong>
+      <div class="place-context-header__attribute-container">
+        <div>{{ placeContext.assessment.application.person.name | default('Limited access offender') }}</div>
+        {% if placeContext.assessment.application.person.dateOfBirth %}
+          <div>Date of birth: {{ formatDate(placeContext.assessment.application.person.dateOfBirth, {format: 'short'}) }}</div>
+        {% endif %}
+        {% if placeContext.assessment.application.person.sex %}
+          <div>Sex: {{ placeContext.assessment.application.person.sex }}</div>
+        {% endif %}
+        {% if placeContext.assessment.application.person.genderIdentity %}
+          <div>Gender identity: {{ placeContext.assessment.application.person.genderIdentity }}</div>
+        {% endif %}
+        <div>CRN: {{ placeContext.assessment.application.person.crn }}</div>
+      </div>
+    </div>
+  {% endif %}
+
+{% endmacro %}

--- a/server/views/temporary-accommodation/components/place-context-value/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-value/macro.njk
@@ -1,0 +1,9 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro placeContextValue(placeContext) %}
+
+	{% if placeContext %}
+	  <input type="hidden" name="placeContextAssessmentId" value="{{ placeContext.assessment.id }}" />
+	{% endif %}
+
+{% endmacro %}


### PR DESCRIPTION
# Changes in this PR

This PR is the first step of having a banner at the top of each page that is part of the journey from a referral that is ready to place, through to successfully booking a bedspace

This PR adds a banner to the top of the bedspace search page indicating the context, and prefills this page's start date fields

Context is preserved using a query parameter that is passed from page-to-page, rather than session data. My intuition is this will give more predictable behaviour particularly when it comes to when context is lost, particularly when users are working in multiple tabs and using the browser back button. A session-based approach would require either a design that allows users to explicitly clear the context, or for us to make choices about when to unrecoverably clear the context that may seem surprising to the user.

## Screenshots of UI changes

### Before
![before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/ae4e568a-6c4e-4711-bfd5-2ad3becd7720)

### After
![after](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/7da5744e-9c53-474e-afe3-7efb30832fd2)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
