### PR TITLE
CAS-106: Arrived bookings should validate that the arrival date is no…

### DIFF
--- a/server/@types/shared/models/WithdrawPlacementRequestReason.ts
+++ b/server/@types/shared/models/WithdrawPlacementRequestReason.ts
@@ -3,4 +3,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type WithdrawPlacementRequestReason = 'DuplicatePlacementRequest' | 'AlternativeProvisionIdentified';
+export type WithdrawPlacementRequestReason = 'DuplicatePlacementRequest' | 'AlternativeProvisionIdentified' | 'ChangeInCircumstances' | 'ChangeInReleaseDecision' | 'NoCapacityDueToLostBed' | 'NoCapacityDueToPlacementPrioritisation' | 'NoCapacity' | 'ErrorInPlacementRequest';

--- a/server/@types/shared/models/WithdrawalReason.ts
+++ b/server/@types/shared/models/WithdrawalReason.ts
@@ -3,4 +3,4 @@
 /* tslint:disable */
 /* eslint-disable */
 
-export type WithdrawalReason = 'change_in_circumstances_new_application_to_be_submitted' | 'error_in_application' | 'duplicate_application' | 'other';
+export type WithdrawalReason = 'change_in_circumstances_new_application_to_be_submitted' | 'error_in_application' | 'duplicate_application' | 'death' | 'other_accommodation_identified' | 'other';

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -18,7 +18,8 @@
     "arrivalDate": {
       "empty": "You must enter a start date",
       "invalid": "The start date is an invalid date",
-      "conflict": "This bedspace is not available for these dates"
+      "conflict": "This bedspace is not available for these dates",
+      "todayOrInThePast": "The arrival date must be today or in the past"
     },
     "date": {
       "empty": "You must enter a valid departure date",

--- a/server/testutils/factories/arrival.ts
+++ b/server/testutils/factories/arrival.ts
@@ -5,7 +5,7 @@ import type { Arrival } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Arrival>(() => {
-  const arrivalDate = faker.date.soon()
+  const arrivalDate = faker.date.past()
 
   return {
     arrivalDate: DateFormats.dateObjToIsoDate(arrivalDate),

--- a/server/testutils/factories/newArrival.ts
+++ b/server/testutils/factories/newArrival.ts
@@ -5,7 +5,7 @@ import type { NewCas3Arrival as NewArrival } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<NewArrival>(() => {
-  const arrivalDate = faker.date.soon()
+  const arrivalDate = faker.date.past()
 
   return {
     arrivalDate: DateFormats.dateObjToIsoDate(arrivalDate),


### PR DESCRIPTION
…t in the future

# Context

<!-- https://dsdmoj.atlassian.net/browse/CAS-106 -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Arrived bookings should validate that the arrival date is not in the future
Shows error message when the arrival date is in the future for create and update
## Screenshots of UI changes
No changes in UI only validation messages should be displayed
### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
