### PR TITLE
Introduce optional local authority field on duty to refer page

### DIFF
--- a/cypress.config.ts
+++ b/cypress.config.ts
@@ -19,6 +19,7 @@ import room from './integration_tests/mockApis/room'
 import tokenVerification from './integration_tests/mockApis/tokenVerification'
 import turnaround from './integration_tests/mockApis/turnaround'
 import user from './integration_tests/mockApis/user'
+import referenceData from './integration_tests/mockApis/referenceData'
 import schemaValidator from './integration_tests/tasks/schemaValidator'
 import accessibilityViolations from './integration_tests/tasks/accessibilityViolations'
 import { resetStubs } from './wiremock'
@@ -61,6 +62,7 @@ export default defineConfig({
         ...bookingSearch,
         ...bedspaceSearch,
         ...accessibilityViolations,
+        ...referenceData,
       })
     },
     baseUrl: 'http://localhost:3007',

--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -62,7 +62,6 @@
       "releaseDate-year": "2123",
       "releaseDate-month": "9",
       "releaseDate-day": "2"
-
     },
     "accommodation-required-from-date": {
       "accommodationRequiredFromDate": "2123-09-16",
@@ -281,8 +280,8 @@
       "date": "2022-04-12",
       "date-year": "2022",
       "date-month": "4",
-      "date-day": "12"
-
+      "date-day": "12",
+      "localAuthorityAreaName": "Barking and Dagenham"
     },
     "crs-submitted": {
       "crsSubmitted": "yes"

--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -231,7 +231,11 @@
           "id": "accommodation-referral-details",
           "content": [
             { "Has the Duty to Refer (DTR) / National Offender Pathway (NOP) been submitted?": "Yes" },
-            { "DTR / NOP reference number": "ABC123", "Date DTR / NOP was submitted": "12 April 2022" },
+            {
+              "DTR / NOP reference number": "ABC123",
+              "Date DTR / NOP was submitted": "12 April 2022",
+              "What is the local authority (optional)?": "Barking and Dagenham"
+            },
             { "Has a referral to Commissioned Rehabilitative Services (CRS) been submitted?": "Yes" },
             { "Have other accommodation options been considered?": "Yes - Other accommodation details" }
           ]

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -25,6 +25,7 @@ import {
   acctAlertFactory,
   adjudicationFactory,
   documentFactory,
+  localAuthorityFactory,
   oasysSectionsFactory,
   oasysSelectionFactory,
 } from '../../server/testutils/factories'
@@ -729,6 +730,13 @@ export default class ApplyHelper {
   }
 
   private completeAccommodationReferralDetails() {
+    let localAuthority
+
+    if (this.environment === 'integration') {
+      localAuthority = localAuthorityFactory.build({ name: 'Barking and Dagenham' })
+      cy.task('stubLocalAuthorities', [localAuthority])
+    }
+
     // Given I click on the accommodation referral details task
     Page.verifyOnPage(TaskListPage, this.application).clickTask('accommodation-referral-details')
 
@@ -742,7 +750,7 @@ export default class ApplyHelper {
 
     if (hasSubmittedDtr(this.application)) {
       const dtrDetailsPage = new DtrDetailsPage(this.application)
-      dtrDetailsPage.completeForm()
+      dtrDetailsPage.completeForm(localAuthority?.name)
       dtrDetailsPage.clickSubmit()
       this.pages.accommodationReferralDetails.push(dtrDetailsPage)
     }

--- a/cypress_shared/pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
+++ b/cypress_shared/pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
@@ -17,8 +17,9 @@ export default class DtrDetailsPage extends ApplyPage {
     )
   }
 
-  completeForm() {
+  completeForm(localAuthorityName?: string) {
     this.completeDateInputsFromPageBody('date')
     this.completeTextInputFromPageBody('reference')
+    this.getSelectInputByIdAndSelectAnEntry('localAuthorityAreaName', localAuthorityName || 'Barking and Dagenham')
   }
 }

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,0 +1,21 @@
+import { LocalAuthorityArea } from '../../server/@types/shared/models/LocalAuthorityArea'
+import { stubFor } from '../../wiremock'
+
+const stubLocalAuthorities = (localAuthorities: Array<LocalAuthorityArea>) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: '/reference-data/local-authority-areas',
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: localAuthorities,
+    },
+  })
+
+export default {
+  stubLocalAuthorities,
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -10,6 +10,7 @@ import {
   TemporaryAccommodationAssessment as Assessment,
   Booking,
   Document,
+  LocalAuthorityArea,
   OASysSection,
   OASysSections,
   Person,
@@ -244,6 +245,9 @@ export type DataServices = Partial<{
   }
   userService: {
     getUserById: (callConfig: CallConfig, id: string) => Promise<User>
+  }
+  referenceDataService: {
+    getLocalAuthorities: (CallConfig: CallConfig) => Promise<Array<LocalAuthorityArea>>
   }
 }>
 

--- a/server/controllers/apply/index.ts
+++ b/server/controllers/apply/index.ts
@@ -9,9 +9,13 @@ import PeopleController from './peopleController'
 import type { Services } from '../../services'
 
 export const controllers = (services: Services) => {
-  const { applicationService, personService } = services
+  const { applicationService, personService, referenceDataService } = services
   const applicationsController = new ApplicationsController(applicationService, personService)
-  const pagesController = new PagesController(applicationService, { personService, applicationService })
+  const pagesController = new PagesController(applicationService, {
+    personService,
+    applicationService,
+    referenceDataService,
+  })
   const offencesController = new OffencesController(personService)
   const documentsController = new DocumentsController(personService)
   const peopleController = new PeopleController(personService)

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.test.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.test.ts
@@ -1,6 +1,9 @@
-import { applicationFactory } from '../../../../testutils/factories'
+import { createMock } from '@golevelup/ts-jest'
+import { applicationFactory, localAuthorityFactory } from '../../../../testutils/factories'
 import { dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInFuture } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import { CallConfig } from '../../../../data/restClient'
+import { ReferenceDataService } from '../../../../services'
 import DtrDetails from './dtrDetails'
 
 jest.mock('../../../../utils/dateUtils', () => {
@@ -14,14 +17,21 @@ jest.mock('../../../../utils/dateUtils', () => {
   }
 })
 
-const body = { reference: 'ABC123', 'date-year': '2022', 'date-month': '7', 'date-day': '23' }
+const localAuthorities = localAuthorityFactory.buildList(3)
+const body = {
+  reference: 'ABC123',
+  'date-year': '2022',
+  'date-month': '7',
+  'date-day': '23',
+  localAuthorityAreaName: localAuthorities[0].name,
+}
 
 describe('DtrDetails', () => {
   const application = applicationFactory.build()
 
   describe('body', () => {
     it('sets the body', () => {
-      const page = new DtrDetails(body, application)
+      const page = new DtrDetails(body, application, localAuthorities)
 
       expect(page.body).toEqual({
         ...body,
@@ -30,8 +40,8 @@ describe('DtrDetails', () => {
     })
   })
 
-  itShouldHavePreviousValue(new DtrDetails({}, application), 'dtr-submitted')
-  itShouldHaveNextValue(new DtrDetails({}, application), 'crs-submitted')
+  itShouldHavePreviousValue(new DtrDetails({}, application, localAuthorities), 'dtr-submitted')
+  itShouldHaveNextValue(new DtrDetails({}, application, localAuthorities), 'crs-submitted')
 
   describe('errors', () => {
     it('returns an empty object if the DTR details are populated', () => {
@@ -39,7 +49,7 @@ describe('DtrDetails', () => {
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInFuture as jest.Mock).mockReturnValue(false)
 
-      const page = new DtrDetails(body, application)
+      const page = new DtrDetails(body, application, localAuthorities)
       expect(page.errors()).toEqual({})
     })
 
@@ -48,7 +58,7 @@ describe('DtrDetails', () => {
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInFuture as jest.Mock).mockReturnValue(false)
 
-      const page = new DtrDetails({ ...body, reference: undefined }, application)
+      const page = new DtrDetails({ ...body, reference: undefined }, application, localAuthorities)
       expect(page.errors()).toEqual({
         reference: 'You must specify the DTR / NOP reference number',
       })
@@ -59,7 +69,7 @@ describe('DtrDetails', () => {
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInFuture as jest.Mock).mockReturnValue(false)
 
-      const page = new DtrDetails(body, application)
+      const page = new DtrDetails(body, application, localAuthorities)
       expect(page.errors()).toEqual({
         date: 'You must specify the date DTR / NOP was submitted',
       })
@@ -70,7 +80,7 @@ describe('DtrDetails', () => {
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(false)
       ;(dateIsInFuture as jest.Mock).mockReturnValue(false)
 
-      const page = new DtrDetails(body, application)
+      const page = new DtrDetails(body, application, localAuthorities)
       expect(page.errors()).toEqual({
         date: 'You must specify a valid date DTR / NOP was submitted',
       })
@@ -81,7 +91,7 @@ describe('DtrDetails', () => {
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInFuture as jest.Mock).mockReturnValue(true)
 
-      const page = new DtrDetails(body, application)
+      const page = new DtrDetails(body, application, localAuthorities)
       expect(page.errors()).toEqual({
         date: 'The date DTR / NOP was submitted must not be in the future',
       })
@@ -89,12 +99,72 @@ describe('DtrDetails', () => {
   })
 
   describe('response', () => {
-    it('returns a translated version of the response', () => {
-      const page = new DtrDetails(body, application)
-      expect(page.response()).toEqual({
-        'DTR / NOP reference number': 'ABC123',
-        'Date DTR / NOP was submitted': '23 July 2022',
+    describe('when local authority is selected', () => {
+      it('returns a translated version of the response', () => {
+        const page = new DtrDetails(body, application, localAuthorities)
+        expect(page.response()).toEqual({
+          'DTR / NOP reference number': 'ABC123',
+          'Date DTR / NOP was submitted': '23 July 2022',
+          'What is the local authority (optional)?': localAuthorities[0].name,
+        })
       })
+    })
+
+    describe('when local authority is not selected', () => {
+      it('returns placeholder copy for local authority', () => {
+        const page = new DtrDetails({ ...body, localAuthorityAreaName: null }, application, localAuthorities)
+        expect(page.response()).toEqual({
+          'DTR / NOP reference number': 'ABC123',
+          'Date DTR / NOP was submitted': '23 July 2022',
+          'What is the local authority (optional)?': 'No local authority selected',
+        })
+      })
+    })
+  })
+
+  describe('initialize', () => {
+    describe('when fetch for local authorities is successful', () => {
+      it('populates the body with a list of local authorities', async () => {
+        const callConfig = { token: 'some-token' } as CallConfig
+        const getLocalAuthoritiesMock = jest.fn().mockResolvedValue(localAuthorities)
+        const referenceDataService = createMock<ReferenceDataService>({
+          getLocalAuthorities: getLocalAuthoritiesMock,
+        })
+
+        await DtrDetails.initialize({}, application, callConfig, { referenceDataService })
+
+        expect(getLocalAuthoritiesMock).toHaveBeenCalledWith(callConfig)
+      })
+    })
+
+    describe('when fetch for local authorities is unsuccessful', () => {
+      it('returns an empty list of local authorities', async () => {
+        const callConfig = { token: 'some-token' } as CallConfig
+        const getLocalAuthoritiesMock = jest.fn().mockImplementation(() => {
+          throw new Error()
+        })
+        const referenceDataService = createMock<ReferenceDataService>({
+          getLocalAuthorities: getLocalAuthoritiesMock,
+        })
+
+        const page = await DtrDetails.initialize({}, application, callConfig, { referenceDataService })
+
+        expect(page.getLocalAuthorities()).toEqual([])
+      })
+    })
+  })
+
+  describe('getLocalAuthorities', () => {
+    it('returns a list of local authorities', async () => {
+      const callConfig = { token: 'some-token' } as CallConfig
+      const getLocalAuthoritiesMock = jest.fn().mockResolvedValue(localAuthorities)
+      const referenceDataService = createMock<ReferenceDataService>({
+        getLocalAuthorities: getLocalAuthoritiesMock,
+      })
+
+      const page = await DtrDetails.initialize({}, application, callConfig, { referenceDataService })
+
+      expect(page.getLocalAuthorities()).toEqual(localAuthorities)
     })
   })
 })

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -22,6 +22,7 @@ import PremisesService from './premisesService'
 import ReportService from './reportService'
 import TurnaroundService from './turnaroundService'
 import UserService from './userService'
+import ReferenceDataService from './referenceDataService'
 
 export const services = () => {
   const {
@@ -58,6 +59,7 @@ export const services = () => {
   const bookingSearchService = new BookingSearchService(bookingClientBuilder)
   const turnaroundService = new TurnaroundService(bookingClientBuilder)
   const assessmentsService = new AssessmentsService(assessmentClientBuilder)
+  const referenceDataService = new ReferenceDataService(referenceDataClientBuilder)
 
   return {
     userService,
@@ -79,6 +81,7 @@ export const services = () => {
     bookingSearchService,
     turnaroundService,
     assessmentsService,
+    referenceDataService,
   }
 }
 

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -103,4 +103,5 @@ export {
   PremisesService,
   TurnaroundService,
   UserService,
+  ReferenceDataService,
 }

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -1,0 +1,32 @@
+import ReferenceDataClient from '../data/referenceDataClient'
+import { CallConfig } from '../data/restClient'
+import ReferenceDataService from './referenceDataService'
+import { localAuthorityFactory } from '../testutils/factories'
+
+jest.mock('../data/referenceDataClient')
+
+describe('ReferenceDataService', () => {
+  describe('getLocalAuthorities', () => {
+    it('returns a list of local authorities sorted by name', async () => {
+      const referenceDataClient = new ReferenceDataClient(null) as jest.Mocked<ReferenceDataClient>
+      const referenceDataClientFactory = jest.fn()
+      const referenceDataService = new ReferenceDataService(referenceDataClientFactory)
+
+      referenceDataClientFactory.mockReturnValue(referenceDataClient)
+
+      const callConfig = { token: 'some-token' } as CallConfig
+
+      const localAuthority1 = localAuthorityFactory.build({ name: 'XYZ' })
+      const localAuthority2 = localAuthorityFactory.build({ name: 'HIJ' })
+      const localAuthority3 = localAuthorityFactory.build({ name: 'ABC' })
+
+      referenceDataClient.getReferenceData.mockImplementation(async () => {
+        return [localAuthority1, localAuthority2, localAuthority3]
+      })
+
+      const result = await referenceDataService.getLocalAuthorities(callConfig)
+
+      expect(result).toEqual([localAuthority3, localAuthority2, localAuthority1])
+    })
+  })
+})

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,0 +1,17 @@
+import { LocalAuthorityArea } from '@approved-premises/api'
+import { ReferenceDataClient, RestClientBuilder } from '../data'
+import { CallConfig } from '../data/restClient'
+
+export default class ReferenceDataService {
+  constructor(private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>) {}
+
+  async getLocalAuthorities(callConfig: CallConfig) {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
+
+    const localAuthorities = (
+      (await referenceDataClient.getReferenceData('local-authority-areas')) as Array<LocalAuthorityArea>
+    ).sort((a, b) => a.name.localeCompare(b.name))
+
+    return localAuthorities
+  }
+}

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
@@ -1,3 +1,4 @@
+{% from "../../../../temporary-accommodation/components/ta-select/macro.njk" import taSelect %}
 {% extends "../../layout.njk" %}
 
 {% block questions %}
@@ -28,5 +29,18 @@
     },
     items: dateFieldValues('date', errors)
   }, fetchContext()) }}
+
+  {% if page.getLocalAuthorities() | length %}
+    {{ taSelect(
+      {
+        label: {
+          text: "What is the local authority (optional)?",
+          classes: "govuk-label--m"
+        },
+        items: convertObjectsToSelectOptions(page.getLocalAuthorities(), '', 'name', 'name', 'localAuthorityAreaId'),
+        fieldName: "localAuthorityAreaName"
+      }
+    ) }}
+  {% endif %}
 
 {% endblock %}


### PR DESCRIPTION
# Context
We're rolling CAS3 out to more regions and Manchester primarily use the local authority in their processes.

This piece of work adds an optional local authority field to the "Duty to Refer" details page.

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
* Render optional select field
* Select field does not render if we fail to fetch the list of local authorities

## Screenshots of UI changes

### Before
![Screenshot 2023-11-02 at 17 22 42](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/564a6fd1-781d-4981-b47b-5753b987e66d)

### After
![Screenshot 2023-11-02 at 17 17 36](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/206d271b-7b8f-4a33-af12-6e8854b94b53)

![Screenshot 2023-11-02 at 17 17 04](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/b9f3b8f6-6e66-4c71-a2ae-849628b19a6a)

![Screenshot 2023-11-02 at 17 15 05](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/119dff86-eabe-4d3d-9204-42d0e2c69769)

![image](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/4b45a682-f73a-4c13-a29d-9c27f6719cf7)

#### When fetching local authorities fail dropdown does not render
![Screenshot 2023-11-02 at 17 22 42](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/0c8b5e78-fe23-42c3-80f2-767090ad29a5)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
