### PR TITLE
Show submitted referrals to CPPs

### DIFF
--- a/cypress_shared/pages/apply/full.ts
+++ b/cypress_shared/pages/apply/full.ts
@@ -1,0 +1,56 @@
+import { TemporaryAccommodationApplication as Application } from '../../../server/@types/shared'
+import paths from '../../../server/paths/apply'
+import type { Section } from '../../../server/utils/applicationUtils'
+import { personName } from '../../../server/utils/personUtils'
+import Page from '../page'
+
+export default class ApplicationFullPage extends Page {
+  constructor(private readonly application: Application) {
+    super(personName(application.person, 'Limited access offender'))
+  }
+
+  static visit(application: Application): ApplicationFullPage {
+    cy.visit(paths.applications.full({ id: application.id }))
+
+    return new ApplicationFullPage(application)
+  }
+
+  shouldShowApplication(applicationTranslatedDocument: Record<'sections', Array<Section>>) {
+    applicationTranslatedDocument.sections.forEach(section => {
+      cy.get('h2').contains(section.title)
+
+      section.tasks.forEach(task => {
+        cy.get('.govuk-summary-card__title-wrapper')
+          .contains(task.title)
+          .parent()
+          .next('div')
+          .within(() => {
+            task.content.forEach(content => {
+              Object.entries(content).forEach(([key, value]) => {
+                if (typeof value === 'string') {
+                  value.split('\n').forEach(line => {
+                    this.assertDefinition(key, line)
+                  })
+                } else {
+                  cy.get('dt')
+                    .contains(key)
+                    .parent()
+                    .within(() => {
+                      value.forEach((embeddedRecord, index) => {
+                        cy.get('dl.govuk-summary-list--embedded')
+                          .eq(index)
+                          .within(() => {
+                            Object.keys(embeddedRecord).forEach(embeddedKey => {
+                              this.assertDefinition(embeddedKey, embeddedRecord[embeddedKey] as string)
+                            })
+                          })
+                      })
+                    })
+                }
+              })
+            })
+          })
+      })
+    })
+  }
+}

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -44,6 +44,7 @@ import SelectOffencePage from './selectOffence'
 import StartPage from './startPage'
 import SubmissionConfirmation from './submissionConfirmation'
 import TaskListPage from './taskListPage'
+import ApplicationFullPage from './full'
 
 export {
   AccommodationRequiredFromDatePage,
@@ -92,4 +93,5 @@ export {
   SubstanceMisusePage,
   SupportInTheCommunityPage,
   TaskListPage,
+  ApplicationFullPage,
 }

--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -42,12 +42,12 @@ export default class ListPage extends Page {
         .within(() => {
           cy.get('th').eq(0).contains(personName(application.person, 'Limited access offender'))
           cy.get('td').eq(0).contains(application.person.crn)
-          cy.get('td').eq(2).contains('In Progress')
+          cy.get('td').eq(1).contains('In Progress')
         })
     })
   }
 
-  shouldShowSubmittedApplication(application: Application): void {
+  shouldShowSubmittedApplication(application: Application, checkSubmittedAtDate = true): void {
     cy.get('#applications-submitted').within(() => {
       cy.get(`a[href*="${paths.applications.full({ id: application.id })}"]`)
         .parent()
@@ -55,10 +55,13 @@ export default class ListPage extends Page {
         .within(() => {
           cy.get('th').eq(0).contains(personName(application.person, 'Limited access offender'))
           cy.get('td').eq(0).contains(application.person.crn)
-          cy.get('td')
-            .eq(1)
-            .contains(DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date()), { format: 'short' }))
           cy.get('td').eq(2).contains('Submitted')
+
+          if (checkSubmittedAtDate) {
+            cy.get('td')
+              .eq(1)
+              .contains(DateFormats.isoDateToUIDate(application.submittedAt, { format: 'short' }))
+          }
         })
     })
   }

--- a/e2e/tests/apply-and-place.feature
+++ b/e2e/tests/apply-and-place.feature
@@ -3,7 +3,8 @@ Feature: Apply for and book a Temporary Accommodation bedspace
     Given I am logged in as a referrer
     When I start a new application
     And I fill in and complete an application
