### PR TITLE
Revert "Update npm version for e2e tests"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,7 +46,7 @@ jobs:
   e2e_environment_test:
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     docker:
-      - image: cypress/browsers:node-18.16.1-chrome-114.0.5735.133-1-ff-114.0.2-edge-114.0.1823.51-1
+      - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge
     parameters:
       environment:
         type: string
@@ -58,7 +58,7 @@ jobs:
           command: apt-get install xz-utils
       - run:
           name: Update npm
-          command: 'npm install -g npm@latest'
+          command: 'npm install -g npm@9.8.1'
       - node/install-packages
       - run:
           name: E2E Check - << parameters.environment >>


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-temporary-accommodation-ui#626

Our e2e tests are failing on CI with the following error due to this change. Looks to be an issue with installing Edge. More testing will be needed to make this change, so reverting for now.

```sh
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Package xz-utils is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source

W: Target Packages (main/binary-amd64/Packages) is configured multiple times in /etc/apt/sources.list.d/microsoft-edge-stable.list:1 and /etc/apt/sources.list.d/microsoft-edge.list:3
W: Target Packages (main/binary-all/Packages) is configured multiple times in /etc/apt/sources.list.d/microsoft-edge-stable.list:1 and /etc/apt/sources.list.d/microsoft-edge.list:3
E: Package 'xz-utils' has no installation candidate

Exited with code exit status 100
```