### PR TITLE
Temporarily add authentication logging to help debug auth issues

### DIFF
--- a/server/middleware/setUpAuthentication.ts
+++ b/server/middleware/setUpAuthentication.ts
@@ -1,9 +1,10 @@
+import flash from 'connect-flash'
 import type { Router } from 'express'
 import express from 'express'
 import passport from 'passport'
-import flash from 'connect-flash'
-import config from '../config'
+import logger from '../../logger'
 import auth from '../authentication/auth'
+import config from '../config'
 
 const router = express.Router()
 
@@ -21,12 +22,39 @@ export default function setUpAuth(): Router {
 
   router.get('/sign-in', passport.authenticate('oauth2'))
 
-  router.get('/sign-in/callback', (req, res, next) =>
-    passport.authenticate('oauth2', {
-      successReturnToOrRedirect: req.session.returnTo || '/',
-      failureRedirect: '/autherror',
-    })(req, res, next),
-  )
+  router.get('/sign-in/callback', (req, res, next) => {
+    const authCallback: passport.AuthenticateCallback = (err, user, info) => {
+      if (err) {
+        return res.redirect('/autherror')
+      }
+      if (!user) {
+        if (Object.prototype.hasOwnProperty.call(info, 'message')) {
+          const { message } = info as { message: string }
+          if (info && message === 'Unable to verify authorization request state.') {
+            // failure to due authorisation state not being there on return, so retry
+            logger.info('Retrying auth callback as no state found')
+            return res.redirect('/')
+          }
+        }
+        logger.info(`Auth failure due to ${JSON.stringify(info)}`)
+        return res.redirect('/autherror')
+      }
+      req.logIn(user, err2 => {
+        if (err2) {
+          return next(err2)
+        }
+        if (Object.prototype.hasOwnProperty.call(req.session, 'returnTo')) {
+          const { returnTo } = req.session
+          if (typeof returnTo === 'string' && returnTo.startsWith('/')) {
+            return res.redirect(returnTo)
+          }
+        }
+        return res.redirect('/')
+      })
+      return null
+    }
+    passport.authenticate('oauth2', authCallback)(req, res, next)
+  })
 
   const authUrl = config.apis.hmppsAuth.externalUrl
   const redirectToDomain = config.secondDomain


### PR DESCRIPTION
Recently our users (as well as others in MoJ) have been seeing lots of autherrors. Our temporary workaround has been to advise users to clear their cookies so we need to resolve this.

On request of the HAAR team we temporarily add in this debugging so that we can assist them debug Auth issues that we and other services have been experiencing. 

This approach is lifted from another team who have already added it[1] where we redefine the implementation of the callback `successReturnToOrRedirect` with our custom handling of the same but which lets us collect more information.

[1] https://github.com/ministryofjustice/hmpps-digital-prison-services/pull/84

Checked sign in still works locally in the happy case:

https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/912473/7b16bbad-61e6-46a6-ae80-c5d81b9b9748

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
