### PR TITLE
Feature/1401 make property references editable

### DIFF
--- a/cypress_shared/components/locationHeader.ts
+++ b/cypress_shared/components/locationHeader.ts
@@ -19,12 +19,6 @@ export default class LocationHeaderComponent extends Component {
         cy.contains('Bedspace reference').should('not.exist')
       }
 
-      if (premises) {
-        cy.get('h2').contains('Property reference').siblings('p').should('contain', premises.name)
-      } else {
-        cy.contains('Property reference').should('not.exist')
-      }
-
       if (premises && !this.hideAddress) {
         cy.get('h2')
           .contains('Property address')

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEdit.ts
@@ -78,6 +78,7 @@ export default class PremisesEditPage extends PremisesEditablePage {
   }
 
   clearForm(): void {
+    this.getTextInputByIdAndClear('name')
     this.getTextInputByIdAndClear('addressLine1')
     this.getTextInputByIdAndClear('addressLine2')
     this.getTextInputByIdAndClear('town')

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesEditable.ts
@@ -3,6 +3,9 @@ import Page from '../../page'
 
 export default abstract class PremisesEditablePage extends Page {
   protected completeEditableForm(newOrUpdatePremises: NewPremises | UpdatePremises): void {
+    this.getLabel('Enter a property reference')
+    this.getTextInputByIdAndEnterDetails('name', newOrUpdatePremises.name)
+
     this.getLabel('Address line 1')
     this.getTextInputByIdAndEnterDetails('addressLine1', newOrUpdatePremises.addressLine1)
 

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesNew.ts
@@ -14,9 +14,6 @@ export default class PremisesNewPage extends PremisesEditablePage {
   }
 
   completeForm(newPremises: NewPremises): void {
-    this.getLabel('Enter a property reference')
-    this.getTextInputByIdAndEnterDetails('name', newPremises.name)
-
     super.completeEditableForm(newPremises)
   }
 

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -262,6 +262,7 @@ context('Premises', () => {
       cy.task('stubPremisesUpdate', premises)
 
       const updatedPremises = premisesFactory.build({
+        name: 'new-premises-name',
         status: 'active',
         probationRegion: this.actingUserProbationRegion,
       })
@@ -273,6 +274,7 @@ context('Premises', () => {
         expect(requests).to.have.length(1)
         const requestBody = JSON.parse(requests[0].body)
 
+        expect(requestBody.name).equal(updatePremises.name)
         expect(requestBody.addressLine1).equal(updatePremises.addressLine1)
         expect(requestBody.addressLine2).equal(updatePremises.addressLine2)
         expect(requestBody.town).equal(updatePremises.town)

--- a/server/controllers/temporary-accommodation/manage/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/premisesController.ts
@@ -119,9 +119,16 @@ export default class PremisesController {
       const { premisesId } = req.params
       const callConfig = extractCallConfig(req)
 
+      const { name } = req.body
+
+      const premises = await this.premisesService.getPremises(callConfig, premisesId)
+
+      const newPremisesName = name === premises.name ? null : name
+
       const updatePremises: UpdatePremises = {
         characteristicIds: [],
         ...req.body,
+        name: newPremisesName,
         turnaroundWorkingDayCount: parseNaturalNumber(req.body.turnaroundWorkingDayCount),
       }
 

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -12,9 +12,6 @@
   {% endif %}
 
   {% if premises %}
-    <h2>Property reference</h2>
-    <p>{{ premises.name }}</p>
-
     {% if not hideAddress %}
       <h2>Property address</h2>
       <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -7,6 +7,20 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
+{{ taInput(
+  {
+    label: {
+      text: 'Enter a property reference',
+      classes: "govuk-label--s"
+    },
+    hint: {
+      text: "This will be used to identify the property"
+    },
+    fieldName: "name"
+  },
+  fetchContext()
+) }}
+
 {% call govukFieldset({
   legend: {
     text: "What is the property address?",

--- a/server/views/temporary-accommodation/premises/_editable.njk
+++ b/server/views/temporary-accommodation/premises/_editable.njk
@@ -9,7 +9,7 @@
 
 {% call govukFieldset({
   legend: {
-    text: "What the property address?",
+    text: "What is the property address?",
     classes: "govuk-fieldset__legend--m"
   }
 }) %}

--- a/server/views/temporary-accommodation/premises/new.njk
+++ b/server/views/temporary-accommodation/premises/new.njk
@@ -24,21 +24,6 @@
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ showErrorSummary(errorSummary) }}
-
-        {{ govukInput({
-          label: {
-            text: "Enter a property reference",
-            classes: "govuk-label--m"
-          },
-          hint: {
-            text: "This will be used to identify the property"
-          },
-          classes: "govuk-input--width-20",
-          id: "name",
-          name: "name",
-          value: name,
-          errorMessage: errors.name
-        }) }}
       
         {% include "./_editable.njk" %}  
       </form>


### PR DESCRIPTION
# Context
We want users to be able to edit a property reference. 

## Screenshots of UI changes

### Before
![Screenshot 2023-10-19 at 15 49 21](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/6139e14e-d0f7-4e35-967c-4fc4838f8a36)

### After
![Screenshot 2023-10-19 at 15 48 59](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/8a6f109e-25f0-4273-bd97-9e791552460d)

### Unchanged
![Screenshot 2023-10-19 at 15 48 43](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/ef7072ee-1d35-4d27-a1b1-470a9cd19b65)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
