### PR TITLE
Feature/1588 add reporter role

### DIFF
--- a/server/controllers/landingController.test.ts
+++ b/server/controllers/landingController.test.ts
@@ -8,6 +8,7 @@ import { userFactory } from '../testutils/factories'
 import { UnauthorizedError } from '../utils/errors'
 import { isApplyEnabledForUser } from '../utils/userUtils'
 import LandingController from './landingController'
+import { TemporaryAccommodationUserRole } from '../@types/shared'
 
 jest.mock('../utils/userUtils', () => {
   const module = jest.requireActual('../utils/userUtils')
@@ -90,6 +91,21 @@ describe('LandingController', () => {
       const requestHandler = landingController.index()
 
       expect(() => requestHandler(request, response, next)).toThrowError(UnauthorizedError)
+    })
+
+    it('redirects to the reports page when the user is a reporter', () => {
+      const response: DeepMocked<Response> = createMock<Response>({
+        locals: {
+          user: userFactory.build({
+            roles: ['reporter' as TemporaryAccommodationUserRole],
+          }),
+        },
+      })
+
+      const requestHandler = landingController.index()
+      requestHandler(request, response, next)
+
+      expect(response.redirect).toHaveBeenCalledWith(managePaths.reports.new({}))
     })
   })
 })

--- a/server/controllers/landingController.ts
+++ b/server/controllers/landingController.ts
@@ -4,7 +4,12 @@ import applyPaths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
 import { UnauthorizedError } from '../utils/errors'
