### PR TITLE
Send referral data as first class fields on application submission

### DIFF
--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -26,6 +26,7 @@ describe('getApplicationSubmissionData', () => {
         releaseType: 'Approved Premises',
       },
       isDutyToReferSubmitted: true,
+      dutyToReferSubmissionDate: '2022-04-12',
     })
   })
 })

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -25,6 +25,7 @@ describe('getApplicationSubmissionData', () => {
         isAbleToShare: true,
         releaseType: 'Approved Premises',
       },
+      isDutyToReferSubmitted: true,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -28,6 +28,7 @@ describe('getApplicationSubmissionData', () => {
       isDutyToReferSubmitted: true,
       dutyToReferSubmissionDate: '2022-04-12',
       needsAccessibleProperty: true,
+      isApplicationEligible: true,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -27,6 +27,7 @@ describe('getApplicationSubmissionData', () => {
       },
       isDutyToReferSubmitted: true,
       dutyToReferSubmissionDate: '2022-04-12',
+      needsAccessibleProperty: true,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -8,6 +8,7 @@ import getSummaryDataFromApplication from './getSummaryDataFromApplication'
 import {
   dutyToReferSubmissionDateFromApplication,
   isDutyToReferSubmittedFromApplication,
+  needsAccessiblePropertyFromApplication,
 } from './reportDataFromApplication'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
@@ -25,5 +26,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     summaryData: getSummaryDataFromApplication(application),
     isDutyToReferSubmitted: isDutyToReferSubmittedFromApplication(application),
     dutyToReferSubmissionDate: dutyToReferSubmissionDateFromApplication(application),
+    needsAccessibleProperty: needsAccessiblePropertyFromApplication(application),
   }
 }

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -5,6 +5,7 @@ import {
 } from '../../@types/shared'
 import { arrivalDateFromApplication } from '../../form-pages/utils'
 import getSummaryDataFromApplication from './getSummaryDataFromApplication'
+import { isDutyToReferSubmittedFromApplication } from './reportDataFromApplication'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
@@ -19,5 +20,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     type: 'CAS3',
     arrivalDate: arrivalDateFromApplication(application),
     summaryData: getSummaryDataFromApplication(application),
+    isDutyToReferSubmitted: isDutyToReferSubmittedFromApplication(application),
   }
 }

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -5,7 +5,10 @@ import {
 } from '../../@types/shared'
 import { arrivalDateFromApplication } from '../../form-pages/utils'
 import getSummaryDataFromApplication from './getSummaryDataFromApplication'
-import { isDutyToReferSubmittedFromApplication } from './reportDataFromApplication'
+import {
+  dutyToReferSubmissionDateFromApplication,
+  isDutyToReferSubmittedFromApplication,
+} from './reportDataFromApplication'
 
 export const getApplicationUpdateData = (application: Application): UpdateApplication => {
   return {
@@ -21,5 +24,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     arrivalDate: arrivalDateFromApplication(application),
     summaryData: getSummaryDataFromApplication(application),
     isDutyToReferSubmitted: isDutyToReferSubmittedFromApplication(application),
+    dutyToReferSubmissionDate: dutyToReferSubmissionDateFromApplication(application),
   }
 }

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -7,6 +7,7 @@ import { arrivalDateFromApplication } from '../../form-pages/utils'
 import getSummaryDataFromApplication from './getSummaryDataFromApplication'
 import {
   dutyToReferSubmissionDateFromApplication,
+  isApplicationEligibleFromApplication,
   isDutyToReferSubmittedFromApplication,
   needsAccessiblePropertyFromApplication,
 } from './reportDataFromApplication'
@@ -27,5 +28,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     isDutyToReferSubmitted: isDutyToReferSubmittedFromApplication(application),
     dutyToReferSubmissionDate: dutyToReferSubmissionDateFromApplication(application),
     needsAccessibleProperty: needsAccessiblePropertyFromApplication(application),
+    isApplicationEligible: isApplicationEligibleFromApplication(application),
   }
 }

--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -1,6 +1,7 @@
 import {
   dutyToReferSubmissionDateFromApplication,
   isDutyToReferSubmittedFromApplication,
+  needsAccessiblePropertyFromApplication,
 } from './reportDataFromApplication'
 import { applicationFactory } from '../../testutils/factories'
 import { SessionDataError } from '../errors'
