### PR TITLE
Ensure premise is active in e2e edit premises test

### DIFF
--- a/e2e/tests/stepDefinitions/manage/premises.ts
+++ b/e2e/tests/stepDefinitions/manage/premises.ts
@@ -131,6 +131,7 @@ Given('I edit the premises details', () => {
     cy.then(function _() {
       const updatedPremises = premisesFactory
         .forEnvironment(actingUserProbationRegion, this.pdus, this.localAuthorities, this.characteristics)
+        .active()
         .build({
           id: premises.id,
           name: premises.name,


### PR DESCRIPTION
# Context
In an earlier commit[1] we changed the success message when updating a property so that if the property was archived, it would specify that in the message.

This change ensures that we always edit an active premises in the e2e test so we can assert the correct success message.

[1]
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/fd430c40eb09ee199c93cf6dd5873c84fb7489d4

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
