### PR TITLE
Feature/enable sign in from new url

### DIFF
--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -29,22 +29,26 @@ const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
 }
 
 function init(): void {
-  const strategy = new Strategy(
+  const defaultStrategyAttributes = {
+    authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
+    tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
+    clientID: config.apis.hmppsAuth.apiClientId,
+    clientSecret: config.apis.hmppsAuth.apiClientSecret,
+    state: true,
+    customHeaders: { Authorization: generateOauthClientToken() },
+  }
+
+  const firstDomainStrategy = new Strategy(
     {
-      authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
-      tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
-      clientID: config.apis.hmppsAuth.apiClientId,
-      clientSecret: config.apis.hmppsAuth.apiClientSecret,
+      ...defaultStrategyAttributes,
       callbackURL: `${config.firstDomain}/sign-in/callback`,
-      state: true,
-      customHeaders: { Authorization: generateOauthClientToken() },
     },
     (token, refreshToken, params, profile, done) => {
       return done(null, { token, username: params.user_name, authSource: params.auth_source })
     },
   )
 
-  passport.use(strategy)
+  passport.use(firstDomainStrategy)
 }
 
 export default {

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -48,7 +48,18 @@ function init(): void {
     },
   )
 
+  const secondDomainStrategy = new Strategy(
+    {
+      ...defaultStrategyAttributes,
+      callbackURL: `${config.secondDomain}/sign-in/callback`,
+    },
+    (token, refreshToken, params, profile, done) => {
+      return done(null, { token, username: params.user_name, authSource: params.auth_source })
+    },
+  )
+
   passport.use(firstDomainStrategy)
+  passport.use(secondDomainStrategy)
 }
 
 export default {


### PR DESCRIPTION
# Context

We need to support transitional-accommodation alongside temporary-accommodation.

- The new domain has been set up as a dns name on our certificates via the platform-environments
- We have only enabled our frontend to listen to it on our test environment while we test it out.
- We add a second strategy here for all environments. The first strategy should maintain previous behaviour for sign ins and the second should sit dormant until auth requests start coming in from that domain

# Changes in this PR

We use the passport library to create a new strategy for the second domain. When passport is authenticating requests via passport.authenticate() it should cycle through the availabe strategies to check for a match to the auth provider.

Testing this locally was a fiddly. We have some branches set up on this repo[1] and our approved-premises-tools repo[2] to simulate the error before this change and how it works after being applied.

With those branches checked out (rather than this one) you can run `docker-compose down -v && tilt up -- --local-api --local-ui` within ap-tools to test.

In this test we aim to replicate the current state of the test environment where we observe an “Authorisation error”. We start two frontend instances on localhost:3000 and 127.0.0.2:3002. This simulates our service running on two different domains: https://temporary-accommodation-test.hmpps.service.justice.gov.uk and https://transitional-accommodation-test.hmpps.service.justice.gov.uk.

We check first we can sign into localhost:3000 as normal. This should test that the original mechanism is still functional. We then sign out.

Finally we visit 127.0.0.2:3002 which is the ‘new’ domain and see if we can sign in without issue. it also shows that we are redirected to 127.0.0.2:3002 rather than the original localhost:3000, which leaves us open to adding a redirect for anyone using the old url.

[1] https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/tree/test-multiple-domain-sign-in
[2] https://github.com/ministryofjustice/hmpps-approved-premises-tools/tree/test-multiple-cas3-sign-in

## Screenshots of UI changes

I have some screen recordings to demo this that i'll send via Slack when you're ready!

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
