### PR TITLE
Remove optional text for DTR local authority

### DIFF
--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -234,7 +234,7 @@
             {
               "DTR / NOP reference number": "ABC123",
               "Date DTR / NOP was submitted": "12 April 2022",
-              "What is the local authority (optional)?": "Barking and Dagenham"
+              "What is the local authority?": "Barking and Dagenham"
             },
             { "Has a referral to Commissioned Rehabilitative Services (CRS) been submitted?": "Yes" },
             { "Have other accommodation options been considered?": "Yes - Other accommodation details" }

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.test.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.test.ts
@@ -105,7 +105,7 @@ describe('DtrDetails', () => {
         expect(page.response()).toEqual({
           'DTR / NOP reference number': 'ABC123',
           'Date DTR / NOP was submitted': '23 July 2022',
-          'What is the local authority (optional)?': localAuthorities[0].name,
+          'What is the local authority?': localAuthorities[0].name,
         })
       })
     })
@@ -116,7 +116,7 @@ describe('DtrDetails', () => {
         expect(page.response()).toEqual({
           'DTR / NOP reference number': 'ABC123',
           'Date DTR / NOP was submitted': '23 July 2022',
-          'What is the local authority (optional)?': 'No local authority selected',
+          'What is the local authority?': 'No local authority selected',
         })
       })
     })

--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
@@ -25,7 +25,7 @@ export default class DtrDetails implements TasklistPage {
   questions = {
     reference: 'DTR / NOP reference number',
     date: 'Date DTR / NOP was submitted',
-    localAuthority: 'What is the local authority (optional)?',
+    localAuthority: 'What is the local authority?',
   }
 
   constructor(

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
@@ -34,7 +34,7 @@
     {{ taSelect(
       {
         label: {
-          text: "Local authority (optional)",
+          text: "Local authority",
           classes: "govuk-label--m"
         },
         hint: {


### PR DESCRIPTION
# Context
We want referrers to complete the local authority field for the Duty to Refer section, therefore we're removing the text that shows the field is optional.

The field remains optional and will not stop a referrer from submitting an application.

## Screenshots of UI changes

### Before
![Screenshot 2023-11-13 at 16 21 54](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/db4cb539-b58f-4468-a2f1-ac39d38165d9)

### After
![Screenshot 2023-11-13 at 16 21 26](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/ce49316b-3012-4031-8cd5-feff10513b96)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
