### PR TITLE
A user can place a referral and is taken to the Find a Bedspace journey and it remembers the referral data (part 2)

### DIFF
--- a/cypress_shared/components/placeContextHeader.ts
+++ b/cypress_shared/components/placeContextHeader.ts
@@ -24,12 +24,13 @@ export default class PlaceContextHeaderComponent extends Component {
           'contain',
           `Date of birth: ${DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' })}`,
         )
-        cy.root().should('contain', `Sex: ${person.sex}`)
 
         if (person.genderIdentity) {
           cy.root().should('contain', `Gender identity: ${person.genderIdentity}`)
+          cy.root().should('not.contain', 'Sex')
         } else {
-          cy.root().should('not.contain', `Gender identity`)
+          cy.root().should('contain', `Sex: ${person.sex}`)
+          cy.root().should('not.contain', 'Gender identity')
         }
       }
       cy.root().should('contain', `CRN: ${person.crn}`)

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -9,6 +9,7 @@ import AssessmentSummaryPage from '../pages/assess/summary'
 import Page from '../pages/page'
 import BedspaceSearchPage from '../pages/temporary-accommodation/manage/bedspaceSearch'
 import BedspaceShowPage from '../pages/temporary-accommodation/manage/bedspaceShow'
+import BookingNewPage from '../pages/temporary-accommodation/manage/bookingNew'
 
 export default class PlaceHelper {
   private readonly bedSearchResults: BedSearchResults
@@ -39,6 +40,7 @@ export default class PlaceHelper {
     this.assessmentToBedspaceSearch()
     this.bedspaceSearchToSearchResults()
     this.searchResultsToBedspace()
+    this.bedspaceToNewBooking()
   }
 
   private assessmentToBedspaceSearch() {
@@ -88,5 +90,19 @@ export default class PlaceHelper {
 
     // And the place context header is visible
     bedspaceShowPage.shouldShowPlaceContextHeader(this.placeContext)
+  }
+
+  private bedspaceToNewBooking() {
+    // Given I am viewing the bedspace show page
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+
+    // And I click "Book bedspace"
+    bedspaceShowPage.clickBookBedspaceLink()
+
+    // I am taken to the new booking page
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+
+    // And the place context banner is visible
+    bookingNewPage.shouldShowPlaceContextHeader(this.placeContext)
   }
 }

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -59,7 +59,9 @@ export default class PlaceHelper {
     const bedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage)
 
     // When I fill out the form
-    const searchParameters = bedSearchParametersFactory.build()
+    const searchParameters = bedSearchParametersFactory.build({
+      startDate: this.placeContext.arrivalDate,
+    })
     bedspaceSearchPage.completeForm(searchParameters)
     bedspaceSearchPage.clickSubmit()
 

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -8,6 +8,7 @@ import {
 import AssessmentSummaryPage from '../pages/assess/summary'
 import Page from '../pages/page'
 import BedspaceSearchPage from '../pages/temporary-accommodation/manage/bedspaceSearch'
+import BedspaceShowPage from '../pages/temporary-accommodation/manage/bedspaceShow'
 
 export default class PlaceHelper {
   private readonly bedSearchResults: BedSearchResults
@@ -26,6 +27,8 @@ export default class PlaceHelper {
     cy.task('stubFindAssessment', this.placeContext.assessment)
     cy.task('stubBedspaceSearchReferenceData')
     cy.task('stubBedSearch', this.bedSearchResults)
+    cy.task('stubSinglePremises', this.premises)
+    cy.task('stubSingleRoom', { premisesId: this.premises.id, room: this.room })
   }
 
   startPlace() {
@@ -35,6 +38,7 @@ export default class PlaceHelper {
   progressPlace() {
     this.assessmentToBedspaceSearch()
     this.bedspaceSearchToSearchResults()
+    this.searchResultsToBedspace()
   }
 
   private assessmentToBedspaceSearch() {
@@ -70,5 +74,19 @@ export default class PlaceHelper {
 
     // And the place context header is visible
     resultsBedspaceSearchPage.shouldShowPlaceContextHeader(this.placeContext)
+  }
+
+  private searchResultsToBedspace() {
+    // Given I am viewing bedspace search results
+    const resultsBedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage, this.bedSearchResults)
+
+    // When I click a bedspace
+    resultsBedspaceSearchPage.clickBedspaceLink(this.room)
+
+    // I am taken to the bedspace show page
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+
+    // And the place context header is visible
+    bedspaceShowPage.shouldShowPlaceContextHeader(this.placeContext)
   }
 }

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -19,8 +19,10 @@ import AssessmentSummaryPage from '../pages/assess/summary'
 import Page from '../pages/page'
 import BedspaceSearchPage from '../pages/temporary-accommodation/manage/bedspaceSearch'
 import BedspaceShowPage from '../pages/temporary-accommodation/manage/bedspaceShow'
+import BookingConfirmPage from '../pages/temporary-accommodation/manage/bookingConfirm'
 import BookingNewPage from '../pages/temporary-accommodation/manage/bookingNew'
 import BookingSelectAssessmentPage from '../pages/temporary-accommodation/manage/bookingSelectAssessment'
+import BookingShowPage from '../pages/temporary-accommodation/manage/bookingShow'
 
 export default class PlaceHelper {
   private readonly bedSearchResults: BedSearchResults
@@ -60,18 +62,22 @@ export default class PlaceHelper {
     cy.task('stubSingleRoom', { premisesId: this.premises.id, room: this.room })
     cy.task('stubFindPerson', { person: this.person })
     cy.task('stubAssessments', this.assessmentSummaries)
+    cy.task('stubBookingCreate', { premisesId: this.premises.id, booking: this.booking })
+    cy.task('stubBooking', { premisesId: this.premises.id, booking: this.booking })
   }
 
   startPlace() {
     AssessmentSummaryPage.visit(this.placeContext.assessment)
   }
 
-  progressPlace() {
+  completePlace() {
     this.assessmentToBedspaceSearch()
     this.bedspaceSearchToSearchResults()
     this.searchResultsToBedspace()
     this.bedspaceToNewBooking()
     this.newBookingToSelectAssessment()
+    this.selectAssessmentToConfirm()
+    this.confirmToShowBooking()
   }
 
   private assessmentToBedspaceSearch() {
@@ -158,5 +164,34 @@ export default class PlaceHelper {
 
     // And the assessment is preselected
     selectAssessmentPage.shouldShowPreselectedAsssessmentFromPlaceContext(this.placeContext)
+  }
+
+  private selectAssessmentToConfirm() {
+    // Given I am viewing the select assessment page
+    const selectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, this.assessmentSummaries)
+
+    // When I complete the form
+    selectAssessmentPage.selectAssessment(assessmentSummaryFactory.build(this.placeContext.assessment))
+    selectAssessmentPage.clickSubmit()
+
+    // I am taken to the booking confirm page
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, this.person)
+
+    // And the place context header is visible
+    bookingConfirmPage.shouldShowPlaceContextHeader(this.placeContext)
+  }
+
+  private confirmToShowBooking() {
+    // Given I am viewing the booking confirm page
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, this.person)
+
+    // When I click submit
+    bookingConfirmPage.clickSubmit()
+
+    // I am taken to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+
+    // And the place context header is not visible
+    bookingShowPage.shouldNotShowPlaceContextHeader()
   }
 }

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -155,5 +155,8 @@ export default class PlaceHelper {
 
     // And the place context header is visible
     selectAssessmentPage.shouldShowPlaceContextHeader(this.placeContext)
+
+    // And the assessment is preselected
+    selectAssessmentPage.shouldShowPreselectedAsssessmentFromPlaceContext(this.placeContext)
   }
 }

--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -104,5 +104,8 @@ export default class PlaceHelper {
 
     // And the place context banner is visible
     bookingNewPage.shouldShowPlaceContextHeader(this.placeContext)
+
+    // And the CRN and arrival date are prefilled
+    bookingNewPage.shouldShowPrefilledBookingDetailsFromPlaceContext(this.placeContext)
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -1,5 +1,6 @@
 import type { NewBooking } from '@approved-premises/api'
 import { TemporaryAccommodationPremises as Premises, Room } from '../../../../server/@types/shared'
+import { PlaceContext } from '../../../../server/@types/ui'
 import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -54,6 +55,11 @@ export default class BookingNewPage extends BookingEditablePage {
     this.shouldShowTextInputByLabel("What is the person's CRN", newBooking.crn)
     this.shouldShowDateInputsByLegend('What is the start date?', newBooking.arrivalDate)
     this.shouldShowDateInputsByLegend('What is the end date?', newBooking.departureDate)
+  }
+
+  shouldShowPrefilledBookingDetailsFromPlaceContext(placeContext: NonNullable<PlaceContext>): void {
+    this.shouldShowTextInputByLabel("What is the person's CRN", placeContext.assessment.application.person.crn)
+    this.shouldShowDateInputsByLegend('What is the start date?', placeContext.arrivalDate!)
   }
 
   private turnaroundText(): string {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment.ts
@@ -1,4 +1,6 @@
 import type { AssessmentSummary } from '@approved-premises/api'
+import { FullPerson } from '../../../../server/@types/shared'
+import { PlaceContext } from '../../../../server/@types/ui'
 import { assessmentSummaryFactory } from '../../../../server/testutils/factories'
 import { noAssessmentId } from '../../../../server/utils/bookingUtils'
 import { DateFormats } from '../../../../server/utils/dateUtils'
@@ -36,6 +38,18 @@ export default class BookingSelectAssessmentPage extends Page {
         .eq(0)
         .contains(DateFormats.isoDateToUIDate(assessmentSummary.createdAt, { format: 'short' }))
     })
+  }
+
+  shouldShowPreselectedAsssessmentFromPlaceContext(placeContext: NonNullable<PlaceContext>): void {
+    const person = placeContext.assessment.application.person as FullPerson
+
+    this.shouldShowRadioInput(
+      'assessmentId',
+      ` ${person.name}, CRN ${person.crn}, referral submitted ${DateFormats.isoDateToUIDate(
+        placeContext.assessment.createdAt,
+        { format: 'short' },
+      )} `,
+    )
   }
 
   selectAssessment(assessmentSummary: AssessmentSummary): void {

--- a/integration_tests/tests/place/place.cy.ts
+++ b/integration_tests/tests/place/place.cy.ts
@@ -22,7 +22,7 @@ context('Place', () => {
     // And I am at the start of the "place" journey
     placeHelper.startPlace()
 
-    // I can progress along the "place" journey
-    placeHelper.progressPlace()
+    // I can complete the "place" journey
+    placeHelper.completePlace()
   })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -291,5 +291,6 @@ export interface OasysPage extends TasklistPage {
 export type PlaceContext =
   | {
       assessment: Assessment
+      arrivalDate?: string
     }
   | undefined

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -10,6 +10,7 @@ import {
   probationRegionFactory,
 } from '../../../testutils/factories'
 import { assessmentActions } from '../../../utils/assessmentUtils'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { appendQueryString } from '../../../utils/utils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -18,6 +19,7 @@ import AssessmentsController, { assessmentsTableHeaders, confirmationPageContent
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/utils')
+jest.mock('../../../utils/placeUtils')
 
 describe('AssessmentsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -100,6 +102,7 @@ describe('AssessmentsController', () => {
         errorSummary: [],
       })
       expect(assessmentsService.findAssessment).toHaveBeenCalledWith(callConfig, assessmentId)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentsService)
     })
   })
 
