### PR TITLE
Fix selecting submitted application in e2e test

### DIFF
--- a/cypress_shared/pages/apply/list.ts
+++ b/cypress_shared/pages/apply/list.ts
@@ -26,6 +26,16 @@ export default class ListPage extends Page {
     }
   }
 
+  clickSubmittedApplication(application: Application) {
+    cy.get('#applications-submitted').within(() => {
+      if (isFullPerson(application.person)) {
+        cy.get('a').contains(application.person.name).click()
+      } else {
+        cy.get(`a[href*="${paths.applications.full({ id: application.id })}"]`).click()
+      }
+    })
+  }
+
   shouldShowInProgressApplications(): void {
     this.shouldShowApplications(this.inProgressApplications, 'in-progress')
   }

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -64,7 +64,7 @@ Then('I can see the full submitted application', () => {
 
     listPage.shouldShowSubmittedApplication(this.application, false)
 
-    listPage.clickApplication(this.application)
+    listPage.clickSubmittedApplication(this.application)
 
     Page.verifyOnPage(ApplicationFullPage, this.application)
   })


### PR DESCRIPTION
# Context
We want to be able to specifically click on a submitted application to avoid scenarios where an in progress application and submitted application share the same PoP name.

We also want to target the path for the full referral if the PoP is an LAO.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
