### PR TITLE
Redirect requests from the old domain to the new one

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -24,6 +24,7 @@ import { setUpSentryErrorHandler, setUpSentryRequestHandler } from './middleware
 import routes from './routes/temporary-accommodation'
 import type { Controllers } from './controllers'
 import type { Services } from './services'
+import setUpDomainRedirect from './middleware/setUpDomainRedirect'
 
 export default function createApp(controllers: Controllers, services: Services): express.Application {
   const app = express()
@@ -33,6 +34,8 @@ export default function createApp(controllers: Controllers, services: Services):
   app.set('port', process.env.PORT || 3000)
 
   setUpSentryRequestHandler(app)
+
+  app.use(setUpDomainRedirect())
 
   // Add method-override to allow us to use PUT and DELETE methods
   app.use(methodOverride('_method'))

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -29,15 +29,27 @@ const authenticationMiddleware: AuthenticationMiddleware = verifyToken => {
 }
 
 function init(): void {
+  const defaultStrategyConfig = {
+    authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
+    tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
+    clientID: config.apis.hmppsAuth.apiClientId,
+    clientSecret: config.apis.hmppsAuth.apiClientSecret,
+    state: true,
+    customHeaders: { Authorization: generateOauthClientToken() },
+  }
+
+  // TODO: Remove this once our sign in testing on our new domain is complete on
+  // the test env.
+  const redirectToDomain = process.env.NODE_ENV === 'test' ? config.secondDomain : config.firstDomain
+
+  const callbackURL = {
+    callbackURL: `${redirectToDomain}/sign-in/callback`,
+  }
+
   const strategy = new Strategy(
     {
-      authorizationURL: `${config.apis.hmppsAuth.externalUrl}/oauth/authorize`,
-      tokenURL: `${config.apis.hmppsAuth.url}/oauth/token`,
-      clientID: config.apis.hmppsAuth.apiClientId,
-      clientSecret: config.apis.hmppsAuth.apiClientSecret,
-      callbackURL: `${config.firstDomain}/sign-in/callback`,
-      state: true,
-      customHeaders: { Authorization: generateOauthClientToken() },
+      ...defaultStrategyConfig,
+      ...callbackURL,
     },
     (token, refreshToken, params, profile, done) => {
       return done(null, { token, username: params.user_name, authSource: params.auth_source })

--- a/server/authentication/auth.ts
+++ b/server/authentication/auth.ts
@@ -40,7 +40,7 @@ function init(): void {
 
   // TODO: Remove this once our sign in testing on our new domain is complete on
   // the test env.
-  const redirectToDomain = process.env.NODE_ENV === 'test' ? config.secondDomain : config.firstDomain
+  const redirectToDomain = config.environment === 'test' ? config.secondDomain : config.firstDomain
 
   const callbackURL = {
     callbackURL: `${redirectToDomain}/sign-in/callback`,

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -29,7 +29,10 @@ export default function setUpAuth(): Router {
   )
 
   const authUrl = config.apis.hmppsAuth.externalUrl
-  const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${config.firstDomain}`
+  // TODO: Remove this once our sign in testing on our new domain is complete on
+  // the test env.
+  const redirectToDomain = process.env.NODE_ENV === 'test' ? config.secondDomain : config.firstDomain
+  const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${redirectToDomain}`
 
   router.use('/sign-out', (req, res, next) => {
     if (req.user) {

--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -31,7 +31,7 @@ export default function setUpAuth(): Router {
   const authUrl = config.apis.hmppsAuth.externalUrl
   // TODO: Remove this once our sign in testing on our new domain is complete on
   // the test env.
-  const redirectToDomain = process.env.NODE_ENV === 'test' ? config.secondDomain : config.firstDomain
+  const redirectToDomain = config.environment === 'test' ? config.secondDomain : config.firstDomain
   const authSignOutUrl = `${authUrl}/sign-out?client_id=${config.apis.hmppsAuth.apiClientId}&redirect_uri=${redirectToDomain}`
 
   router.use('/sign-out', (req, res, next) => {

--- a/server/middleware/setUpDomainRedirect.test.ts
+++ b/server/middleware/setUpDomainRedirect.test.ts
@@ -1,0 +1,46 @@
+import express, { Express } from 'express'
+import request from 'supertest'
+import setUpDomainRedirect from './setUpDomainRedirect'
+import config from '../config'
+
+jest.mock('../config', () => ({
+  secondDomain: 'http://example.com',
+  firstDomain: 'http://example.org',
+}))
+
+const setupApp = (): Express => {
+  const app = express()
+  app.use(setUpDomainRedirect())
+
+  app.get('/known', (_req, res, _next) => {
+    res.send('known')
+  })
+
+  return app
+}
+describe('setUpDomainRedirect', () => {
+  it('should redirect to the target domain when in test mode', () => {
+    process.env.NODE_ENV = 'test'
+    const app = setupApp()
+    const targetHost = new URL(config.firstDomain).host
+    return request(app).get('/known').set('host', targetHost).expect(301)
+  })
+
+  it('should not redirect requests already coming from the second domain', () => {
+    process.env.NODE_ENV = 'test'
+    const app = setupApp()
+    const targetHost = new URL(config.secondDomain).host
+    return request(app).get('/known').set('host', targetHost).expect(200)
+  })
+
+  it('should not redirect when not in test mode', () => {
+    process.env.NODE_ENV = 'production'
+    const app = setupApp()
+    const targetHost = new URL(config.firstDomain).host
+    return request(app).get('/known').set('host', targetHost).expect(200)
+  })
+
+  afterEach(() => {
+    process.env.NODE_ENV = 'test'
+  })
+})

--- a/server/middleware/setUpDomainRedirect.test.ts
+++ b/server/middleware/setUpDomainRedirect.test.ts
@@ -20,27 +20,27 @@ const setupApp = (): Express => {
 }
 describe('setUpDomainRedirect', () => {
   it('should redirect to the target domain when in test mode', () => {
-    process.env.NODE_ENV = 'test'
+    config.environment = 'test'
     const app = setupApp()
     const targetHost = new URL(config.firstDomain).host
     return request(app).get('/known').set('host', targetHost).expect(301)
   })
 
   it('should not redirect requests already coming from the second domain', () => {
-    process.env.NODE_ENV = 'test'
+    config.environment = 'test'
     const app = setupApp()
     const targetHost = new URL(config.secondDomain).host
     return request(app).get('/known').set('host', targetHost).expect(200)
   })
 
   it('should not redirect when not in test mode', () => {
-    process.env.NODE_ENV = 'production'
+    config.environment = 'production'
     const app = setupApp()
     const targetHost = new URL(config.firstDomain).host
     return request(app).get('/known').set('host', targetHost).expect(200)
   })
 
   afterEach(() => {
-    process.env.NODE_ENV = 'test'
+    config.environment = 'test'
   })
 })

--- a/server/middleware/setUpDomainRedirect.ts
+++ b/server/middleware/setUpDomainRedirect.ts
@@ -1,0 +1,20 @@
+import type { Router } from 'express'
+import express from 'express'
+import config from '../config'
+
+const router = express.Router()
+
+export default function setUpDomainRedirect(): Router {
+  const source = new URL(config.firstDomain)
+  const target = new URL(config.secondDomain)
+
+  router.use((req, res, next) => {
+    if (process.env.NODE_ENV === 'test' && req.headers.host === source.host) {
+      target.pathname = req.path
+      return res.redirect(301, `${target.toString()}`)
+    }
+    return next()
+  })
+
+  return router
+}

--- a/server/middleware/setUpDomainRedirect.ts
+++ b/server/middleware/setUpDomainRedirect.ts
@@ -9,7 +9,7 @@ export default function setUpDomainRedirect(): Router {
   const target = new URL(config.secondDomain)
 
   router.use((req, res, next) => {
-    if (process.env.NODE_ENV === 'test' && req.headers.host === source.host) {
+    if (config.environment === 'test' && req.headers.host === source.host) {
       target.pathname = req.path
       return res.redirect(301, `${target.toString()}`)
     }


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-temporary-accommodation-ui#698 plus adds a correction to how we check the current environment to use [config.environment](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/blob/b1ae840baa930ce17373d2fa2616fcc7c244a8f5/server/config.ts#L45) which I was lucky to catch after investigating the e2e errors we now believe are being caused by the api.