### PR TITLE
Update Cypress’s BaseUrl to the new dev domain

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -65,7 +65,7 @@ jobs:
           command: |
             npm run test:e2e:ci --\
               --env "assessor_username=${CYPRESS_ASSESSOR_USERNAME_<< parameters.environment >>},assessor_password=${CYPRESS_ASSESSOR_PASSWORD_<< parameters.environment >>},referrer_username=${CYPRESS_REFERRER_USERNAME_<< parameters.environment >>},referrer_password=${CYPRESS_REFERRER_PASSWORD_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"\
-              --config baseUrl=https://temporary-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
+              --config baseUrl=https://transitional-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
       - store_artifacts:
           path: e2e/screenshots
           destination: screenshots


### PR DESCRIPTION
All e2e tests started to fail when we went on in all environments. It’s not clear why the timeout however the cypress feedback trace quotes the old domain name:

```
1) Manage Temporary Accommodation - Lost beds
       Marking a bedspace as void:
     AssertionError: Timed out retrying after 4000ms: Expected to find content: 'Manage estate' within the element: <h1.govuk-heading-l> but never did.
      at _DashboardPage.checkOnPage (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:31898:24)
      at new _Page (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:31886:16)
      at new _DashboardPage (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:33288:11)
      at _Page.verifyOnPage (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:31889:18)
      at Context.eval (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:45737:36)
      at Registry.runStepDefininition (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:8566:48)
      at Object.fn (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:15014:43)
      at runStepWithLogGroup (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:14648:29)
      at Context.eval (https://temporary-accommodation-dev.hmpps.service.justice.gov.uk/__cypress/****s?p=e2e/****s/lostBed.feature:15010:62)
```

The running theory is that the redirect we’re now doing is causing these to not be a match.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
