### PR TITLE
Update base image to patch CVE-2023-4911

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:18.16-bullseye-slim as base
+FROM node:18.18.0-bullseye-slim as base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
In response to Trivy reporting 2 high vulnerabilities https://app.circleci.com/jobs/github/ministryofjustice/hmpps-temporary-accommodation-ui/9384

After basing on this change you can test this by running `docker build -t test-18.18` and then running the Trivy check locally: 

```
docker run --rm -v trivy-cache:/root/.cache/ -v /var/run/docker.sock:/var/run/docker.sock aquasec/trivy:latest image --exit-code 100 --no-progress --severity HIGH,CRITICAL --ignore-unfixed --skip-dirs /usr/local/lib/node_modules/npm --skip-files /app/agent.jar test-18.18
```
![Screenshot 2023-10-04 at 10 45 41](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/bf7565f2-0003-4107-aa20-0bd480a14e9f)

