### PR TITLE
Dedupe form questions

### DIFF
--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -42,7 +42,7 @@
           "id": "eligibility",
           "content": [
             {
-              "How is this person eligible for Temporary Accommodation (TA)?": "Moving on as homeless from an Approved Premises"
+              "How is the person eligible for Temporary Accommodation (TA)?": "Moving on as homeless from an Approved Premises"
             },
             { "Release date": "2 September 2123" },
             { "Accommodation required from date": "16 September 2123" }
@@ -141,13 +141,13 @@
           "title": "Placement considerations",
           "id": "placement-considerations",
           "content": [
-            { "Is this person suitable to share accommodation with others?": "Yes - Some detail" },
-            { "How you will support this person's placement?": "Support detail" },
+            { "Is the person suitable to share accommodation with others?": "Yes - Some detail" },
+            { "How you will support the person's placement?": "Support detail" },
             {
               "Are there any concerns or risks relating to anti-social behaviour?": "Yes - Anti-social behaviour concerns detail"
             },
             {
-              "Does this person have any current or previous issues with drug or alcohol misuse?": "Yes - Details of drug and alcohol misuse"
+              "Does the person have any current or previous issues with drug or alcohol misuse?": "Yes - Details of drug and alcohol misuse"
             },
             {
               "How will risk to children impact placement?": "Risk to children detail",
@@ -167,7 +167,7 @@
           "title": "Behaviour in CAS",
           "id": "behaviour-in-cas",
           "content": [
-            { "Has this person previously stayed in Community Accommodation Services (CAS)?": "Yes" },
+            { "Has the person previously stayed in Community Accommodation Services (CAS)?": "Yes" },
             {
               "Approved Premises (AP or CAS1)": "Approved Premises detail",
               "Temporary Accommodation (CAS3)": "Temporary Accommodation detail"
@@ -194,9 +194,9 @@
               "Other": "Other needs detail"
             },
             {
-              "Will this person require a property with specific attributes or adaptations?": "Yes - Adaptation requirements detail"
+              "Will the person require a property with specific attributes or adaptations?": "Yes - Adaptation requirements detail"
             },
-            { "Does this person have any religious or cultural needs?": "Yes - Religious needs detail" }
+            { "Does the person have any religious or cultural needs?": "Yes - Religious needs detail" }
           ]
         },
         {
@@ -206,20 +206,20 @@
             { "Do you have any concerns about safeguarding and/or vulnerability?": "Yes - Concerns A, B, and C" },
             { "Details of support in the community": "Community support details" },
             { "Details of local connections": "Local connection details" },
-            { "Does this person have any caring responsibilities?": "Yes - Caring responsibilities X, Y, and Z" }
+            { "Does the person have any caring responsibilities?": "Yes - Caring responsibilities X, Y, and Z" }
           ]
         },
         {
           "title": "Food allergies",
           "id": "food-allergies",
           "content": [
-            { "Does this person have any food allergies or dietary requirements?": "Yes - Allergic to X, Y, Z" }
+            { "Does the person have any food allergies or dietary requirements?": "Yes - Allergic to X, Y, Z" }
           ]
         },
         {
           "title": "Move on plan",
           "id": "move-on-plan",
-          "content": [{ "How will you prepare this person for move on after placement?": "A move on plan" }]
+          "content": [{ "How will you prepare the person for move on after placement?": "A move on plan" }]
         }
       ]
     },

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.test.ts
@@ -54,7 +54,7 @@ describe('EligibilityReason', () => {
       const page = new EligibilityReason(body, application)
 
       expect(page.response()).toEqual({
-        'How is this person eligible for Temporary Accommodation (TA)?':
+        'How is the person eligible for Temporary Accommodation (TA)?':
           'Moving on as homeless from an Approved Premises',
       })
     })

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
@@ -4,6 +4,7 @@ import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
 import { personName } from '../../../../utils/personUtils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 export const eligibilityReasons = {
   homelessFromCustody: 'Moving on as homeless from custody',
