### PR TITLE
All prod access from new ip range

### DIFF
--- a/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
@@ -74,6 +74,8 @@ generic-service:
     ark-nps-hmcts-ttp3: "194.33.193.0/25"
     ark-nps-hmcts-ttp4: "194.33.196.0/25"
     ark-nps-hmcts-ttp5: "194.33.197.0/25"
+    moj-official-ark-c-expo-e: "51.149.249.0/29"
+    moj-official-ark-f-expo-e: "51.149.249.32/29"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-temporary-accommodation-ui


### PR DESCRIPTION
A user has reported being unable to access the service from Kent. They report being on an ip address (51.149.249.0) that fits into the range of “ARK Corsham Internet Egress Exponential-E” which is defined in both another MOJ service[1] and a list of trusted ranges[2].

When we originally added IP addresses for HPTs we expected we may eventually need to add more[3].

[1] https://github.com/ministryofjustice/create-and-vary-a-licence/blob/main/helm_deploy/create-and-vary-a-licence/values.yaml#L83C33-L83C33
[2] https://github.com/ministryofjustice/hmpps-env-configs/blob/a222488e6e7a3f233f793b80197384b2136b5aee/common-prod/common.tfvars#L429C26-L429C67
[3] https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/773b614834f8751ecd8f10b4ea09bb276527b1d4

