### PR TITLE
In E2E tests submit application as assessor

### DIFF
--- a/e2e/tests/apply-and-place.feature
+++ b/e2e/tests/apply-and-place.feature
@@ -1,6 +1,6 @@
 Feature: Apply for and book a Temporary Accommodation bedspace
   Scenario: Creating an application
-    Given I am logged in as a referrer
+    Given I am logged in as an assessor who visits the referrer landing page
     When I start a new application
     And I fill in and complete an application
     Then I should see a confirmation of the application

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -3,25 +3,11 @@ import Page from '../../../cypress_shared/pages/page'
 import { throwMissingCypressEnvError } from './utils'
 
 Given('I am logged in as an assessor', () => {
-  const username = Cypress.env('assessor_username') || throwMissingCypressEnvError('assessor_username')
-  const password = Cypress.env('assessor_password') || throwMissingCypressEnvError('assessor_password')
-
-  cy.visit('/')
-  cy.get('input[name="username"]').type(username)
-  cy.get('input[name="password"]').type(password, { log: false })
-
-  cy.get('.govuk-button').contains('Sign in').click()
+  signIn('assessor_username', 'assessor_password')
 })
 
 Given('I am logged in as a referrer', () => {
-  const username = Cypress.env('referrer_username') || throwMissingCypressEnvError('referrer_username')
-  const password = Cypress.env('referrer_password') || throwMissingCypressEnvError('referrer_password')
-
-  cy.visit('/')
-  cy.get('input[name="username"]').type(username)
-  cy.get('input[name="password"]').type(password, { log: false })
-
-  cy.get('.govuk-button').contains('Sign in').click()
+  signIn('referrer_username', 'referrer_password')
 })
 
 Given('I return to the dashboard', () => {
@@ -31,3 +17,14 @@ Given('I return to the dashboard', () => {
 Given('I go up a breadcrumb level', () => {
   Page.clickBreadCrumbUp()
 })
+
+const signIn = (usernameVariable: string, passwordVariable: string) => {
+  const username = Cypress.env(usernameVariable) || throwMissingCypressEnvError(usernameVariable)
+  const password = Cypress.env(passwordVariable) || throwMissingCypressEnvError(passwordVariable)
+
+  cy.visit('/')
+  cy.get('input[name="username"]').type(username)
+  cy.get('input[name="password"]').type(password, { log: false })
+
+  cy.get('.govuk-button').contains('Sign in').click()
+}

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,4 +1,5 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
+import ApplicationsListPage from '../../../cypress_shared/pages/apply/list'
 import Page from '../../../cypress_shared/pages/page'
 import { throwMissingCypressEnvError } from './utils'
 
@@ -8,6 +9,12 @@ Given('I am logged in as an assessor', () => {
 
 Given('I am logged in as a referrer', () => {
   signIn('referrer_username', 'referrer_password')
+})
+
+Given('I am logged in as an assessor who visits the referrer landing page', () => {
+  signIn('assessor_username', 'assessor_password')
+
+  ApplicationsListPage.visit([])
 })
 
 Given('I return to the dashboard', () => {


### PR DESCRIPTION
As a temporary measure until we have assessor and referrer test users in the same region, we use our assessor user to submit our application, ensuring it will be visible in the assessor's assessment listing after submissions

Currently our E2E tests fail as the referrer and assessor are in different regions, so the assessor does not see the application submitted by the referrer