### PR TITLE
Send eligiblityReason on referral submit

### DIFF
--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -29,6 +29,7 @@ describe('getApplicationSubmissionData', () => {
       dutyToReferSubmissionDate: '2022-04-12',
       needsAccessibleProperty: true,
       isApplicationEligible: true,
+      eligibilityReason: applicationDataJson.eligibility['eligibility-reason'].reason,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -7,6 +7,7 @@ import { arrivalDateFromApplication } from '../../form-pages/utils'
 import getSummaryDataFromApplication from './getSummaryDataFromApplication'
 import {
   dutyToReferSubmissionDateFromApplication,
+  eligibilityReasonFromApplication,
   isApplicationEligibleFromApplication,
   isDutyToReferSubmittedFromApplication,
   needsAccessiblePropertyFromApplication,
@@ -29,5 +30,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     dutyToReferSubmissionDate: dutyToReferSubmissionDateFromApplication(application),
     needsAccessibleProperty: needsAccessiblePropertyFromApplication(application),
     isApplicationEligible: isApplicationEligibleFromApplication(application),
+    eligibilityReason: eligibilityReasonFromApplication(application),
   }
 }

--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -1,5 +1,6 @@
 import {
   dutyToReferSubmissionDateFromApplication,
+  eligibilityReasonFromApplication,
   isApplicationEligibleFromApplication,
   isDutyToReferSubmittedFromApplication,
   needsAccessiblePropertyFromApplication,
@@ -111,6 +112,31 @@ describe('reportDataFromApplication', () => {
       })
 
       expect(() => isApplicationEligibleFromApplication(application)).toThrow(
+        new SessionDataError('No application eligibility data'),
+      )
+    })
+  })
+
+  describe('eligibilityReasonFromApplication', () => {
+    it('returns reason for application eligibility for CAS3 from the application', () => {
+      const application = applicationFactory.build({
+        data: {
+          eligibility: {
+            'eligibility-reason': { reason: 'homelessFromCustody' },
+          },
+        },
+      })
+      expect(eligibilityReasonFromApplication(application)).toEqual('homelessFromCustody')
+    })
+
+    it('throws an error when the eligibility data is not present', () => {
+      const application = applicationFactory.build({
+        data: {
+          eligibility: {},
+        },
+      })
+
+      expect(() => eligibilityReasonFromApplication(application)).toThrow(
         new SessionDataError('No application eligibility data'),
       )
     })

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -61,8 +61,24 @@ const isApplicationEligibleFromApplication = (application: Application): boolean
   return false
 }
 
+const eligibilityReasonFromApplication = (application: Application): string => {
+  const eligibilityReason: string = (application.data as Record<string, unknown>)?.eligibility?.['eligibility-reason']
+    ?.reason
+
+  if (!eligibilityReason) {
+    throw new SessionDataError('No application eligibility data')
+  }
+
+  if (Object.keys(eligibilityReasons).includes(eligibilityReason)) {
+    return eligibilityReason
+  }
+
+  return null
+}
+
 export {
   dutyToReferSubmissionDateFromApplication,
+  eligibilityReasonFromApplication,
   isApplicationEligibleFromApplication,
   isDutyToReferSubmittedFromApplication,
   needsAccessiblePropertyFromApplication,


### PR DESCRIPTION
# Context

# Changes in this PR

We now know we need to send the `eligiblityReason` in our MI reports. This change builds on [this work](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/be5eac83fbeae23d480749cf63f78e02e96afd31) to send the new field through.

API changes: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1054

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
