### PR TITLE
Allow Reporting endpoints more time to respond

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -97,6 +97,15 @@ export default {
       agent: new AgentConfig(Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 10000))),
       serviceName: 'temporary-accommodation',
     },
+    approvedPremisesReports: {
+      url: get('APPROVED_PREMISES_API_URL', 'http://localhost:9092', requiredInProduction),
+      timeout: {
+        response: 50000,
+        deadline: 50000,
+      },
+      agent: new AgentConfig(Number(get('COMMUNITY_ACCOMMODATION_API_TIMEOUT_RESPONSE', 40000))),
+      serviceName: 'temporary-accommodation',
+    },
     audit: {
       region: get('AUDIT_SQS_REGION', 'eu-west-2'),
       queueUrl: get('AUDIT_SQS_QUEUE_URL', ''),

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -15,8 +15,8 @@ describe('ReportClient', () => {
   const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
-    config.apis.approvedPremises.url = 'http://localhost:8080'
-    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
+    config.apis.approvedPremisesReports.url = 'http://localhost:8080'
+    fakeApprovedPremisesApi = nock(config.apis.approvedPremisesReports.url)
     reportClient = new ReportClient(callConfig)
   })
 

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -9,7 +9,7 @@ export default class ReportClient {
   restClient: RestClient
 
   constructor(callConfig: CallConfig) {
-    this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig)
+    this.restClient = new RestClient('personClient', config.apis.approvedPremisesReports as ApiConfig, callConfig)
   }
 
   async bookings(response: Response, filename: string, month: string, year: string): Promise<void> {


### PR DESCRIPTION

# Context

We’re finding these endpoints can take more than 30 seconds to respond. This is understandable as the data they’re loading on demand is big.

A longer term solution will be to move this reports from being on demand and to being generated in advance. This will take more time that we have left to do at this point so we try to find a compromise.

The timeout of RestClient doesn’t seem configurable from the reports controller. This might have be a cleaner option rather than repeating the API config.

# Changes in this PR

Requests to the API for reports have their timeout extended to 50 seconds. Giving the API 20 more seconds to respond as it itself timeouts after 60s.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
