### PR TITLE
Remove dotenv usage from the prod context

### DIFF
--- a/server/config.ts
+++ b/server/config.ts
@@ -1,7 +1,6 @@
 /* istanbul ignore file */
 
 import { ServiceName } from '@approved-premises/api'
-import 'dotenv/config'
 
 const production = process.env.NODE_ENV === 'production'
 


### PR DESCRIPTION
We recently merged this change to fix app insights[1] however deploys fail with:

```
Error: Cannot find module 'dotenv/config'
```

Which implies we shouldn’t be importing this anymore.

[1] https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/781


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
