### PR TITLE
Revert "Show offence ID on check your answers and full referral pages"

### DIFF
--- a/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.test.ts
@@ -47,7 +47,6 @@ describe('OffendingSummary', () => {
       const page = new OffendingSummary(body, application)
 
       expect(page.response()).toEqual({
-        'Offence ID': application.offenceId,
         'Summary of offending history': 'Offending summary',
       })
     })

--- a/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/offendingSummary.ts
@@ -9,8 +9,6 @@ export type OffendingSummaryBody = {
   summary: string
 }
 
-export const offenceIdKey = 'Offence ID'
-
 @Page({ name: 'offending-summary', bodyProperties: ['summary'] })
 export default class OffendingSummary implements TasklistPage {
   title: string
@@ -25,10 +23,7 @@ export default class OffendingSummary implements TasklistPage {
   }
 
   response() {
-    return {
-      [offenceIdKey]: this.application.offenceId,
-      'Summary of offending history': this.body.summary,
-    }
+    return { 'Summary of offending history': this.body.summary }
   }
 
   previous() {

--- a/server/utils/checkYourAnswersUtils/index.test.ts
+++ b/server/utils/checkYourAnswersUtils/index.test.ts
@@ -24,11 +24,6 @@ describe('checkYourAnswersUtils', () => {
   })
 
   describe('getTaskResponsesAsSummaryListItems', () => {
-    beforeEach(() => {
-      ;(formatLines as jest.Mock).mockReset()
-      ;(formatLines as jest.Mock).mockImplementation((value: string) => `Formatted "${value}"`)
-    })
-
     it('returns the task responses as Summary List items and adds the actions object', () => {
       const application = applicationFactory.build()
       ;(forPagesInTask as jest.MockedFunction<typeof forPagesInTask>).mockImplementation((_1, _2, callback) => {
@@ -40,6 +35,7 @@ describe('checkYourAnswersUtils', () => {
 
         callback(page, 'some-page')
       })
+      ;(formatLines as jest.Mock).mockImplementation((value: string) => `Formatted "${value}"`)
 
       expect(
         getTaskResponsesAsSummaryListItems(
@@ -67,39 +63,6 @@ describe('checkYourAnswersUtils', () => {
       ])
 
       expect(formatLines).toHaveBeenCalledWith('An answer')
-    })
-
-    describe('when the item is offence ID', () => {
-      it('returns the task response as a Summary List item without the actions object', () => {
-        const application = applicationFactory.build()
-        ;(forPagesInTask as jest.MockedFunction<typeof forPagesInTask>).mockImplementation((_1, _2, callback) => {
-          const page = createMock<TasklistPage>()
-
-          page.response.mockReturnValue({
-            'Offence ID': '1234455',
-          })
-
-          callback(page, 'some-page')
-        })
-
-        expect(
-          getTaskResponsesAsSummaryListItems(
-            { id: 'some-task', title: 'Some task', actionText: 'Complete some task', pages: {} },
-            application,
-          ),
-        ).toEqual([
-          {
-            key: {
-              text: 'Offence ID',
-            },
-            value: {
-              html: 'Formatted "1234455"',
-            },
-          },
-        ])
-
-        expect(formatLines).toHaveBeenCalledWith('1234455')
-      })
     })
   })
 })

--- a/server/utils/checkYourAnswersUtils/index.ts
+++ b/server/utils/checkYourAnswersUtils/index.ts
@@ -7,7 +7,6 @@ import reviewSections from '../reviewUtils'
 import { formatLines } from '../viewUtils'
 import { embeddedSummaryListItem } from './embeddedSummaryListItem'
 import { forPagesInTask } from '../applicationUtils'
-import { offenceIdKey } from '../../form-pages/apply/accommodation-need/sentence-information/offendingSummary'
 
 const checkYourAnswersSections = (application: TemporaryAccommodationApplication) =>
   reviewSections(application, getTaskResponsesAsSummaryListItems)
@@ -41,22 +40,20 @@ const summaryListItemForResponse = (
   pageName: string,
   application: TemporaryAccommodationApplication,
 ) => {
-  const actions = {
-    items: [
-      {
-        href: paths.applications.pages.show({ task: task.id, page: pageName, id: application.id }),
-        text: 'Change',
-        visuallyHiddenText: key,
-      },
-    ],
-  }
-
   return {
     key: {
       text: key,
     },
     value,
-    ...(key === offenceIdKey ? {} : { actions }),
+    actions: {
+      items: [
+        {
+          href: paths.applications.pages.show({ task: task.id, page: pageName, id: application.id }),
+          text: 'Change',
+          visuallyHiddenText: key,
+        },
+      ],
+    },
   }
 }
 


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-temporary-accommodation-ui#656

The e2e tests are failing due to the offence ID not being updated in this [step definition](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/main/e2e/tests/stepDefinitions/apply.ts#L43). Reverting so I can apply the fix.