### PR TITLE
Show guidance when CRN is missing NOMS number

### DIFF
--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -58,19 +58,28 @@ export default class ApplicationsController {
       if (crnArr.length) {
         const crn = crnArr[0]
         const person = await this.personService.findByCrn(callConfig, crn)
-        const offences = await this.personService.getOffences(callConfig, crn)
 
-        const offenceId = offences.length === 1 ? offences[0].offenceId : null
+        try {
+          const offences = await this.personService.getOffences(callConfig, crn)
 
-        return res.render(`applications/people/confirm`, {
-          person,
-          date: DateFormats.dateObjtoUIDate(new Date()),
-          crn,
-          offenceId,
-          errors,
-          errorSummary,
-          ...userInput,
-        })
+          const offenceId = offences.length === 1 ? offences[0].offenceId : null
+
+          return res.render(`applications/people/confirm`, {
+            person,
+            date: DateFormats.dateObjtoUIDate(new Date()),
+            crn,
+            offenceId,
+            errors,
+            errorSummary,
+            ...userInput,
+          })
+        } catch (e) {
+          if (e?.data?.status === 404) {
+            return res.render('applications/people/missingNoms')
+          }
+
+          throw e
+        }
       }
 
       return res.render('applications/new', {

--- a/server/views/applications/people/missingNoms.njk
+++ b/server/views/applications/people/missingNoms.njk
@@ -1,0 +1,30 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "NOMS number missing from NDelius - " + applicationName %}
+
+{% block beforeContent %}
+
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.applications.start()
+  }) }}
+
+{% endblock%}
+
+{% block content %}
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <h1 class="govuk-heading-l">NOMS number missing from NDelius</h1>
+      <p class="govuk-body">The person’s NOMS number is not on NDelius. We are unable to import the person’s index offence or adjudications and ACCT information from NOMIS.</p>
+      <p class="govuk-body">Check the person’s NOMS number on NOMIS and add it to their NDelius record.</p>
+      <p class="govuk-body">Once their NOMS number has been added you will need to start a new referral.</p>
+        <p>
+          <a class="govuk-link" href="{{ paths.applications.index() }}">Return to home page</a>
+        </p>
+    </div>
+  </div>
+
+{% endblock %}


### PR DESCRIPTION
# Context
Previously, if we received a 404 when fetching the offences for a PoP
we'd render the generic error page.

We've identified this scenario to be caused by a missing NOMS number
for the CRN, so we want to show guidance to the user on how to correct it.

## Screenshots of UI changes

### Before
![Screenshot 2023-09-20 at 10 14 12](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/cf2ae65d-2e87-4a24-b5d7-d6bb5eb3f721)

### After
![Screenshot 2023-09-20 at 11 54 42](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/f4e7c35f-c3ab-485b-bc6b-bcdf6954da47)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
