### PR TITLE
Conditionally render the ACCT alert expiry date when rendering the check your answers page

### DIFF
--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.test.ts
@@ -25,6 +25,22 @@ describe('acctAlertResponse', () => {
       'Expiry date': '9 January 2022',
     })
   })
+
+  it('returns a response for an ACCT Alert when the alert expiry date is not provided', () => {
+    const acctAlert = acctAlertFactory.build({
+      alertId: 123,
+      comment: 'Some description',
+      dateCreated: '2022-01-01T10:00:00Z',
+      dateExpires: undefined,
+    })
+
+    expect(acctAlertResponse(acctAlert)).toEqual({
+      'Alert type': 123,
+      'ACCT description': 'Some description',
+      'Date created': '1 January 2022',
+      'Expiry date': '',
+    })
+  })
 })
 
 describe('AcctAlerts', () => {

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
@@ -15,7 +15,7 @@ export const acctAlertResponse = (acctAlert: PersonAcctAlert) => {
     'Alert type': acctAlert.alertId,
     'ACCT description': acctAlert.comment,
     'Date created': DateFormats.isoDateToUIDate(acctAlert.dateCreated),
-    'Expiry date': DateFormats.isoDateToUIDate(acctAlert.dateExpires),
+    'Expiry date': acctAlert.dateExpires ? DateFormats.isoDateToUIDate(acctAlert.dateExpires) : '',
   }
 }
 


### PR DESCRIPTION
# Context
We received two support tickets[1] from users who were unable to submit
their application. We can see issues[2] coming through to sentry on the
'Check your answers' page before submitting a referral.

Upon inspection, it is possiblle for an ACCT alert to have a missing
`dateExpires` property, so this change adds a null guard against that
scenario. We render an empty string, which aligns with how we handle it
elsewhere[3].

[1]
https://mojdt.slack.com/archives/C04NJ6BATUL/p1693409827077599?thread_ts=1693409758.827739&cid=C04NJ6BATUL
https://mojdt.slack.com/archives/C04NJ6BATUL/p1693411279302619?thread_ts=1693409758.827739&cid=C04NJ6BATUL

[2]
https://ministryofjustice.sentry.io/issues/4347240074/events/39b224f1720e4e10af3e3aa7d4e6d8dc/

[3]
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/main/server/views/applications/pages/assess-placement-risks-and-needs/prison-information/acct-alerts.njk#L27

## Screenshots of UI changes
![Screenshot 2023-08-31 at 11 48 25](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/1ca64663-1bb5-45fd-9740-26dbd20bb809)


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
