### PR TITLE
Enable transitional domain in dev

### DIFF
--- a/helm_deploy/values-dev.yaml
+++ b/helm_deploy/values-dev.yaml
@@ -7,6 +7,7 @@ generic-service:
   ingress:
     hosts:
       - temporary-accommodation-dev.hmpps.service.justice.gov.uk
+      - transitional-accommodation-dev.hmpps.service.justice.gov.uk
     contextColour: green
     tlsSecretName: hmpps-temporary-accommodation-dev-cert
 


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

Signing in on dev isn't working after [this change to strategies](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/685). This change was designed to work in the test environment as the domain name is enabled there however because dev isn't working, e2e failures block this release. We may need to [roll this back](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/686) but before we do we quickly check to see if turning the domain on fixes it.



# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