-    Then I should see a confirmation of the application
+    And I see a confirmation of the application
+    Then I can see the submitted application
   Scenario: Booking a bedspace from an assessment
     Given I am logged in as an assessor
     When I view an existing active premises

--- a/e2e/tests/apply-and-place.feature
+++ b/e2e/tests/apply-and-place.feature
@@ -4,7 +4,7 @@ Feature: Apply for and book a Temporary Accommodation bedspace
     When I start a new application
     And I fill in and complete an application
     And I see a confirmation of the application
-    Then I can see the submitted application
+    Then I can see the full submitted application
   Scenario: Booking a bedspace from an assessment
     Given I am logged in as an assessor
     When I view an existing active premises

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -2,6 +2,7 @@ import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
 import ApplyHelper from '../../../cypress_shared/helpers/apply'
 import ListPage from '../../../cypress_shared/pages/apply/list'
+import ApplicationFullPage from '../../../cypress_shared/pages/apply/full'
 import SelectOffencePage from '../../../cypress_shared/pages/apply/selectOffence'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import Page from '../../../cypress_shared/pages/page'
@@ -55,12 +56,16 @@ Given('I see a confirmation of the application', () => {
   confirmationPage.clickBackToDashboard()
 })
 
-Then('I can see the submitted application', () => {
+Then('I can see the full submitted application', () => {
   cy.url().then(function _() {
     const listPage = Page.verifyOnPage(ListPage, [], [])
 
     listPage.clickSubmittedTab()
 
     listPage.shouldShowSubmittedApplication(this.application)
+
+    listPage.clickApplication(this.application)
+
+    Page.verifyOnPage(ApplicationFullPage, this.application)
   })
 })

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -1,6 +1,7 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 
 import ApplyHelper from '../../../cypress_shared/helpers/apply'
+import ListPage from '../../../cypress_shared/pages/apply/list'
 import SelectOffencePage from '../../../cypress_shared/pages/apply/selectOffence'
 import SubmissionConfirmation from '../../../cypress_shared/pages/apply/submissionConfirmation'
 import Page from '../../../cypress_shared/pages/page'
@@ -48,8 +49,18 @@ Given('I fill in and complete an application', () => {
   })
 })
 
