### PR TITLE
Don't set up redirect for local development

### DIFF
--- a/server/app.ts
+++ b/server/app.ts
@@ -25,6 +25,7 @@ import routes from './routes/temporary-accommodation'
 import type { Controllers } from './controllers'
 import type { Services } from './services'
 import setUpDomainRedirect from './middleware/setUpDomainRedirect'
+import config from './config'
 
 export default function createApp(controllers: Controllers, services: Services): express.Application {
   const app = express()
@@ -35,7 +36,9 @@ export default function createApp(controllers: Controllers, services: Services):
 
   setUpSentryRequestHandler(app)
 
-  app.use(setUpDomainRedirect())
+  if (config.environment !== 'local') {
+    app.use(setUpDomainRedirect())
+  }
 
   // Add method-override to allow us to use PUT and DELETE methods
   app.use(methodOverride('_method'))


### PR DESCRIPTION
# Context
We previously introduced a redirect to the application. This causes a redirect loop when run locally. This commit ensures we only set up the redirect in non-local environments.

Note: `app.ts` has no test set up but the change is straightforward and we're guarded by our e2e tests.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
