### PR TITLE
Fix bedspace search E2E test fragility

### DIFF
--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -40,7 +40,11 @@ Given('I attempt to search for a bedspace with required details missing', () => 
 Then('I should see the bedspace search results', () => {
   cy.then(function _() {
     const results = bedSearchResultsFactory.build({
-      results: [bedSearchResultFactory.forBedspace(this.premises, this.room).build()],
+      results: [
+        bedSearchResultFactory.forBedspace(this.premises, this.room).build({
+          overlaps: [],
+        }),
+      ],
     })
 
     cy.wrap({ room: this.room, sr: results })


### PR DESCRIPTION
We update our bedspace search E2E test to ensure that the search results we pass into BedspaceSearchPage contain zero overlaps. Since our test creates a new premises and bedspace to search for, we can guarantee this will match what the test sees on the page.

This fixes an issue where our tests would only pass on the one-in-six chance that the result generated by bedSearchResultFactory contained zero overlaps.