### PR TITLE
Add accommodation sharing to tracking banner

### DIFF
--- a/cypress_shared/components/placeContextHeader.ts
+++ b/cypress_shared/components/placeContextHeader.ts
@@ -39,6 +39,7 @@ export default class PlaceContextHeaderComponent extends Component {
         'contain',
         `Accommodation required from: ${DateFormats.isoDateToUIDate(application.arrivalDate, { format: 'short' })}`,
       )
+      cy.root().should('contain', 'Suitable to share: Yes')
     })
   }
 }

--- a/cypress_shared/fixtures/summaryData.json
+++ b/cypress_shared/fixtures/summaryData.json
@@ -1,0 +1,4 @@
+{
+  "isAbleToShare": true,
+  "releaseType": "Custody"
+}

--- a/server/testutils/factories/assessment.ts
+++ b/server/testutils/factories/assessment.ts
@@ -4,6 +4,7 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 import type { TemporaryAccommodationAssessment as Assessment } from '@approved-premises/api'
 
+import summaryData from '../../../cypress_shared/fixtures/summaryData.json'
 import { DateFormats } from '../../utils/dateUtils'
 import { fakeObject } from '../utils'
 import applicationFactory from './application'
@@ -27,7 +28,7 @@ class AssessmentFactory extends Factory<Assessment> {
 export default AssessmentFactory.define(() => ({
   id: faker.string.uuid(),
   application: applicationFactory.withReleaseDate().build(),
-  summaryData: fakeObject(),
+  summaryData,
   allocatedToStaffMemberId: faker.string.uuid(),
   schemaVersion: faker.string.uuid(),
   outdatedSchema: false,

--- a/server/views/temporary-accommodation/components/place-context-header/macro.njk
+++ b/server/views/temporary-accommodation/components/place-context-header/macro.njk
@@ -21,6 +21,12 @@
         {% if placeContext.assessment.application.arrivalDate %}
           <div>Accommodation required from: {{ formatDate(placeContext.assessment.application.arrivalDate, {format: 'short'}) }}</div>
         {% endif %}
+        {% if placeContext.assessment.summaryData.isAbleToShare === true %}
+          <div>Suitable to share: Yes</div>
+        {% endif %}
+        {% if placeContext.assessment.summaryData.isAbleToShare === false %}
+          <div>Suitable to share: No</div>
+        {% endif %}
       </div>
       <a class="govuk-link" href="{{ addPlaceContext(paths.assessments.summary({ id: placeContext.assessment.id })) }}" rel="noreferrer noopener" target="_blank">View referral summary (opens in new tab)</a>
     </div>


### PR DESCRIPTION
# Context
In a previous change[1], we included presentation data in the initial submission of a referral, for easier extraction in the assess & manage journeys.

This change makes use of this data by adding the suitability for a PoP to share accommodation in the place tracking banner.

[1]
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/620

# Changes in this PR

## Screenshots of UI changes

### Before
![suitable_to_share_undefined](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/f531a9b7-6d89-47b3-9c24-77e17aa40b19)

### After
#### Is suitable to share
![suitable_to_share_yes](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/2812e080-4d9d-4fe7-acd8-68d2429996da)

#### Not suitable to share
![suitable_to_share_no](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/c7817dd8-251c-4954-8626-15e72961ea0a)

#### Suitability not set (backwards compatible with older applications)
![suitable_to_share_undefined](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/0e0c491a-0b63-4e87-af83-653f0efb46bc)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
