### PR TITLE
Feature/turn on preprod and prod domains

### DIFF
--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -5,6 +5,7 @@ generic-service:
   ingress:
     hosts:
       - temporary-accommodation-preprod.hmpps.service.justice.gov.uk
+      - transitional-accommodation-preprod.hmpps.service.justice.gov.uk
     contextColour: green
     tlsSecretName: hmpps-temporary-accommodation-preprod-cert
 

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -5,6 +5,7 @@ generic-service:
   ingress:
     hosts:
       - temporary-accommodation.hmpps.service.justice.gov.uk
+      - transitional-accommodation.hmpps.service.justice.gov.uk
     contextColour: green
     tlsSecretName: hmpps-temporary-accommodation-prod-cert
 


### PR DESCRIPTION
# Context

We've turned it on for [dev](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/687) and [test](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/7e8c6572948faf12945c2c90e56e17eba65f3757) now and everything looks good. We now need to turn this on so the services in the remaining two environments are listening too.

To test you can sign into http://temporary-accommodation-dev.hmpps.service.justice.gov.uk/ or http://temporary-accommodation-test.hmpps.service.justice.gov.uk/ and be taken to the transitional equivalent.


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
