### PR TITLE
Show offence ID on check your answers and full referral pages

### DIFF
--- a/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.test.ts
@@ -47,6 +47,7 @@ describe('OffendingSummary', () => {
       const page = new OffendingSummary(body, application)
 
       expect(page.response()).toEqual({
+        'Offence ID': application.offenceId,
         'Summary of offending history': 'Offending summary',
       })
     })

--- a/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.ts
@@ -9,6 +9,8 @@ export type OffendingSummaryBody = {
   summary: string
 }
 
+export const offenceIdKey = 'Offence ID'
+
 @Page({ name: 'offending-summary', bodyProperties: ['summary'] })
 export default class OffendingSummary implements TasklistPage {
   title: string
@@ -23,7 +25,10 @@ export default class OffendingSummary implements TasklistPage {
   }
 
   response() {
-    return { 'Summary of offending history': this.body.summary }
+    return {
+      [offenceIdKey]: this.application.offenceId,
+      'Summary of offending history': this.body.summary,
+    }
   }
 
   previous() {

--- a/server/utils/checkYourAnswersUtils/index.test.ts
+++ b/server/utils/checkYourAnswersUtils/index.test.ts
@@ -24,6 +24,11 @@ describe('checkYourAnswersUtils', () => {
   })
 
   describe('getTaskResponsesAsSummaryListItems', () => {
+    beforeEach(() => {
+      ;(formatLines as jest.Mock).mockReset()
+      ;(formatLines as jest.Mock).mockImplementation((value: string) => `Formatted "${value}"`)
+    })
+
     it('returns the task responses as Summary List items and adds the actions object', () => {
       const application = applicationFactory.build()
       ;(forPagesInTask as jest.MockedFunction<typeof forPagesInTask>).mockImplementation((_1, _2, callback) => {
@@ -35,7 +40,6 @@ describe('checkYourAnswersUtils', () => {
 
         callback(page, 'some-page')
       })
-      ;(formatLines as jest.Mock).mockImplementation((value: string) => `Formatted "${value}"`)
 
       expect(
         getTaskResponsesAsSummaryListItems(
@@ -63,6 +67,39 @@ describe('checkYourAnswersUtils', () => {
       ])
 
       expect(formatLines).toHaveBeenCalledWith('An answer')
+    })
+
+    describe('when the item is offence ID', () => {
+      it('returns the task response as a Summary List item without the actions object', () => {
+        const application = applicationFactory.build()
+        ;(forPagesInTask as jest.MockedFunction<typeof forPagesInTask>).mockImplementation((_1, _2, callback) => {
+          const page = createMock<TasklistPage>()
+
+          page.response.mockReturnValue({
+            'Offence ID': '1234455',
+          })
+
+          callback(page, 'some-page')
+        })
+
+        expect(
+          getTaskResponsesAsSummaryListItems(
+            { id: 'some-task', title: 'Some task', actionText: 'Complete some task', pages: {} },
+            application,
+          ),
+        ).toEqual([
+          {
+            key: {
+              text: 'Offence ID',
+            },
+            value: {
+              html: 'Formatted "1234455"',
+            },
+          },
+        ])
+
+        expect(formatLines).toHaveBeenCalledWith('1234455')
+      })
     })
   })
 })

--- a/server/utils/checkYourAnswersUtils/index.ts
+++ b/server/utils/checkYourAnswersUtils/index.ts
@@ -7,6 +7,7 @@ import reviewSections from '../reviewUtils'
 import { formatLines } from '../viewUtils'
 import { embeddedSummaryListItem } from './embeddedSummaryListItem'
 import { forPagesInTask } from '../applicationUtils'
+import { offenceIdKey } from '../../form-pages/apply/accommodation-need/sentence-information/offendingSummary'
 
 const checkYourAnswersSections = (application: TemporaryAccommodationApplication) =>
   reviewSections(application, getTaskResponsesAsSummaryListItems)
@@ -40,20 +41,22 @@ const summaryListItemForResponse = (
   pageName: string,
   application: TemporaryAccommodationApplication,
 ) => {
+  const actions = {
+    items: [
+      {
+        href: paths.applications.pages.show({ task: task.id, page: pageName, id: application.id }),
+        text: 'Change',
+        visuallyHiddenText: key,
+      },
+    ],
+  }
+
   return {
     key: {
       text: key,
     },
     value,
-    actions: {
-      items: [
-        {
-          href: paths.applications.pages.show({ task: task.id, page: pageName, id: application.id }),
-          text: 'Change',
-          visuallyHiddenText: key,
-        },
-      ],
-    },
+    ...(key === offenceIdKey ? {} : { actions }),
   }
 }
 


### PR DESCRIPTION
# Context
HPTs currently have no way of knowing which index offence a referral belongs to and are having to ask the CPP, therefore, we want to show the offence ID on the referral page under the 'sentence information' section.

To achieve this we are adding the offence ID to the response of the first page of the 'sentence information' task. As there is no way to change the offence ID without starting a new referral, we hide the "change" action on the check your answers page.

This isn't an ideal solution as it doesn't follow the conventions of the other form pages, but here is some rationale:

* Offence ID is fetched by the server without the need for user input. We only ask the user to choose an offence ID if more than one offence is retrieved from the API. This means making a TaskListPage for offence ID non-trivial and would require a different approach to what we have now. Given there are limited dev days left on CAS3, taking on this work isn't feasible.

* I thought about adding a new type of TaskListPage which wouldn't be visible to the user, but changing the existing domain model for this one instance felt a bit premature, and would still be a good chunk of work.

* The solution in this commit is a hack but is fairly non-invasive and easy to change in the future.

Let me know if this is something you've encountered in CAS1/CAS2. Alternative solutions are welcome!

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![referral_before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/b536bcf6-6bc2-40d8-ae3a-c48c4f988618)
![check_your_answers_before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/20c5b7bf-0805-4765-ab8d-e432fa50ed03)

### After
![referral_after](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/e6168878-d71f-4d3a-a464-d5bd5e871e56)
![check_your_answers_after](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/ace7672f-0d0b-49a8-8b2c-c9ecd39313c0)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
