### PR TITLE
Introduce PoP phone number field to application

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -51,6 +51,9 @@
     },
     "practitioner-pdu": {
       "pdu": "Some PDU"
+    },
+    "pop-phone-number": {
+      "phone": "01235 467890"
     }
   },
   "eligibility": {

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -58,6 +58,7 @@ import {
   NeedsPage,
   OffendingSummaryPage,
   OtherAccommodationOptionsPage,
+  PopPhoneNumberPage,
   PractitionerPduPage,
   PreviousStaysDetailsPage,
   PreviousStaysPage,
@@ -377,7 +378,11 @@ export default class ApplyHelper {
     practitionerPduPage.completeForm()
     practitionerPduPage.clickSubmit()
 
-    this.pages.contactDetails = [probationPractitionerPage, backupContactPage, practitionerPduPage]
+    const popPhoneNumberPage = new PopPhoneNumberPage(this.application)
+    popPhoneNumberPage.completeForm()
+    popPhoneNumberPage.clickSubmit()
+
+    this.pages.contactDetails = [probationPractitionerPage, backupContactPage, practitionerPduPage, popPhoneNumberPage]
 
     // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(TaskListPage, this.application)

--- a/cypress_shared/pages/apply/accommodation-need/contact-details/popPhoneNumber.ts
+++ b/cypress_shared/pages/apply/accommodation-need/contact-details/popPhoneNumber.ts
@@ -1,0 +1,21 @@
+import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
+import paths from '../../../../../server/paths/apply'
+
+import ApplyPage from '../../applyPage'
+import { personName } from '../../../../../server/utils/personUtils'
+
+export default class PopPhoneNumber extends ApplyPage {
+  constructor(application: Application) {
+    super(
+      `What is ${personName(application.person)}'s phone number?`,
+      application,
+      'contact-details',
+      'pop-phone-number',
+      paths.applications.pages.show({ id: application.id, task: 'contact-details', page: 'practitioner-pdu' }),
+    )
+  }
+
+  completeForm() {
+    this.completeTextInputFromPageBody('phone')
+  }
+}

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -1,5 +1,6 @@
 import ConsentGivenPage from './accommodation-need/consent/consentGiven'
 import BackupContactPage from './accommodation-need/contact-details/backupContact'
+import PopPhoneNumberPage from './accommodation-need/contact-details/popPhoneNumber'
 import PractitionerPduPage from './accommodation-need/contact-details/practitionerPdu'
 import ProbationPractitionerPage from './accommodation-need/contact-details/probationPractitioner'
 import AccommodationRequiredFromDatePage from './accommodation-need/eligibility/accommodationRequiredFromDate'
@@ -73,6 +74,7 @@ export {
   NeedsPage,
   OffendingSummaryPage,
   OtherAccommodationOptionsPage,
+  PopPhoneNumberPage,
   PractitionerPduPage,
   PreviousStaysDetailsPage,
   PreviousStaysPage,

--- a/server/form-pages/apply/accommodation-need/contact-details/index.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/index.ts
@@ -4,11 +4,12 @@ import { Task } from '../../../utils/decorators'
 import BackupContact from './backupContact'
 import PractitionerPdu from './practitionerPdu'
 import ProbationPractitioner from './probationPractitioner'
+import PopPhoneNumber from './popPhoneNumber'
 
 @Task({
   name: 'Contact details',
   actionText: 'Enter contact details',
   slug: 'contact-details',
-  pages: [ProbationPractitioner, BackupContact, PractitionerPdu],
+  pages: [ProbationPractitioner, BackupContact, PractitionerPdu, PopPhoneNumber],
 })
 export default class ContactDetails {}

--- a/server/form-pages/apply/accommodation-need/contact-details/popPhoneNumber.test.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/popPhoneNumber.test.ts
@@ -1,0 +1,51 @@
+import { applicationFactory } from '../../../../testutils/factories'
+import { personName } from '../../../../utils/personUtils'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+import PopPhoneNumber from './popPhoneNumber'
+
+jest.mock('../../../../utils/personUtils')
+
+const body = { phone: '12345' }
+
+describe('PopPhoneNumber', () => {
+  const application = applicationFactory.build()
+
+  describe('body', () => {
+    it('sets the body', () => {
+      const page = new PopPhoneNumber(body, application)
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  describe('title', () => {
+    it('sets the title', () => {
+      ;(personName as jest.Mock).mockReturnValue('Some Name')
+
+      const page = new PopPhoneNumber(body, application)
+
+      expect(page.title).toEqual("What is Some Name's phone number?")
+    })
+  })
+
+  describe('response', () => {
+    it('returns a translated version of the response', () => {
+      const page = new PopPhoneNumber(body, application)
+
+      expect(page.response()).toEqual({
+        "What is the person's phone number?": '12345',
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns an empty object', () => {
+      const page = new PopPhoneNumber(body, application)
+
+      expect(page.errors()).toEqual({})
+    })
+  })
+
+  itShouldHavePreviousValue(new PopPhoneNumber(body, application), 'practitioner-pdu')
+  itShouldHaveNextValue(new PopPhoneNumber(body, application), '')
+})

--- a/server/form-pages/apply/accommodation-need/contact-details/popPhoneNumber.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/popPhoneNumber.ts
@@ -1,0 +1,39 @@
+import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
+import { personName } from '../../../../utils/personUtils'
+import { Page } from '../../../utils/decorators'
+import TasklistPage from '../../../tasklistPage'
+
+type PopPhoneNumberBody = { phone?: string }
+@Page({ name: 'pop-phone-number', bodyProperties: ['phone'] })
+export default class PopPhoneNumber implements TasklistPage {
+  title: string
+
+  htmlDocumentTitle = "What is the person's phone number?"
+
+  constructor(
+    readonly body: Partial<PopPhoneNumberBody>,
+    readonly application: Application,
+  ) {
+    this.title = `What is ${personName(application.person)}'s phone number?`
+  }
+
+  response() {
+    return {
+      "What is the person's phone number?": this.body.phone,
+    }
+  }
+
+  previous() {
+    return 'practitioner-pdu'
+  }
+
+  next() {
+    return ''
+  }
+
+  errors() {
+    const errors = {}
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.test.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.test.ts
@@ -29,7 +29,7 @@ describe('PractitionerPdu', () => {
   })
 
   itShouldHavePreviousValue(new PractitionerPdu({}, application), 'backup-contact')
-  itShouldHaveNextValue(new PractitionerPdu({}, application), '')
+  itShouldHaveNextValue(new PractitionerPdu({}, application), 'pop-phone-number')
 
   describe('errors', () => {
     it('returns an empty object if the PDU is defined', () => {

--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
@@ -31,7 +31,7 @@ export default class PractitionerPdu implements TasklistPage {
   }
 
   next() {
-    return ''
+    return 'pop-phone-number'
   }
 
   errors() {

--- a/server/views/applications/pages/accommodation-need/contact-details/pop-phone-number.njk
+++ b/server/views/applications/pages/accommodation-need/contact-details/pop-phone-number.njk
@@ -1,0 +1,23 @@
+{% extends "../../layout.njk" %}
+
+{% block questions %}
+
+  <h1 class="govuk-heading-l">
+    <span class="govuk-caption-l">{{ task.title }}</span>
+    {{ page.title }}
+  </h1>
+
+  {{ formPageInput({
+    fieldName: "phone",
+    label: {
+      text: "Please provide an up to date contact number for the person on probation.",
+      classes: "govuk-label--s"
+    }
+  }, fetchContext()) }}
+
+
+  {{ govukDetails({
+    summaryText: "Why do we need the person’s telephone number?",
+    html: "<p>The accommodation support worker is required to make regular telephone contact with the person on probation during a CAS3 stay, therefore contact details must be provided.</p>"
+  }) }}
+{% endblock %}

--- a/server/views/applications/pages/layout.njk
+++ b/server/views/applications/pages/layout.njk
@@ -7,6 +7,7 @@
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% from "../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 {% from "../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}


### PR DESCRIPTION
# Context
We want to record the PoP's (person on probation) phone number in the
contact details section of the application.

This is an optional field and should not produce errors if it is not supplied.

# Changes in this PR

## Screenshots of UI changes
![Screenshot 2023-11-13 at 15 44 54](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/6b3537fd-97af-4096-a20a-aff289f03036)

![Screenshot 2023-11-13 at 12 08 43](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/3dac3998-34bb-4ebd-be43-2dc6bd3260e9)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