@@ -60,6 +61,31 @@ describe('reportDataFromApplication', () => {
 
       expect(() => dutyToReferSubmissionDateFromApplication(application)).toThrow(
         new SessionDataError('No duty to refer submitted date'),
+      )
+    })
+  })
+
+  describe('needsAccessiblePropertyFromApplication', () => {
+    it('returns data for whether the application is for an accessible property from the application', () => {
+      const application = applicationFactory.build({
+        data: {
+          'disability-cultural-and-specific-needs': {
+            'property-attributes-or-adaptations': { propertyAttributesOrAdaptations: 'yes' },
+          },
+        },
+      })
+      expect(needsAccessiblePropertyFromApplication(application)).toEqual(true)
+    })
+
+    it('throws an error when the accessible property data is not present', () => {
+      const application = applicationFactory.build({
+        data: {
+          'disability-cultural-and-specific-needs': {},
+        },
+      })
+
+      expect(() => needsAccessiblePropertyFromApplication(application)).toThrow(
+        new SessionDataError('No accessible property data'),
       )
     })
   })

--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -1,5 +1,6 @@
 import {
   dutyToReferSubmissionDateFromApplication,
+  isApplicationEligibleFromApplication,
   isDutyToReferSubmittedFromApplication,
   needsAccessiblePropertyFromApplication,
 } from './reportDataFromApplication'
@@ -86,6 +87,31 @@ describe('reportDataFromApplication', () => {
 
       expect(() => needsAccessiblePropertyFromApplication(application)).toThrow(
         new SessionDataError('No accessible property data'),
+      )
+    })
+  })
+
+  describe('isApplicationEligibleFromApplication', () => {
+    it('returns whether the application is eligible for CAS3 from the application', () => {
+      const application = applicationFactory.build({
+        data: {
+          eligibility: {
+            'eligibility-reason': { reason: 'homelessFromCustody' },
+          },
+        },
+      })
+      expect(isApplicationEligibleFromApplication(application)).toEqual(true)
+    })
+
+    it('throws an error when the eligibility data is not present', () => {
+      const application = applicationFactory.build({
+        data: {
+          eligibility: {},
+        },
+      })
+
+      expect(() => isApplicationEligibleFromApplication(application)).toThrow(
+        new SessionDataError('No application eligibility data'),
       )
     })
   })

--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -1,0 +1,26 @@
+import { isDutyToReferSubmittedFromApplication } from './reportDataFromApplication'
+import { applicationFactory } from '../../testutils/factories'
+import { SessionDataError } from '../errors'
+
+describe('reportDataFromApplication', () => {
+  describe('isDutyToReferSubmittedFromApplication', () => {
+    it('returns data for whether the duty to refer has been submitted from the application', () => {
+      const application = applicationFactory.build({
+        data: { 'accommodation-referral-details': { 'dtr-submitted': { dtrSubmitted: 'yes' } } },
+      })
+      expect(isDutyToReferSubmittedFromApplication(application)).toEqual(true)
+    })
+
+    it('throws an error when the duty to refer submitted data is not known', () => {
+      const application = applicationFactory.build({
+        data: {
+          'accommodation-referral-details': {},
+        },
+      })
+
+      expect(() => isDutyToReferSubmittedFromApplication(application)).toThrow(
+        new SessionDataError('No duty to refer submitted data'),
+      )
+    })
+  })
+})

--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -1,4 +1,7 @@
-import { isDutyToReferSubmittedFromApplication } from './reportDataFromApplication'
+import {
+  dutyToReferSubmissionDateFromApplication,
+  isDutyToReferSubmittedFromApplication,
+} from './reportDataFromApplication'
 import { applicationFactory } from '../../testutils/factories'
 import { SessionDataError } from '../errors'
 
@@ -20,6 +23,43 @@ describe('reportDataFromApplication', () => {
 
       expect(() => isDutyToReferSubmittedFromApplication(application)).toThrow(
         new SessionDataError('No duty to refer submitted data'),
+      )
+    })
+  })
+
+  describe('dutyToReferSubmissionDateFromApplication', () => {
+    describe('when isDutyToReferSubmittedFromApplication is true', () => {
+      it('returns the duty to refer submission date from the application', () => {
+        const application = applicationFactory.build({
+          data: {
+            'accommodation-referral-details': {
+              'dtr-submitted': { dtrSubmitted: 'yes' },
+              'dtr-details': { date: 'Duty of care submission date' },
+            },
+          },
+        })
+        expect(dutyToReferSubmissionDateFromApplication(application)).toEqual('Duty of care submission date')
+      })
+    })
+
+    describe('when isDutyToReferSubmittedFromApplication is false', () => {
+      it('returns an empty string', () => {
+        const application = applicationFactory.build({
+          data: { 'accommodation-referral-details': { 'dtr-submitted': { dtrSubmitted: 'no' } } },
+        })
+        expect(dutyToReferSubmissionDateFromApplication(application)).toEqual('')
+      })
+    })
+
+    it('throws an error when the duty to refer submitted date is not known', () => {
+      const application = applicationFactory.build({
+        data: {
+          'accommodation-referral-details': { 'dtr-submitted': { dtrSubmitted: 'yes' } },
+        },
+      })
+
+      expect(() => dutyToReferSubmissionDateFromApplication(application)).toThrow(
+        new SessionDataError('No duty to refer submitted date'),
       )
     })
   })

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -31,4 +31,22 @@ const dutyToReferSubmissionDateFromApplication = (application: Application): str
   return dutyToReferSubmissionDate
 }
 
