### PR TITLE
Migrating project to use groups in allowlist

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  hmpps: ministryofjustice/hmpps@7.3.3
+  hmpps: ministryofjustice/hmpps@7
   slack: circleci/slack@4.10.1
   node: circleci/node@4.5.2
 

--- a/helm_deploy/hmpps-temporary-accommodation-ui/Chart.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/Chart.yaml
@@ -5,7 +5,7 @@ name: hmpps-temporary-accommodation-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 2.8.1
+    version: "2.8"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
     version: 1.3.3

--- a/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
@@ -1,4 +1,3 @@
----
 generic-service:
   nameOverride: hmpps-temporary-accommodation-ui
   serviceAccountName: hmpps-temporary-accommodation-service-account
@@ -61,21 +60,9 @@ generic-service:
       REDIS_AUTH_TOKEN: 'auth_token'
 
   allowlist:
-    office: '217.33.148.210/32'
-    health-kick: '35.177.252.195/32'
-    petty-france-wifi: '213.121.161.112/28'
-    global-protect: '35.176.93.186/32'
-    mojvpn: '81.134.202.29/32'
-    cloudplatform-live1-1: '35.178.209.113/32'
-    cloudplatform-live1-2: '3.8.51.207/32'
-    cloudplatform-live1-3: '35.177.252.54/32'
-    ark-nps-hmcts-ttp1: "195.59.75.0/24"
-    ark-nps-hmcts-ttp2: "194.33.192.0/25"
-    ark-nps-hmcts-ttp3: "194.33.193.0/25"
-    ark-nps-hmcts-ttp4: "194.33.196.0/25"
-    ark-nps-hmcts-ttp5: "194.33.197.0/25"
-    moj-official-ark-c-expo-e: "51.149.249.0/29"
-    moj-official-ark-f-expo-e: "51.149.249.32/29"
+    groups:
+      - internal
+      - prisons
 
 generic-prometheus-alerts:
   targetApplication: hmpps-temporary-accommodation-ui


### PR DESCRIPTION
This PR migrates the project to use groups of IPs in their allowlist.

By referring to groups to IP addresses, we can centralize the definition of groups of ip addresses.
If these lists require changing in the future, we can change the definition once and future deploys across all services will automatically include these new IPs.

1 allowlist(s) have been detected that can be migrated.



## Allowlist: helm_deploy/hmpps-temporary-accommodation-ui/values.yaml

### New Groups

The effect of applying this PR is as follows:

- The following groups will be applied: `internal,prisons`
- The size of the allowlist defined in this file will change: `15 => 0 (15 removed)`

### Added IPs

The new Group membership will result in the following IPs being added to your allowlist by applying this PR:


- moj-official-tgw-prod
  

- moj-official-tgw-preprod
  

- moj-official-ark-c-vodafone
  

- moj-official-ark-f-vodafone
  

- mojo-azure-landing-zone-public-egress-1
  

- mojo-azure-landing-zone-public-egress-2
  

- mojo-azure-landing-zone-public-egress-3
  

- mojo-azure-landing-zone-public-egress-4
  

### Removed IPs

The following IPs have been identified as unnecessary and will be removed by applying this PR:


- health-kick
  
