### PR TITLE
Remove whitespace from CRN before creating a booking

### DIFF
--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -212,7 +212,7 @@ export default class BookingsController {
       const { premisesId, roomId } = req.params
       const callConfig = extractCallConfig(req)
 
-      const { assessmentId } = req.body
+      const { assessmentId, crn } = req.body
 
       const { arrivalDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'arrivalDate')
       const { departureDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'departureDate')
@@ -222,6 +222,7 @@ export default class BookingsController {
       const newBooking: NewBooking = {
         service: 'temporary-accommodation',
         ...req.body,
+        crn: crn.trim(),
         assessmentId: assessmentId === noAssessmentId ? undefined : assessmentId,
         arrivalDate,
         departureDate,


### PR DESCRIPTION
# Context
We've been getting [errors](https://ministryofjustice.sentry.io/issues/4383361316/events/?environment=prod&project=4504129156218880&query=transaction%3A%22POST+%2Fproperties%2F%3ApremisesId%2Fbedspaces%2F%3AroomId%2Fbookings%22&referrer=project-issue-stream) due to including CRNs with white space when creating a booking. This change ensures CRNs are stripped before making the API call.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
