### PR TITLE
Remove homeless after re-release eligibility option

### DIFF
--- a/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/eligibilityReason.ts
@@ -8,7 +8,6 @@ import anonymiseFormContent from '../../../utils/anonymiseFormContent'
 
 export const eligibilityReasons = {
   homelessFromCustody: 'Released as homeless from Prison (Licence/PSS)',
-  homelessAfterRerelease: 'Re-released as homeless following recall',
   homelessFromApprovedPremises: 'Moving on as homeless from an Approved Premises (CAS1)',
   homelessFromBailAccommodation: 'Moving on as homeless from CAS2 (formerly Bail Accommodation Support Services)',
 } as const

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -210,12 +210,7 @@
           "type": "object",
           "properties": {
             "reason": {
-              "enum": [
-                "homelessAfterRerelease",
-                "homelessFromApprovedPremises",
-                "homelessFromBailAccommodation",
-                "homelessFromCustody"
-              ],
+              "enum": ["homelessFromApprovedPremises", "homelessFromBailAccommodation", "homelessFromCustody"],
               "type": "string"
             }
           }

--- a/server/utils/applications/getSummaryDataFromApplication.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.ts
@@ -26,10 +26,6 @@ function getIsAbleToShare(ableToShare?: YesOrNo) {
 }
 
 function getReleaseType(reason?: EligibilityReasonsT) {
-  if (reason === 'homelessAfterRerelease') {
-    return 'Rerelease'
-  }
-
   if (reason === 'homelessFromApprovedPremises') {
     return 'Approved Premises'
   }


### PR DESCRIPTION
We remove this option as if someone is leaving custody after a recall, they will still technically just be leaving custody.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![Screenshot 2023-10-31 at 14 59 22](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/c3614a7f-6bb0-4d03-b7d1-f3c973b4b28f)

### After
![Screenshot 2023-10-31 at 14 59 01](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/18e01a33-6ddf-4bde-815f-60fa547a09b7)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