@@ -30,7 +31,7 @@ export default class EligibilityReason implements TasklistPage {
   }
 
   response() {
-    return { 'How is this person eligible for Temporary Accommodation (TA)?': eligibilityReasons[this.body.reason] }
+    return { [anonymiseFormContent(this.title, this.application.person)]: eligibilityReasons[this.body.reason] }
   }
 
   previous() {

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.test.ts
@@ -63,7 +63,7 @@ describe('PreviousStays', () => {
       const page = new PreviousStays(body, application)
 
       expect(page.response()).toEqual({
-        'Has this person previously stayed in Community Accommodation Services (CAS)?':
+        'Has the person previously stayed in Community Accommodation Services (CAS)?':
           "Yes, no, or don't know response",
       })
       expect(yesNoOrDontKnowResponse).toHaveBeenCalledWith('previousStays', body)

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
@@ -5,6 +5,7 @@ import { TemporaryAccommodationApplication as Application } from '../../../../@t
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { yesNoOrDontKnowResponse } from '../../../utils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type PreviousStaysBody = { previousStays: YesNoOrIDK }
 
@@ -31,7 +32,7 @@ export default class PreviousStays implements TasklistPage {
 
   response() {
     return {
-      'Has this person previously stayed in Community Accommodation Services (CAS)?': yesNoOrDontKnowResponse(
+      [anonymiseFormContent(this.questions.previousStays, this.application.person)]: yesNoOrDontKnowResponse(
         'previousStays',
         this.body,
       ),

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.test.ts
@@ -71,7 +71,7 @@ describe('AccommodationSharing', () => {
       )
       expect(page.errors()).toEqual({
         accommodationSharingNoDetail:
-          'You must provide details of why this person is unsuitable to share accommodation with others',
+          'You must provide details of why the person is unsuitable to share accommodation with others',
       })
     })
   })
@@ -80,7 +80,7 @@ describe('AccommodationSharing', () => {
     it('returns a translated version of the response when the answer is yes', () => {
       const page = new AccommodationSharing(body, application)
       expect(page.response()).toEqual({
-        'Is this person suitable to share accommodation with others?': 'Yes - Yes detail',
+        'Is the person suitable to share accommodation with others?': 'Yes - Yes detail',
       })
     })
 
@@ -90,7 +90,7 @@ describe('AccommodationSharing', () => {
         application,
       )
       expect(page.response()).toEqual({
-        'Is this person suitable to share accommodation with others?': 'No - No detail',
+        'Is the person suitable to share accommodation with others?': 'No - No detail',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/accommodationSharing.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import { personName } from '../../../../utils/personUtils'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
 import TasklistPage from '../../../tasklistPage'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type AccommodationSharingBody = {
   accommodationSharing: string
@@ -39,15 +40,19 @@ export default class AccommodationSharing implements TasklistPage {
   }
 
   response() {
-    const accommodationSharingQuestion = 'Is this person suitable to share accommodation with others?'
-
     if (this.body.accommodationSharing === 'yes') {
       return {
-        [accommodationSharingQuestion]: `Yes - ${this.body.accommodationSharingYesDetail}`,
+        [anonymiseFormContent(
+          this.questions.accommodationSharing,
+          this.application.person,
+        )]: `Yes - ${this.body.accommodationSharingYesDetail}`,
       }
     }
     return {
-      [accommodationSharingQuestion]: `No - ${this.body.accommodationSharingNoDetail}`,
+      [anonymiseFormContent(
+        this.questions.accommodationSharing,
+        this.application.person,
+      )]: `No - ${this.body.accommodationSharingNoDetail}`,
     }
   }
 
@@ -75,7 +80,7 @@ export default class AccommodationSharing implements TasklistPage {
 
     if (this.body.accommodationSharing === 'no' && !this.body.accommodationSharingNoDetail) {
       errors.accommodationSharingNoDetail =
-        'You must provide details of why this person is unsuitable to share accommodation with others'
+        'You must provide details of why the person is unsuitable to share accommodation with others'
     }
 
     return errors

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.test.ts
@@ -50,7 +50,7 @@ describe('Cooperation', () => {
     it('returns a translated version of the response', () => {
       const page = new Cooperation(body, application)
       expect(page.response()).toEqual({
-        "How will you support this person's placement considering any risks to the support worker?": 'Support detail',
+        "How will you support the person's placement considering any risks to the support worker?": 'Support detail',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/cooperation.ts
@@ -40,7 +40,7 @@ export default class Cooperation implements TasklistPage {
 
   response() {
     return {
-      [`How will you support this person's placement considering any risks to the support worker?`]: this.body.support,
+      [`How will you support the person's placement considering any risks to the support worker?`]: this.body.support,
     }
   }
 

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.test.ts
@@ -68,7 +68,7 @@ describe('SubstanceMisuse', () => {
 
       const page = new SubstanceMisuse(body, application)
       expect(page.response()).toEqual({
-        'Does this person have any current or previous issues with drug or alcohol misuse?':
+        'Does the person have any current or previous issues with drug or alcohol misuse?':
           'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('substanceMisuse', body)

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/substanceMisuse.ts
@@ -6,6 +6,7 @@ import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { yesOrNoResponseWithDetail } from '../../../utils'
 import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type SubstanceMisuseBody = YesOrNoWithDetail<'substanceMisuse'>
 
@@ -36,7 +37,7 @@ export default class SubstanceMisuse implements TasklistPage {
 
   response() {
     return {
-      'Does this person have any current or previous issues with drug or alcohol misuse?': yesOrNoResponseWithDetail(
+      [anonymiseFormContent(this.questions.substanceMisuse, this.application.person)]: yesOrNoResponseWithDetail(
         'substanceMisuse',
         this.body,
       ),

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.test.ts
@@ -102,7 +102,7 @@ describe('AcctAlerts', () => {
       const page = new AcctAlerts({ acctAlerts: [] }, application)
 
       expect(page.response()).toEqual({
-        'ACCT Alerts': 'No ACCT information available for this person at the time of referral',
+        'ACCT Alerts': 'No ACCT information available for the person at the time of referral',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/acctAlerts.ts
@@ -62,7 +62,7 @@ export default class AcctAlerts implements TasklistPage {
 
     response['ACCT Alerts'] = this.body.acctAlerts.length
       ? this.body.acctAlerts.map(acctAlertResponse)
-      : `No ACCT information available for this person at the time of referral`
+      : `No ACCT information available for the person at the time of referral`
 
     return response
   }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.test.ts
@@ -90,7 +90,7 @@ describe('Adjudications', () => {
       const page = new Adjudications({ adjudications: [] }, application)
 
       expect(page.response()).toEqual({
-        Adjudications: 'No adjudication information available for this person at the time of referral',
+        Adjudications: 'No adjudication information available for the person at the time of referral',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/prison-information/adjudications.ts
@@ -65,7 +65,7 @@ export default class Adjudications implements TasklistPage {
 
     response.Adjudications = this.body.adjudications.length
       ? this.body.adjudications.map(adjudicationResponse)
-      : `No adjudication information available for this person at the time of referral`
+      : `No adjudication information available for the person at the time of referral`
 
     return response
   }

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.test.ts
@@ -64,7 +64,7 @@ describe('PropertyAttributesOrAdaptations', () => {
 
       const page = new PropertyAttributesOrAdaptations(body, application)
       expect(page.response()).toEqual({
-        'Will this person require a property with specific attributes or adaptations?': 'Response with optional detail',
+        'Will the person require a property with specific attributes or adaptations?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('propertyAttributesOrAdaptations', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/propertyAttributesOrAdaptations.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { yesOrNoResponseWithDetail } from '../../../utils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type PropertyAttributesOrAdaptationsBody = YesOrNoWithDetail<'propertyAttributesOrAdaptations'>
 
@@ -26,7 +27,7 @@ export default class PropertyAttributesOrAdaptations implements TasklistPage {
 
   response() {
     return {
-      'Will this person require a property with specific attributes or adaptations?': yesOrNoResponseWithDetail(
+      [anonymiseFormContent(this.title, this.application.person)]: yesOrNoResponseWithDetail(
         'propertyAttributesOrAdaptations',
         this.body,
       ),

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.test.ts
@@ -57,7 +57,7 @@ describe('ReligiousOrCulturalNeeds', () => {
 
       const page = new ReligiousOrCulturalNeeds(body, application)
       expect(page.response()).toEqual({
-        'Does this person have any religious or cultural needs?': 'Response with optional detail',
+        'Does the person have any religious or cultural needs?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('religiousOrCulturalNeeds', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.ts
+++ b/server/form-pages/apply/requirements-for-placement/disability-cultural-and-specific-needs/religiousOrCulturalNeeds.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { yesOrNoResponseWithDetail } from '../../../utils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type ReligiousOrCulturalNeedsBody = YesOrNoWithDetail<'religiousOrCulturalNeeds'>
 
@@ -26,7 +27,7 @@ export default class ReligiousOrCulturalNeeds implements TasklistPage {
 
   response() {
     return {
-      'Does this person have any religious or cultural needs?': yesOrNoResponseWithDetail(
+      [anonymiseFormContent(this.title, this.application.person)]: yesOrNoResponseWithDetail(
         'religiousOrCulturalNeeds',
         this.body,
       ),

--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.test.ts
@@ -62,7 +62,7 @@ describe('FoodAllergies', () => {
 
       const page = new FoodAllergies(body, application)
       expect(page.response()).toEqual({
-        'Does this person have any food allergies or dietary requirements?': 'Response with optional detail',
+        'Does the person have any food allergies or dietary requirements?': 'Response with optional detail',
       })
       expect(yesNoOrDontKnowResponseWithDetail).toHaveBeenCalledWith('foodAllergies', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
+++ b/server/form-pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { yesNoOrDontKnowResponseWithDetail } from '../../../utils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type FoodAllergiesBody = YesNoOrIDKWithDetail<'foodAllergies'>
 
@@ -29,7 +30,7 @@ export default class FoodAllergies implements TasklistPage {
 
   response() {
     return {
-      'Does this person have any food allergies or dietary requirements?': yesNoOrDontKnowResponseWithDetail(
+      [anonymiseFormContent(this.questions.foodAllergies, this.application.person)]: yesNoOrDontKnowResponseWithDetail(
         'foodAllergies',
         this.body,
       ),

--- a/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.test.ts
@@ -47,7 +47,7 @@ describe('MoveOnPlan', () => {
       const page = new MoveOnPlan(body, application)
 
       expect(page.response()).toEqual({
-        'How will you prepare this person for move on after placement?': 'A plan',
+        'How will you prepare the person for move on after placement?': 'A plan',
       })
     })
   })

--- a/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.ts
+++ b/server/form-pages/apply/requirements-for-placement/move-on-plan/moveOnPlan.ts
@@ -3,6 +3,7 @@ import type { TaskListErrors } from '@approved-premises/ui'
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { Page } from '../../../utils/decorators'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type MoveOnPlanBody = { plan: string }
 @Page({ name: 'move-on-plan', bodyProperties: ['plan'] })
@@ -22,7 +23,7 @@ export default class MoveOnPlan implements TasklistPage {
 
   response() {
     return {
-      'How will you prepare this person for move on after placement?': this.body.plan,
+      [anonymiseFormContent(this.title, this.application.person)]: this.body.plan,
     }
   }
 

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.test.ts
@@ -57,7 +57,7 @@ describe('CaringResponsibilities', () => {
 
       const page = new CaringResponsibilities(body, application)
       expect(page.response()).toEqual({
-        'Does this person have any caring responsibilities?': 'Response with optional detail',
+        'Does the person have any caring responsibilities?': 'Response with optional detail',
       })
       expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('caringResponsibilities', body)
     })

--- a/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.ts
+++ b/server/form-pages/apply/requirements-for-placement/safeguarding-and-support/caringResponsibilities.ts
@@ -5,6 +5,7 @@ import { Page } from '../../../utils/decorators'
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
 import { yesOrNoResponseWithDetail } from '../../../utils'
+import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 type CaringResponsibilitiesBody = YesOrNoWithDetail<'caringResponsibilities'>
 
@@ -29,7 +30,7 @@ export default class CaringResponsibilities implements TasklistPage {
 
   response() {
     return {
-      'Does this person have any caring responsibilities?': yesOrNoResponseWithDetail(
+      [anonymiseFormContent(this.questions.caringResponsibilities, this.application.person)]: yesOrNoResponseWithDetail(
         'caringResponsibilities',
         this.body,
       ),

--- a/server/form-pages/utils/anonymiseFormContent.test.ts
+++ b/server/form-pages/utils/anonymiseFormContent.test.ts
@@ -1,0 +1,25 @@
+import { personFactory, restrictedPersonFactory } from '../../testutils/factories'
+import anonymiseFormContent from './anonymiseFormContent'
+
+describe('anonymiseFormContent', () => {
+  it("replaces a person's name with 'the person'", () => {
+    const person = personFactory.build()
+
+    expect(anonymiseFormContent(`Please provide information on ${person.name}`, person)).toEqual(
+      'Please provide information on the person',
+    )
+    expect(anonymiseFormContent(`Please provide ${person.name}'s history`, person)).toEqual(
+      "Please provide the person's history",
+    )
+  })
+
+  describe('when the person is an LAO', () => {
+    it('returns the text unchanged', () => {
+      const person = restrictedPersonFactory.build()
+
+      expect(anonymiseFormContent(`Please provide the person's history`, person)).toEqual(
+        "Please provide the person's history",
+      )
+    })
+  })
+})

--- a/server/form-pages/utils/anonymiseFormContent.ts
+++ b/server/form-pages/utils/anonymiseFormContent.ts
@@ -1,0 +1,10 @@
+import { isFullPerson, personNameFallback } from '../../utils/personUtils'
+import { Person } from '../../@types/shared'
+
+export default function anonymiseFormContent(content: string, person: Person): string {
+  if (isFullPerson(person)) {
+    return content.replace(new RegExp(person.name, 'g'), personNameFallback)
+  }
+
+  return content
+}

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -26,7 +26,9 @@ const isApplicableTier = (sex: string, tier: string): boolean => {
   return applicableTiers.includes(tier)
 }
 
-const personName = (person: Person, fallback: string = 'the person') => {
+const personNameFallback = 'the person'
+
+const personName = (person: Person, fallback: string = personNameFallback) => {
   if (isFullPerson(person)) {
     return person.name
   }
@@ -37,4 +39,4 @@ const isFullPerson = (person: Person): person is FullPerson => {
   return person.type === 'FullPerson'
 }
 
-export { isApplicableTier, isFullPerson, personName, statusTag, tierBadge }
+export { isApplicableTier, isFullPerson, personName, personNameFallback, statusTag, tierBadge }


### PR DESCRIPTION
# Context
In a previous change[1] we made a change to how we save some of the form
responses by rewriting the questions that contained a person's name to
not include it. This was to ensure we weren't saving person names in the
translated document.

However, this means we have the question copy twice; one we render to
the user and one we save as part of the translated document. To avoid
confusion in the future, we will use a function to transform the
original question instead of duplicating it.

[1]
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/546

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
