### PR TITLE
Call users/:id endpoint on sign in to force user update

### DIFF
--- a/cypress_shared/utils/setupTestUser.ts
+++ b/cypress_shared/utils/setupTestUser.ts
@@ -20,4 +20,5 @@ function setupTestWithRoles(roles: Array<UserRole>) {
   cy.wrap(probationRegion).as('actingUserProbationRegion')
 
   cy.task('stubActingUser', actingUser)
+  cy.task('stubGetUserById', actingUser)
 }

--- a/integration_tests/mockApis/user.ts
+++ b/integration_tests/mockApis/user.ts
@@ -6,7 +6,22 @@ const stubGetActingUser = (user: User) =>
   stubFor({
     request: {
       method: 'GET',
-      urlPath: path.users.actingUser.show({}),
+      urlPath: path.users.actingUser.profile({}),
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: user,
+    },
+  })
+
+const stubGetUserById = (user: User) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPath: path.users.actingUser.show({ id: user.id }),
     },
     response: {
       status: 200,
@@ -19,4 +34,5 @@ const stubGetActingUser = (user: User) =>
 
 export default {
   stubActingUser: (user: User) => stubGetActingUser(user),
+  stubGetUserById: (user: User) => stubGetUserById(user),
 }

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -78,6 +78,7 @@ context('SignIn', () => {
     const actingUser = userFactory.build({ region: probationRegion, roles: ['assessor', 'referrer'] })
 
     cy.task('stubActingUser', actingUser)
+    cy.task('stubGetUserById', actingUser)
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -32,11 +32,27 @@ describe('UserClient', () => {
       const user = userFactory.build()
 
       fakeApprovedPremisesApi
-        .get(paths.users.actingUser.show({}))
+        .get(paths.users.actingUser.profile({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, user)
 
       const result = await userClient.getActingUser()
+
+      expect(result).toEqual(user)
+      expect(nock.isDone()).toBeTruthy()
+    })
+  })
+
+  describe('getUserById', () => {
+    it('should return the acting user', async () => {
+      const user = userFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.users.actingUser.show({ id: user.id }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, user)
+
+      const result = await userClient.getUserById(user.id)
 
       expect(result).toEqual(user)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -11,6 +11,10 @@ export default class UserClient {
   }
 
   async getActingUser(): Promise<User> {
-    return (await this.restClient.get({ path: paths.users.actingUser.show({}) })) as User
+    return (await this.restClient.get({ path: paths.users.actingUser.profile({}) })) as User
+  }
+
+  async getUserById(id: string): Promise<User> {
+    return (await this.restClient.get({ path: paths.users.actingUser.show({ id }) })) as User
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -151,7 +151,8 @@ export default {
   },
   users: {
     actingUser: {
-      show: path('/profile'),
+      show: path('/users/:id'),
+      profile: path('/profile'),
     },
   },
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -23,11 +23,12 @@ describe('User service', () => {
   })
 
   describe('getActingUser', () => {
-    it('gets the acting user, collating results from the Community Accommoation API and the HMPPS Auth API', async () => {
+    it('gets the acting user, collating results from the Community Accommodation API and the HMPPS Auth API', async () => {
       const communityAccommodationUser = userFactory.build()
       const hmppsAuthUser = { name: 'john smith' } as User
 
       userClient.getActingUser.mockResolvedValue(communityAccommodationUser)
+      userClient.getUserById.mockResolvedValue(communityAccommodationUser)
       hmppsAuthClient.getActingUser.mockResolvedValue(hmppsAuthUser)
 
       const result = await userService.getActingUser(callConfig)

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -20,7 +20,9 @@ export default class UserService {
     const hmppsAuthUser = await this.hmppsAuthClient.getActingUser(callConfig)
 
     const client = this.userClientFactory(callConfig)
-    const communityAccommodationUser = await client.getActingUser()
+
+    const { id } = await client.getActingUser()
+    const communityAccommodationUser = await client.getUserById(id)
 
     return {
       ...hmppsAuthUser,

--- a/wiremock/userStub.ts
+++ b/wiremock/userStub.ts
@@ -1,4 +1,5 @@
 import paths from '../server/paths/api'
+import { guidRegex } from './index'
 import { userFactory } from '../server/testutils/factories'
 
 const userStubs: Array<Record<string, unknown>> = []
@@ -6,7 +7,23 @@ const userStubs: Array<Record<string, unknown>> = []
 userStubs.push({
   request: {
     method: 'GET',
-    urlPath: paths.users.actingUser.show({}),
+    urlPath: paths.users.actingUser.profile({}),
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: userFactory.build({
+      roles: ['assessor', 'referrer'],
+    }),
+  },
+})
+
+userStubs.push({
+  request: {
+    method: 'GET',
+    urlPathPattern: paths.users.actingUser.show({ id: guidRegex }),
   },
   response: {
     status: 200,


### PR DESCRIPTION
# Context
We want to ensure that any changes on Delius is updated automatically for users logging in. To enable this, we have added an extra API call to the `/users/:id` endpoint which updates the user[1].

[1]
https://github.com/ministryofjustice/hmpps-approved-premises-api/blob/main/src/main/kotlin/uk/gov/justice/digital/hmpps/approvedpremisesapi/controller/UsersController.kt#L29

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