-Then('I should see a confirmation of the application', () => {
+Given('I see a confirmation of the application', () => {
   const confirmationPage = Page.verifyOnPage(SubmissionConfirmation)
 
   confirmationPage.clickBackToDashboard()
+})
+
+Then('I can see the submitted application', () => {
+  cy.url().then(function _() {
+    const listPage = Page.verifyOnPage(ListPage, [], [])
+
+    listPage.clickSubmittedTab()
+
+    listPage.shouldShowSubmittedApplication(this.application)
+  })
 })

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -62,7 +62,7 @@ Then('I can see the full submitted application', () => {
 
     listPage.clickSubmittedTab()
 
-    listPage.shouldShowSubmittedApplication(this.application)
+    listPage.shouldShowSubmittedApplication(this.application, false)
 
     listPage.clickApplication(this.application)
 

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -187,7 +187,7 @@ context('Apply', () => {
     confirmationPage.clickBackToDashboard()
 
     // Then I am taken back to the dashboard
-    Page.verifyOnPage(ListPage, applications)
+    Page.verifyOnPage(ListPage, applications, [])
   })
 
   it('shows an error if the application is submitted without checking the confirm checkbox', function test() {
@@ -198,7 +198,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([this.application])
+    const listPage = ListPage.visit([this.application], [])
 
     // And I click on the application
     listPage.clickApplication(this.application)
@@ -220,7 +220,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([application])
+    const listPage = ListPage.visit([application], [])
 
     // And I click on the application
     listPage.clickApplication(application)
@@ -238,7 +238,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([this.application])
+    const listPage = ListPage.visit([this.application], [])
 
     // And I click on the application
     listPage.clickApplication(this.application)
@@ -277,7 +277,7 @@ context('Apply', () => {
     apply.setupApplicationStubs()
 
     // When I visit the application listing page
-    const listPage = ListPage.visit([this.application])
+    const listPage = ListPage.visit([this.application], [])
 
     // And I click on the application
     listPage.clickApplication(this.application)

--- a/integration_tests/tests/apply/apply.cy.ts
+++ b/integration_tests/tests/apply/apply.cy.ts
@@ -1,4 +1,5 @@
 import {
+  ApplicationFullPage,
   EnterCRNPage,
   ListPage,
   MoveOnPlanPage,
@@ -295,5 +296,26 @@ context('Apply', () => {
 
     // Then I check your answers should be marked as completed
     taskListPage.shouldShowTaskStatus('check-your-answers', 'Completed')
+  })
+
+  it('shows the full submitted application', function test() {
+    // Given there is a complete and submitted application
+    const application = { ...this.application, status: 'submitted' }
+
+    cy.task('stubApplications', [application])
+    cy.task('stubApplicationGet', { application })
+
+    // When I visit the application listing page
+    const listPage = ListPage.visit([], [application])
+
+    // And I click on the submitted tab
+    listPage.clickSubmittedTab()
+
+    // And I click on an application
+    listPage.clickApplication(application)
+
+    // Then I should see the full application
+    const applicationFullPage = Page.verifyOnPage(ApplicationFullPage, application)
+    applicationFullPage.shouldShowApplication(application.document)
   })
 })

--- a/integration_tests/tests/apply/list.cy.ts
+++ b/integration_tests/tests/apply/list.cy.ts
@@ -21,10 +21,16 @@ context('Applications dashboard', () => {
     cy.signIn()
 
     // When I visit the Previous Applications page
-    const page = ListPage.visit(inProgressApplications)
+    const page = ListPage.visit(inProgressApplications, submittedApplications)
 
     // Then I should see all of the in progress applications
     page.shouldShowInProgressApplications()
+
+    // And I click on the submitted tab
+    page.clickSubmittedTab()
+
+    // Then I should see the applications that have been submitted
+    page.shouldShowSubmittedApplications()
 
     // And I the button should take me to the application start page
     page.clickSubmit()

--- a/integration_tests/tests/apply/show.cy.ts
+++ b/integration_tests/tests/apply/show.cy.ts
@@ -28,6 +28,6 @@ context('Application Page', () => {
     page.clickBack()
 
     // Then I navigate to the list application page
-    Page.verifyOnPage(ListPage, inProgressApplications)
+    Page.verifyOnPage(ListPage, inProgressApplications, [])
   })
 })

--- a/integration_tests/tests/landing.cy.ts
+++ b/integration_tests/tests/landing.cy.ts
@@ -27,7 +27,7 @@ context('Landing', () => {
     cy.signIn()
 
     // I am redirected to the application listing page
-    Page.verifyOnPage(ListPage, [])
+    Page.verifyOnPage(ListPage, [], [])
   })
 
   it('redirects a user who is not an assessor or a referrer', () => {

--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -348,4 +348,19 @@ describe('applicationsController', () => {
       expect(response.render).toHaveBeenCalledWith('applications/confirm')
     })
   })
+
+  describe('full', () => {
+    it('renders the full application page for submitted referrals', async () => {
+      const application = createMock<TemporaryAccommodationApplication>()
+
+      request = createMock<Request>({
+        params: { id: application.id },
+      })
+
+      const requestHandler = applicationsController.full()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('applications/full', application)
+    })
+  })
 })

--- a/server/controllers/apply/applicationsController.ts
+++ b/server/controllers/apply/applicationsController.ts
@@ -135,4 +135,17 @@ export default class ApplicationsController {
       return res.render('applications/confirm')
     }
   }
+
+  full(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      const callConfig = extractCallConfig(req)
+
+      const { id } = req.params
+      const application = await this.applicationService.findApplication(callConfig, id)
+
+      return res.render('applications/full', {
+        application,
+      })
+    }
+  }
 }

--- a/server/paths/apply.ts
+++ b/server/paths/apply.ts
@@ -20,6 +20,7 @@ const paths = {
     index: applicationsPath,
     show: applicationPath,
     update: applicationPath,
+    full: applicationPath.path('full'),
     checkYourAnswers: applicationPath.path('check-your-answers'),
     submission: applicationPath.path('submission'),
     confirm: applicationPath.path('confirm'),

--- a/server/routes/apply.ts
+++ b/server/routes/apply.ts
@@ -21,6 +21,7 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.applications.index.pattern, applicationsController.index(), { auditEvent: 'VIEW_APPLICATIONS_LIST' })
   get(paths.applications.new.pattern, applicationsController.new(), { auditEvent: 'VIEW_APPLICATION_NEW' })
   get(paths.applications.show.pattern, applicationsController.show(), { auditEvent: 'VIEW_APPLICATION' })
+  get(paths.applications.full.pattern, applicationsController.full(), { auditEvent: 'VIEW_FULL_APPLICATION' })
   get(paths.applications.confirm.pattern, applicationsController.confirm(), {
     auditEvent: 'VIEW_APPLICATION_CONFIRM',
   })

--- a/server/services/applicationService.test.ts
+++ b/server/services/applicationService.test.ts
@@ -71,6 +71,7 @@ describe('ApplicationService', () => {
 
       expect(result).toEqual({
         inProgress: inProgressApplications,
+        submitted: submittedApplications,
       })
 
       expect(applicationClientFactory).toHaveBeenCalledWith(callConfig)

--- a/server/services/applicationService.ts
+++ b/server/services/applicationService.ts
@@ -35,6 +35,7 @@ export default class ApplicationService {
     const allApplications = await applicationClient.all()
     const result = {
       inProgress: [],
+      submitted: [],
     } as GroupedApplications
 
     await Promise.all(
@@ -42,6 +43,9 @@ export default class ApplicationService {
         switch (application.status) {
           case 'inProgress':
             result.inProgress.push(application)
+            break
+          case 'submitted':
+            result.submitted.push(application)
             break
           default:
             break

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -15,7 +15,6 @@ import {
   getResponses,
   getSectionAndTask,
   getStatus,
-  retrieveQuestionResponseFromApplication,
   taskResponsesToSummaryListRowItems,
 } from './applicationUtils'
 import getSections from './assessments/getSections'
@@ -373,42 +372,6 @@ describe('applicationUtils', () => {
       const application = applicationFactory.build()
 
       expect(firstPageOfApplicationJourney(application)).toEqual(paths.applications.show({ id: application.id }))
-    })
-  })
-
-  describe('retrieveQuestionResponseFromApplication', () => {
-    it("throws a SessionDataError if the property doesn't exist", () => {
-      const application = applicationFactory.build()
-      expect(() => retrieveQuestionResponseFromApplication(application, 'basic-information', '')).toThrow(
-        SessionDataError,
-      )
-    })
-
-    it('returns the property if it does exist and a question is not provided', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': { 'my-page': { myPage: 'no' } },
-        },
-      })
-
-      const questionResponse = retrieveQuestionResponseFromApplication(application, 'basic-information', 'myPage')
-      expect(questionResponse).toBe('no')
-    })
-
-    it('returns the property if it does exist and a question is provided', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': { 'my-page': { questionResponse: 'no' } },
-        },
-      })
-
-      const questionResponse = retrieveQuestionResponseFromApplication(
-        application,
-        'basic-information',
-        'myPage',
-        'questionResponse',
-      )
-      expect(questionResponse).toBe('no')
     })
   })
 

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -7,6 +7,7 @@ import { isApplicableTier, personName, tierBadge } from './personUtils'
 
 import { FullPerson } from '../@types/shared'
 import {
+  createNameAnchorElement,
   dashboardTableRows,
   firstPageOfApplicationJourney,
   forPagesInTask,
@@ -475,6 +476,28 @@ describe('applicationUtils', () => {
           value: { html: 'answer three' },
         },
       ])
