### PR TITLE
Update assessment links

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingShow.ts
@@ -72,7 +72,7 @@ export default class BookingShowPage extends Page {
     this.bookingInfoComponent.shouldShowBookingDetails()
 
     if (this.booking.assessmentId) {
-      this.popDetailsHeaderComponent.shouldHaveNameLink(paths.assessments.full({ id: this.booking.assessmentId }))
+      this.popDetailsHeaderComponent.shouldHaveNameLink(paths.assessments.summary({ id: this.booking.assessmentId }))
     }
   }
 

--- a/server/views/temporary-accommodation/assessments/confirm.njk
+++ b/server/views/temporary-accommodation/assessments/confirm.njk
@@ -9,7 +9,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.assessments.full({ id: id })
+    href: paths.assessments.summary({ id: id })
   }) }}
 {% endblock %}
 

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -31,7 +31,7 @@
     items: actions
   }) }}
 
-  {{ popDetailsHeader(booking.person, { nameLink: paths.assessments.full({ id: booking.assessmentId }) if booking.assessmentId else "" }) }}
+  {{ popDetailsHeader(booking.person, { nameLink: paths.assessments.summary({ id: booking.assessmentId }) if booking.assessmentId else "" }) }}
   {{ locationHeader({ room: room, premises: premises }) }}
 
   {{ bookingInfo(booking, paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })) }}


### PR DESCRIPTION
We update the back link on the state change confirmation page, and the link on the booking page to link to the assessment summary, rather than the full assessment