-import { isApplyEnabledForUser, userHasAssessorRole, userHasReferrerRole } from '../utils/userUtils'
+import {
+  isApplyEnabledForUser,
+  userHasAssessorRole,
+  userHasReferrerRole,
+  userHasReporterRole,
+} from '../utils/userUtils'
 
 export default class LandingController {
   index(): RequestHandler {
@@ -20,6 +25,10 @@ export default class LandingController {
           return res.redirect(applyPaths.applications.index({}))
         }
         return res.redirect(staticPaths.static.useNDelius.pattern)
+      }
+
+      if (userHasReporterRole(user)) {
+        return res.redirect(managePaths.reports.new({}))
       }
 
       throw new UnauthorizedError()

--- a/server/controllers/temporary-accommodation/manage/reportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.ts
@@ -4,7 +4,7 @@ import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import ReportService from '../../../services/reportService'
 import extractCallConfig from '../../../utils/restUtils'
-import { filterProbationRegions } from '../../../utils/userUtils'
+import { filterProbationRegions, userHasReporterRole } from '../../../utils/userUtils'
 import { getYearsSince, monthsArr } from '../../../utils/dateUtils'
 
 export default class ReportsController {
@@ -19,7 +19,9 @@ export default class ReportsController {
       const { probationRegions: allProbationRegions } = await this.reportService.getReferenceData(callConfig)
 
       return res.render('temporary-accommodation/reports/new', {
-        allProbationRegions: filterProbationRegions(allProbationRegions, req),
+        allProbationRegions: userHasReporterRole(res.locals.user)
+          ? allProbationRegions
+          : filterProbationRegions(allProbationRegions, req),
         errors,
         errorSummary: requestErrorSummary,
         probationRegionId: req.session.probationRegion.id,

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -9,7 +9,7 @@ import populateCurrentUser from './populateCurrentUser'
 
 jest.mock('../utils/restUtils')
 
-describe('populateUserRegion', () => {
+describe('populateCurrentUser', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
   const userService = createMock<UserService>()
 

--- a/server/middleware/userCheckMiddleware.test.ts
+++ b/server/middleware/userCheckMiddleware.test.ts
@@ -2,8 +2,9 @@ import { createMock } from '@golevelup/ts-jest'
 import { Request, Response } from 'express'
 import { userFactory } from '../testutils/factories'
 import { UnauthorizedError } from '../utils/errors'
-import { TemporaryAccommodationUser as User } from '../@types/shared'
-import { createUserCheckMiddleware } from './userCheckMiddleware'
+import { TemporaryAccommodationUserRole, TemporaryAccommodationUser as User } from '../@types/shared'
+import { createUserCheckMiddleware, userIsAuthorisedForManage } from './userCheckMiddleware'
+import paths from '../paths/temporary-accommodation/manage'
 
 describe('createUserCheckMiddleware', () => {
   it('returns middleware that calls the handler when the user predicate succeeds', async () => {
@@ -44,5 +45,98 @@ describe('createUserCheckMiddleware', () => {
 
     expect(handler).not.toHaveBeenCalled()
     expect(next).toHaveBeenCalledWith(new UnauthorizedError())
+  })
+
+  describe('userIsAuthorisedForManage', () => {
+    it('returns middleware that calls next() with an unauthorized error when the path is not reports', async () => {
+      const handler = jest.fn()
+      const request = createMock<Request>({ path: paths.assessments.index({}) })
+      const response = createMock<Response>({
+        locals: {
+          user: userFactory.build({ roles: ['referrer'] }),
+        },
+      })
+      const next = jest.fn()
+
+      const middleware = createUserCheckMiddleware(userIsAuthorisedForManage)
+
+      middleware(handler)(request, response, next)
+
+      expect(handler).not.toHaveBeenCalled()
+      expect(next).toHaveBeenCalledWith(new UnauthorizedError())
+    })
+
+    describe('when the user has assessor role', () => {
+      it('returns middleware that calls the handler', async () => {
+        const handler = jest.fn()
+        const request = createMock<Request>({ path: paths.assessments.index({}) })
+        const response = createMock<Response>({
+          locals: {
+            user: userFactory.build({ roles: ['assessor'] }),
+          },
+        })
+        const next = jest.fn()
+
+        const middleware = createUserCheckMiddleware(userIsAuthorisedForManage)
+
+        middleware(handler)(request, response, next)
+
+        expect(handler).toHaveBeenCalledWith(request, response, next)
+      })
+    })
+
+    describe('when the user has reporter role', () => {
+      it('returns middleware that calls the handler when the the path is reports#new', async () => {
+        const handler = jest.fn()
+        const request = createMock<Request>({ path: paths.reports.new({}) })
+        const response = createMock<Response>({
+          locals: {
+            user: userFactory.build({ roles: ['reporter' as TemporaryAccommodationUserRole] }),
+          },
+        })
+        const next = jest.fn()
+
+        const middleware = createUserCheckMiddleware(userIsAuthorisedForManage)
+
+        middleware(handler)(request, response, next)
+
+        expect(handler).toHaveBeenCalledWith(request, response, next)
+      })
+
+      it('returns middleware that calls the handler when the path is reports#create', async () => {
+        const handler = jest.fn()
+        const request = createMock<Request>({ path: paths.reports.create({}) })
+        const response = createMock<Response>({
+          locals: {
+            user: userFactory.build({ roles: ['reporter' as TemporaryAccommodationUserRole] }),
+          },
+        })
+        const next = jest.fn()
+
+        const middleware = createUserCheckMiddleware(userIsAuthorisedForManage)
+
+        middleware(handler)(request, response, next)
+
+        expect(handler).toHaveBeenCalledWith(request, response, next)
+      })
+
+      it('returns middleware that calls next() with an unauthorized error when the path is not reports', async () => {
+        const handler = jest.fn()
+        const request = createMock<Request>({ path: paths.assessments.index({}) })
+        const response = createMock<Response>({
+          locals: {
+            user: userFactory.build({ roles: ['reporter' as TemporaryAccommodationUserRole] }),
+          },
+        })
+        const next = jest.fn()
+
+        const middleware = createUserCheckMiddleware(userIsAuthorisedForManage)
+
+        middleware(handler)(request, response, next)
+
+        expect(handler).not.toHaveBeenCalled()
+        expect(next).toHaveBeenCalledWith(new UnauthorizedError())
+      })
+    })
   })
 })

--- a/server/middleware/userCheckMiddleware.ts
+++ b/server/middleware/userCheckMiddleware.ts
@@ -1,17 +1,27 @@
 import { NextFunction, Request, RequestHandler, Response } from 'express'
+import paths from '../paths/temporary-accommodation/manage'
 import { TemporaryAccommodationUser as User } from '../@types/shared'
 import { UnauthorizedError } from '../utils/errors'
+import { userHasAssessorRole, userHasReporterRole } from '../utils/userUtils'
 
-export const createUserCheckMiddleware = (check: (user: User) => boolean) => {
+export const createUserCheckMiddleware = (check: (user: User, path: string) => boolean) => {
   return (handler: RequestHandler) => wrapHandler(handler, check)
 }
 
 const wrapHandler =
-  (handler: RequestHandler, check: (user: User) => boolean) =>
+  (handler: RequestHandler, check: (user: User, path: string) => boolean) =>
   async (req: Request, res: Response, next: NextFunction) => {
-    if (check(res.locals.user)) {
+    if (check(res.locals.user, req.path)) {
       await handler(req, res, next)
     } else {
       next(new UnauthorizedError())
     }
   }
+
+const isReportPath = (path: string): boolean => path === paths.reports.new({}) || path === paths.reports.create({})
+
+const userHasReporterRoleAndPathIsReports = (user: User, path: string): boolean =>
+  userHasReporterRole(user) && isReportPath(path)
+
+export const userIsAuthorisedForManage = (user: User, path: string): boolean =>
+  userHasAssessorRole(user) || userHasReporterRoleAndPathIsReports(user, path)

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -2,16 +2,15 @@
 
 import type { Router } from 'express'
 import type { Controllers } from '../../controllers'
-import { createUserCheckMiddleware } from '../../middleware/userCheckMiddleware'
+import { createUserCheckMiddleware, userIsAuthorisedForManage } from '../../middleware/userCheckMiddleware'
 import paths from '../../paths/temporary-accommodation/manage'
 import { Services } from '../../services'
-import { userHasAssessorRole } from '../../utils/userUtils'
 import { actions, compose } from '../utils'
 
 export default function routes(controllers: Controllers, services: Services, router: Router): Router {
   const { get, post, put } = compose(
     actions(router, services.auditService),
-    createUserCheckMiddleware(userHasAssessorRole),
+    createUserCheckMiddleware(userIsAuthorisedForManage),
   )
 
   const {

--- a/server/utils/userUtils.test.ts
+++ b/server/utils/userUtils.test.ts
@@ -8,8 +8,9 @@ import {
   userHasAssessorRoleAndIsApplyEnabled,
   userHasReferrerRole,
   userHasReferrerRoleAndIsApplyEnabled,
+  userHasReporterRole,
 } from './userUtils'
-import { TemporaryAccommodationUserRole as Role } from '../@types/shared'
+import { TemporaryAccommodationUserRole as Role, TemporaryAccommodationUserRole } from '../@types/shared'
 import config from '../config'
 
 jest.mock('./enabledRegions', () => {
@@ -116,6 +117,18 @@ describe('userHasAssessorRole', () => {
   it('returns false when user hasnt got the role "assessor"', () => {
     const user = userFactory.build({ roles: ['referrer'] })
     expect(userHasAssessorRole(user)).toBe(false)
+  })
+})
+
+describe('userHasReporterRole', () => {
+  it('returns true when user has got the role "reporter"', () => {
+    const user = userFactory.build({ roles: ['reporter' as TemporaryAccommodationUserRole] })
+    expect(userHasReporterRole(user)).toBe(true)
+  })
+
+  it('returns false when user hasnt got the role "reporter"', () => {
+    const user = userFactory.build({ roles: ['referrer'] })
+    expect(userHasReporterRole(user)).toBe(false)
   })
 })
 

--- a/server/utils/userUtils.ts
+++ b/server/utils/userUtils.ts
@@ -1,5 +1,5 @@
 import { Request } from 'express'
-import { ProbationRegion, TemporaryAccommodationUser as User } from '../@types/shared'
+import { ProbationRegion, TemporaryAccommodationUserRole, TemporaryAccommodationUser as User } from '../@types/shared'
 import enabledRegions from './enabledRegions'
 import config from '../config'
 
@@ -17,6 +17,10 @@ export function userHasReferrerRole(user: User): boolean {
 
 export function userHasAssessorRole(user: User): boolean {
   return user.roles.includes('assessor')
+}
+
+export function userHasReporterRole(user: User): boolean {
+  return user.roles.includes('reporter' as TemporaryAccommodationUserRole)
 }
 
 export function userHasReferrerRoleAndIsApplyEnabled(user: User): boolean {

--- a/wiremock/reportStubs.ts
+++ b/wiremock/reportStubs.ts
@@ -2,18 +2,46 @@ import paths from '../server/paths/api'
 
 const reportStubs: Array<Record<string, unknown>> = []
 
-reportStubs.push({
-  request: {
-    method: 'GET',
-    urlPath: paths.reports.bookings({}),
-  },
-  response: {
-    status: 200,
-    headers: {
-      'Content-Type': 'text/csv',
+reportStubs.push(
+  {
+    request: {
+      method: 'GET',
+      urlPath: paths.reports.bookings({}),
     },
-    body: '"Column 1","Column 2"\n"Entry 1A","Entry 1B"\n"Entry 2A","Entry 2B"',
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+      },
+      body: '"Column 1","Column 2"\n"Entry 1A","Entry 1B"\n"Entry 2A","Entry 2B"',
+    },
   },
-})
+  {
+    request: {
+      method: 'GET',
+      urlPath: paths.reports.bedspaceUsage({}),
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+      },
+      body: '"Column 1","Column 2"\n"Entry 1A","Entry 1B"\n"Entry 2A","Entry 2B"',
+    },
+  },
+  {
+    request: {
+      method: 'GET',
+      urlPath: paths.reports.bedspaceUtilisation({}),
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'text/csv',
+      },
+      body: '"Column 1","Column 2"\n"Entry 1A","Entry 1B"\n"Entry 2A","Entry 2B"',
+    },
+  },
+)
 
 export default reportStubs


### PR DESCRIPTION
# Context
We want to add a new 'reporter' role which will enable reporters to
download reports for all regions.

# Changes in this PR
* Add `reporter` role
* Allow reporters to only see `reports/bookings` page
* Allow reporters to download reports from all regions

## Screenshots of UI changes

### Before
![Screenshot 2023-10-18 at 15 28 36](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/8adc4758-c6d5-4845-b706-bcc4beefc4d5)

### After
![Screenshot 2023-10-18 at 15 22 40](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/e4f790ed-1c91-4006-9115-3151e99cc240)

### Screen recording

https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/cec89a99-7377-4a14-b7b0-9f7fdee89c48


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
