### PR TITLE
Add referral summary link to tracking banner

### DIFF
--- a/cypress_shared/components/placeContextHeader.ts
+++ b/cypress_shared/components/placeContextHeader.ts
@@ -18,6 +18,7 @@ export default class PlaceContextHeaderComponent extends Component {
       const { person } = application
 
       cy.root().should('contain', personName(person, 'Limited access offender'))
+      cy.root().should('contain', 'View referral summary (opens in new tab)')
 
       if (isFullPerson(person)) {
         cy.root().should(

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -38,7 +38,6 @@ describe('AssessmentsController', () => {
       text: 'Some action',
       href: '/some/action/path',
       classes: 'govuk-button--secondary',
-      newTab: false,
     },
   ]
 

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -106,13 +106,11 @@ describe('assessmentUtils', () => {
           text: 'In review',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'in_review' }),
-          newTab: false,
         },
         {
           text: 'Reject',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
-          newTab: false,
         },
       ])
     })
@@ -129,19 +127,16 @@ describe('assessmentUtils', () => {
           text: 'Ready to place',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'ready_to_place' }),
-          newTab: false,
         },
         {
           text: 'Unallocated',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'unallocated' }),
-          newTab: false,
         },
         {
           text: 'Reject',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
-          newTab: false,
         },
       ])
     })
@@ -163,25 +158,21 @@ describe('assessmentUtils', () => {
           text: 'Archive',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'closed' }),
-          newTab: false,
         },
         {
           text: 'In review',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'in_review' }),
-          newTab: false,
         },
         {
           text: 'Reject',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
-          newTab: false,
         },
         {
           classes: 'govuk-button--secondary',
           href: '/path/with/place/context',
           text: 'Place referral',
-          newTab: true,
         },
       ])
 
@@ -201,7 +192,6 @@ describe('assessmentUtils', () => {
           text: 'Ready to place',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'ready_to_place' }),
-          newTab: false,
         },
       ])
     })
@@ -218,7 +208,6 @@ describe('assessmentUtils', () => {
           text: 'Unallocated',
           classes: 'govuk-button--secondary',
           href: paths.assessments.confirm({ id: assessment.id, status: 'unallocated' }),
-          newTab: false,
         },
       ])
     })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -66,37 +66,31 @@ export const assessmentActions = (assessment: Assessment) => {
       text: 'Unallocated',
       classes: 'govuk-button--secondary',
       href: paths.assessments.update({ id: assessment.id, status: 'unallocated' }),
-      newTab: false,
     },
     inReview: {
       text: 'In review',
       classes: 'govuk-button--secondary',
       href: paths.assessments.update({ id: assessment.id, status: 'in_review' }),
-      newTab: false,
     },
     reject: {
       text: 'Reject',
       classes: 'govuk-button--secondary',
       href: paths.assessments.confirm({ id: assessment.id, status: 'rejected' }),
-      newTab: false,
     },
     readyToPlace: {
       text: 'Ready to place',
       classes: 'govuk-button--secondary',
       href: paths.assessments.confirm({ id: assessment.id, status: 'ready_to_place' }),
-      newTab: false,
     },
     close: {
       text: 'Archive',
       classes: 'govuk-button--secondary',
       href: paths.assessments.confirm({ id: assessment.id, status: 'closed' }),
-      newTab: false,
     },
     findABedspace: {
       classes: 'govuk-button--secondary',
       href: addPlaceContext(paths.bedspaces.search({}), createPlaceContext(assessment)),
       text: 'Place referral',
-      newTab: true,
     },
   }
 

--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -44,8 +44,8 @@
             <div class="moj-button-menu__wrapper">
               {% for action in actions %}
                 {% if action.newTab %}
-                  <a href="{{ action.href }}" role="menuitem" draggable="false" class="moj-button-menu__item {{ action.classes }}" data-module="govuk-button" data-secondary="true" rel="noreferrer noopener" target="_blank">
-                    {{ action.text }} (opens in new tab)
+                  <a href="{{ action.href }}" role="menuitem" draggable="false" class="moj-button-menu__item {{ action.classes }}" data-module="govuk-button" data-secondary="true">
+                    {{ action.text }}
                   </a>
                 {% else %}
                   <a href="{{ action.href }}" role="menuitem" draggable="false" class="moj-button-menu__item {{ action.classes }}" data-module="govuk-button" data-secondary="true">

--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -43,15 +43,8 @@
           <div class="moj-button-menu">
             <div class="moj-button-menu__wrapper">
               {% for action in actions %}
-                {% if action.newTab %}
-                  <a href="{{ action.href }}" role="menuitem" draggable="false" class="moj-button-menu__item {{ action.classes }}" data-module="govuk-button" data-secondary="true">
-                    {{ action.text }}
-                  </a>
-                {% else %}
-                  <a href="{{ action.href }}" role="menuitem" draggable="false" class="moj-button-menu__item {{ action.classes }}" data-module="govuk-button" data-secondary="true">
-                    {{ action.text }}
-                  </a>
-                {% endif %}
+                <a href="{{ action.href }}" role="menuitem" draggable="false" class="moj-button-menu__item {{ action.classes }}" data-module="govuk-button" data-secondary="true">
+                  {{ action.text }}
                 </a>
               {% endfor %}
             </div>

--- a/server/views/temporary-accommodation/components/place-context-header/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-header/macro.njk
@@ -7,7 +7,7 @@
 
     <div class="place-context-header govuk-body">
       <strong class="govuk-heading-s govuk-!-margin-bottom-2">Person to place</strong>
-      <div class="place-context-header__attribute-container">
+      <div class="place-context-header__attribute-container govuk-!-margin-bottom-2">
         <div>{{ personName(person, 'Limited access offender') }}</div>
         {% if isFullPerson(person) %}
           <div>Date of birth: {{ formatDate(person.dateOfBirth, {format: 'short'}) }}</div>
@@ -22,6 +22,7 @@
           <div>Accommodation required from: {{ formatDate(placeContext.assessment.application.arrivalDate, {format: 'short'}) }}</div>
         {% endif %}
       </div>
+      <a class="govuk-link" href="{{ addPlaceContext(paths.assessments.summary({ id: placeContext.assessment.id })) }}" rel="noreferrer noopener" target="_blank">View referral summary (opens in new tab)</a>
     </div>
   {% endif %}
 


### PR DESCRIPTION
# Context
This change stops the "place referral" action link on the summary page from opening in a new tab and instead renders a link back to the referral summary from the tracking banner which opens in a new tab.

This is to preserve the current user experience by not interrupting their workflow by sending them to another page.

## Screenshots of UI changes

### Before
![Screenshot 2023-08-31 at 17 07 43](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/038029dc-b430-494d-9ae1-bfcec694de1f)
![Screenshot 2023-08-31 at 15 40 12](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/c982e9ef-5e97-4968-9bce-aca91dd20eea)

### After
![Screenshot 2023-08-31 at 16 25 58](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/e6c241b4-da9d-465f-89d3-b3f20de69580)
![Screenshot 2023-08-31 at 15 39 45](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/ab38698c-51c9-4503-9403-73d0f47d333e)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
