### PR TITLE
Redirect all requests to our new domain

### DIFF
--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -38,9 +38,7 @@ function init(): void {
     customHeaders: { Authorization: generateOauthClientToken() },
   }
 
-  // TODO: Remove this once our sign in testing on our new domain is complete on
-  // the test env.
-  const redirectToDomain = config.environment === 'test' ? config.secondDomain : config.firstDomain
+  const redirectToDomain = config.secondDomain
 
   const callbackURL = {
     callbackURL: `${redirectToDomain}/sign-in/callback`,

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -29,9 +29,7 @@ export default function setUpAuth(): Router {
   )
 
   const authUrl = config.apis.hmppsAuth.externalUrl
-  // TODO: Remove this once our sign in testing on our new domain is complete on
-  // the test env.
-  const redirectToDomain = config.environment === 'test' ? config.secondDomain : config.firstDomain
+  const redirectToDomain = config.secondDomain
   const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${redirectToDomain}`
 
   router.use('/sign-out', (req, res, next) => {

--- a/server/middleware/setUpDomainRedirect.test.ts
+++ b/server/middleware/setUpDomainRedirect.test.ts
@@ -33,13 +33,6 @@ describe('setUpDomainRedirect', () => {
     return request(app).get('/known').set('host', targetHost).expect(200)
   })
 
-  it('should not redirect when not in test mode', () => {
-    config.environment = 'production'
-    const app = setupApp()
-    const targetHost = new URL(config.firstDomain).host
-    return request(app).get('/known').set('host', targetHost).expect(200)
-  })
-
   afterEach(() => {
     config.environment = 'test'
   })

--- a/server/middleware/setUpDomainRedirect.ts
+++ b/server/middleware/setUpDomainRedirect.ts
@@ -9,7 +9,7 @@ export default function setUpDomainRedirect(): Router {
   const target = new URL(config.secondDomain)
 
   router.use((req, res, next) => {
-    if (config.environment === 'test' && req.headers.host === source.host) {
+    if (req.headers.host === source.host) {
       target.pathname = req.path
       return res.redirect(301, `${target.toString()}`)
     }


### PR DESCRIPTION
Remove the restriction for this only to work in test.

# Context

[We pushed a change to redirect all traffic on the test environment](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/691). That has now verified this is working and so we can push ahead with this change on dev, preprod and prod.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
