### PR TITLE
In E2E tests submit application as referrer

### DIFF
--- a/e2e/tests/apply-and-place.feature
+++ b/e2e/tests/apply-and-place.feature
@@ -1,6 +1,6 @@
 Feature: Apply for and book a Temporary Accommodation bedspace
   Scenario: Creating an application
-    Given I am logged in as an assessor who visits the referrer landing page
+    Given I am logged in as a referrer
     When I start a new application
     And I fill in and complete an application
     Then I should see a confirmation of the application

--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -1,5 +1,4 @@
 import { Given } from '@badeball/cypress-cucumber-preprocessor'
-import ApplicationsListPage from '../../../cypress_shared/pages/apply/list'
 import Page from '../../../cypress_shared/pages/page'
 import { throwMissingCypressEnvError } from './utils'
 
@@ -9,12 +8,6 @@ Given('I am logged in as an assessor', () => {
 
 Given('I am logged in as a referrer', () => {
   signIn('referrer_username', 'referrer_password')
-})
-
-Given('I am logged in as an assessor who visits the referrer landing page', () => {
-  signIn('assessor_username', 'assessor_password')
-
-  ApplicationsListPage.visit([])
 })
 
 Given('I return to the dashboard', () => {


### PR DESCRIPTION
Reverting a previous temporary fix, needed until we could bring our referrer into the same region as our assessor, we now submit our application as a referrer in our E2E tests

This reverts the temporary fix from #597, and can be merged once the referrer test user has been moved to Kent, Surrey, and Sussex