### PR TITLE
Anonymise names in page titles

### DIFF
--- a/integration_tests/tests/temporary-accommodation/cookies.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/cookies.cy.ts
@@ -9,7 +9,7 @@ context('Cookies', () => {
   it('should navigate to the cookie policy page', () => {
     cy.signIn()
     cy.contains('Cookies').click()
-    cy.title().should('eq', 'Cookies')
+    cy.title().should('eq', 'Cookies - Temporary Accommodation')
     cy.contains('Cookies are small files saved on your phone, tablet or computer when you visit a website.')
   })
 })

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -23,6 +23,7 @@ import { CallConfig } from '../../data/restClient'
 
 interface TasklistPage {
   body: Record<string, unknown>
+  htmlDocumentTitle: string
 }
 interface PersonService {}
 

--- a/server/form-pages/apply/accommodation-need/consent/consentGiven.ts
+++ b/server/form-pages/apply/accommodation-need/consent/consentGiven.ts
@@ -13,6 +13,8 @@ type ConsentGivenBody = {
 export default class ConsentGiven implements TasklistPage {
   title = 'Has consent for Temporary Accommodation been given?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<ConsentGivenBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/contact-details/backupContact.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/backupContact.ts
@@ -6,6 +6,8 @@ import ContactDetails from '../../contactDetails'
 export default class BackupContact extends ContactDetails implements TasklistPage {
   title = 'Backup contact / senior probation officer details'
 
+  htmlDocumentTitle = this.title
+
   nextPageId = 'practitioner-pdu'
 
   previousPageId = 'probation-practitioner'

--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
@@ -9,6 +9,8 @@ type PractitionerPduBody = { pdu: string }
 export default class PractitionerPdu implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = "What is the person's PDU?"
+
   constructor(
     readonly body: Partial<PractitionerPduBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/contact-details/probationPractitioner.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/probationPractitioner.ts
@@ -6,6 +6,8 @@ import ContactDetails from '../../contactDetails'
 export default class ProbationPractitioner extends ContactDetails implements TasklistPage {
   title = 'Probation practitioner details'
 
+  htmlDocumentTitle = this.title
+
   previousPageId = 'dashboard'
 
   nextPageId = 'backup-contact'

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
@@ -14,6 +14,8 @@ type AccommodationRequiredFromDateBody = ObjectWithDateParts<'accommodationRequi
 export default class AccommodationRequiredFromDate implements TasklistPage {
   title = 'What date is accommodation required from?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     private _body: Partial<AccommodationRequiredFromDateBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
@@ -19,6 +19,8 @@ type EligibilityReasonBody = { reason: EligibilityReasonsT }
 export default class EligibilityReason implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = 'How is the person eligible for Temporary Accommodation (TA)?'
+
   constructor(
     readonly body: Partial<EligibilityReasonBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -15,6 +15,8 @@ type ReleaseDateBody = ObjectWithDateParts<'releaseDate'>
 export default class ReleaseDate implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = "What is the person's release date?"
+
   constructor(
     private _body: Partial<ReleaseDateBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.ts
@@ -13,6 +13,8 @@ export type OffendingSummaryBody = {
 export default class OffendingSummary implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = "Provide a brief summary of the person's offending history"
+
   constructor(
     readonly body: Partial<OffendingSummaryBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -26,6 +26,8 @@ type ReleaseTypeBody = {
 export default class ReleaseType implements TasklistPage {
   title = 'What is the release type?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     private _body: Partial<ReleaseTypeBody>,
     readonly application: Application,

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceExpiry.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceExpiry.ts
@@ -9,14 +9,14 @@ type SentenceExpiryBody = ObjectWithDateParts<'sentenceExpiryDate'>
 
 @Page({ name: 'sentence-expiry', bodyProperties: dateBodyProperties('sentenceExpiryDate') })
 export default class SentenceExpiry implements TasklistPage {
-  title: string
+  title = 'Sentence expiry date'
+
+  htmlDocumentTitle = this.title
 
   constructor(
     private _body: Partial<SentenceExpiryBody>,
     readonly application: Application,
-  ) {
-    this.title = 'Sentence expiry date'
-  }
+  ) {}
 
   public set body(value: Partial<SentenceExpiryBody>) {
     this._body = {

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceLength.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceLength.ts
@@ -24,14 +24,14 @@ const sentenceLengthComponentResponse = (value: string, singularLabel: string, p
 
 @Page({ name: 'sentence-length', bodyProperties: ['years', 'months', 'weeks', 'days'] })
 export default class SentenceLength implements TasklistPage {
-  title: string
+  title = 'What is the sentence length?'
+
+  htmlDocumentTitle = this.title
 
   constructor(
     readonly body: Partial<SentenceLengthBody>,
     readonly application: Application,
-  ) {
-    this.title = 'What is the sentence length?'
-  }
+  ) {}
 
   response() {
     const years = sentenceLengthComponentResponse(this.body.years, 'year', 'years')

--- a/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/sentenceType.ts
@@ -18,6 +18,8 @@ export type SentenceTypesT = keyof typeof sentenceTypes
 export default class SentenceType implements TasklistPage {
   title = 'Which of the following best describes the sentence type?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: { sentenceType?: SentenceTypesT },
     readonly application: Application,

--- a/server/form-pages/apply/assess-placement-risks-and-needs/approvals-for-specific-risks/approvalsForSpecificRisks.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/approvals-for-specific-risks/approvalsForSpecificRisks.ts
@@ -27,6 +27,8 @@ type ApprovalsForSpecificRisksBody = {
 export default class ApprovalsForSpecificRisks implements TasklistPage {
   title = 'Approvals for specific risks'
 
+  htmlDocumentTitle = this.title
+
   questions = {
     approvals: 'Have your received approval for this referral?',
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
@@ -10,7 +10,9 @@ type PreviousStaysBody = { previousStays: YesNoOrIDK }
 
 @Page({ name: 'previous-stays', bodyProperties: ['previousStays'] })
 export default class PreviousStays implements TasklistPage {
-  title: string
+  title = 'Behaviour in previous accommodation'
+
+  htmlDocumentTitle = this.title
 
   questions: {
     previousStays: string
@@ -21,8 +23,6 @@ export default class PreviousStays implements TasklistPage {
     readonly application: Application,
   ) {
     const name = personName(application.person)
-
-    this.title = 'Behaviour in previous accommodation'
 
     this.questions = {
       previousStays: `Has ${name} previously stayed in Community Accommodation Services (CAS)?`,

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStaysDetails.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStaysDetails.ts
@@ -31,6 +31,8 @@ type PreviousStaysDetailsBody = {
 export default class PreviousStaysDetails implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = 'What type of accommodation did the person stay at?'
+
   constructor(
     readonly body: Partial<PreviousStaysDetailsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/assess-placement-risks-and-needs/licence-conditions/additionalLicenceConditions.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/licence-conditions/additionalLicenceConditions.ts
@@ -76,6 +76,8 @@ type AdditionalLicenceConditionsBody = {
 export default class AdditionalLicenceConditions implements TasklistPage {
   title = 'Additional licence conditions'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<AdditionalLicenceConditionsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.ts
@@ -19,6 +19,8 @@ type AccommodationSharingBody = {
 export default class AccommodationSharing implements TasklistPage {
   title = 'Accommodation sharing'
 
+  htmlDocumentTitle = this.title
+
   questions: {
     accommodationSharing: string
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/antiSocialBehaviour.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/antiSocialBehaviour.ts
@@ -12,6 +12,8 @@ type AntiSocialBehaviourBody = YesOrNoWithDetail<'concerns'>
 export default class AntiSocialBehaviour implements TasklistPage {
   title = 'Anti-social behaviour'
 
+  htmlDocumentTitle = this.title
+
   questions = {
     concerns: 'Are there any concerns or risks relating to anti-social behaviour?',
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.ts
@@ -17,6 +17,8 @@ type CooperationBody = {
 export default class Cooperation implements TasklistPage {
   title = 'Cooperation'
 
+  htmlDocumentTitle = this.title
+
   questions: {
     support: string
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/riskManagementPlan.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/riskManagementPlan.ts
@@ -25,6 +25,8 @@ export default class RiskManagementPlan implements OasysPage {
 
   title = 'Risk management plan'
 
+  htmlDocumentTitle = this.title
+
   risks: PersonRisksUI
 
   oasysSuccess: boolean

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
@@ -19,6 +19,8 @@ type RoshLevelBody = {
 export default class RoshLevel implements TasklistPage {
   title = 'RoSH level'
 
+  htmlDocumentTitle = this.title
+
   risks: PersonRisksUI
 
   constructor(

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.ts
@@ -13,6 +13,8 @@ type SubstanceMisuseBody = YesOrNoWithDetail<'substanceMisuse'>
 export default class SubstanceMisuse implements TasklistPage {
   title = 'Substance misuse'
 
+  htmlDocumentTitle = this.title
+
   questions: {
     substanceMisuse: string
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
@@ -26,6 +26,8 @@ export const acctAlertResponse = (acctAlert: PersonAcctAlert) => {
 export default class AcctAlerts implements TasklistPage {
   title = 'ACCT'
 
+  htmlDocumentTitle = this.title
+
   importDate: string
 
   constructor(

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.ts
@@ -28,6 +28,8 @@ export const adjudicationResponse = (adjudication: Adjudication) => {
 export default class Adjudications implements TasklistPage {
   title = 'Adjudications'
 
+  htmlDocumentTitle = this.title
+
   importDate: string
 
   constructor(

--- a/server/form-pages/apply/check-your-answers/review.ts
+++ b/server/form-pages/apply/check-your-answers/review.ts
@@ -10,6 +10,8 @@ export default class Review implements TasklistPage {
 
   title = 'Check your answers'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     public body: { reviewed?: string },
     readonly application: TemporaryAccommodationApplication,

--- a/server/form-pages/apply/contactDetails.test.ts
+++ b/server/form-pages/apply/contactDetails.test.ts
@@ -7,6 +7,8 @@ import ContactDetails from './contactDetails'
 class ConcreteContactDetails extends ContactDetails implements TasklistPage {
   title = 'A title'
 
+  htmlDocumentTitle = this.title
+
   previousPageId = 'previous-page-id'
 
   nextPageId = 'next-page-id'

--- a/server/form-pages/apply/contactDetails.ts
+++ b/server/form-pages/apply/contactDetails.ts
@@ -5,6 +5,8 @@ type ContactDetailsBody = { name: string; phone: string; email: string }
 export default abstract class ContactDetails {
   abstract title: string
 
+  abstract htmlDocumentTitle: string
+
   abstract previousPageId: string
 
   abstract nextPageId: string

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/crsSubmitted.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/crsSubmitted.ts
@@ -14,6 +14,8 @@ type CrsSubmittedBody = {
 export default class CrsSubmitted implements TasklistPage {
   title = 'Has a referral to Commissioned Rehabilitative Services (CRS) been submitted?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<CrsSubmittedBody>,
     readonly application: Application,

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
@@ -14,6 +14,8 @@ type DtrDetailsBody = {
 export default class DtrDetails implements TasklistPage {
   title = 'Provide further details'
 
+  htmlDocumentTitle = this.title
+
   questions = {
     reference: 'DTR / NOP reference number',
     date: 'Date DTR / NOP was submitted',

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrSubmitted.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrSubmitted.ts
@@ -13,6 +13,8 @@ type DtrSubmittedBody = {
 export default class DtrSubmitted implements TasklistPage {
   title = 'Has the Duty to Refer (DTR) / National Offender Pathway (NOP) been submitted?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<DtrSubmittedBody>,
     readonly application: Application,

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/otherAccommodationOptions.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/otherAccommodationOptions.ts
@@ -11,6 +11,8 @@ type OtherAccommodationOptionsBody = YesOrNoWithDetail<'otherOptions'>
 export default class OtherAccommodationOptions implements TasklistPage {
   title = 'Have other accommodation options been considered?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<OtherAccommodationOptionsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/needs.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/needs.ts
@@ -64,6 +64,8 @@ type NeedsBody = {
 export default class Needs implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = 'Does the person have any of the following needs?'
+
   constructor(
     readonly body: Partial<NeedsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.ts
@@ -15,6 +15,8 @@ type PropertyAttributesOrAdaptationsBody = YesOrNoWithDetail<'propertyAttributes
 export default class PropertyAttributesOrAdaptations implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = 'Will the person require a property with specific attributes or adaptations?'
+
   constructor(
     readonly body: Partial<PropertyAttributesOrAdaptationsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.ts
@@ -15,6 +15,8 @@ type ReligiousOrCulturalNeedsBody = YesOrNoWithDetail<'religiousOrCulturalNeeds'
 export default class ReligiousOrCulturalNeeds implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = 'Does the person have any religious or cultural needs?'
+
   constructor(
     readonly body: Partial<ReligiousOrCulturalNeedsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
@@ -12,6 +12,8 @@ type FoodAllergiesBody = YesNoOrIDKWithDetail<'foodAllergies'>
 export default class FoodAllergies implements TasklistPage {
   title = 'Food allergies'
 
+  htmlDocumentTitle = this.title
+
   questions: {
     foodAllergies: string
   }

--- a/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.ts
+++ b/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.ts
@@ -9,6 +9,8 @@ type MoveOnPlanBody = { plan: string }
 export default class MoveOnPlan implements TasklistPage {
   title: string
 
+  htmlDocumentTitle = 'How will you prepare the person for move on after placement?'
+
   constructor(
     readonly body: Partial<MoveOnPlanBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/placement-location/alternativePdu.ts
+++ b/server/form-pages/apply/requirements-for-placement/placement-location/alternativePdu.ts
@@ -11,6 +11,8 @@ type AlternativePduBody = YesOrNoWithDetail<'alternativePdu'>
 export default class AlternativePdu implements TasklistPage {
   title = 'Is placement required in an alternative PDU?'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<AlternativePduBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.ts
@@ -12,6 +12,8 @@ type CaringResponsibilitiesBody = YesOrNoWithDetail<'caringResponsibilities'>
 export default class CaringResponsibilities implements TasklistPage {
   title = 'Caring responsibilities'
 
+  htmlDocumentTitle = this.title
+
   questions: {
     caringResponsibilities: string
   }

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/localConnections.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/localConnections.ts
@@ -12,6 +12,8 @@ type LocalConnectionsBody = {
 export default class LocalConnections implements TasklistPage {
   title = 'Local connections'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<LocalConnectionsBody>,
     readonly application: Application,

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/safeguardingAndVulnerability.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/safeguardingAndVulnerability.ts
@@ -11,6 +11,8 @@ type SafeguardingAndVulnerabilityBody = YesOrNoWithDetail<'concerns'>
 export default class SafeguardingAndVulnerability implements TasklistPage {
   title = 'Safeguarding and vulnerability'
 
+  htmlDocumentTitle = this.title
+
   questions = {
     concerns: 'Do you have any concerns about safeguarding and/or vulnerability?',
   }

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/supportInTheComunity.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/supportInTheComunity.ts
@@ -12,6 +12,8 @@ type SupportInTheCommunityBody = {
 export default class SupportInTheCommunity implements TasklistPage {
   title = 'Support in the community'
 
+  htmlDocumentTitle = this.title
+
   constructor(
     readonly body: Partial<SupportInTheCommunityBody>,
     readonly application: Application,

--- a/server/form-pages/tasklistPage.ts
+++ b/server/form-pages/tasklistPage.ts
@@ -21,6 +21,8 @@ export interface TasklistPageInterface {
 export default abstract class TasklistPage {
   abstract title: string
 
+  abstract htmlDocumentTitle: string
+
   abstract body: Record<string, unknown>
 
   abstract previous(): string

--- a/server/form-pages/utils/decorators/task.decorator.test.ts
+++ b/server/form-pages/utils/decorators/task.decorator.test.ts
@@ -5,6 +5,8 @@ import Task from './task.decorator'
 class PageBase implements TasklistPage {
   title: string
 
+  htmlDocumentTitle: string
+
   body: Record<string, unknown>
 
   previous() {

--- a/server/views/applications/confirm.njk
+++ b/server/views/applications/confirm.njk
@@ -4,7 +4,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Referral complete" %}
+{% set pageTitle = "Referral complete - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -6,7 +6,7 @@
 {% from "./_table.njk" import applicationsTable %}
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Temporary Accommodation (TA) referrals" %}
+{% set pageTitle = "Temporary Accommodation (TA) referrals - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -5,7 +5,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Enter the person's CRN"  %}
+{% set pageTitle = "Enter the person's CRN - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/applications/pages/check-your-answers/check-your-answers/review.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers/review.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + page.title %}
+{% set pageTitle = page.title + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent%}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -16,7 +16,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - " + page.title %}
+{% set pageTitle = page.title + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -16,7 +16,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = page.title + " - " + applicationName %}
+{% set pageTitle = page.htmlDocumentTitle + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = "Confirm " + personName(person) + "'s details - " + applicationName %}
+{% set pageTitle = "Confirm the person's details - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/applications/people/confirm.njk
+++ b/server/views/applications/people/confirm.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Confirm " + personName(person) + "'s details" %}
+{% set pageTitle = "Confirm " + personName(person) + "'s details - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -3,7 +3,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Select the index offence for " + personName(person) %}
+{% set pageTitle = "Select the index offence for " + personName(person) + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/applications/people/selectOffence.njk
+++ b/server/views/applications/people/selectOffence.njk
@@ -3,7 +3,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = "Select the index offence for " + personName(person) + " - " + applicationName %}
+{% set pageTitle = "Select the index offence for the person - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -8,7 +8,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Make a referral for Temporary Accommodation" %}
+{% set pageTitle = "Make a referral for Temporary Accommodation - " + applicationName %}
 
 {% block beforeContent %}
   {{ govukBackLink({

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -4,7 +4,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Make a referral for Temporary Accommodation" %}
+{% set pageTitle = "Make a referral for Temporary Accommodation - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -1,6 +1,6 @@
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Error" %}
+{% set pageTitle = "Error - " + applicationName %}
 
 {% block content %}
 

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -10,7 +10,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Mark booking as active" %}
+{% set pageTitle = "Mark booking as active - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/assessments/archive.njk
+++ b/server/views/temporary-accommodation/assessments/archive.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Archived referrals" %}
+{% set pageTitle = "Archived referrals - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/assessments/confirm.njk
+++ b/server/views/temporary-accommodation/assessments/confirm.njk
@@ -3,7 +3,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - confirmation" %}
+{% set pageTitle = "Confirmation - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/assessments/full.njk
+++ b/server/views/temporary-accommodation/assessments/full.njk
@@ -6,7 +6,7 @@
 {% extends "../../partials/layout.njk" %}
 
 {% set name = personName(assessment.application.person, 'Limited access offender') %}
-{% set pageTitle = applicationName + " - " + name + " referral" %}
+{% set pageTitle = name + " referral - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/assessments/full.njk
+++ b/server/views/temporary-accommodation/assessments/full.njk
@@ -5,8 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set name = personName(assessment.application.person, 'Limited access offender') %}
-{% set pageTitle = name + " referral - " + applicationName %}
+{% set pageTitle = "The person's referral - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -17,6 +16,7 @@
   {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
+{% set name = personName(assessment.application.person, 'Limited access offender') %}
 {% block content %}
   {% include "../../_messages.njk" %}
 

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Referrals" %}
+{% set pageTitle = "Referrals - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% set unallocatedTableHtml %}

--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -13,7 +13,7 @@
 {% extends "../../partials/layout.njk" %}
 
 {% set name = personName(assessment.application.person, 'Limited access offender') %}
-{% set pageTitle = applicationName + " - " + name + " referral summary" %}
+{% set pageTitle = name + " referral summary - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% set breadCrumbTitle = name + " - Summary" %}

--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -12,10 +12,10 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set name = personName(assessment.application.person, 'Limited access offender') %}
-{% set pageTitle = name + " referral summary - " + applicationName %}
+{% set pageTitle = "The person's referral summary - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
+{% set name = personName(assessment.application.person, 'Limited access offender') %}
 {% set breadCrumbTitle = name + " - Summary" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -11,7 +11,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Search for available bedspaces" %}
+{% set pageTitle = "Search for available bedspaces - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/bedspaces/edit.njk
@@ -4,7 +4,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Edit a bedspace" %}
+{% set pageTitle = "Edit a bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Add a bedspace" %}
+{% set pageTitle = "Add a bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -10,7 +10,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - View a bedspace" %}
+{% set pageTitle = "View a bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set bodyClasses = "temporary-accommodation-bedspaces-show" %}
 

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -3,7 +3,7 @@
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
-{% set pageTitle = applicationName + " - View bookings" %}
+{% set pageTitle = "View bookings - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -8,7 +8,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Book bedspace" %}
+{% set pageTitle = "Book bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Booking history" %}
+{% set pageTitle = "Booking history - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Book bedspace" %}
+{% set pageTitle = "Book bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bookings/selectAssessment.njk
+++ b/server/views/temporary-accommodation/bookings/selectAssessment.njk
@@ -8,7 +8,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Book bedspace" %}
+{% set pageTitle = "Book bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -9,7 +9,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - View a booking" %}
+{% set pageTitle = "View a booking - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set bodyClasses = "temporary-accommodation-bookings-show" %}
 

--- a/server/views/temporary-accommodation/cancellations/edit.njk
+++ b/server/views/temporary-accommodation/cancellations/edit.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Update cancelled booking" %}
+{% set pageTitle = "Update cancelled booking - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Cancel booking" %}
+{% set pageTitle = "Cancel booking - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Mark booking as confirmed" %}
+{% set pageTitle = "Mark booking as confirmed - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -1,6 +1,6 @@
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Manage estate" %}
+{% set pageTitle = "Manage estate - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set bodyClasses = "temporary-accommodation-dashboard-index" %}
 

--- a/server/views/temporary-accommodation/departures/edit.njk
+++ b/server/views/temporary-accommodation/departures/edit.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Update departure details" %}
+{% set pageTitle = "Update departure details - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -6,7 +6,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Mark booking as departed" %}
+{% set pageTitle = "Mark booking as departed - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -9,7 +9,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Extend or shorten booking" %}
+{% set pageTitle = "Extend or shorten booking - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/lost-beds/cancel.njk
+++ b/server/views/temporary-accommodation/lost-beds/cancel.njk
@@ -8,7 +8,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Cancel void booking" %}
+{% set pageTitle = "Cancel void booking - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/lost-beds/edit.njk
+++ b/server/views/temporary-accommodation/lost-beds/edit.njk
@@ -3,7 +3,7 @@
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
 
-{% set pageTitle = applicationName + " - Void bedspace" %}
+{% set pageTitle = "Void bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/lost-beds/new.njk
+++ b/server/views/temporary-accommodation/lost-beds/new.njk
@@ -3,7 +3,7 @@
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../components/location-header/macro.njk" import locationHeader %}
 
-{% set pageTitle = applicationName + " - Void bedspace" %}
+{% set pageTitle = "Void bedspace - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/lost-beds/show.njk
+++ b/server/views/temporary-accommodation/lost-beds/show.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Void booking" %}
+{% set pageTitle = "Void booking - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/premises/edit.njk
+++ b/server/views/temporary-accommodation/premises/edit.njk
@@ -5,7 +5,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Add a property" %}
+{% set pageTitle = "Add a property - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/premises/index.njk
+++ b/server/views/temporary-accommodation/premises/index.njk
@@ -6,7 +6,7 @@
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
-{% set pageTitle = applicationName + " - List of properties" %}
+{% set pageTitle = "List of properties - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -3,7 +3,7 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
-{% set pageTitle = applicationName + " - Add a property" %}
+{% set pageTitle = "Add a property - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - View a property" %}
+{% set pageTitle = "View a property - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 {% set bodyClasses = "temporary-accommodation-premises-show" %}
 

--- a/server/views/temporary-accommodation/reports/new.njk
+++ b/server/views/temporary-accommodation/reports/new.njk
@@ -4,7 +4,7 @@
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../components/ta-select/macro.njk" import taSelect %}
 
-{% set pageTitle = applicationName + " - Reports" %}
+{% set pageTitle = "Reports - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}

--- a/server/views/temporary-accommodation/static/cookies.njk
+++ b/server/views/temporary-accommodation/static/cookies.njk
@@ -1,6 +1,6 @@
 {% extends "partials/layout.njk" %}
 
-{% set pageTitle = "Cookies" %}
+{% set pageTitle = "Cookies - " + applicationName %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/temporary-accommodation/static/notAuthorised.njk
+++ b/server/views/temporary-accommodation/static/notAuthorised.njk
@@ -1,6 +1,6 @@
 {% extends "partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Not Authorised" %}
+{% set pageTitle = "Not Authorised - " + applicationName %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/temporary-accommodation/static/useNDelius.njk
+++ b/server/views/temporary-accommodation/static/useNDelius.njk
@@ -1,6 +1,6 @@
 {% extends "partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Referrals should be submitted through nDelius" %}
+{% set pageTitle = "Referrals should be submitted through nDelius - " + applicationName %}
 
 {% block content %}
   <div class="govuk-grid-row">

--- a/server/views/temporary-accommodation/turnarounds/new.njk
+++ b/server/views/temporary-accommodation/turnarounds/new.njk
@@ -8,7 +8,7 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = applicationName + " - Change turnaround time" %}
+{% set pageTitle = "Change turnaround time - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}


### PR DESCRIPTION
# Context
We currently use a form page's title field to populate the document
title <title> element.

In order to protect PII leaking through Google Analytics (and
potentially other platforms) we need to remove the person's name from
this element. We still want to preserve the name in the page heading as
it provides a better user experience.

This PR follows the approach of [CAS2](https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-ui/pull/202) to introduce a required `htmlDocumentTitle` property,
decoupling the `h1` title with the document title.

We also update the formatting for the page titles to be more accessible.

## Screenshots of UI changes

### Before
![Screenshot 2023-09-13 at 15 37 19](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/60a1d9e3-b67c-45ea-b9a9-4998f147d8d7)

### After
![Screenshot 2023-09-13 at 15 36 41](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/63e5ae61-d527-4fe3-b4b4-279727669548)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
