### PR TITLE
Revert "Feature/enable sign in from new url"

### DIFF
--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -29,37 +29,22 @@ const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
 }
 
 function init(): void {
-  const defaultStrategyAttributes = {
-    authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
-    tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
-    clientID: config.apis.hmppsAuth.apiClientId,
-    clientSecret: config.apis.hmppsAuth.apiClientSecret,
-    state: true,
-    customHeaders: { Authorization: generateOauthClientToken() },
-  }
-
-  const firstDomainStrategy = new Strategy(
+  const strategy = new Strategy(
     {
-      ...defaultStrategyAttributes,
+      authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
+      tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
+      clientID: config.apis.hmppsAuth.apiClientId,
+      clientSecret: config.apis.hmppsAuth.apiClientSecret,
       callbackURL: `${config.firstDomain}/sign-in/callback`,
+      state: true,
+      customHeaders: { Authorization: generateOauthClientToken() },
     },
     (token, refreshToken, params, profile, done) => {
       return done(null, { token, username: params.user_name, authSource: params.auth_source })
     },
   )
 
-  const secondDomainStrategy = new Strategy(
-    {
-      ...defaultStrategyAttributes,
-      callbackURL: `${config.secondDomain}/sign-in/callback`,
-    },
-    (token, refreshToken, params, profile, done) => {
-      return done(null, { token, username: params.user_name, authSource: params.auth_source })
-    },
-  )
-
-  passport.use(firstDomainStrategy)
-  passport.use(secondDomainStrategy)
+  passport.use(strategy)
 }
 
 export default {


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-temporary-accommodation-ui#685

Sign in doesn't seem to work in dev as a result of this. I noticed that when signing into temporary-accommodation.x the auth redirect was to transitional-accommodation.x. Perhaps the assumption of how the strategies work is wrong.