@@ -118,6 +121,7 @@ describe('AssessmentsController', () => {
         actions: assessmentActions(assessment),
       })
       expect(assessmentsService.findAssessment).toHaveBeenCalledWith(callConfig, assessmentId)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentsService)
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -7,6 +7,7 @@ import {
 import paths from '../../../paths/temporary-accommodation/manage'
 import AssessmentsService from '../../../services/assessmentsService'
 import { assessmentActions, statusName } from '../../../utils/assessmentUtils'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { appendQueryString, lowerCase } from '../../../utils/utils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -102,6 +103,8 @@ export default class AssessmentsController {
 
       const callConfig = extractCallConfig(req)
 
+      await preservePlaceContext(req, res, this.assessmentsService)
+
       const assessment = await this.assessmentsService.findAssessment(callConfig, req.params.id)
 
       return res.render('temporary-accommodation/assessments/summary', {
@@ -118,6 +121,8 @@ export default class AssessmentsController {
   full(): RequestHandler {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
+
+      await preservePlaceContext(req, res, this.assessmentsService)
 
       const assessment = await this.assessmentsService.findAssessment(callConfig, req.params.id)
 

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -7,7 +7,7 @@ import { AssessmentsService } from '../../../services'
 import BedspaceSearchService from '../../../services/bedspaceSearchService'
 import { DateFormats } from '../../../utils/dateUtils'
 import { parseNaturalNumber } from '../../../utils/formUtils'
-import { addPlaceContext, preservePlaceContext } from '../../../utils/placeUtils'
+import { addPlaceContext, preservePlaceContext, updatePlaceContextWithArrivalDate } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, setUserInput } from '../../../utils/validation'
 
@@ -54,6 +54,8 @@ export default class BedspaceSearchController {
             startDate,
             durationDays,
           })
+
+          updatePlaceContextWithArrivalDate(res, placeContext, startDate)
         }
 
         res.render('temporary-accommodation/bedspace-search/index', {

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -4,7 +4,7 @@ import type { NextFunction, Request, Response } from 'express'
 import { ErrorsAndUserInput, SummaryListItem } from '../../../@types/ui'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BookingService, PremisesService } from '../../../services'
+import { AssessmentsService, BookingService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
 import { ListingEntry } from '../../../services/bookingService'
 import {
@@ -18,10 +18,12 @@ import { bedspaceActions } from '../../../utils/bedspaceUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BedspacesController from './bedspacesController'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/bedspaceUtils')
+jest.mock('../../../utils/placeUtils')
 
 describe('BedspacesController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -39,7 +41,13 @@ describe('BedspacesController', () => {
   const premisesService = createMock<PremisesService>({})
   const bedspaceService = createMock<BedspaceService>({})
   const bookingService = createMock<BookingService>({})
-  const bedspacesController = new BedspacesController(premisesService, bedspaceService, bookingService)
+  const assessmentService = createMock<AssessmentsService>({})
+  const bedspacesController = new BedspacesController(
+    premisesService,
+    bedspaceService,
+    bookingService,
+    assessmentService,
+  )
 
   beforeEach(() => {
     request = createMock<Request>()
@@ -286,6 +294,7 @@ describe('BedspacesController', () => {
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
       expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(callConfig, premises.id, room.id)
       expect(bookingService.getListingEntries).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -776,6 +776,7 @@ describe('BookingsController', () => {
       expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
       expect(deriveBookingHistory).toHaveBeenCalledWith(booking)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -21,6 +21,7 @@ import {
   noAssessmentId,
 } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import { appendQueryString } from '../../../utils/utils'
@@ -37,6 +38,7 @@ jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/utils')
 jest.mock('../../../utils/userUtils')
+jest.mock('../../../utils/placeUtils')
 
 describe('BookingsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -729,6 +731,7 @@ describe('BookingsController', () => {
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
       expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -96,6 +96,7 @@ describe('BookingsController', () => {
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premisesId)
       expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premisesId, roomId)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/new', {
         premises,

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -276,6 +276,48 @@ describe('BookingsController', () => {
       })
     })
 
+    it('prefills the asssessment ID if present in a place context', async () => {
+      const newBooking = newBookingFactory.build()
+      const person = personFactory.build({
+        crn: newBooking.crn,
+      })
+      const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+      const placeContext = placeContextFactory.build({
+        assessment: assessmentFactory.build({
+          id: 'some-assessment-id',
+          application: applicationFactory.build({ person }),
+        }),
+      })
+
+      request.params = {
+        premisesId,
+        roomId,
+      }
+      request.query = {
+        crn: newBooking.crn,
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
+        ...DateFormats.isoToDateAndTimeInputs(newBooking.departureDate, 'departureDate'),
+      }
+
+      personService.findByCrn.mockResolvedValue(person)
+      assessmentService.getReadyToPlaceForCrn.mockResolvedValue(assessmentSummaries)
+      ;(assessmentRadioItems as jest.MockedFunction<typeof assessmentRadioItems>).mockReturnValue(radioItems)
+      ;(preservePlaceContext as jest.MockedFunction<typeof preservePlaceContext>).mockResolvedValue(placeContext)
+      ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
+
+      const requestHandler = bookingsController.selectAssessment()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith(
+        'temporary-accommodation/bookings/selectAssessment',
+        expect.objectContaining({
+          assessmentId: 'some-assessment-id',
+        }),
+      )
+    })
+
     it.each([
       [
         'crn is empty',

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -119,6 +119,8 @@ export default class BookingsController {
           throw error
         }
 
+        const assessmentIdPrefill = placeContext ? { assessmentId: placeContext.assessment.id } : {}
+
         await this.personsService.findByCrn(callConfig, crn)
         const assessments = await this.assessmentService.getReadyToPlaceForCrn(callConfig, crn)
 
@@ -132,6 +134,7 @@ export default class BookingsController {
           errors,
           errorSummary,
           errorTitle,
+          ...assessmentIdPrefill,
           ...req.query,
         })
       } catch (err) {

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -158,6 +158,13 @@ export default class BookingsController {
 
       const callConfig = extractCallConfig(req)
 
+      let placeContext = await preservePlaceContext(req, res, this.assessmentService)
+
+      if (placeContext && placeContext.assessment.id !== assessmentId) {
+        clearPlaceContext(req, res)
+        placeContext = undefined
+      }
+
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
       const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -12,6 +12,7 @@ import {
   noAssessmentId,
 } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import { appendQueryString } from '../../../utils/utils'
@@ -231,6 +232,8 @@ export default class BookingsController {
     return async (req: Request, res: Response) => {
       const { premisesId, roomId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
+
+      await preservePlaceContext(req, res, this.assessmentService)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
       const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -40,7 +40,11 @@ export default class BookingsController {
 
       const callConfig = extractCallConfig(req)
 
-      await preservePlaceContext(req, res, this.assessmentService)
+      const placeContext = await preservePlaceContext(req, res, this.assessmentService)
+      const arrivalDatePrefill = placeContext?.arrivalDate
+        ? DateFormats.isoToDateAndTimeInputs(placeContext.arrivalDate, 'arrivalDate')
+        : {}
+      const crnPrefill = placeContext ? { crn: placeContext.assessment.application.person.crn } : {}
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
       const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
@@ -51,6 +55,8 @@ export default class BookingsController {
         errors,
         errorSummary,
         errorTitle,
+        ...arrivalDatePrefill,
+        ...crnPrefill,
         ...req.query,
       })
     }

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -40,6 +40,8 @@ export default class BookingsController {
 
       const callConfig = extractCallConfig(req)
 
+      await preservePlaceContext(req, res, this.assessmentService)
+
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
       const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -254,6 +254,8 @@ export default class BookingsController {
       const { premisesId, roomId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
+      await preservePlaceContext(req, res, this.assessmentService)
+
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
       const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
 

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -12,7 +12,7 @@ import {
   noAssessmentId,
 } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
-import { preservePlaceContext } from '../../../utils/placeUtils'
+import { clearPlaceContext, preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { isApplyEnabledForUser } from '../../../utils/userUtils'
 import { appendQueryString } from '../../../utils/utils'
@@ -73,6 +73,13 @@ export default class BookingsController {
       const { departureDate } = DateFormats.dateAndTimeInputsToIsoString(req.query, 'departureDate')
 
       const callConfig = extractCallConfig(req)
+
+      let placeContext = await preservePlaceContext(req, res, this.assessmentService)
+
+      if (placeContext && crn !== placeContext.assessment.application.person.crn) {
+        clearPlaceContext(req, res)
+        placeContext = undefined
+      }
 
       const backLink = appendQueryString(paths.bookings.new({ premisesId, roomId }), req.query)
       const applyDisabled = !isApplyEnabledForUser(res.locals.user)

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -81,6 +81,7 @@ export const controllers = (services: Services) => {
     services.lostBedService,
     services.premisesService,
     services.bedspaceService,
+    services.assessmentsService,
   )
 
   const bedspaceSearchController = new BedspaceSearchController(

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -28,6 +28,7 @@ export const controllers = (services: Services) => {
     services.premisesService,
     services.bedspaceService,
     services.bookingService,
+    services.assessmentsService,
   )
   const bookingsController = new BookingsController(
     services.premisesService,

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -19,7 +19,11 @@ import TurnaroundsController from './turnaroundsController'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
-  const premisesController = new PremisesController(services.premisesService, services.bedspaceService)
+  const premisesController = new PremisesController(
+    services.premisesService,
+    services.bedspaceService,
+    services.assessmentsService,
+  )
   const bedspacesController = new BedspacesController(
     services.premisesService,
     services.bedspaceService,

--- a/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
@@ -3,7 +3,7 @@ import type { NextFunction, Request, Response } from 'express'
 import { BespokeError } from '../../../@types/ui'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { LostBedService, PremisesService } from '../../../services'
+import { AssessmentsService, LostBedService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
 import {
   lostBedCancellationFactory,
@@ -18,6 +18,7 @@ import {
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import { allStatuses, lostBedActions } from '../../../utils/lostBedUtils'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import {
   catchValidationErrorOrPropogate,
@@ -31,6 +32,7 @@ jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/lostBedUtils')
 jest.mock('../../../utils/bookingUtils')
+jest.mock('../../../utils/placeUtils')
 
 describe('LostBedsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -46,8 +48,9 @@ describe('LostBedsController', () => {
   const lostBedService = createMock<LostBedService>({})
   const premisesService = createMock<PremisesService>({})
   const bedspaceService = createMock<BedspaceService>({})
+  const assessmentService = createMock<AssessmentsService>({})
 
-  const lostBedsController = new LostBedsController(lostBedService, premisesService, bedspaceService)
+  const lostBedsController = new LostBedsController(lostBedService, premisesService, bedspaceService, assessmentService)
 
   beforeEach(() => {
     request = createMock<Request>()
@@ -201,6 +204,7 @@ describe('LostBedsController', () => {
           actions: mockActions,
           allStatuses,
         })
+        expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
       })
     })
 

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -9,6 +9,7 @@ import BedspaceService from '../../../services/bedspaceService'
 import PremisesService from '../../../services/premisesService'
 import {
   newPremisesFactory,
+  placeContextFactory,
   premisesFactory,
   probationRegionFactory,
   referenceDataFactory,
@@ -88,14 +89,18 @@ describe('PremisesController', () => {
 
   describe('index', () => {
     it('returns the table rows to the template', async () => {
+      const placeContext = placeContextFactory.build()
+
       premisesService.tableRows.mockResolvedValue([])
+      ;(preservePlaceContext as jest.MockedFunction<typeof preservePlaceContext>).mockResolvedValue(placeContext)
 
       const requestHandler = premisesController.index()
       await requestHandler(request, response, next)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/premises/index', { tableRows: [] })
 
-      expect(premisesService.tableRows).toHaveBeenCalledWith(callConfig)
+      expect(premisesService.tableRows).toHaveBeenCalledWith(callConfig, placeContext)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.test.ts
@@ -15,11 +15,13 @@ import {
   roomFactory,
   updatePremisesFactory,
 } from '../../../testutils/factories'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { filterProbationRegions } from '../../../utils/userUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import PremisesController from './premisesController'
+import { AssessmentsService } from '../../../services'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
@@ -33,6 +35,7 @@ jest.mock('../../../utils/premisesUtils', () => {
   }
 })
 jest.mock('../../../utils/userUtils')
+jest.mock('../../../utils/placeUtils')
 
 describe('PremisesController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -70,7 +73,9 @@ describe('PremisesController', () => {
 
   const premisesService = createMock<PremisesService>({})
   const bedspaceService = createMock<BedspaceService>({})
-  const premisesController = new PremisesController(premisesService, bedspaceService)
+  const assessmentService = createMock<AssessmentsService>({})
+
+  const premisesController = new PremisesController(premisesService, bedspaceService, assessmentService)
 
   beforeEach(() => {
     request = createMock<Request>({
@@ -354,6 +359,7 @@ describe('PremisesController', () => {
 
       expect(premisesService.getPremisesDetails).toHaveBeenCalledWith(callConfig, premises.id)
       expect(bedspaceService.getBedspaceDetails).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
     })
   })
 })

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -23,7 +23,9 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
 
-      const tableRows = await this.premisesService.tableRows(callConfig)
+      const placeContext = await preservePlaceContext(req, res, this.assessmentService)
+
+      const tableRows = await this.premisesService.tableRows(callConfig, placeContext)
       return res.render('temporary-accommodation/premises/index', { tableRows })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -2,18 +2,21 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import type { NewPremises, UpdatePremises } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
+import { AssessmentsService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
 import PremisesService from '../../../services/premisesService'
 import { parseNaturalNumber } from '../../../utils/formUtils'
 import { allStatuses, getActiveStatuses, premisesActions } from '../../../utils/premisesUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { filterProbationRegions } from '../../../utils/userUtils'
+import { preservePlaceContext } from '../../../utils/placeUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 
 export default class PremisesController {
   constructor(
     private readonly premisesService: PremisesService,
     private readonly bedspaceService: BedspaceService,
+    private readonly assessmentService: AssessmentsService,
   ) {}
 
   index(): RequestHandler {
@@ -131,6 +134,8 @@ export default class PremisesController {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
       const { premisesId } = req.params
+
+      await preservePlaceContext(req, res, this.assessmentService)
 
       const details = await this.premisesService.getPremisesDetails(callConfig, premisesId)
 

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -6,12 +6,13 @@ import type {
   StaffMember,
   UpdatePremises,
 } from '@approved-premises/api'
-import type { ReferenceData, SummaryList, TableRow } from '@approved-premises/ui'
+import type { PlaceContext, ReferenceData, SummaryList, TableRow } from '@approved-premises/ui'
 import type { PremisesClient, ReferenceDataClient, RestClientBuilder } from '../data'
 import paths from '../paths/temporary-accommodation/manage'
 
 import { CallConfig } from '../data/restClient'
 import { filterCharacteristics, formatCharacteristics } from '../utils/characteristicUtils'
+import { addPlaceContext } from '../utils/placeUtils'
 import { statusTag } from '../utils/premisesUtils'
 import { escape, formatLines } from '../utils/viewUtils'
 
@@ -61,7 +62,7 @@ export default class PremisesService {
     return { localAuthorities, characteristics, probationRegions, pdus }
   }
 
-  async tableRows(callConfig: CallConfig): Promise<Array<TableRow>> {
+  async tableRows(callConfig: CallConfig, placeContext: PlaceContext): Promise<Array<TableRow>> {
     const premisesClient = this.premisesClientFactory(callConfig)
     const premises = await premisesClient.all()
 
@@ -75,9 +76,12 @@ export default class PremisesService {
           this.textValue(entry.pdu),
           this.htmlValue(statusTag(entry.status)),
           this.htmlValue(
-            `<a href="${paths.premises.show({
-              premisesId: entry.id,
-            })}">Manage<span class="govuk-visually-hidden"> ${entry.shortAddress}</span></a>`,
+            `<a href="${addPlaceContext(
+              paths.premises.show({
+                premisesId: entry.id,
+              }),
+              placeContext,
+            )}">Manage<span class="govuk-visually-hidden"> ${entry.shortAddress}</span></a>`,
           ),
         ]
       })

--- a/server/testutils/factories/placeContext.ts
+++ b/server/testutils/factories/placeContext.ts
@@ -1,9 +1,12 @@
+import { faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 import { PlaceContext } from '../../@types/ui'
+import { DateFormats } from '../../utils/dateUtils'
 import assessmentFactory from './assessment'
 
 export default Factory.define<PlaceContext>(() => ({
   assessment: assessmentFactory.build({
     status: 'ready_to_place',
   }),
+  arrivalDate: DateFormats.dateObjToIsoDate(faker.date.future()),
 }))

--- a/server/utils/bedspaceUtils.test.ts
+++ b/server/utils/bedspaceUtils.test.ts
@@ -1,6 +1,9 @@
 import paths from '../paths/temporary-accommodation/manage'
-import { premisesFactory, roomFactory } from '../testutils/factories'
+import { placeContextFactory, premisesFactory, roomFactory } from '../testutils/factories'
 import { bedspaceActions } from './bedspaceUtils'
+import { addPlaceContext } from './placeUtils'
+
+jest.mock('./placeUtils')
 
 describe('bedspaceUtils', () => {
   describe('bedspaceUtils', () => {
@@ -9,12 +12,15 @@ describe('bedspaceUtils', () => {
         status: 'active',
       })
       const room = roomFactory.build()
+      const placeContext = placeContextFactory.build()
 
-      expect(bedspaceActions(premises, room)).toEqual([
+      ;(addPlaceContext as jest.MockedFunction<typeof addPlaceContext>).mockReturnValue('/path/with/place/context')
+
+      expect(bedspaceActions(premises, room, placeContext)).toEqual([
         {
           text: 'Book bedspace',
           classes: 'govuk-button--secondary',
-          href: paths.bookings.new({ premisesId: premises.id, roomId: room.id }),
+          href: '/path/with/place/context',
         },
         {
           text: 'Void bedspace',
@@ -22,15 +28,22 @@ describe('bedspaceUtils', () => {
           href: paths.lostBeds.new({ premisesId: premises.id, roomId: room.id }),
         },
       ])
+
+      expect(addPlaceContext).toHaveBeenCalledWith(
+        paths.bookings.new({ premisesId: premises.id, roomId: room.id }),
+        placeContext,
+      )
     })
 
     it('returns null for an archived premises', () => {
+      const placeContext = placeContextFactory.build()
+
       const premises = premisesFactory.build({
         status: 'archived',
       })
       const room = roomFactory.build()
 
-      expect(bedspaceActions(premises, room)).toEqual(null)
+      expect(bedspaceActions(premises, room, placeContext)).toEqual(null)
     })
   })
 })

--- a/server/utils/bedspaceUtils.ts
+++ b/server/utils/bedspaceUtils.ts
@@ -1,8 +1,9 @@
 import { Premises, Room } from '../@types/shared'
-import { PageHeadingBarItem } from '../@types/ui'
+import { PageHeadingBarItem, PlaceContext } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
+import { addPlaceContext } from './placeUtils'
 
-export function bedspaceActions(premises: Premises, room: Room): Array<PageHeadingBarItem> {
+export function bedspaceActions(premises: Premises, room: Room, placeContext: PlaceContext): Array<PageHeadingBarItem> {
   if (premises.status === 'archived') {
     return null
   }
@@ -10,7 +11,7 @@ export function bedspaceActions(premises: Premises, room: Room): Array<PageHeadi
     {
       text: 'Book bedspace',
       classes: 'govuk-button--secondary',
-      href: paths.bookings.new({ premisesId: premises.id, roomId: room.id }),
+      href: addPlaceContext(paths.bookings.new({ premisesId: premises.id, roomId: room.id }), placeContext),
     },
   ]
 

--- a/server/utils/placeUtils.test.ts
+++ b/server/utils/placeUtils.test.ts
@@ -53,7 +53,7 @@ describe('placeUtils', () => {
 
       const assessmentService = createMock<AssessmentsService>()
 
-      const assessment = assessmentFactory.build()
+      const assessment = assessmentFactory.build({ status: 'ready_to_place' })
       assessmentService.findAssessment.mockResolvedValue(assessment)
 
       const req = createMock<Request>({
@@ -81,6 +81,30 @@ describe('placeUtils', () => {
 
       const req = createMock<Request>({
         query: { placeContextAssessmentId: 'some-assessment-id' },
+      })
+      const res = createMock<Response>({
+        locals: {},
+      })
+
+      const result = await preservePlaceContext(req, res, assessmentService)
+
+      expect(result).toEqual(undefined)
+      expect(res.locals.placeContext).toEqual(undefined)
+      expect(assessmentService.findAssessment).toHaveBeenCalledWith(callConfig, 'some-assessment-id')
+    })
+
+    it('returns undefined when the assessment is not ready to place', async () => {
+      const callConfig = { token: 'some-call-config-token' } as CallConfig
+
+      ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
+
+      const assessmentService = createMock<AssessmentsService>()
+
+      const assessment = assessmentFactory.build({ status: 'rejected' })
+      assessmentService.findAssessment.mockResolvedValue(assessment)
+
+      const req = createMock<Request>({
+        query: { placeContextAssessmentId: 'some-assessment-id', placeContextArrivalDate: '2024-05-01' },
       })
       const res = createMock<Response>({
         locals: {},

--- a/server/utils/placeUtils.test.ts
+++ b/server/utils/placeUtils.test.ts
@@ -5,6 +5,7 @@ import type { AssessmentsService } from '../services'
 import { assessmentFactory, placeContextFactory } from '../testutils/factories'
 import {
   addPlaceContext,
+  clearPlaceContext,
   createPlaceContext,
   preservePlaceContext,
   updatePlaceContextWithArrivalDate,
@@ -156,6 +157,28 @@ describe('placeUtils', () => {
       expect(result).toEqual(undefined)
       expect(res.locals.placeContext).toEqual(undefined)
       expect(assessmentService.findAssessment).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('clearPlaceContext', () => {
+    it('removes any place context date from our query and our response locals', () => {
+      const placeContext = placeContextFactory.build()
+
+      const req = createMock<Request>({
+        query: {
+          placeContextAssessmentId: 'some-assessment-id',
+          placeContextArrivalDate: '2024-07-01',
+          'other-field': 'other-value',
+        },
+      })
+      const res = createMock<Response>({
+        locals: { placeContext, 'other-field': 'other-value' },
+      })
+
+      clearPlaceContext(req, res)
+
+      expect(req.query).toEqual({ 'other-field': 'other-value' })
+      expect(res.locals).toEqual({ 'other-field': 'other-value' })
     })
   })
 })

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -9,9 +9,24 @@ export const createPlaceContext = (assessment: Assessment) => {
   return { assessment }
 }
 
+export const updatePlaceContextWithArrivalDate = (res: Response, placeContext: PlaceContext, arrivalDate: string) => {
+  if (placeContext) {
+    const updatedPlaceContext = { ...placeContext, arrivalDate }
+
+    res.locals.placeContext = updatedPlaceContext
+
+    return updatedPlaceContext
+  }
+
+  return undefined
+}
+
 export const addPlaceContext = (path: string, placeContext: PlaceContext) => {
   if (placeContext) {
-    return appendQueryString(path, { placeContextAssessmentId: placeContext.assessment.id })
+    return appendQueryString(path, {
+      placeContextAssessmentId: placeContext.assessment.id,
+      placeContextArrivalDate: placeContext.arrivalDate,
+    })
   }
   return path
 }
@@ -37,8 +52,9 @@ export const preservePlaceContext = async (
       return undefined
     }
 
-    res.locals.placeContext = { assessment }
-    return { assessment }
+    const placeContext = { assessment, arrivalDate: req.query.placeContextArrivalDate as string }
+    res.locals.placeContext = placeContext
+    return placeContext
   }
 
   return undefined

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -33,6 +33,10 @@ export const preservePlaceContext = async (
       return undefined
     }
 
+    if (assessment.status !== 'ready_to_place') {
+      return undefined
+    }
+
     res.locals.placeContext = { assessment }
     return { assessment }
   }

--- a/server/utils/placeUtils.ts
+++ b/server/utils/placeUtils.ts
@@ -59,3 +59,9 @@ export const preservePlaceContext = async (
 
   return undefined
 }
+
+export const clearPlaceContext = (req: Request, res: Response) => {
+  res.locals.placeContext = undefined
+  req.query.placeContextAssessmentId = undefined
+  req.query.placeContextArrivalDate = undefined
+}

--- a/server/views/temporary-accommodation/assessments/full.njk
+++ b/server/views/temporary-accommodation/assessments/full.njk
@@ -1,6 +1,7 @@
 {%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -11,8 +12,9 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.assessments.summary({ id: assessment.id })
+    href: addPlaceContext(paths.assessments.summary({ id: assessment.id }))
   }) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -8,6 +8,7 @@
 {%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -21,6 +22,7 @@
   {{ breadCrumb(breadCrumbTitle, [
     {title: 'Referrals', href: paths.assessments.index()}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -67,7 +69,7 @@
     govukButton({
       text: "View full referral",
       type: "button",
-      href: paths.assessments.full({ id: assessment.id }),
+      href: addPlaceContext(paths.assessments.full({ id: assessment.id })),
       classes: "govuk-button--secondary"
     }) 
   }}

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -6,6 +6,7 @@
 {% from "../components/location-header/macro.njk" import locationHeader %}
 {% from "../components/booking-listing/macro.njk" import bookingListing %}
 {% from "../components/lost-bed-listing/macro.njk" import lostBedListing %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -15,9 +16,10 @@
 
 {% block beforeContent %}
   {{ breadCrumb('View a bedspace', [
-    {title: 'List of properties', href: paths.premises.index()},
-    {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })}
+    {title: 'List of properties', href: addPlaceContext(paths.premises.index())},
+    {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -80,9 +82,9 @@
 
   {% for listingEntry in listingEntries %}
     {% if listingEntry.type === 'booking'%}
-      {{ bookingListing(listingEntry.body, listingEntry.path) }}
+      {{ bookingListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
     {% elif listingEntry.type === 'lost-bed' %}
-      {{ lostBedListing(listingEntry.body, listingEntry.path) }}
+      {{ lostBedListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
     {% endif %}
   {% endfor %}
 

--- a/server/views/temporary-accommodation/bookings/_editable.njk
+++ b/server/views/temporary-accommodation/bookings/_editable.njk
@@ -1,6 +1,9 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../components/ta-input/macro.njk" import taInput %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
+{% from "../components/place-context-value/macro.njk" import placeContextValue %}
+
+{{ placeContextValue(placeContext) }}
 
 {{ taInput(
     {

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -3,6 +3,8 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
 {% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
+{% from "../components/place-context-value/macro.njk" import placeContextValue %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -14,6 +16,7 @@
     text: "Back",
     href: backLink
   }) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -26,8 +29,10 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.create({ premisesId: premises.id, roomId: room.id }) }}" method="post">
+      <form action="{{ addPlaceContext(paths.bookings.create({ premisesId: premises.id, roomId: room.id })) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+
+        {{ placeContextValue(placeContext) }}
 
         {% set context = fetchContext() %}
 

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -3,6 +3,7 @@
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
 {% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -12,8 +13,9 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: addPlaceContext(paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
   }) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -30,6 +32,5 @@
       {{ bookingInfo(historicBookingDetail.booking) }}
     </div>
   {%endfor%}
-
 
 {% endblock %}

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -1,6 +1,7 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -11,8 +12,9 @@
   {{ breadCrumb('Book bedspace', [
     {title: 'List of properties', href: paths.premises.index()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+    {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/temporary-accommodation/bookings/selectAssessment.njk
+++ b/server/views/temporary-accommodation/bookings/selectAssessment.njk
@@ -3,6 +3,8 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../components/ta-radios/macro.njk" import taRadios %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
+{% from "../components/place-context-value/macro.njk" import placeContextValue %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -14,6 +16,7 @@
     text: "Back",
     href: backLink
   }) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -30,6 +33,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.bookings.confirm({ premisesId: premisesId, roomId: roomId }) }}" method="get">
+
+        {{ placeContextValue(placeContext) }}
 
         {% set context = fetchContext() %}
 

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -3,6 +3,7 @@
 {% from "../components/booking-info/macro.njk" import bookingInfo %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
 {% from "../components/pop-details-header/macro.njk" import popDetailsHeader%}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
@@ -14,10 +15,11 @@
 
 {% block beforeContent %}
   {{ breadCrumb('View a booking', [
-    {title: 'List of properties', href: paths.premises.index()},
-    {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+    {title: 'List of properties', href: addPlaceContext(paths.premises.index())},
+    {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))},
+    {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -31,10 +33,10 @@
     items: actions
   }) }}
 
-  {{ popDetailsHeader(booking.person, { nameLink: paths.assessments.summary({ id: booking.assessmentId }) if booking.assessmentId else "" }) }}
+  {{ popDetailsHeader(booking.person, { nameLink: addPlaceContext(paths.assessments.summary({ id: booking.assessmentId })) if booking.assessmentId else "" }) }}
   {{ locationHeader({ room: room, premises: premises }) }}
 
-  {{ bookingInfo(booking, paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })) }}
+  {{ bookingInfo(booking, addPlaceContext(paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))) }}
 
 {% endblock %}
 

--- a/server/views/temporary-accommodation/components/place-context-header/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-header/macro.njk
@@ -11,11 +11,10 @@
         <div>{{ personName(person, 'Limited access offender') }}</div>
         {% if isFullPerson(person) %}
           <div>Date of birth: {{ formatDate(person.dateOfBirth, {format: 'short'}) }}</div>
-          {% if person.sex %}
-            <div>Sex: {{ person.sex }}</div>
-          {% endif %}
           {% if person.genderIdentity %}
             <div>Gender identity: {{ person.genderIdentity }}</div>
+          {% else %}
+            <div>Sex: {{ person.sex }}</div>
           {% endif %}
         {% endif %}
         <div>CRN: {{ person.crn }}</div>

--- a/server/views/temporary-accommodation/components/place-context-value/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-value/macro.njk
@@ -4,6 +4,9 @@
 
   {% if placeContext %}
     <input type="hidden" name="placeContextAssessmentId" value="{{ placeContext.assessment.id }}" />
+    {% if placeContext.arrivalDate %}
+      <input type="hidden" name="placeContextArrivalDate" value="{{ placeContext.arrivalDate }}" />
+    {% endif %}
   {% endif %}
 
 {% endmacro %}

--- a/server/views/temporary-accommodation/lost-beds/show.njk
+++ b/server/views/temporary-accommodation/lost-beds/show.njk
@@ -3,6 +3,7 @@
 {% from "../components/lost-bed-info/macro.njk" import lostBedInfo %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -11,9 +12,10 @@
 
 {% block beforeContent %}
   {{ breadCrumb('View a void booking', [
-    {title: 'List of bedspaces', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+    {title: 'List of bedspaces', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))},
+    {title: 'View bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/temporary-accommodation/premises/index.njk
+++ b/server/views/temporary-accommodation/premises/index.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
@@ -10,6 +11,7 @@
 
 {% block beforeContent %}
   {{ breadCrumb('List of properties', []) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "moj/components/page-header-actions/macro.njk" import mojPageHeaderActions %}
+{% from "../components/place-context-header/macro.njk" import placeContextHeader %}
 
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
@@ -12,8 +13,9 @@
 
 {% block beforeContent %}
   {{ breadCrumb('View a property', [
-    {title: 'List of properties', href: paths.premises.index()}
+    {title: 'List of properties', href: addPlaceContext(paths.premises.index())}
   ]) }}
+  {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
@@ -69,7 +71,7 @@
             <h4>{{ bedspace.room.name }}</h4>
           </div>
           <div class="edit-bar__action">
-            <a href="{{ paths.premises.bedspaces.show({ premisesId: premises.id, roomId: bedspace.room.id }) }}">View</a>
+            <a href="{{ addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: bedspace.room.id })) }}">View</a>
           </div>
         </div>
       </div>


### PR DESCRIPTION
# Changes in this PR

This PR builds on #588 and expands the set of pages where we display a place context banner. The place context banner will be in place until the user completes a booking or exits the place journey. Generally this PR is generous with what it counts as "the place journey" - if the user does't go all the way back to the dashboard, and doesn't attempt to perform any actions other than making a booking (editing a property, recording a lost bed, etc.), the user will still see the banner.

It felt natural to preserve the banner if the user tried to add a note to a referral. However, getting this working without disrupting auditing proved to be a rabbit hole, and so it seems worth leaving until someone specifically asks for it

## Screenshots of UI changes
![localhost_3000_properties_2d91558e-f9b5-499f-a3e3-00e64134470f_bedspaces_c9b2be59-3dc7-48e3-a8f6-ecd35b05cac0_placeContextAssessmentId=dd4c0194-5086-432c-9168-a7a79f6e64ab placeContextArrivalDate=2023-04-18](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/969f5cb9-c90c-4396-ab21-25efa20762f6)
![localhost_3000_properties_2d91558e-f9b5-499f-a3e3-00e64134470f_bedspaces_6cfa8911-846c-4b7a-9ff6-85cde1e02bbf_bookings_new_placeContextAssessmentId=dd4c0194-5086-432c-9168-a7a79f6e64ab placeContextArrivalDate=2023-04-18](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/ed16bca1-d22b-48ff-b6fc-06a4d514d885)
![localhost_3000_properties_2d91558e-f9b5-499f-a3e3-00e64134470f_bedspaces_6cfa8911-846c-4b7a-9ff6-85cde1e02bbf_bookings_select-assessment_placeContextAssessmentId=dd4c0194-5086-432c-9168-a7a79f6e64ab placeContextArrivalDate=2023-04-18 crn=C4](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/dd699c2a-fbad-4ca4-bb16-7323ffb73f9b)
![localhost_3000_properties_2d91558e-f9b5-499f-a3e3-00e64134470f_bedspaces_6cfa8911-846c-4b7a-9ff6-85cde1e02bbf_bookings_confirm_placeContextAssessmentId=dd4c0194-5086-432c-9168-a7a79f6e64ab placeContextArrivalDate=2023-04-18 crn=C477095 arri](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/94137563/b692bfb2-d8d0-494f-97bc-dfefe759e61c)



# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
