### PR TITLE
Update copy for when RoSH info can't be retrieved

### DIFF
--- a/server/form-pages/utils/index.test.ts
+++ b/server/form-pages/utils/index.test.ts
@@ -545,7 +545,7 @@ describe('personRisksRoshResponse', () => {
 
     expect(utils.personRisksRoshResponse(risks)).toEqual({
       'Risk of serious harm':
-        'Something went wrong. We are unable to include RoSH information. This risk data must be checked manually outside of this service.',
+        'We were unable to automatically import RoSH information. Check the "Placement considerations" section to find the OASys risk levels. If the risk levels are not present, they must be checked manually outside of this service.',
     })
   })
 })

--- a/server/form-pages/utils/index.ts
+++ b/server/form-pages/utils/index.ts
@@ -274,7 +274,7 @@ export const personRisksRoshResponse = (risks: PersonRisks): PageResponse => {
   }
   return {
     'Risk of serious harm':
-      'Something went wrong. We are unable to include RoSH information. This risk data must be checked manually outside of this service.',
+      'We were unable to automatically import RoSH information. Check the "Placement considerations" section to find the OASys risk levels. If the risk levels are not present, they must be checked manually outside of this service.',
   }
 }
 


### PR DESCRIPTION
# Context
When RoSH information can't be retrieved, we show guidance to the CPPs to manually copy the information from Oasys and include it in the placement consideration risk sections.

However, the guidance for HPTs is for them to manually check outside the service so they wouldn't know to check that location for the manually included information.

This change updates the copy in the RoSH section to prompt HPTs to look in the placement considerations section for this information.

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

## Screenshots of UI changes

### Before
(Taken from the Check Your Answers page, but the copy is the same as the full referral that HPTs see)
![cya_rosh_before](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/0cb44f31-9fca-4fee-89c5-5625ee60517f)

### After
![image](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/b9b3b966-9c17-46f8-bd7e-189f40842d8d)


https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/e574294a-a526-4046-80cf-f5b4166458c7



# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
