### PR TITLE
A user can place a referral and is taken to the Find a Bedspace journey and it remembers the referral data (part 1)

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -14,6 +14,7 @@ $path: "/assets/images/"
 @import './components/_listing-entry'
 @import './components/_probation-region-header'
 @import './components/_attributes-header'
+@import './components/_place-context-header'
 @import './local'
 
 @import './pages/temporary-accommodation/show'

--- a/assets/sass/components/_place-context-header.scss
+++ b/assets/sass/components/_place-context-header.scss
@@ -1,0 +1,19 @@
+.place-context-header {
+  background-color:  govuk-colour("light-grey");
+  padding: govuk-spacing(3);
+  border-left: $govuk-border-width solid govuk-colour("blue");
+  margin-bottom: govuk-spacing(0);
+}
+
+.place-context-header__attribute-container {
+  > div {
+    display: inline;
+    padding-right: govuk-spacing(2);
+    margin-right: govuk-spacing(2);
+    border-right: 1px solid govuk-colour("black");
+
+    &:last-child {
+      border-right: 0;
+    }
+  }
+}

--- a/cypress_shared/components/placeContextHeader.ts
+++ b/cypress_shared/components/placeContextHeader.ts
@@ -1,0 +1,42 @@
+import { PlaceContext } from '../../server/@types/ui'
+import { DateFormats } from '../../server/utils/dateUtils'
+import { isFullPerson, personName } from '../../server/utils/personUtils'
+import Component from './component'
+
+export default class PlaceContextHeaderComponent extends Component {
+  constructor(private readonly placeContext: PlaceContext) {
+    super()
+  }
+
+  static shouldNotShowPlaceContextDetails(): void {
+    cy.get('.place-context-header').should('not.exist')
+  }
+
+  shouldShowPlaceContextDetails(): void {
+    cy.get('.place-context-header').within(() => {
+      const { application } = this.placeContext!.assessment
+      const { person } = application
+
+      cy.root().should('contain', personName(person, 'Limited access offender'))
+
+      if (isFullPerson(person)) {
+        cy.root().should(
+          'contain',
+          `Date of birth: ${DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' })}`,
+        )
+        cy.root().should('contain', `Sex: ${person.sex}`)
+
+        if (person.genderIdentity) {
+          cy.root().should('contain', `Gender identity: ${person.genderIdentity}`)
+        } else {
+          cy.root().should('not.contain', `Gender identity`)
+        }
+      }
+      cy.root().should('contain', `CRN: ${person.crn}`)
+      cy.root().should(
+        'contain',
+        `Accommodation required from: ${DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' })}`,
+      )
+    })
+  }
+}

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -1,0 +1,72 @@
+import { BedSearchResults, TemporaryAccommodationPremises as Premises, Room } from '../../server/@types/shared'
+import { PlaceContext } from '../../server/@types/ui'
+import {
+  bedSearchParametersFactory,
+  bedSearchResultFactory,
+  bedSearchResultsFactory,
+} from '../../server/testutils/factories'
+import AssessmentSummaryPage from '../pages/assess/summary'
+import Page from '../pages/page'
+import BedspaceSearchPage from '../pages/temporary-accommodation/manage/bedspaceSearch'
+
+export default class PlaceHelper {
+  private readonly bedSearchResults: BedSearchResults
+
+  constructor(
+    private readonly placeContext: NonNullable<PlaceContext>,
+    private readonly premises: Premises,
+    private readonly room: Room,
+  ) {
+    this.bedSearchResults = bedSearchResultsFactory.build({
+      results: [bedSearchResultFactory.forBedspace(this.premises, this.room).build()],
+    })
+  }
+
+  setupStubs() {
+    cy.task('stubFindAssessment', this.placeContext.assessment)
+    cy.task('stubBedspaceSearchReferenceData')
+    cy.task('stubBedSearch', this.bedSearchResults)
+  }
+
+  startPlace() {
+    AssessmentSummaryPage.visit(this.placeContext.assessment)
+  }
+
+  progressPlace() {
+    this.assessmentToBedspaceSearch()
+    this.bedspaceSearchToSearchResults()
+  }
+
+  private assessmentToBedspaceSearch() {
+    // Given I am viewing a ready to place assessment
+    const assessmentSummaryPage = Page.verifyOnPage(AssessmentSummaryPage, this.placeContext.assessment)
+
+    // When I click "Place referral"
+    assessmentSummaryPage.clickAction('Place referral')
+
+    // I am taken to the bedspace search page
+    const bedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage)
+
+    // And the place context header is visible
+    bedspaceSearchPage.shouldShowPlaceContextHeader(this.placeContext)
+
+    // And the start date is prefilled
+    bedspaceSearchPage.shouldShowPrefilledSearchParametersFromPlaceContext(this.placeContext)
+  }
+
+  private bedspaceSearchToSearchResults() {
+    // Given I am viewing the bedspace search page
+    const bedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage)
+
+    // When I fill out the form
+    const searchParameters = bedSearchParametersFactory.build()
+    bedspaceSearchPage.completeForm(searchParameters)
+    bedspaceSearchPage.clickSubmit()
+
+    // I am taken to the search results page
+    const resultsBedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage, this.bedSearchResults)
+
+    // And the place context header is visible
+    resultsBedspaceSearchPage.shouldShowPlaceContextHeader(this.placeContext)
+  }
+}