+    })
+  })
+
+  describe('createNameAnchorElement', () => {
+    it('returns the name in an anchor tag to the application show page', () => {
+      const application = applicationFactory.build({ status: 'inProgress' })
+
+      expect(createNameAnchorElement('Limited access offender', application)).toEqual({
+        html: `<a href=/referrals/${application.id}>Limited access offender</a>`,
+      })
+    })
+
+    describe('when the application has submitted status', () => {
+      it('returns the name in an anchor tag to the full application page', () => {
+        const application = applicationFactory.build({
+          status: 'submitted',
+        })
+
+        expect(createNameAnchorElement('Limited access offender', application)).toEqual({
+          html: `<a href=/referrals/${application.id}/full>Limited access offender</a>`,
+        })
+      })
     })
   })
 })

--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -11,7 +11,6 @@ import {
   dashboardTableRows,
   firstPageOfApplicationJourney,
   forPagesInTask,
-  getArrivalDate,
   getPage,
   getResponses,
   getSectionAndTask,
@@ -307,60 +306,21 @@ describe('applicationUtils', () => {
     })
   })
 
-  describe('getArrivalDate', () => {
-    it('returns the arrival date when the release date is known and is the same as the start date', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': {
-            'release-date': { knowReleaseDate: 'yes', releaseDate: '2022-11-14' },
-            'placement-date': { startDateSameAsReleaseDate: 'yes' },
-          },
-        },
-      })
-      expect(getArrivalDate(application)).toEqual('2022-11-14')
-    })
-
-    it('returns the arrival date when the release date is known but there is a different start date', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': {
-            'release-date': { knowReleaseDate: 'yes', releaseDate: '2022-11-14' },
-            'placement-date': { startDateSameAsReleaseDate: 'no', startDate: '2023-10-13' },
-          },
-        },
-      })
-
-      expect(getArrivalDate(application)).toEqual('2023-10-13')
-    })
-
-    it('throws an error or returns null when the release date is not known', () => {
-      const application = applicationFactory.build({
-        data: {
-          'basic-information': {
-            'release-date': { knowReleaseDate: 'no' },
-          },
-        },
-      })
-
-      expect(() => getArrivalDate(application)).toThrow(new SessionDataError('No known release date'))
-      expect(getArrivalDate(application, false)).toEqual(null)
-    })
-  })
-
   describe('dashboardTableRows', () => {
     it('returns an array of applications as table rows', async () => {
       ;(tierBadge as jest.MockedFunction<typeof tierBadge>).mockReturnValue('TIER_BADGE')
       ;(personName as jest.MockedFunction<typeof personName>).mockImplementation(person => (person as FullPerson).name)
 
-      const arrivalDate = DateFormats.dateObjToIsoDate(new Date(2021, 0, 3))
+      const submittedAtDate = DateFormats.dateObjToIsoDate(new Date(2023, 0, 3))
 
       const applicationA = applicationFactory.build({
         person: personFactory.build({ name: 'A' }),
-        data: {},
-        submittedAt: null,
+        status: 'inProgress',
       })
-      const applicationB = applicationFactory.withReleaseDate(arrivalDate).build({
+      const applicationB = applicationFactory.build({
         person: personFactory.build({ name: 'B' }),
+        status: 'submitted',
+        submittedAt: submittedAtDate,
       })
 
       const result = dashboardTableRows([applicationA, applicationB])
@@ -374,21 +334,18 @@ describe('applicationUtils', () => {
             text: applicationA.person.crn,
           },
           {
-            text: 'N/A',
-          },
-          {
-            html: getStatus(applicationB),
+            html: getStatus(applicationA),
           },
         ],
         [
           {
-            html: `<a href=${paths.applications.show({ id: applicationB.id })}>B</a>`,
+            html: `<a href=${paths.applications.full({ id: applicationB.id })}>B</a>`,
           },
           {
             text: applicationB.person.crn,
           },
           {
-            text: DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }),
+            text: DateFormats.isoDateToUIDate(submittedAtDate, { format: 'short' }),
           },
           {
             html: getStatus(applicationB),

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -12,7 +12,6 @@ import isAssessment from './assessments/isAssessment'
 import { DateFormats } from './dateUtils'
 import { SessionDataError, UnknownPageError, UnknownTaskError } from './errors'
 import { personName } from './personUtils'
-import { kebabCase } from './utils'
 import { formatLines } from './viewUtils'
 import { embeddedSummaryListItem } from './checkYourAnswersUtils/embeddedSummaryListItem'
 
@@ -163,27 +162,6 @@ const firstPageOfApplicationJourney = (application: Application) => {
   return paths.applications.show({ id: application.id })
 }
 
-/**
- * Retrieves response for a given question from the application object.
- * @param application the application to fetch the response from.
- * @param task the task to retrieve the response for.
- * @param page the page that we need the response for in camelCase.
- * @param {string} question [question=page] the page that we need the response for. Defaults to the value of `page`.
- * @returns the response for the given task/page/question.
- */
-const retrieveQuestionResponseFromApplication = <T>(
-  application: Application,
-  task: string,
-  page: string,
-  question?: string,
-) => {
-  try {
-    return application.data[task][kebabCase(page)][question || page] as T
-  } catch (e) {
-    throw new SessionDataError(`Question ${question} was not found in the session`)
-  }
-}
-
 const taskResponsesToSummaryListRowItems = (
   taskResponses: TaskResponse['content'],
 ): Array<{ key: string; value: HtmlItem }> => {
@@ -215,6 +193,5 @@ export {
   getResponses,
   getSectionAndTask,
   getStatus,
-  retrieveQuestionResponseFromApplication,
   taskResponsesToSummaryListRowItems,
 }

--- a/server/utils/applicationUtils.ts
+++ b/server/utils/applicationUtils.ts
@@ -21,7 +21,7 @@ const dashboardTableRows = (applications: Array<Application>): Array<TableRow> =
     const arrivalDate = getArrivalDate(application, false)
 
     return [
-      createNameAnchorElement(personName(application.person, 'Limited access offender'), application.id),
+      createNameAnchorElement(personName(application.person, 'Limited access offender'), application),
       textValue(application.person.crn),
       textValue(arrivalDate ? DateFormats.isoDateToUIDate(arrivalDate, { format: 'short' }) : 'N/A'),
       htmlValue(getStatus(application)),
@@ -46,8 +46,10 @@ const htmlValue = (value: string) => {
   return { html: value }
 }
 
-const createNameAnchorElement = (name: string, applicationId: string) => {
-  return htmlValue(`<a href=${paths.applications.show({ id: applicationId })}>${name}</a>`)
+const createNameAnchorElement = (name: string, application: Application) => {
+  return application.status === 'submitted'
+    ? htmlValue(`<a href=${paths.applications.full({ id: application.id })}>${name}</a>`)
+    : htmlValue(`<a href=${paths.applications.show({ id: application.id })}>${name}</a>`)
 }
 
 export type ApplicationOrAssessmentResponse = Record<string, Array<PageResponse>>
@@ -243,6 +245,7 @@ const taskResponsesToSummaryListRowItems = (
 }
 
 export {
+  createNameAnchorElement,
   dashboardTableRows,
   firstPageOfApplicationJourney,
   forPagesInTask,

--- a/server/views/applications/_table.njk
+++ b/server/views/applications/_table.njk
@@ -1,26 +1,44 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 
-{% macro applicationsTable(title, rows) %}
+{% macro applicationsTable(title, rows, submitted) %}
   {% if rows %}
+    {% set headers = [
+      {
+        text: "Person"
+      },
+      {
+        text: "CRN"
+      },
+      {
+        text: "Status"
+      }
+    ] %}
+
+    {% set headersWithSubmitted = [
+      {
+        text: "Person"
+      },
+      {
+        text: "CRN"
+      },
+      {
+        text: "Date submitted"
+      },
+      {
+        text: "Status"
+      }
+    ] %}
+
+    {% if submitted %}
+      {% set headers = headersWithSubmitted %}
+    {% endif %}
+
     {{
         govukTable({
           caption: title,
           captionClasses: "govuk-table__caption--m",
           firstCellIsHeader: true,
-          head: [
-            {
-              text: "Person"
-            },
-            {
-              text: "CRN"
-            },
-            {
-              text: "Arrival date"
-            },
-            {
-              text: "Status"
-            }
-          ],
+          head: headers,
           rows: rows
         })
       }}

--- a/server/views/applications/full.njk
+++ b/server/views/applications/full.njk
@@ -1,0 +1,52 @@
+{%- from "moj/components/identity-bar/macro.njk" import mojIdentityBar -%}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
+
+{% extends "../partials/layout.njk" %}
+
+{% set pageTitle = "The person's referral - " + applicationName %}
+{% set mainClasses = "app-container govuk-body" %}
+{% set backLinkUrl = paths.applications.index({}) + "#applications-submitted" %}
+
+{% block beforeContent %}
+  {{ govukBackLink({
+    text: "Back",
+    href: backLinkUrl
+  }) }}
+{% endblock %}
+
+{% set name = personName(application.person, 'Limited access offender') %}
+{% block content %}
+  {% include "../_messages.njk" %}
+
+  <div class="moj-identity-bar">
+    <div class="moj-identity-bar__container">
+      <div class="moj-identity-bar__details">
+        <span class="moj-identity-bar__title">
+          <span class="govuk-caption-xl">Transitional Accommodation (CAS3) referral</span>
+          <h1 class="govuk-heading-xl">{{ name }}</h1>
+        </span>
+      </div>
+    </div>
+  </div>
+
+  <div class="govuk-!-margin-4">
+    {% for section in application.document.sections %}
+      <h2 class="govuk-heading-l govuk-!-margin-top-3" >{{ section.title }}</h2>
+      {% for task in section.tasks %}
+
+        {{
+          govukSummaryList({
+            card: {
+              title: {
+                text: task.title
+              }
+              },
+              rows: taskResponsesToSummaryListRowItems(task.content)
+          })
+        }}
+      {% endfor %}
+    {% endfor %}
+  </div>
+
+{% endblock %}

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -29,7 +29,7 @@
             label: "Submitted",
             id: "applications-submitted",
             panel: {
-              html: applicationsTable("Referrals", dashboardTableRows(applications.submitted))
+              html: applicationsTable("Referrals", dashboardTableRows(applications.submitted), true)
             }
           }
         ]

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -24,6 +24,13 @@
             panel: {
               html: applicationsTable("Referrals", dashboardTableRows(applications.inProgress))
             }
+          },
+          {
+            label: "Submitted",
+            id: "applications-submitted",
+            panel: {
+              html: applicationsTable("Referrals", dashboardTableRows(applications.submitted))
+            }
           }
         ]
       }) }}


### PR DESCRIPTION
> We [reverted an earlier version](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/669) of this PR due to an e2e test failing. This is because the `submitted_at` property is set by the API so it is difficult to assert in our e2e test. The fix for that can be found [here](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/672/files#diff-5ab38e4cae716fb7dfab743f058248a42dd649a66b38158998acdd6f4a54f999R60), where a flag has been added to not check on e2e tests. It will still check in integration tests.

# Context
In a previous change[1], we hid submitted referrals due to it causing
confusion for users. We were linking the user back to the check your
answers page which gave the impression that the application wasn't
submitted.

We are now going to link these referrals to a new page which shows the
full submitted referral.

[1]
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/516

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
* Reinstate the submitted referrals tab
* Introduce full submitted referral page

## Screenshots of UI changes

### Before
![Screenshot 2023-10-05 at 12 10 55](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/de9dad07-e801-457f-b529-b603a83be578)

### After
![Screenshot 2023-10-05 at 12 47 48](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/557605af-5ce3-45f3-bbb5-034653d46ae9)
![Screenshot 2023-10-05 at 12 03 16](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/f21917cf-0b45-4c84-8e8a-65329dbfe68e)
![Screenshot 2023-10-05 at 12 03 30](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/ce2dc82a-e8b9-44d9-a293-414a620e19eb)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
