### PR TITLE
Redirect requests from the old domain to the new one

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import { setUpSentryErrorHandler, setUpSentryRequestHandler } from './middleware
 import routes from './routes/temporary-accommodation'
 import type { Controllers } from './controllers'
 import type { Services } from './services'
+import setUpDomainRedirect from './middleware/setUpDomainRedirect'
 
 export default function createApp(controllers: Controllers, services: Services): express.Application {
   const app = express()
@@ -33,6 +34,8 @@ export default function createApp(controllers: Controllers, services: Services):
   app.set('port', process.env.PORT || 3000)
 
   setUpSentryRequestHandler(app)
+
+  app.use(setUpDomainRedirect())
 
   // Add method-override to allow us to use PUT and DELETE methods
   app.use(methodOverride('_method'))

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -29,15 +29,23 @@ const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
 }
 
 function init(): void {
+  const defaultStrategyConfig = {
+    authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
+    tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
+    clientID: config.apis.hmppsAuth.apiClientId,
+    clientSecret: config.apis.hmppsAuth.apiClientSecret,
+    state: true,
+    customHeaders: { Authorization: generateOauthClientToken() },
+  }
+
+  let callbackURL = {
+    callbackURL: `${config.firstDomain}/sign-in/callback`,
+  }
+
   const strategy = new Strategy(
     {
-      authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
-      tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
-      clientID: config.apis.hmppsAuth.apiClientId,
-      clientSecret: config.apis.hmppsAuth.apiClientSecret,
-      callbackURL: `${config.firstDomain}/sign-in/callback`,
-      state: true,
-      customHeaders: { Authorization: generateOauthClientToken() },
+      ...defaultStrategyConfig,
+      ...callbackURL,
     },
     (token, refreshToken, params, profile, done) => {
       return done(null, { token, username: params.user_name, authSource: params.auth_source })

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -38,8 +38,12 @@ function init(): void {
     customHeaders: { Authorization: generateOauthClientToken() },
   }
 
-  let callbackURL = {
-    callbackURL: `${config.firstDomain}/sign-in/callback`,
+  // TODO: Remove this once our sign in testing on our new domain is complete on
+  // the test env.
+  const redirectToDomain = process.env.NODE_ENV === 'test' ? config.secondDomain : config.firstDomain
+
+  const callbackURL = {
+    callbackURL: `${redirectToDomain}/sign-in/callback`,
   }
 
   const strategy = new Strategy(

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -29,7 +29,10 @@ export default function setUpAuth(): Router {
   )
 
   const authUrl = config.apis.hmppsAuth.externalUrl
-  const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${config.firstDomain}`
+  // TODO: Remove this once our sign in testing on our new domain is complete on
+  // the test env.
+  const redirectToDomain = process.env.NODE_ENV === 'test' ? config.secondDomain : config.firstDomain
+  const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${redirectToDomain}`
 
   router.use('/sign-out', (req, res, next) => {
     if (req.user) {

--- a/server/middleware/setUpDomainRedirect.test.ts
+++ b/server/middleware/setUpDomainRedirect.test.ts
@@ -1,0 +1,46 @@
+import express, { Express } from 'express'
+import request from 'supertest'
+import setUpDomainRedirect from './setUpDomainRedirect'
+import config from '../config'
+
+jest.mock('../config', () => ({
+  secondDomain: 'http://example.com',
+  firstDomain: 'http://example.org',
+}))
+
+const setupApp = (): Express => {
+  const app = express()
+  app.use(setUpDomainRedirect())
+
+  app.get('/known', (_req, res, _next) => {
+    res.send('known')
+  })
+
+  return app
+}
+describe('setUpDomainRedirect', () => {
+  it('should redirect to the target domain when in test mode', () => {
+    process.env.NODE_ENV = 'test'
+    const app = setupApp()
+    const targetHost = new URL(config.firstDomain).host
+    return request(app).get('/known').set('host', targetHost).expect(301)
+  })
+
+  it('should not redirect requests already coming from the second domain', () => {
+    process.env.NODE_ENV = 'test'
+    const app = setupApp()
+    const targetHost = new URL(config.secondDomain).host
+    return request(app).get('/known').set('host', targetHost).expect(200)
+  })
+
+  it('should not redirect when not in test mode', () => {
+    process.env.NODE_ENV = 'production'
+    const app = setupApp()
+    const targetHost = new URL(config.firstDomain).host
+    return request(app).get('/known').set('host', targetHost).expect(200)
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = 'test'
+  })
+})

--- a/server/middleware/setUpDomainRedirect.ts
+++ b/server/middleware/setUpDomainRedirect.ts
@@ -1,0 +1,20 @@
+import type { Router } from 'express'
+import express from 'express'
+import config from '../config'
+
+const router = express.Router()
+
+export default function setUpDomainRedirect(): Router {
+  const source = new URL(config.firstDomain)
+  const target = new URL(config.secondDomain)
+
+  router.use((req, res, next) => {
+    if (process.env.NODE_ENV === 'test' && req.headers.host === source.host) {
+      target.pathname = req.path
+      return res.redirect(301, `${target.toString()}`)
+    }
+    return next()
+  })
+
+  return router
+}


### PR DESCRIPTION
# Context

# Changes in this PR

[The previous attempt to allow users to sign into the new domain name](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/681) failed and had to be [reverted](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/686).

This is probably due to the fact we were using two strategies with the same callback url. It always redirected the user to transitional-accommodation.x despite starting from temporary. This appeared worked when we tested locally but on a real environment we didn't see the same thing. Presumably a problem in the fiddly attempt to replicate locally.

This time we change approach.

We are going to try first redirecting all traffic from the old url to the new one. From there we can go back to a single passport strategy. That way when the user signs in they're always signing in on the "transitional" equivalent.

In order to protect production while we test this sensitive code change we add some plumbing in so that the new behaviour only works in the test environment for now.

What i'd like to observe in test is that I arrive at temporary-accommodation and am redirected to transitional-accommodation. From there I can sign in and am taken back to transitional-accommodation successfully.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