--- a/cypress_shared/pages/assess/summary.ts
+++ b/cypress_shared/pages/assess/summary.ts
@@ -19,7 +19,7 @@ export default class AssessmentSummaryPage extends Page {
 
   clickAction(option: string) {
     cy.get('.moj-button-menu__toggle-button').contains('Update referral status').click()
-    cy.get('.moj-button-menu__wrapper').contains(option).click()
+    cy.get('.moj-button-menu__wrapper').contains(option).invoke('removeAttr', 'target').click()
   }
 
   clickFullReferral() {

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -94,17 +94,18 @@ export default abstract class Page extends Component {
       .contains(legend)
       .siblings('.govuk-date-input')
       .within(() => {
-        cy.get('label').contains('Day').siblings('input').type(parsedDate.getDate().toString())
+        cy.get('label').contains('Day').siblings('input').clear().type(parsedDate.getDate().toString())
         cy.get('label')
           .contains('Month')
           .siblings('input')
+          .clear()
           .type(`${parsedDate.getMonth() + 1}`)
-        cy.get('label').contains('Year').siblings('input').type(parsedDate.getFullYear().toString())
+        cy.get('label').contains('Year').siblings('input').clear().type(parsedDate.getFullYear().toString())
       })
   }
 
   completeTextInputByLabel(label: string, value: string): void {
-    cy.get('label').contains(label).parent().find('input').type(value)
+    cy.get('label').contains(label).parent().find('input').clear().type(value)
   }
 
   completeSelectInputByLabel(label: string, value: string): void {

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -63,6 +63,10 @@ export default abstract class Page extends Component {
     cy.get(`select[id="${id}"]`).children('option').contains(exact(contents)).should('be.selected')
   }
 
+  shouldShowRadioInput(id: string, contents: string) {
+    cy.get(`input[name="${id}"]`).siblings('label').contains(exact(contents)).siblings('input').should('be.checked')
+  }
+
   shouldShowDateInputsByLegend(legend: string, date: string): void {
     const parsedDate = DateFormats.isoToDateObj(date)
 

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -1,8 +1,9 @@
-import { PersonRisksUI, ReferenceData } from '../../server/@types/ui'
+import { PersonRisksUI, PlaceContext, ReferenceData } from '../../server/@types/ui'
 import errorLookups from '../../server/i18n/en/errors.json'
 import { DateFormats } from '../../server/utils/dateUtils'
 import { exact } from '../../server/utils/utils'
 import Component from '../components/component'
+import PlaceContextHeaderComponent from '../components/placeContextHeader'
 
 export type PageElement = Cypress.Chainable<JQuery>
 
@@ -255,6 +256,15 @@ export default abstract class Page extends Component {
     cy.get(`[data-cy-check-your-answers-section="${taskName}"]`).within(() => {
       cy.get('.box-title').should('contain', taskTitle)
     })
+  }
+
+  shouldShowPlaceContextHeader(placeContext: PlaceContext) {
+    const component = new PlaceContextHeaderComponent(placeContext)
+    component.shouldShowPlaceContextDetails()
+  }
+
+  shouldNotShowPlaceContextHeader() {
+    PlaceContextHeaderComponent.shouldNotShowPlaceContextDetails()
   }
 
   getSelectOptionsAsReferenceData(label: string, alias: string): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -4,6 +4,7 @@ import {
   Room,
   TemporaryAccommodationBedSearchResult,
 } from '../../../../server/@types/shared'
+import { PlaceContext } from '../../../../server/@types/ui'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BedspaceSearchResult from '../../../components/bedspaceSearchResult'
@@ -50,6 +51,10 @@ export default class BedspaceSearchPage extends Page {
     this.shouldShowDateInputsByLegend('Available from', searchParameters.startDate)
     this.shouldShowTextInputByLabel('Number of days required', `${searchParameters.durationDays}`)
     this.shouldShowSelectInputByLabel('Probation Delivery Unit (PDU)', searchParameters.probationDeliveryUnit)
+  }
+
+  shouldShowPrefilledSearchParametersFromPlaceContext(placeContext: NonNullable<PlaceContext>) {
+    this.shouldShowDateInputsByLegend('Available from', placeContext.assessment.application.arrivalDate)
   }
 
   completeForm(searchParameters: BedSearchParameters) {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
@@ -33,14 +33,9 @@ export default abstract class BookingEditablePage extends Page {
   }
 
   protected completeEditableForm(newOrUpdateBooking: NewBooking): void {
-    this.getLabel("What is the person's CRN")
-    this.getTextInputByIdAndEnterDetails('crn', newOrUpdateBooking.crn)
-
-    this.getLegend('What is the start date?')
-    this.completeDateInputs('arrivalDate', newOrUpdateBooking.arrivalDate)
-
-    this.getLegend('What is the end date?')
-    this.completeDateInputs('departureDate', newOrUpdateBooking.departureDate)
+    this.completeTextInputByLabel("What is the person's CRN", newOrUpdateBooking.crn)
+    this.completeDateInputsByLegend('What is the start date?', newOrUpdateBooking.arrivalDate)
+    this.completeDateInputsByLegend('What is the end date?', newOrUpdateBooking.departureDate)
 
     this.clickSubmit()
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -51,10 +51,9 @@ export default class BookingNewPage extends BookingEditablePage {
   }
 
   shouldShowPrefilledBookingDetails(newBooking: NewBooking): void {
-    this.shouldShowDateInputs('arrivalDate', newBooking.arrivalDate)
-    this.shouldShowDateInputs('departureDate', newBooking.departureDate)
-
-    cy.get('#crn').should('have.value', newBooking.crn)
+    this.shouldShowTextInputByLabel("What is the person's CRN", newBooking.crn)
+    this.shouldShowDateInputsByLegend('What is the start date?', newBooking.arrivalDate)
+    this.shouldShowDateInputsByLegend('What is the end date?', newBooking.departureDate)
   }
 
   private turnaroundText(): string {

--- a/integration_tests/tests/place/place.cy.ts
+++ b/integration_tests/tests/place/place.cy.ts
@@ -1,0 +1,28 @@
+import PlaceHelper from '../../../cypress_shared/helpers/place'
+import { setupTestUser } from '../../../cypress_shared/utils/setupTestUser'
+import { placeContextFactory, premisesFactory, roomFactory } from '../../../server/testutils/factories'
+
+context('Place', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    setupTestUser('assessor')
+  })
+
+  it('allows the user progress along the "place" joureny', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    const premises = premisesFactory.active().build()
+    const room = roomFactory.build()
+
+    const placeContext = placeContextFactory.build()
+    const placeHelper = new PlaceHelper(placeContext, premises, room)
+    placeHelper.setupStubs()
+
+    // And I am at the start of the "place" journey
+    placeHelper.startPlace()
+
+    // I can progress along the "place" journey
+    placeHelper.progressPlace()
+  })
+})

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,5 +1,5 @@
 import type { TemporaryAccommodationApplication as Application, ProbationRegion } from '@approved-premises/api'
-import type { ErrorMessages } from '@approved-premises/ui'
+import type { ErrorMessages, PlaceContext } from '@approved-premises/ui'
 
 export default {}
 
@@ -12,6 +12,12 @@ declare module 'express-session' {
     previousPage: string
     probationRegion: ProbationRegion
     userDetails: UserDetails
+  }
+}
+
+declare module 'express-serve-static-core' {
+  interface Locals {
+    placeContext: PlaceContext
   }
 }
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -287,3 +287,9 @@ export interface OasysPage extends TasklistPage {
   risks: PersonRisksUI
   oasysSuccess: boolean
 }
+
+export type PlaceContext =
+  | {
+      assessment: Assessment
+    }
+  | undefined

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -1,6 +1,7 @@
 import {
   Adjudication,
   Application,
+  TemporaryAccommodationApplicationSummary as ApplicationSummary,
   ArrayOfOASysOffenceDetailsQuestions,
   ArrayOfOASysRiskManagementPlanQuestions,
   ArrayOfOASysRiskOfSeriousHarmSummaryQuestions,
@@ -251,8 +252,8 @@ export interface GroupedAssessments {
 }
 
 export interface GroupedApplications {
-  inProgress: Array<Application>
-  submitted: Array<Application>
+  inProgress: Array<ApplicationSummary>
+  submitted: Array<ApplicationSummary>
 }
 
 export interface ApplicationWithRisks extends Application {

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -4,10 +4,10 @@ import {
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   NewReferralHistoryUserNote as NewNote,
 } from '../../../@types/shared'
-import AssessmentsService from '../../../services/assessmentsService'
-import extractCallConfig from '../../../utils/restUtils'
-import { assessmentActions, statusName } from '../../../utils/assessmentUtils'
 import paths from '../../../paths/temporary-accommodation/manage'
+import AssessmentsService from '../../../services/assessmentsService'
+import { assessmentActions, statusName } from '../../../utils/assessmentUtils'
+import extractCallConfig from '../../../utils/restUtils'
 import { appendQueryString, lowerCase } from '../../../utils/utils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
@@ -2,15 +2,23 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
+import { AssessmentsService } from '../../../services'
 import BedspaceSearchService from '../../../services/bedspaceSearchService'
-import { bedSearchParametersFactory, bedSearchResultsFactory, referenceDataFactory } from '../../../testutils/factories'
+import {
+  bedSearchParametersFactory,
+  bedSearchResultsFactory,
+  placeContextFactory,
+  referenceDataFactory,
+} from '../../../testutils/factories'
 import { DateFormats } from '../../../utils/dateUtils'
+import { addPlaceContext, preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, setUserInput } from '../../../utils/validation'
 import BedspaceSearchController from './bedspaceSearchController'
 
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
+jest.mock('../../../utils/placeUtils')
 
 describe('BedspaceSearchController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -25,8 +33,9 @@ describe('BedspaceSearchController', () => {
   const next: DeepMocked<NextFunction> = createMock<NextFunction>({})
 
   const bedspaceSearchService = createMock<BedspaceSearchService>({})
+  const assessmentService = createMock<AssessmentsService>({})
 
-  const bedspaceSearchController = new BedspaceSearchController(bedspaceSearchService)
+  const bedspaceSearchController = new BedspaceSearchController(bedspaceSearchService, assessmentService)
 
   beforeEach(() => {
     request = createMock<Request>()
@@ -35,7 +44,9 @@ describe('BedspaceSearchController', () => {
 
   describe('index', () => {
     it('renders the search page when not given a search query', async () => {
-      request.query = {}
+      request.query = {
+        'other-parameter': 'other-data',
+      }
 
       bedspaceSearchService.getReferenceData.mockResolvedValue(referenceData)
 
@@ -46,6 +57,7 @@ describe('BedspaceSearchController', () => {
 
       expect(bedspaceSearchService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(bedspaceSearchService.search).not.toHaveBeenCalled()
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspace-search/index', {
         allPdus: referenceData.pdus,
@@ -75,6 +87,7 @@ describe('BedspaceSearchController', () => {
 
       expect(bedspaceSearchService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(bedspaceSearchService.search).toHaveBeenCalledWith(callConfig, expect.objectContaining(searchParameters))
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspace-search/index', {
         allPdus: referenceData.pdus,
@@ -87,6 +100,7 @@ describe('BedspaceSearchController', () => {
 
     it('renders with errors if the API returns an error', async () => {
       const searchParameters = bedSearchParametersFactory.build()
+      const placeContext = placeContextFactory.build()
 
       request.query = {
         ...searchParameters,
@@ -103,18 +117,22 @@ describe('BedspaceSearchController', () => {
 
       const requestHandler = bedspaceSearchController.index()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+      ;(preservePlaceContext as jest.MockedFunction<typeof preservePlaceContext>).mockResolvedValue(placeContext)
+      ;(addPlaceContext as jest.MockedFunction<typeof addPlaceContext>).mockReturnValue('/path/with/place/context')
 
       await requestHandler(request, response, next)
 
       expect(bedspaceSearchService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(bedspaceSearchService.search).toHaveBeenCalledWith(callConfig, expect.objectContaining(searchParameters))
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
+      expect(addPlaceContext).toHaveBeenCalledWith(paths.bedspaces.search({}), placeContext)
 
       expect(setUserInput).toHaveBeenCalledWith(request.query, 'get')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,
         err,
-        paths.bedspaces.search({}),
+        '/path/with/place/context',
         'bedspaceSearch',
       )
     })

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -32,6 +32,11 @@ export default class BedspaceSearchController {
       const query =
         (req.query as BedspaceSearchQuery).durationDays !== undefined ? (req.query as BedspaceSearchQuery) : undefined
 
+      const placeContextArrivalDate = placeContext?.assessment.application.arrivalDate
+      const startDatePrefill = placeContextArrivalDate
+        ? DateFormats.isoToDateAndTimeInputs(placeContextArrivalDate, 'startDate')
+        : {}
+
       let results: BedSearchResults
       let startDate: string
 
@@ -57,6 +62,7 @@ export default class BedspaceSearchController {
           startDate,
           errors,
           errorSummary,
+          ...startDatePrefill,
           ...query,
           ...userInput,
         })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -150,7 +150,7 @@ describe('BookingsController', () => {
       })
     })
 
-    it('renders the select with a "no assessment" assessment ID if there are no assessments for the given CRN', async () => {
+    it('renders the select with a "no assessment" assessment ID if the Apply feature is disabled', async () => {
       const newBooking = newBookingFactory.build()
       const person = personFactory.build()
       const assessmentSummaries = assessmentSummaryFactory.buildList(5)
@@ -192,7 +192,7 @@ describe('BookingsController', () => {
       })
     })
 
-    it('renders the select with a "no assessment" assessment ID if the Apply feature is disabled', async () => {
+    it('renders the select with a "no assessment" assessment ID if there are no assessments for the given CRN', async () => {
       const newBooking = newBookingFactory.build()
       const person = personFactory.build()
 

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
+import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import { appendQueryString } from '../../../utils/utils'
 import {
   catchValidationErrorOrPropogate,
@@ -29,7 +30,6 @@ import {
   insertBespokeError,
   insertGenericError,
 } from '../../../utils/validation'
-import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import BookingsController from './bookingsController'
 
 jest.mock('../../../utils/bookingUtils')

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -13,6 +13,7 @@ import {
 } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
+import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import { appendQueryString } from '../../../utils/utils'
 import {
   catchValidationErrorOrPropogate,
@@ -21,7 +22,6 @@ import {
   insertBespokeError,
   insertGenericError,
 } from '../../../utils/validation'
-import { isApplyEnabledForUser } from '../../../utils/userUtils'
 
 export default class BookingsController {
   constructor(

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -221,7 +221,7 @@ export default class BookingsController {
           req,
           res,
           err,
-          appendQueryString(paths.bookings.new({ premisesId, roomId }), req.body),
+          appendQueryString(paths.bookings.new({ premisesId, roomId }), { ...req.body, _csrf: undefined }),
         )
       }
     }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -78,7 +78,10 @@ export const controllers = (services: Services) => {
     services.bedspaceService,
   )
 
-  const bedspaceSearchController = new BedspaceSearchController(services.bedspaceSearchService)
+  const bedspaceSearchController = new BedspaceSearchController(
+    services.bedspaceSearchService,
+    services.assessmentsService,
+  )
   const bookingSearchController = new BookingSearchController(services.bookingSearchService)
 
   const assessmentsController = new AssessmentsController(services.assessmentsService)

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -4,11 +4,11 @@ import type { NewPremises, UpdatePremises } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import BedspaceService from '../../../services/bedspaceService'
 import PremisesService from '../../../services/premisesService'
+import { parseNaturalNumber } from '../../../utils/formUtils'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { filterProbationRegions } from '../../../utils/userUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
-import { parseNaturalNumber } from '../../../utils/formUtils'
 
 export default class PremisesController {
   constructor(

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -1,6 +1,7 @@
 import type {
   Arrival,
   Booking,
+  BookingSearchResults,
   Cancellation,
   Confirmation,
   Departure,
@@ -17,7 +18,6 @@ import type {
   Turnaround,
 } from '@approved-premises/api'
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
-import type { BookingSearchResults } from 'server/@types/shared/models/BookingSearchResults'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 import { appendQueryString } from '../utils/utils'

--- a/server/testutils/factories/application.ts
+++ b/server/testutils/factories/application.ts
@@ -3,6 +3,7 @@ import { Factory } from 'fishery'
 
 import type { OASysSection, TemporaryAccommodationApplication } from '@approved-premises/api'
 
+import applicationTranslatedDocument from '../../../cypress_shared/fixtures/applicationTranslatedDocument.json'
 import { DateFormats } from '../../utils/dateUtils'
 import { fakeObject } from '../utils'
 import { fullPersonFactory } from './person'
@@ -51,9 +52,10 @@ export default ApplicationFactory.define(() => ({
   createdAt: DateFormats.dateObjToIsoDate(faker.date.past()),
   submittedAt: DateFormats.dateObjToIsoDate(faker.date.past()),
   data: {},
-  document: {},
+  document: applicationTranslatedDocument,
   outdatedSchema: faker.datatype.boolean(),
   risks: risksFactory.build(),
   status: 'inProgress' as const,
   type: 'CAS3',
+  arrivalDate: DateFormats.dateObjToIsoDate(faker.date.past()),
 }))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -48,6 +48,7 @@ import oasysSelectionFactory from './oasysSelection'
 import overlapFactory from './overlap'
 import pduFactory from './pdu'
 import { fullPersonFactory as personFactory, restrictedPersonFactory } from './person'
+import placeContextFactory from './placeContext'
 import premisesFactory from './premises'
 import premisesSummaryFactory from './premisesSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
@@ -117,6 +118,7 @@ export {
   overlapFactory,
   pduFactory,
   personFactory,
+  placeContextFactory,
   premisesFactory,
   premisesSummaryFactory,
   prisonCaseNotesFactory,

--- a/server/testutils/factories/placeContext.ts
+++ b/server/testutils/factories/placeContext.ts
@@ -1,0 +1,9 @@
+import { Factory } from 'fishery'
+import { PlaceContext } from '../../@types/ui'
+import assessmentFactory from './assessment'
+
+export default Factory.define<PlaceContext>(() => ({
+  assessment: assessmentFactory.build({
+    status: 'ready_to_place',
+  }),
+}))

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -3,15 +3,18 @@ import {
   assessmentFactory,
   assessmentSummaryFactory,
   personFactory,
+  placeContextFactory,
   referralHistoryNoteFactory,
   referralHistoryUserNoteFactory,
   restrictedPersonFactory,
 } from '../testutils/factories'
 import { assessmentActions, assessmentTableRows, statusName, statusTag, timelineItems } from './assessmentUtils'
+import { addPlaceContext, createPlaceContext } from './placeUtils'
 import { formatLines } from './viewUtils'
 
 jest.mock('./viewUtils')
 jest.mock('./userUtils')
+jest.mock('./placeUtils')
 
 describe('assessmentUtils', () => {
   describe('statusTag', () => {
@@ -160,6 +163,11 @@ describe('assessmentUtils', () => {
         status: 'ready_to_place',
       })
 
+      const placeContext = placeContextFactory.build()
+
+      ;(createPlaceContext as jest.MockedFunction<typeof createPlaceContext>).mockReturnValue(placeContext)
+      ;(addPlaceContext as jest.MockedFunction<typeof addPlaceContext>).mockReturnValue('/path/with/place/context')
+
       const result = assessmentActions(assessment)
 
       expect(result).toEqual([
@@ -183,11 +191,14 @@ describe('assessmentUtils', () => {
         },
         {
           classes: 'govuk-button--secondary',
-          href: paths.bedspaces.search({}),
+          href: '/path/with/place/context',
           text: 'Place referral',
           newTab: true,
         },
       ])
+
+      expect(createPlaceContext).toHaveBeenCalledWith(assessment)
+      expect(addPlaceContext).toHaveBeenCalledWith(paths.bedspaces.search({}), placeContext)
     })
 
     it('returns the "ready_to_place" action for an assessment with a status of "closed"', () => {

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -8,6 +8,7 @@ import { TableRow, TimelineItem } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from './dateUtils'
 import { personName } from './personUtils'
+import { addPlaceContext, createPlaceContext } from './placeUtils'
 import { convertToTitleCase } from './utils'
 import { formatLines } from './viewUtils'
 
@@ -128,7 +129,7 @@ export const assessmentActions = (assessment: Assessment) => {
     },
     findABedspace: {
       classes: 'govuk-button--secondary',
-      href: paths.bedspaces.search({}),
+      href: addPlaceContext(paths.bedspaces.search({}), createPlaceContext(assessment)),
       text: 'Place referral',
       newTab: true,
     },

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -38,6 +38,7 @@ import applyPaths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
 import { checkYourAnswersSections } from './checkYourAnswersUtils'
+import { addPlaceContext } from './placeUtils'
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
 const getMojFilters = require('@ministryofjustice/frontend/moj/filters/all')
@@ -159,6 +160,10 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
 
   njkEnv.addGlobal('fetchContext', function fetchContext() {
     return this.ctx
+  })
+
+  njkEnv.addGlobal('addPlaceContext', function _(link: string) {
+    return addPlaceContext(link, this.ctx.placeContext)
   })
 
   njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)

--- a/server/utils/placeUtils.test.ts
+++ b/server/utils/placeUtils.test.ts
@@ -1,0 +1,41 @@
+import { assessmentFactory, placeContextFactory } from '../testutils/factories'
+import { addPlaceContext, createPlaceContext } from './placeUtils'
+import { appendQueryString } from './utils'
+
+jest.mock('./utils')
+
+describe('placeUtils', () => {
+  beforeEach(() => {
+    jest.resetAllMocks()
+  })
+
+  describe('createPlaceContext', () => {
+    it('returns a PlaceContext type object', () => {
+      const assessment = assessmentFactory.build()
+
+      expect(createPlaceContext(assessment)).toEqual({ assessment })
+    })
+  })
+
+  describe('addPlaceContext', () => {
+    it('returns a path with a reference to the given place context', () => {
+      const placeContext = placeContextFactory.build({
+        assessment: assessmentFactory.build({
+          id: 'some-id',
+        }),
+      })
+
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockImplementation(
+        path => `${path}?some-query-string`,
+      )
+
+      expect(addPlaceContext('/some/path', placeContext)).toEqual('/some/path?some-query-string')
+      expect(appendQueryString).toHaveBeenCalledWith('/some/path', { placeContextAssessmentId: 'some-id' })
+    })
+
+    it('returns the original path if the place context is undefinded', () => {
+      expect(addPlaceContext('/some/path', undefined)).toEqual('/some/path')
+      expect(appendQueryString).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/server/utils/placeUtils.test.ts
+++ b/server/utils/placeUtils.test.ts
@@ -1,8 +1,14 @@
+import { createMock } from '@golevelup/ts-jest'
+import { Request, Response } from 'express'
+import { CallConfig } from '../data/restClient'
+import type { AssessmentsService } from '../services'
 import { assessmentFactory, placeContextFactory } from '../testutils/factories'
-import { addPlaceContext, createPlaceContext } from './placeUtils'
+import { addPlaceContext, createPlaceContext, preservePlaceContext } from './placeUtils'
+import extractCallConfig from './restUtils'
 import { appendQueryString } from './utils'
 
 jest.mock('./utils')
+jest.mock('./restUtils')
 
 describe('placeUtils', () => {
   beforeEach(() => {
@@ -36,6 +42,72 @@ describe('placeUtils', () => {
     it('returns the original path if the place context is undefinded', () => {
       expect(addPlaceContext('/some/path', undefined)).toEqual('/some/path')
       expect(appendQueryString).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('preservePlaceContext', () => {
+    it('uses the assessment service to set and return place context data', async () => {
+      const callConfig = { token: 'some-call-config-token' } as CallConfig
+
+      ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+
+      const assessmentService = createMock<AssessmentsService>()
+
+      const assessment = assessmentFactory.build()
+      assessmentService.findAssessment.mockResolvedValue(assessment)
+
+      const req = createMock<Request>({
+        query: { placeContextAssessmentId: 'some-assessment-id' },
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual({ assessment })
+      expect(res.locals.placeContext).toEqual({ assessment })
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(callConfig, 'some-assessment-id')
+    })
+
+    it('returns undefined when the assessment service throws an error', async () => {
+      const callConfig = { token: 'some-call-config-token' } as CallConfig
+
+      ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+
+      const assessmentService = createMock<AssessmentsService>()
+
+      assessmentService.findAssessment.mockRejectedValue(new Error())
+
+      const req = createMock<Request>({
+        query: { placeContextAssessmentId: 'some-assessment-id' },
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual(undefined)
+      expect(res.locals.placeContext).toEqual(undefined)
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(callConfig, 'some-assessment-id')
+    })
+
+    it('does nothing when the place context assessment ID is not set in the query parameters', async () => {
+      const assessmentService = createMock<AssessmentsService>()
+
+      const req = createMock<Request>({
+        query: {},
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual(undefined)
+      expect(res.locals.placeContext).toEqual(undefined)
+      expect(assessmentService.findAssessment).not.toHaveBeenCalled()
     })
   })
 })

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -1,0 +1,14 @@
+import { TemporaryAccommodationAssessment as Assessment } from '../@types/shared'
+import { PlaceContext } from '../@types/ui'
+import { appendQueryString } from './utils'
+
+export const createPlaceContext = (assessment: Assessment) => {
+  return { assessment }
+}
+
+export const addPlaceContext = (path: string, placeContext: PlaceContext) => {
+  if (placeContext) {
+    return appendQueryString(path, { placeContextAssessmentId: placeContext.assessment.id })
+  }
+  return path
+}

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -1,5 +1,8 @@
+import { Request, Response } from 'express'
 import { TemporaryAccommodationAssessment as Assessment } from '../@types/shared'
 import { PlaceContext } from '../@types/ui'
+import type { AssessmentsService } from '../services'
+import extractCallConfig from './restUtils'
 import { appendQueryString } from './utils'
 
 export const createPlaceContext = (assessment: Assessment) => {
@@ -11,4 +14,28 @@ export const addPlaceContext = (path: string, placeContext: PlaceContext) => {
     return appendQueryString(path, { placeContextAssessmentId: placeContext.assessment.id })
   }
   return path
+}
+
+export const preservePlaceContext = async (
+  req: Request,
+  res: Response,
+  assessmentService: AssessmentsService,
+): Promise<PlaceContext> => {
+  if (req.query.placeContextAssessmentId) {
+    let assessment: Assessment
+
+    try {
+      assessment = await assessmentService.findAssessment(
+        extractCallConfig(req),
+        req.query.placeContextAssessmentId as string,
+      )
+    } catch (err) {
+      return undefined
+    }
+
+    res.locals.placeContext = { assessment }
+    return { assessment }
+  }
+
+  return undefined
 }

--- a/server/utils/utils.test.ts
+++ b/server/utils/utils.test.ts
@@ -224,4 +224,10 @@ describe('unique', () => {
       expect(appendQueryString('/some/path', {})).toEqual('/some/path')
     })
   })
+
+  it('appends a query string to a path that already contais a query string', () => {
+    expect(appendQueryString('/some/path?userId=some-user', { bookingId: 'some-booking' })).toEqual(
+      '/some/path?userId=some-user&bookingId=some-booking',
+    )
+  })
 })

--- a/server/utils/utils.ts
+++ b/server/utils/utils.ts
@@ -113,5 +113,8 @@ export const appendQueryString = (
 ): string => {
   const queryString = createQueryString(params, options)
 
+  if (path.includes('?')) {
+    return `${path}${queryString ? `&${queryString}` : ''}`
+  }
   return `${path}${queryString ? `?${queryString}` : ''}`
 }

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -21,7 +21,7 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.applications.new() }}" method="get">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <h1>Make a referral for Temporary Accommodation</h1>
+        <h1 class="govuk-heading-l">Make a referral for Temporary Accommodation</h1>
 
         <p class="govuk-body">Temporary Accommodation (TA) is for people on probation who are at risk of homelessness on their first night of release. </p>
 

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -22,7 +22,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Mark booking as active</h1>
+  <h1 class="govuk-heading-l">Mark booking as active</h1>
 
   {{ showErrorSummary(errorSummary, errorTitle) }}
 

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -6,6 +6,8 @@
 {% from "../components/ta-select/macro.njk" import taSelect %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
+{% from "../components/place-context-value/macro.njk" import placeContextValue %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -14,6 +16,7 @@
 
 {% block beforeContent %}
   {{ breadCrumb('Search for available bedspaces', []) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -22,6 +25,8 @@
   <h1 class="govuk-heading-l">Search for available bedspaces</h1>
   <form action="{{ paths.bedspaces.search({}) }}" method="get">
     {{ showErrorSummary(errorSummary) }}
+
+    {{ placeContextValue(placeContext) }}
 
     {{ taDateInput(
       {
@@ -87,10 +92,11 @@
           {{ results.results.length }} {{ 'result' if results.results.length === 1 else 'results' }}
         </p>
 
-
         {% for result in results.results %}
           <div data-cy-bedspace>
-            <h2 class="govuk-heading-m"><a class="govuk-link--no-underline" href="{{ paths.premises.bedspaces.show({premisesId: result.premises.id, roomId: result.room.id}) }}">{{ result.room.name }}</a></h2>
+            <h2 class="govuk-heading-m">
+              <a class="govuk-link--no-underline" href="{{ addPlaceContext(paths.premises.bedspaces.show({premisesId: result.premises.id, roomId: result.room.id})) }}">{{ result.room.name }}</a>
+            </h2>
             <h3 class="govuk-heading-s">{{ PremisesUtils.shortAddress(result.premises) }}</h3>
 
             {% set premisesKeyCharacteristics = BedspaceSearchResultUtils.premisesKeyCharacteristics(result)  %}
@@ -125,7 +131,7 @@
                 <ul class="govuk-list" data-cy-overlaps>
                   {% for overlap in result.overlaps %}
                     <li>
-                      <a class="govuk-link" href="{{ paths.bookings.show({premisesId: result.premises.id, roomId: overlap.roomId, bookingId: overlap.bookingId}) }}">{{ overlap.crn }}</a>
+                      <a class="govuk-link" href="{{ addPlaceContext(paths.bookings.show({premisesId: result.premises.id, roomId: overlap.roomId, bookingId: overlap.bookingId})) }}">{{ overlap.crn }}</a>
                       ({{ overlap.days }} day overlap)
                     </li>
                   {% endfor %}

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -18,7 +18,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
   
-  <h1>Edit a bedspace</h1>
+  <h1 class="govuk-heading-l">Edit a bedspace</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -18,7 +18,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
   
-  <h1>Add a bedspace</h1>
+  <h1 class="govuk-heading-l">Add a bedspace</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -11,7 +11,7 @@
 {% endblock %}
 
 {% block content %}
-  <h1>View bookings</h1>
+  <h1 class="govuk-heading-l">View bookings</h1>
 
   <div class="govuk-grid-row">
 

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -17,7 +17,7 @@
 {% endblock %}
 
 {% block content %}
-  <h1>Confirm CRN</h1>
+  <h1 class="govuk-heading-l">Confirm CRN</h1>
 
   <p>Confirm that the CRN is correct. This information cannot be changed once a bedspace has been booked.</p>
 

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -19,7 +19,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Booking history</h1>
+  <h1 class="govuk-heading-l">Booking history</h1>
 
   {{ popDetailsHeader(booking.person) }}
   {{ locationHeader({ room: room, premises: premises }) }}

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -18,7 +18,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
   
-  <h1>Book bedspace</h1>
+  <h1 class="govuk-heading-l">Book bedspace</h1>
 
   {{ showErrorSummary(errorSummary, errorTitle) }}
 

--- a/server/views/temporary-accommodation/cancellations/edit.njk
+++ b/server/views/temporary-accommodation/cancellations/edit.njk
@@ -19,7 +19,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Update cancelled booking</h1>
+  <h1 class="govuk-heading-l">Update cancelled booking</h1>
 
   {{ showErrorSummary(errorSummary) }}
 

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -19,7 +19,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Cancel booking</h1>
+  <h1 class="govuk-heading-l">Cancel booking</h1>
 
   {{ showErrorSummary(errorSummary) }}
 

--- a/server/views/temporary-accommodation/components/place-context-header/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-header/macro.njk
@@ -1,0 +1,29 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro placeContextHeader(placeContext) %}
+
+  {% if placeContext %}
+    {% set person = placeContext.assessment.application.person %}
+
+    <div class="place-context-header govuk-body">
+      <strong class="govuk-heading-s govuk-!-margin-bottom-2">Person to place</strong>
+      <div class="place-context-header__attribute-container">
+        <div>{{ personName(person, 'Limited access offender') }}</div>
+        {% if isFullPerson(person) %}
+          <div>Date of birth: {{ formatDate(person.dateOfBirth, {format: 'short'}) }}</div>
+          {% if person.sex %}
+            <div>Sex: {{ person.sex }}</div>
+          {% endif %}
+          {% if person.genderIdentity %}
+            <div>Gender identity: {{ person.genderIdentity }}</div>
+          {% endif %}
+        {% endif %}
+        <div>CRN: {{ person.crn }}</div>
+        {% if placeContext.assessment.application.arrivalDate %}
+          <div>Accommodation required from: {{ formatDate(placeContext.assessment.application.arrivalDate, {format: 'short'}) }}</div>
+        {% endif %}
+      </div>
+    </div>
+  {% endif %}
+
+{% endmacro %}

--- a/server/views/temporary-accommodation/components/place-context-value/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-value/macro.njk
@@ -1,0 +1,9 @@
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+
+{% macro placeContextValue(placeContext) %}
+
+  {% if placeContext %}
+    <input type="hidden" name="placeContextAssessmentId" value="{{ placeContext.assessment.id }}" />
+  {% endif %}
+
+{% endmacro %}

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -20,7 +20,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Mark booking as confirmed</h1>
+  <h1 class="govuk-heading-l">Mark booking as confirmed</h1>
 
   {{ popDetailsHeader(booking.person) }}
   {{ locationHeader({ premises: premises, room: room }) }}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -8,7 +8,7 @@
 
   {% include "../../_messages.njk" %}
 
-  <h1>Manage estate</h1>
+  <h1 class="govuk-heading-l">Manage estate</h1>
 
   <div class="card-container">
     {% if userReferralsEnabled %}

--- a/server/views/temporary-accommodation/departures/edit.njk
+++ b/server/views/temporary-accommodation/departures/edit.njk
@@ -19,7 +19,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Update departure details</h1>
+  <h1 class="govuk-heading-l">Update departure details</h1>
 
   {{ showErrorSummary(errorSummary) }}
 

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -19,7 +19,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Mark booking as departed</h1>
+  <h1 class="govuk-heading-l">Mark booking as departed</h1>
 
   {{ showErrorSummary(errorSummary) }}
 

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -22,7 +22,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Extend or shorten booking</h1>
+  <h1 class="govuk-heading-l">Extend or shorten booking</h1>
 
   {{ showErrorSummary(errorSummary, errorTitle) }}
 

--- a/server/views/temporary-accommodation/lost-beds/edit.njk
+++ b/server/views/temporary-accommodation/lost-beds/edit.njk
@@ -17,7 +17,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Void a bedspace</h1>
+  <h1 class="govuk-heading-l">Void a bedspace</h1>
 
   {{ showErrorSummary(errorSummary, errorTitle) }}
   {{ locationHeader({ premises: premises, room: room }) }}

--- a/server/views/temporary-accommodation/lost-beds/new.njk
+++ b/server/views/temporary-accommodation/lost-beds/new.njk
@@ -17,7 +17,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
     
-  <h1>Void a bedspace</h1>
+  <h1 class="govuk-heading-l">Void a bedspace</h1>
   {{ showErrorSummary(errorSummary, errorTitle) }}
 
   {{ locationHeader({ premises: premises, room: room }) }}

--- a/server/views/temporary-accommodation/premises/edit.njk
+++ b/server/views/temporary-accommodation/premises/edit.njk
@@ -18,7 +18,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
   
-  <h1>Edit a property</h1>
+  <h1 class="govuk-heading-l">Edit a property</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -6,11 +6,13 @@
 {% set pageTitle = applicationName + " - Add a property" %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block content %}
-
+{% block beforeContent %}
   {{ breadCrumb('Add a property', [
     {title: 'List of properties', href: paths.premises.index()}
   ]) }}
+{% endblock %}
+
+{% block content %}
 
   {% include "../../_messages.njk" %}
   

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -14,7 +14,7 @@
 
   {% include "../../_messages.njk" %}
   
-  <h1>Add a property</h1>
+  <h1 class="govuk-heading-l">Add a property</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -30,7 +30,7 @@
     }) }}
   {% endif %}
 
-  <h1>View a property</h1>
+  <h1 class="govuk-heading-l">View a property</h1>
 
   {{ mojPageHeaderActions({
     heading: {

--- a/server/views/temporary-accommodation/reports/new.njk
+++ b/server/views/temporary-accommodation/reports/new.njk
@@ -14,7 +14,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
   
-  <h1>Reports</h1>
+  <h1 class="govuk-heading-l">Reports</h1>
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">

--- a/server/views/temporary-accommodation/turnarounds/new.njk
+++ b/server/views/temporary-accommodation/turnarounds/new.njk
@@ -21,7 +21,7 @@
 {% block content %}
   {% include "../../_messages.njk" %}
 
-  <h1>Change turnaround time</h1>
+  <h1 class="govuk-heading-l">Change turnaround time</h1>
 
   {{ showErrorSummary(errorSummary, errorTitle) }}
 


### PR DESCRIPTION
# Changes in this PR

This PR is the first step of having a banner at the top of each page that is part of the journey from a referral that is ready to place, through to successfully booking a bedspace.

This PR adds a banner to the top of the bedspace search page indicating the context, and prefills this page's start date fields. A future PR will build on this, and preserve the banner through until a bedspace is successfully booked.

As development of this feature as a whole has involved a tour across the codebase, this PR begin with a lot of minor tidying, followed by building up the utility functions we will use in this feature, then the nunjucks macros, then finally putting them to use, and integration this initial stub of the feature.

This PR takes takes the approach of tracking place context with a query parameter in a URL. Though this approach was initially chosen for expediency over a session-based approach, it has the advantages that what happens in one tab will not influence what happens in another tab, and if the context is "cleared" it is retrievable using the back button

## Screenshots of UI changes

### Before
![localhost_3000_find-a-bedspace](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/0f44f05e-1b6f-466b-aaeb-6f511f672f30)

### After
![localhost_3000_find-a-bedspace_placeContextAssessmentId=caa81af5-0f3c-45d6-986b-c007fdf8007f (1)](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/90b3b528-8b1a-4a84-8cfb-55e3085980d4)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