-export { dutyToReferSubmissionDateFromApplication, isDutyToReferSubmittedFromApplication }
+const needsAccessiblePropertyFromApplication = (application: Application): boolean => {
+  const needsAccessibleProperty: string = (application.data as Record<string, unknown>)?.[
+    'disability-cultural-and-specific-needs'
+  ]?.['property-attributes-or-adaptations']?.propertyAttributesOrAdaptations
+
+  if (!needsAccessibleProperty) {
+    throw new SessionDataError('No accessible property data')
+  }
+
+  if (needsAccessibleProperty === 'no') return false
+
+  return true
+}
+
+export {
+  dutyToReferSubmissionDateFromApplication,
+  isDutyToReferSubmittedFromApplication,
+  needsAccessiblePropertyFromApplication,
+}

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -1,0 +1,18 @@
+import { TemporaryAccommodationApplication as Application } from '../../@types/shared'
+import { SessionDataError } from '../errors'
+
+const isDutyToReferSubmittedFromApplication = (application: Application): boolean => {
+  const isDutyToReferSubmitted: string = (application.data as Record<string, unknown>)?.[
+    'accommodation-referral-details'
+  ]?.['dtr-submitted']?.dtrSubmitted
+
+  if (!isDutyToReferSubmitted) {
+    throw new SessionDataError('No duty to refer submitted data')
+  }
+
+  if (isDutyToReferSubmitted === 'no') return false
+
+  return true
+}
+
+export { isDutyToReferSubmittedFromApplication }

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -1,3 +1,4 @@
+import { eligibilityReasons } from '../../form-pages/apply/accommodation-need/eligibility/eligibilityReason'
 import { TemporaryAccommodationApplication as Application } from '../../@types/shared'
 import { SessionDataError } from '../errors'
 
@@ -45,8 +46,24 @@ const needsAccessiblePropertyFromApplication = (application: Application): boole
   return true
 }
 
+const isApplicationEligibleFromApplication = (application: Application): boolean => {
+  const eligibilityReason: string = (application.data as Record<string, unknown>)?.eligibility?.['eligibility-reason']
+    ?.reason
+
+  if (!eligibilityReason) {
+    throw new SessionDataError('No application eligibility data')
+  }
+
+  if (Object.keys(eligibilityReasons).includes(eligibilityReason)) {
+    return true
+  }
+
+  return false
+}
+
 export {
   dutyToReferSubmissionDateFromApplication,
+  isApplicationEligibleFromApplication,
   isDutyToReferSubmittedFromApplication,
   needsAccessiblePropertyFromApplication,
 }

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -15,4 +15,20 @@ const isDutyToReferSubmittedFromApplication = (application: Application): boolea
   return true
 }
 
-export { isDutyToReferSubmittedFromApplication }
+const dutyToReferSubmissionDateFromApplication = (application: Application): string => {
+  if (!isDutyToReferSubmittedFromApplication(application)) {
+    return ''
+  }
+
+  const dutyToReferSubmissionDate: string = (application.data as Record<string, unknown>)?.[
+    'accommodation-referral-details'
+  ]?.['dtr-details']?.date
+
+  if (!dutyToReferSubmissionDate) {
+    throw new SessionDataError('No duty to refer submitted date')
+  }
+
+  return dutyToReferSubmissionDate
+}
+
+export { dutyToReferSubmissionDateFromApplication, isDutyToReferSubmittedFromApplication }


### PR DESCRIPTION
# Context
We require extra fields to be added to the application submission model for reporting purposes.

# Changes in this PR
This change adds the following fields:

```typescript
needsAccessibleProperty: boolean
isDutyToReferSubmitted: boolean
dutyToReferSubmissionDate: string
isApplicationEligible: boolean
```

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
