### PR TITLE
Handle empty turnaround in booking info component

### DIFF
--- a/server/components/bookingInfo.test.ts
+++ b/server/components/bookingInfo.test.ts
@@ -552,5 +552,27 @@ describe('BookingInfo', () => {
         ]),
       )
     })
+
+    it('returns summary list rows containing the turnaround time when the turnaround is not present', () => {
+      const booking = bookingFactory.build({
+        effectiveEndDate: '2023-02-11',
+        turnaround: undefined,
+      })
+
+      const result = summaryListRows(booking)
+
+      expect(result).toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({
+            key: {
+              text: 'Turnaround time',
+            },
+            value: {
+              text: '0 working days',
+            },
+          }),
+        ]),
+      )
+    })
   })
 })

--- a/server/components/bookingInfo.ts
+++ b/server/components/bookingInfo.ts
@@ -42,7 +42,7 @@ export default (booking: Booking): SummaryList['rows'] => {
     })
   }
 
-  const days = booking.turnaround.workingDays
+  const days = booking.turnaround?.workingDays || 0
 
   rows.push(
     {


### PR DESCRIPTION
We update our booking info component to handle the turnaround field on a booking being undefined. We already handle this possibility in other places we work with turnarounds, but missed this instance