### PR TITLE
Fix overlaps and characteristics display in bedspace search results

### DIFF
--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -116,6 +116,8 @@
                   </ul>
                 {% endif %}
               {% endset %}
+            {% else %}
+              {% set keyCharacteristicsHtml = undefined %}
             {% endif %}
 
             {% if result.overlaps.length %}
@@ -129,6 +131,8 @@
                   {% endfor %}
                 </ul>
               {% endset %}
+            {% else %}
+              {% set overlapsHtml = undefined %}
             {% endif %}
 
             {{ govukSummaryList({


### PR DESCRIPTION
We update the bedspace search template to fix a bug where a result with no overlaps could display the previous result's overlaps, and a result with no characteristics could display the previous result's characteristics