### PR TITLE
Fix select offence referral page

### DIFF
--- a/server/utils/offenceUtils.test.ts
+++ b/server/utils/offenceUtils.test.ts
@@ -63,5 +63,33 @@ describe('offenceUtils', () => {
         ],
       ])
     })
+
+    it('returns table rows when no date is given', () => {
+      const offences = [
+        activeOffenceFactory.build({
+          offenceDate: undefined,
+        }),
+      ]
+
+      expect(offenceTableRows(offences)).toEqual([
+        [
+          {
+            html: offenceRadioButton(offences[0]),
+          },
+          {
+            text: offences[0].offenceId,
+          },
+          {
+            text: offences[0].offenceDescription,
+          },
+          {
+            text: 'Not known',
+          },
+          {
+            text: String(offences[0].convictionId),
+          },
+        ],
+      ])
+    })
   })
 })

--- a/server/utils/offenceUtils.ts
+++ b/server/utils/offenceUtils.ts
@@ -17,7 +17,7 @@ const offenceTableRows = (offences: Array<ActiveOffence>): Array<TableRow> => {
         text: offence.offenceDescription,
       },
       {
-        text: DateFormats.isoDateToUIDate(offence.offenceDate),
+        text: offence.offenceDate ? DateFormats.isoDateToUIDate(offence.offenceDate) : 'Not known',
       },
       {
         text: String(offence.convictionId),


### PR DESCRIPTION
We update offenceTableRows() to handle the offence date possibly being empty

![localhost_3000_referrals_people_C954470_select-offence](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/fa8967cd-4339-42b5-afa8-8828fbbd33cd)
