### PR TITLE
Hide system notes from assessments

### DIFF
--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -236,10 +236,9 @@ describe('assessmentUtils', () => {
         createdAt: '2024-05-01',
       })
 
-      const systemNote1 = referralHistoryNoteFactory.build({ createdAt: '2024-04-02' })
-      const systemNote2 = referralHistoryNoteFactory.build({ createdAt: '2024-05-02' })
+      const systemNote = referralHistoryNoteFactory.build({ createdAt: '2024-04-02', message: '' })
 
-      const notes = [systemNote1, userNote2, userNote1, systemNote2]
+      const notes = [systemNote, userNote2, userNote1]
 
       const assessment = assessmentFactory.build({ referralHistoryNotes: notes })
       const html = 'some formatted html'
@@ -254,31 +253,11 @@ describe('assessmentUtils', () => {
           },
           html,
           datetime: {
-            timestamp: systemNote2.createdAt,
-            type: 'datetime',
-          },
-        },
-        {
-          label: {
-            text: 'Note',
-          },
-          html,
-          datetime: {
             timestamp: userNote2.createdAt,
             type: 'datetime',
           },
           byline: {
             text: 'Another User',
-          },
-        },
-        {
-          label: {
-            text: 'Note',
-          },
-          html,
-          datetime: {
-            timestamp: systemNote1.createdAt,
-            type: 'datetime',
           },
         },
         {

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -170,23 +170,25 @@ export const timelineItems = (assessment: Assessment): Array<TimelineItem> => {
     return noteA.createdAt < noteB.createdAt ? 1 : -1
   })
 
-  return notes.map(note => {
-    return {
-      label: {
-        text: 'Note',
-      },
-      html: formatLines(note.message),
-      datetime: {
-        timestamp: note.createdAt,
-        type: 'datetime',
-      },
-      byline: isUserNote(note)
-        ? {
-            text: convertToTitleCase(note.createdByUserName),
-          }
-        : undefined,
-    }
-  })
+  return notes
+    .filter(note => !!note.message)
+    .map(note => {
+      return {
+        label: {
+          text: 'Note',
+        },
+        html: formatLines(note.message),
+        datetime: {
+          timestamp: note.createdAt,
+          type: 'datetime',
+        },
+        byline: isUserNote(note)
+          ? {
+              text: convertToTitleCase(note.createdByUserName),
+            }
+          : undefined,
+      }
+    })
 }
 
 const isUserNote = (note: Note): note is UserNote => {


### PR DESCRIPTION
An [upcoming API PR](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/919) will add system notes to assessments. To prevent these showing in a way that will be confusing to users, we hide them until we can implement display of system notes properly.

Though the upcoming PR will send a 'type' field with each note, we cannot use that yet, and to resolve this chicken-and-egg situation, we check if 'message' is populated to determine if this is a system note.