### PR TITLE
Remove check for in progress applications in e2e test

### DIFF
--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -1,7 +1,6 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
 import ApplyHelper from '../../../cypress_shared/helpers/apply'
-import ListPage from '../../../cypress_shared/pages/apply/list'
 import SelectOffencePage from '../../../cypress_shared/pages/apply/selectOffence'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import Page from '../../../cypress_shared/pages/page'
@@ -53,9 +52,4 @@ Then('I should see a confirmation of the application', () => {
   const confirmationPage = Page.verifyOnPage(SubmissionConfirmation)
 
   confirmationPage.clickBackToDashboard()
-
-  cy.then(function _() {
-    const listPage = Page.verifyOnPage(ListPage, [])
-    listPage.shouldShowInProgressApplications()
-  })
 })


### PR DESCRIPTION
# Context
After submitting an application we were attempting to check the list of in-progress applications in our e2e tests.

However, as the list of in-progress applications was never provided to `ListPage`, we would always expect the length to be 0. This caused failures on CI when there were in-progress applications present.

Instead of fixing this test, I'm choosing to remove it as we already check for the confirmation page beforehand. Also, the completed application would never show up as in progress after submission, so this check isn't providing any value.

<img width="837" alt="image" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/4da90f97-b53f-4a98-8bb8-be42e9251987">

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
