### PR TITLE
Update service name to include "CAS3" everywhere

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -215,7 +215,7 @@
       "accommodationTypes": ["cas1", "cas3"],
       "cas1Detail": "Approved Premises detail",
       "cas2Detail": "",
-      "cas3Detail": "Transitional Accommodation detail"
+      "cas3Detail": "Transitional Accommodation (CAS3) detail"
     }
   },
   "placement-location": {

--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -42,7 +42,7 @@
           "id": "eligibility",
           "content": [
             {
-              "How is the person eligible for Transitional Accommodation (TA)?": "Moving on as homeless from an Approved Premises"
+              "How is the person eligible for Transitional Accommodation (CAS3)?": "Moving on as homeless from an Approved Premises"
             },
             { "Release date": "2 September 2123" },
             { "Accommodation required from date": "16 September 2123" }
@@ -51,7 +51,7 @@
         {
           "title": "Consent",
           "id": "consent",
-          "content": [{ "Has consent for Transitional Accommodation been given?": "Yes" }]
+          "content": [{ "Has consent for Transitional Accommodation (CAS3) been given?": "Yes" }]
         }
       ]
     },
@@ -170,7 +170,7 @@
             { "Has the person previously stayed in Community Accommodation Services (CAS)?": "Yes" },
             {
               "Approved Premises (AP or CAS1)": "Approved Premises detail",
-              "Transitional Accommodation (CAS3)": "Transitional Accommodation detail"
+              "Transitional Accommodation (CAS3)": "Transitional Accommodation (CAS3) detail"
             }
           ]
         }

