### PR TITLE
Send summary data on application submission

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -306,4 +306,6 @@ export type MessageContents =
     }
   | string
 
-export type ApplicationSummaryData = {}
+export type ApplicationSummaryData = {
+  isAbleToShare: boolean | null
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -305,3 +305,5 @@ export type MessageContents =
       html: string
     }
   | string
+
+export type ApplicationSummaryData = {}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -308,4 +308,5 @@ export type MessageContents =
 
 export type ApplicationSummaryData = {
   isAbleToShare: boolean | null
+  releaseType: 'Rerelease' | 'Custody' | 'Approved Premises' | 'Bail accommodation and support' | null
 }

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -21,7 +21,9 @@ describe('getApplicationSubmissionData', () => {
       translatedDocument: application.document,
       type: 'CAS3',
       arrivalDate: applicationDataJson.eligibility['accommodation-required-from-date'].accommodationRequiredFromDate,
-      summaryData: {},
+      summaryData: {
+        isAbleToShare: true,
+      },
     })
   })
 })

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -21,6 +21,7 @@ describe('getApplicationSubmissionData', () => {
       translatedDocument: application.document,
       type: 'CAS3',
       arrivalDate: applicationDataJson.eligibility['accommodation-required-from-date'].accommodationRequiredFromDate,
+      summaryData: {},
     })
   })
 })

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -23,6 +23,7 @@ describe('getApplicationSubmissionData', () => {
       arrivalDate: applicationDataJson.eligibility['accommodation-required-from-date'].accommodationRequiredFromDate,
       summaryData: {
         isAbleToShare: true,
+        releaseType: 'Approved Premises',
       },
     })
   })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -4,6 +4,7 @@ import {
   UpdateTemporaryAccommodationApplication as UpdateApplication,
 } from '../../@types/shared'
 import { arrivalDateFromApplication } from '../../form-pages/utils'
+import getSummaryDataFromApplication from './getSummaryDataFromApplication'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
@@ -17,5 +18,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     translatedDocument: application.document,
     type: 'CAS3',
     arrivalDate: arrivalDateFromApplication(application),
+    summaryData: getSummaryDataFromApplication(application),
   }
 }

--- a/server/utils/applications/getSummaryDataFromApplication.test.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.test.ts
@@ -8,6 +8,7 @@ describe('getSummaryDataFromApplication', () => {
 
     expect(getSummaryDataFromApplication(application)).toEqual({
       isAbleToShare: true,
+      releaseType: 'Approved Premises',
     })
   })
 })

--- a/server/utils/applications/getSummaryDataFromApplication.test.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.test.ts
@@ -1,10 +1,13 @@
+import applicationDataJson from '../../../cypress_shared/fixtures/applicationData.json'
 import { applicationFactory } from '../../testutils/factories'
 import getSummaryDataFromApplication from './getSummaryDataFromApplication'
 
 describe('getSummaryDataFromApplication', () => {
   it('returns summary data from the application', () => {
-    const application = applicationFactory.build()
+    const application = applicationFactory.build({ data: applicationDataJson })
 
-    expect(getSummaryDataFromApplication(application)).toEqual({})
+    expect(getSummaryDataFromApplication(application)).toEqual({
+      isAbleToShare: true,
+    })
   })
 })

--- a/server/utils/applications/getSummaryDataFromApplication.test.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.test.ts
@@ -1,0 +1,10 @@
+import { applicationFactory } from '../../testutils/factories'
+import getSummaryDataFromApplication from './getSummaryDataFromApplication'
+
+describe('getSummaryDataFromApplication', () => {
+  it('returns summary data from the application', () => {
+    const application = applicationFactory.build()
+
+    expect(getSummaryDataFromApplication(application)).toEqual({})
+  })
+})

--- a/server/utils/applications/getSummaryDataFromApplication.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.ts
@@ -1,0 +1,6 @@
+import { TemporaryAccommodationApplication as Application } from '../../@types/shared'
+import { ApplicationSummaryData } from '../../@types/ui'
+
+export default function getSummaryDataFromApplication(application: Application): ApplicationSummaryData {
+  return {}
+}

--- a/server/utils/applications/getSummaryDataFromApplication.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.ts
@@ -1,6 +1,24 @@
 import { TemporaryAccommodationApplication as Application } from '../../@types/shared'
-import { ApplicationSummaryData } from '../../@types/ui'
+import { ApplicationSummaryData, YesOrNo } from '../../@types/ui'
 
 export default function getSummaryDataFromApplication(application: Application): ApplicationSummaryData {
-  return {}
+  return {
+    /* eslint-disable dot-notation */
+    isAbleToShare: getIsAbleToShare(
+      application.data?.['placement-considerations']?.['accommodation-sharing']?.['accommodationSharing'],
+    ),
+    /* eslint-enable dot-notation */
+  }
+}
+
+function getIsAbleToShare(ableToShare?: YesOrNo) {
+  if (ableToShare === 'yes') {
+    return true
+  }
+
+  if (ableToShare === 'no') {
+    return false
+  }
+
+  return null
 }

--- a/server/utils/applications/getSummaryDataFromApplication.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.ts
@@ -1,3 +1,4 @@
+import { EligibilityReasonsT } from 'server/form-pages/apply/accommodation-need/eligibility/eligibilityReason'
 import { TemporaryAccommodationApplication as Application } from '../../@types/shared'
 import { ApplicationSummaryData, YesOrNo } from '../../@types/ui'
 
@@ -7,6 +8,7 @@ export default function getSummaryDataFromApplication(application: Application):
     isAbleToShare: getIsAbleToShare(
       application.data?.['placement-considerations']?.['accommodation-sharing']?.['accommodationSharing'],
     ),
+    releaseType: getReleaseType(application.data?.['eligibility']?.['eligibility-reason']?.['reason']),
     /* eslint-enable dot-notation */
   }
 }
@@ -18,6 +20,26 @@ function getIsAbleToShare(ableToShare?: YesOrNo) {
 
   if (ableToShare === 'no') {
     return false
+  }
+
+  return null
+}
+
+function getReleaseType(reason?: EligibilityReasonsT) {
+  if (reason === 'homelessAfterRerelease') {
+    return 'Rerelease'
+  }
+
+  if (reason === 'homelessFromApprovedPremises') {
+    return 'Approved Premises'
+  }
+
+  if (reason === 'homelessFromBailAccommodation') {
+    return 'Bail accommodation and support'
+  }
+
+  if (reason === 'homelessFromCustody') {
+    return 'Custody'
   }
 
   return null


### PR DESCRIPTION
# Context
We need to use data from the referral on pages other than the full
referral page. As the full referral page renders it's content from a
JSON object, we decided it'd be unwieldly to rely on deeply nested keys
which tightly coupled to the question copy we present in the initial
referral form.

To get around this, we are sending a `summaryData` object on submission
of the referral which will contain the summary data needed to be
presented on other pages. We still don't get true type safety, but the
object is one level deep, meaning extraction of data is more
straight-forward.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
