### PR TITLE
Update content on booking form page for when no associated referrals exist

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment.ts
@@ -6,12 +6,12 @@ import Page from '../../page'
 
 export default class BookingSelectAssessmentPage extends Page {
   constructor(private readonly assessmentSummaries: Array<AssessmentSummary>) {
-    super(assessmentSummaries.length ? 'Confirm which referral this booking is for' : 'No referrals found')
+    super(assessmentSummaries.length ? 'Confirm which referral this booking is for' : 'Book without linking a referral')
   }
 
   static assignAssessmentSummaries(alias: string): void {
     cy.get('h1').then(titleElement => {
-      if (Cypress.$(titleElement).text() === 'No referrals found') {
+      if (Cypress.$(titleElement).text() === 'Book without linking a referral') {
         cy.wrap([]).as(alias)
       } else {
         cy.get('.govuk-radios')

--- a/server/views/temporary-accommodation/bookings/selectAssessment.njk
+++ b/server/views/temporary-accommodation/bookings/selectAssessment.njk
@@ -20,7 +20,7 @@
   {% if applyDisabled %}
     <h1 class="govuk-heading-l">Book bedspace for a person referred through nDelius</h1>
   {% elif forceAssessmentId %}
-    <h1 class="govuk-heading-l">No referrals found</h1>
+    <h1 class="govuk-heading-l">Book without linking a referral</h1>
   {% else %}
     <h1 class="govuk-heading-l">Confirm which referral this booking is for</h1>
   {% endif %}
@@ -63,11 +63,12 @@
 
           <input type="hidden" name="assessmentId" value="{{ forceAssessmentId }}"/>
         {% elif forceAssessmentId %}
-          <p class="govuk-body">There are no referrals for this person that are ready to place.</p>
-          <p class="govuk-body">Check the list of <a class="govuk-link" href="{{ paths.assessments.index({}) }}">submitted referrals</a> to see if there is a referral for this person that should be marked as ready to place.</p>
+          <p class="govuk-body">There are no digital referrals for this person that are ready to place.</p>
+          <p class="govuk-body">If this is expected you can continue to book this bedspace without linking a referral.</p>
 
-          <h2 class="govuk-heading-m">Book without linking a referral</h1>
-          <p class="govuk-body">You can continue to book this bedspace without linking a referral.</p>
+          <h2 class="govuk-heading-m">No digital referrals found</h1>
+          <p class="govuk-body">If a referral has been submitted through the Temporary Accommodation service check the list of <a class="govuk-link" href="{{ paths.assessments.index({}) }}">submitted referrals</a>.</p>
+          <p class="govuk-body">Referrals must be marked as ready to place before a placement is booked.</p>
           
           <input type="hidden" name="assessmentId" value="{{ forceAssessmentId }}"/>
 


### PR DESCRIPTION
# Context
This commit changes the content of the page shown when attempting to
make a booking for which a corresponding referral doesn't exist for the
person.

We received a support ticket for the page as the user thought they
had encountered an error.

This new content should help give the user better guidance on what to do
next.

## Screenshots of UI changes

### Before
![Screenshot 2023-08-24 at 11 14 22](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/c2b2b971-ef42-4e97-bb3f-cde73b2f0a54)

### After
![Screenshot 2023-08-24 at 11 28 23](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/ee65e22c-59a0-4e57-941a-e5fdeb680926)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