--- a/cypress_shared/pages/apply/accommodation-need/consent/consentGiven.ts
+++ b/cypress_shared/pages/apply/accommodation-need/consent/consentGiven.ts
@@ -5,7 +5,7 @@ import ApplyPage from '../../applyPage'
 export default class ConsentGivenPage extends ApplyPage {
   constructor(application: TemporaryAccommodationApplication) {
     super(
-      'Has consent for Transitional Accommodation been given?',
+      'Has consent for Transitional Accommodation (CAS3) been given?',
       application,
       'consent',
       'consent-given',

--- a/cypress_shared/pages/apply/accommodation-need/eligibility/eligibilityReason.ts
+++ b/cypress_shared/pages/apply/accommodation-need/eligibility/eligibilityReason.ts
@@ -6,7 +6,7 @@ import { personName } from '../../../../../server/utils/personUtils'
 export default class EligibilityReasonPage extends ApplyPage {
   constructor(application: TemporaryAccommodationApplication) {
     super(
-      `How is ${personName(application.person)} eligible for Transitional Accommodation (TA)?`,
+      `How is ${personName(application.person)} eligible for Transitional Accommodation (CAS3)?`,
       application,
       'eligibility',
       'eligibility-reason',

--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -6,7 +6,7 @@ import Page from '../page'
 
 export default class ListPage extends Page {
   constructor(private readonly inProgressApplications: Array<Application>) {
-    super('Transitional Accommodation (TA) referrals')
+    super('Transitional Accommodation (CAS3) referrals')
   }
 
   static visit(inProgressApplications: Array<Application>): ListPage {

--- a/cypress_shared/pages/apply/startPage.ts
+++ b/cypress_shared/pages/apply/startPage.ts
@@ -4,7 +4,7 @@ import paths from '../../../server/paths/apply'
 
 export default class StartPage extends Page {
   constructor() {
-    super('Make a referral for Transitional Accommodation')
+    super('Make a referral for Transitional Accommodation (CAS3)')
   }
 
   static visit(): StartPage {

--- a/cypress_shared/pages/apply/taskListPage.ts
+++ b/cypress_shared/pages/apply/taskListPage.ts
@@ -4,7 +4,7 @@ import paths from '../../../server/paths/apply'
 
 export default class TaskListPage extends Page {
   constructor(private readonly inProgressApplication: Application) {
-    super('Make a referral for Transitional Accommodation')
+    super('Make a referral for Transitional Accommodation (CAS3)')
   }
 
   static visit(inProgressApplication: Application): TaskListPage {

--- a/integration_tests/tests/temporary-accommodation/cookies.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/cookies.cy.ts
@@ -9,7 +9,7 @@ context('Cookies', () => {
   it('should navigate to the cookie policy page', () => {
     cy.signIn()
     cy.contains('Cookies').click()
-    cy.title().should('eq', 'Cookies - Transitional Accommodation')
+    cy.title().should('eq', 'Cookies - Transitional Accommodation (CAS3)')
     cy.contains('Cookies are small files saved on your phone, tablet or computer when you visit a website.')
   })
 })

--- a/server/form-pages/apply/accommodation-need/consent/consentGiven.test.ts
+++ b/server/form-pages/apply/accommodation-need/consent/consentGiven.test.ts
@@ -27,7 +27,7 @@ describe('ConsentGiven', () => {
     it('returns an error if the consent given field is not populated', () => {
       const page = new ConsentGiven({ ...body, consentGiven: undefined }, application)
       expect(page.errors()).toEqual({
-        consentGiven: 'You must specify if consent for Transitional Accommodation has been given',
+        consentGiven: 'You must specify if consent for Transitional Accommodation (CAS3) has been given',
       })
     })
   })
@@ -36,7 +36,7 @@ describe('ConsentGiven', () => {
     it('returns a translated version of the response', () => {
       const page = new ConsentGiven(body, application)
       expect(page.response()).toEqual({
-        'Has consent for Transitional Accommodation been given?': 'Yes',
+        'Has consent for Transitional Accommodation (CAS3) been given?': 'Yes',
       })
     })
   })

--- a/server/form-pages/apply/accommodation-need/consent/consentGiven.ts
+++ b/server/form-pages/apply/accommodation-need/consent/consentGiven.ts
@@ -11,7 +11,7 @@ type ConsentGivenBody = {
 
 @Page({ name: 'consent-given', bodyProperties: ['consentGiven'] })
 export default class ConsentGiven implements TasklistPage {
-  title = 'Has consent for Transitional Accommodation been given?'
+  title = 'Has consent for Transitional Accommodation (CAS3) been given?'
 
   htmlDocumentTitle = this.title
 
@@ -36,7 +36,7 @@ export default class ConsentGiven implements TasklistPage {
     const errors: TaskListErrors<this> = {}
 
     if (!this.body.consentGiven) {
-      errors.consentGiven = 'You must specify if consent for Transitional Accommodation has been given'
+      errors.consentGiven = 'You must specify if consent for Transitional Accommodation (CAS3) has been given'
     }
 
     return errors

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.test.ts
@@ -54,7 +54,7 @@ describe('EligibilityReason', () => {
       const page = new EligibilityReason(body, application)
 
       expect(page.response()).toEqual({
-        'How is the person eligible for Transitional Accommodation (TA)?':
+        'How is the person eligible for Transitional Accommodation (CAS3)?':
           'Moving on as homeless from an Approved Premises',
       })
     })

--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
@@ -20,14 +20,14 @@ type EligibilityReasonBody = { reason: EligibilityReasonsT }
 export default class EligibilityReason implements TasklistPage {
   title: string
 
-  htmlDocumentTitle = 'How is the person eligible for Transitional Accommodation (TA)?'
+  htmlDocumentTitle = 'How is the person eligible for Transitional Accommodation (CAS3)?'
 
   constructor(
     readonly body: Partial<EligibilityReasonBody>,
     readonly application: Application,
   ) {
     const name = personName(application.person)
-    this.title = `How is ${name} eligible for Transitional Accommodation (TA)?`
+    this.title = `How is ${name} eligible for Transitional Accommodation (CAS3)?`
   }
 
   response() {

--- a/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStaysDetails.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStaysDetails.test.ts
@@ -5,7 +5,7 @@ import PreviousStaysDetails from './previousStaysDetails'
 const body = {
   accommodationTypes: ['cas1' as const, 'cas3' as const],
   cas1Detail: 'Approved Premises detail',
-  cas3Detail: 'Transitional Accommodation detail',
+  cas3Detail: 'Transitional Accommodation (CAS3) detail',
 }
 
 describe('PreviousStaysDetails', () => {
@@ -61,7 +61,7 @@ describe('PreviousStaysDetails', () => {
       const page = new PreviousStaysDetails(body, application)
       expect(page.response()).toEqual({
         'Approved Premises (AP or CAS1)': 'Approved Premises detail',
-        'Transitional Accommodation (CAS3)': 'Transitional Accommodation detail',
+        'Transitional Accommodation (CAS3)': 'Transitional Accommodation (CAS3) detail',
       })
     })
   })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -49,7 +49,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   app.set('view engine', 'njk')
 
   app.locals.asset_path = '/assets/'
-  app.locals.applicationName = 'Transitional Accommodation'
+  app.locals.applicationName = 'Transitional Accommodation (CAS3)'
 
   // Cachebusting version string
   if (production) {

--- a/server/views/applications/confirm.njk
+++ b/server/views/applications/confirm.njk
@@ -16,7 +16,7 @@
       }) }}
       <h2 class="govuk-heading-m">What happens next?</h2>
 
-      <p>We've sent your referral to your regional Homeless Prevention Team (HPT) for Transitional Accommodation.</p>
+      <p>We've sent your referral to your regional Homeless Prevention Team (HPT) for Transitional Accommodation (CAS3).</p>
       <p>The HPT will assess your referral within 3 to 5 working days. You’ll receive an email when a decision is made.</p>
       <p>If you have any questions about your referral, contact your regional HPT.</a></p>
       <p><a href="https://forms.office.com/Pages/ResponsePage.aspx?id=KEeHxuZx_kGp4S6MNndq2EXSevEnO7lHpH52Z5zJdrxUQjQ0OTZERFI4N0w4Q1Q5ODRYWVFIVFBGNy4u">What did you think of this service?</a> (takes 30 seconds)</p>

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -6,7 +6,7 @@
 {% from "./_table.njk" import applicationsTable %}
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "Transitional Accommodation (TA) referrals - " + applicationName %}
+{% set pageTitle = "Transitional Accommodation (CAS3) referrals - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block content %}
@@ -14,7 +14,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
 
-      <h1 class="govuk-heading-l">Transitional Accommodation (TA) referrals</h1>
+      <h1 class="govuk-heading-l">Transitional Accommodation (CAS3) referrals</h1>
 
       {{ govukTabs({
         items: [
@@ -32,7 +32,7 @@
 
     <div class="govuk-grid-column-two-thirds">
       <h2 class="govuk-heading-m">Start a new referral</h2>
-      <p class="govuk-body">Start a new referral for Transitional Accommodation below.</p>
+      <p class="govuk-body">Start a new referral for Transitional Accommodation (CAS3) below.</p>
 
       {{ govukButton({
         text: "Start now",

--- a/server/views/applications/new.njk
+++ b/server/views/applications/new.njk
@@ -26,7 +26,7 @@
                 isPageHeading: true
               },
               hint: {
-                text: "Enter the CRN for the person needing Transitional Accommodation"
+                text: "Enter the CRN for the person needing Transitional Accommodation (CAS3)"
               },
               classes: "govuk-input--width-10",
               fieldName: "crn"

--- a/server/views/applications/pages/accommodation-need/consent/consent-given.njk
+++ b/server/views/applications/pages/accommodation-need/consent/consent-given.njk
@@ -10,7 +10,7 @@
 
   {% set conditionalHtml %}
     {{ govukNotificationBanner({
-      text: "Consent must be given before an application to Transitional Accommodation (TA) is made"
+      text: "Consent must be given before an application to Transitional Accommodation (CAS3) is made"
     }) }}
   {% endset %}
 

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/cooperation.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/cooperation.njk
@@ -14,7 +14,7 @@
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <p class="govuk-body">People placed into Transitional Accommodation are required to engage in weekly support sessions with the accommodation supplier support worker.</p>
+      <p class="govuk-body">People placed into Transitional Accommodation (CAS3) are required to engage in weekly support sessions with the accommodation supplier support worker.</p>
 
       <p class="govuk-body">Provide information relating to:</p>
       <ul class="govuk-list govuk-list--bullet"> 

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/risk-management-plan.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/risk-management-plan.njk
@@ -32,7 +32,7 @@
 
         <p class="govuk-body">
           Provide an outline of the risk management plan.
-          Summarise how risks relating to accommodation will be managed whilst the person is in Transitional Accommodation.
+          Summarise how risks relating to accommodation will be managed whilst the person is in Transitional Accommodation (CAS3).
         </p>
 
       {% endif %}

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/crs-submitted.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/crs-submitted.njk
@@ -10,7 +10,7 @@
 
   {% set noHtml %}
     {% set html %}
-      <h3 class="govuk-notification-banner__heading">CRS referral must be submitted before an application to Transitional Accommodation (TA) is made</h3>
+      <h3 class="govuk-notification-banner__heading">CRS referral must be submitted before an application to Transitional Accommodation (CAS3) is made</h3>
       <p class="govuk-body">You can still submit your application</p>
     {% endset %}
 

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-submitted.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-submitted.njk
@@ -10,7 +10,7 @@
 
   {% set noHtml %}
     {% set html %}
-      <h3 class="govuk-notification-banner__heading">Duty to Refer (DTR) / National Offender Pathway (NOP) must be submitted before application to Transitional Accommodation (TA) is made</h3>
+      <h3 class="govuk-notification-banner__heading">Duty to Refer (DTR) / National Offender Pathway (NOP) must be submitted before application to Transitional Accommodation (CAS3) is made</h3>
       <p class="govuk-body">The person must also agree to sign an Accommodation Compact</p>
       <p class="govuk-body">You can still submit your application</p>
     {% endset %}

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/other-accommodation-options.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/other-accommodation-options.njk
@@ -17,7 +17,7 @@
     {{ page.title }}
   </h1>
 
-  <p>All accommodation services available through the person's local authority or HMPPS should be explored before an application to Transitional Accommodation (TA) is made.</p>
+  <p>All accommodation services available through the person's local authority or HMPPS should be explored before an application to Transitional Accommodation (CAS3) is made.</p>
 
   {{ formPageRadios({
       fieldName: "otherOptions",

--- a/server/views/applications/pages/requirements-for-placement/food-allergies/food-allergies.njk
+++ b/server/views/applications/pages/requirements-for-placement/food-allergies/food-allergies.njk
@@ -59,7 +59,7 @@
   },fetchContext()) }}
 
   {% set detailsHtml %}
-    <p class="govuk-body">Transitional Accommodation placements provide a welcome pack that includes food.</p>
+    <p class="govuk-body">Transitional Accommodation (CAS3) placements provide a welcome pack that includes food.</p>
     <p class="govuk-body">The information provided will help make sure that any allergies or dietary requirements are catered for.</p>
   {% endset %}
 

--- a/server/views/applications/pages/requirements-for-placement/move-on-plan/move-on-plan.njk
+++ b/server/views/applications/pages/requirements-for-placement/move-on-plan/move-on-plan.njk
@@ -17,7 +17,7 @@
   }, fetchContext()) }}
 
   {% set detailsHtml %}
-    <p>The move on plan should be discussed with the person before the Transitional Accommodation placement starts.</p>
+    <p>The move on plan should be discussed with the person before the Transitional Accommodation (CAS3) placement starts.</p>
     <p>Examples of move on planning could include:</p>
     <ul>
       <li>any information about move on that is included as part of the person's sentence plan</li>

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -8,7 +8,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "Make a referral for Transitional Accommodation - " + applicationName %}
+{% set pageTitle = "Make a referral for Transitional Accommodation (CAS3) - " + applicationName %}
 
 {% block beforeContent %}
   {{ govukBackLink({
@@ -21,7 +21,7 @@
   <div class="govuk-grid-row">
     <div class="govuk-width-container">
       <h1 class="govuk-heading-xl">
-        Make a referral for Transitional Accommodation
+        Make a referral for Transitional Accommodation (CAS3)
       </h1>
 
       {{ showErrorSummary(errorSummary) }}

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -4,7 +4,7 @@
 
 {% extends "../partials/layout.njk" %}
 
-{% set pageTitle = "Make a referral for Transitional Accommodation - " + applicationName %}
+{% set pageTitle = "Make a referral for Transitional Accommodation (CAS3) - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -21,9 +21,9 @@
     <div class="govuk-grid-column-two-thirds">
       <form action="{{ paths.applications.new() }}" method="get">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <h1 class="govuk-heading-l">Make a referral for Transitional Accommodation</h1>
+        <h1 class="govuk-heading-l">Make a referral for Transitional Accommodation (CAS3)</h1>
 
-        <p class="govuk-body">Transitional Accommodation (TA) is for people on probation who are at risk of homelessness on their first night of release. </p>
+        <p class="govuk-body">Transitional Accommodation (CAS3) is for people on probation who are at risk of homelessness on their first night of release. </p>
 
         <p class="govuk-body">This includes release from prison, an Approved Premises, or Bail Accommodation and Support Services.</p>
 

--- a/server/views/temporary-accommodation/bookings/selectAssessment.njk
+++ b/server/views/temporary-accommodation/bookings/selectAssessment.njk
@@ -50,7 +50,7 @@
         {% set bookingWithoutReferralGuidance %}
           {% set detailsHtml %}
             <p class="govuk-body">Choosing this option will impact the management information (MI) data for your region. Bookings will not be associated with a specific referral.</p>
-            <p class="govuk-body">This option should only be used where a referral could not be submitted through the Transitional Accommodation service. For example, in Wales where the referral process is different.</p>
+            <p class="govuk-body">This option should only be used where a referral could not be submitted through the Transitional Accommodation (CAS3) service. For example, in Wales where the referral process is different.</p>
           {% endset %}
 
           {{ govukDetails({
@@ -60,10 +60,10 @@
         {% endset %}
         
         {% if applyDisabled %}
-          <p class="govuk-body">Book this bedspace for a person who has been referred to Transitional Accommodation (formerly CAS3) through nDelius.</p>
+          <p class="govuk-body">Book this bedspace for a person who has been referred to Transitional Accommodation (CAS3) through nDelius.</p>
 
           <h2 class="govuk-heading-m">Digital referrals</h1>
-          <p class="govuk-body">We are working on creating a digital referral for the Transitional Accommodation service. Is it not currently available in your region.</p>
+          <p class="govuk-body">We are working on creating a digital referral for the Transitional Accommodation (CAS3) service. Is it not currently available in your region.</p>
           <p class="govuk-body">In the future you will be able to link this booking to a digital referral.</p>
 
           <input type="hidden" name="assessmentId" value="{{ forceAssessmentId }}"/>
@@ -72,7 +72,7 @@
           <p class="govuk-body">If this is expected you can continue to book this bedspace without linking a referral.</p>
 
           <h2 class="govuk-heading-m">No digital referrals found</h1>
-          <p class="govuk-body">If a referral has been submitted through the Transitional Accommodation service check the list of <a class="govuk-link" href="{{ paths.assessments.index({}) }}">submitted referrals</a>.</p>
+          <p class="govuk-body">If a referral has been submitted through the Transitional Accommodation (CAS3) service check the list of <a class="govuk-link" href="{{ paths.assessments.index({}) }}">submitted referrals</a>.</p>
           <p class="govuk-body">Referrals must be marked as ready to place before a placement is booked.</p>
           
           <input type="hidden" name="assessmentId" value="{{ forceAssessmentId }}"/>

--- a/server/views/temporary-accommodation/static/cookies.njk
+++ b/server/views/temporary-accommodation/static/cookies.njk
@@ -9,11 +9,11 @@
       <p class="govuk-body">
         Cookies are small files saved on your phone, tablet or computer when you visit a website.
       </p>
-      <p class="govuk-body">We use cookies to make the Transitional Accommodation service work and collect information about how you use our service.</p>
+      <p class="govuk-body">We use cookies to make the Transitional Accommodation (CAS3) service work and collect information about how you use our service.</p>
 
       <h2 class="govuk-heading-m">Essential cookies</h2>
       <p class="govuk-body">
-        Essential cookies keep your information secure while you use the Transitional Accommodation service. We do not need to ask permission to use them.
+        Essential cookies keep your information secure while you use the Transitional Accommodation (CAS3) service. We do not need to ask permission to use them.
       </p>
       <table class="govuk-table">
         <caption class="govuk-visually-hidden">Essential cookies</caption>

--- a/server/views/temporary-accommodation/static/notAuthorised.njk
+++ b/server/views/temporary-accommodation/static/notAuthorised.njk
@@ -10,7 +10,7 @@
         This may be because:
         <ul class="govuk-list govuk-list--bullet">
           <li>the CRN is not in your caseload</li>
-          <li>referrals through the Transitional Accommodation service are not currently available in your region</li>
+          <li>referrals through the Transitional Accommodation (CAS3) service are not currently available in your region</li>
         </ul>
       </p>
       <p class="govuk-body">

--- a/server/views/temporary-accommodation/static/useNDelius.njk
+++ b/server/views/temporary-accommodation/static/useNDelius.njk
@@ -14,7 +14,7 @@
       </p>
 
       <p class="govuk-body">
-          In the future you will be able to submit a digital referral for CAS3 through the Transitional Accommodation service. You will be notified when this service is available.
+          In the future you will be able to submit a digital referral for CAS3 through the Transitional Accommodation (CAS3) service. You will be notified when this service is available.
       </p>
     </div>
   </div>


### PR DESCRIPTION
# Context
In a previous commit we updated the service name to be "Transitional Accommodation" from "Temporary Accommodation"[1] in the UI.

The name appears in the service in different forms:

* Transitional Accommodation (CAS3)
* Transitional Accommodation (TA)
* Transitional Accommodation
* Transitional Accommodation (formerly CAS3)

This commit updates all occurrences to be "Transitional Accommodation (CAS3).

[1]
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/637

## Screenshots of UI changes

### Before
![Screenshot 2023-09-21 at 12 22 43](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/e7736779-ab33-448c-b7d9-173c13d0d463)

### After
![Screenshot 2023-09-21 at 12 15 42](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/071609c6-f5cc-4522-b0c8-d753b2e3213c)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
