### PR TITLE
(1329) Make bedspace references editable

### DIFF
--- a/cypress_shared/components/locationHeader.ts
+++ b/cypress_shared/components/locationHeader.ts
@@ -10,15 +10,9 @@ export default class LocationHeaderComponent extends Component {
   }
 
   shouldShowLocationDetails(): void {
-    const { premises, room } = this.details
+    const { premises } = this.details
 
     cy.get('.location-header').within(() => {
-      if (room) {
-        cy.get('h2').contains('Bedspace reference').siblings('p').should('contain', room.name)
-      } else {
-        cy.contains('Bedspace reference').should('not.exist')
-      }
-
       if (premises && !this.hideAddress) {
         cy.get('h2')
           .contains('Property address')

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
@@ -45,6 +45,7 @@ export default class BedspaceEditPage extends BedspaceEditablePage {
   }
 
   clearForm(): void {
+    this.getTextInputByIdAndClear('name')
     cy.get('legend')
       .contains('Does the bedspace have any of the following attributes?')
       .parent()

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
@@ -3,6 +3,9 @@ import Page from '../../page'
 
 export default abstract class BedspaceEditablePage extends Page {
   protected completeEditableForm(newOrUpdateRoom: NewRoom | UpdateRoom): void {
+    this.getLabel('Enter a bedspace reference')
+    this.getTextInputByIdAndEnterDetails('name', newOrUpdateRoom.name)
+
     newOrUpdateRoom.characteristicIds.forEach(characteristicId => {
       this.checkCheckboxByNameAndValue('characteristicIds[]', characteristicId)
     })

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceNew.ts
@@ -23,9 +23,6 @@ export default class BedspaceNewPage extends BedspaceEditablePage {
   }
 
   completeForm(newRoom: NewRoom): void {
-    this.getLabel('Enter a bedspace reference')
-    this.getTextInputByIdAndEnterDetails('name', newRoom.name)
-
     super.completeEditableForm(newRoom)
   }
 }

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -204,16 +204,17 @@ context('Bedspace', () => {
 
     // And when I fill out the form
     cy.task('stubRoomUpdate', { premisesId, room })
-    const updatePremises = updateRoomFactory.build()
-    page.completeForm(updatePremises)
+    const updatedRoom = updateRoomFactory.build({ name: 'new-room-name' })
+    page.completeForm(updatedRoom)
 
     // Then the room should have been update in the API
     cy.task('verifyRoomUpdate', { premisesId, room }).then(requests => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
 
-      expect(requestBody.characteristicIds).members(updatePremises.characteristicIds)
-      expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(updatePremises.notes)
+      expect(requestBody.name).equal(updatedRoom.name)
+      expect(requestBody.characteristicIds).members(updatedRoom.characteristicIds)
+      expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(updatedRoom.notes)
     })
 
     // And I should be redirected to the show bedspace page

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -89,9 +89,16 @@ export default class BedspacesController {
       const { premisesId, roomId } = req.params
       const callConfig = extractCallConfig(req)
 
+      const { name } = req.body
+
+      const room = await this.bedspaceService.getRoom(callConfig, premisesId, roomId)
+
+      const newRoomName = name === room.name ? null : name
+
       const updateRoom: UpdateRoom = {
         characteristicIds: [],
         ...req.body,
+        name: newRoomName,
       }
 
       try {

--- a/server/views/temporary-accommodation/bedspaces/_editable.njk
+++ b/server/views/temporary-accommodation/bedspaces/_editable.njk
@@ -1,6 +1,21 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "../components/ta-input/macro.njk" import taInput %}
+
+{{ taInput(
+  {
+    label: {
+      text: 'Enter a bedspace reference',
+      classes: "govuk-label--m"
+    },
+    hint: {
+      text: "This will be used to identify the bedspace when making bookings and reporting on the service"
+    },
+    fieldName: "name"
+  },
+  fetchContext()
+) }}
 
 {{ govukCheckboxes({
   fieldset: {

--- a/server/views/temporary-accommodation/bedspaces/new.njk
+++ b/server/views/temporary-accommodation/bedspaces/new.njk
@@ -29,21 +29,6 @@
 
         {{ locationHeader({ premises: premises }) }}
 
-        {{ govukInput({
-          label: {
-            text: "Enter a bedspace reference",
-            classes: "govuk-label--m"
-          },
-          hint: {
-            text: "This will be used to identify the bedspace when making bookings and reporting on the service"
-          },
-          classes: "govuk-input--width-20",
-          id: "name",
-          name: "name",
-          value: name,
-          errorMessage: errors.name
-        }) }}
-
         {% include "./_editable.njk" %}  
       </form>
     </div>

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -4,12 +4,6 @@
 
 <div class="location-header">
   {% set premises = locationDetails.premises %}
-  {% set room = locationDetails.room %}
-
-  {% if room %}
-    <h2>Bedspace reference</h2>
-    <p>{{ room.name }}</p>
-  {% endif %}
 
   {% if premises %}
     {% if not hideAddress %}


### PR DESCRIPTION
# Context
We want to allow users to be able to change a bed space reference.

## Screenshots of UI changes

### Before
![Screenshot 2023-11-15 at 16 18 35](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/e4a6c772-1e17-481c-bc47-047bf6f6010f)

### After
![Screenshot 2023-11-15 at 11 35 56](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/6377078/c9d36291-a030-4de5-942a-90ac8838788d)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
