### PR TITLE
Add guidance for when user has incorrect home area set in NDelius

### DIFF
--- a/server/views/temporary-accommodation/static/notAuthorised.njk
+++ b/server/views/temporary-accommodation/static/notAuthorised.njk
@@ -11,10 +11,19 @@
         <ul class="govuk-list govuk-list--bullet">
           <li>the CRN is not in your caseload</li>
           <li>referrals through the Transitional Accommodation (CAS3) service are not currently available in your region</li>
+          <li>the home area on your NDelius account is incorrect</li>
         </ul>
       </p>
+      <h2 class="govuk-heading-m">Incorrect home area on NDelius account</h2>
       <p class="govuk-body">
-        If this is incorrect contact <a href="mailto:cas3support@digital.justice.gov.uk">cas3support@digital.justice.gov.uk</a>
+        Your home area is currently set to '{{ actingUserProbationRegion.name }}' within NDelius. If this is incorrect this service may not recognise your account as being in the correct region.
+      </p>
+      <p class="govuk-body">
+        Submit an NDelius change request through the <a href="https://mojprod.service-now.com/moj_sp?id=sc_cat_item&table=sc_cat_item&sys_id=21952b8edb73e7441b4ffc45ae96197b">Technology Portal</a> to update it. The form does not have a section for a home area change. You will need to use the ‘other’ option and provide the correct home area.
+      </p>
+      <h2 class="govuk-heading-m">All other issues</h2>
+      <p class="govuk-body">
+        Contact <a href="mailto:cas3support@digital.justice.gov.uk">cas3support@digital.justice.gov.uk</a> and describe the problem you are experiencing.
       </p>
     </div>
   </div>


### PR DESCRIPTION
# Context
Currently, if a user's home area does not match one of the enabled regions for the CAS3 service they will be presented with the unauthorised page.

This change updates this page with guidance for those users who may be experiencing this problem.

## Screenshots of UI changes

### Before
![unauthorised_before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/34eb785e-547e-4d1c-923f-6baeb7f57a62)

### After
![image](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/3cd2e899-81da-4ea9-a4ea-eec84e5e1d18)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
