### PR TITLE
CAS-81 Show town or city in property address

### DIFF
--- a/cypress_shared/components/locationHeader.ts
+++ b/cypress_shared/components/locationHeader.ts
@@ -18,6 +18,7 @@ export default class LocationHeaderComponent extends Component {
           .contains('Property address')
           .siblings('p')
           .should('contain', premises.addressLine1)
+          .should('contain', premises.town)
           .should('contain', premises.postcode)
       } else {
         cy.contains('Property address').should('not.exist')

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -8,7 +8,9 @@
   {% if premises %}
     {% if not hideAddress %}
       <h2>Property address</h2>
-      <p>{{ premises.addressLine1 }}<br />{{ premises.postcode }}</p>
+      <p>{{ premises.addressLine1 }}
+            {% if premises.town.length %}<br/>{{ premises.town }}{% endif %}
+            <br />{{ premises.postcode }}</p>
     {% endif %}
   {% endif %}
 </div>

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -49,7 +49,7 @@
     <div class="edit-bar">
       <div class="edit-bar__container">
         <div class="edit-bar__title">
-          <h3>{{ premises.name }}</h4>
+          <h3>{{ premises.name }}</h3>
         </div>
         <div class="edit-bar__action">
           <a href="{{ paths.premises.edit({ premisesId: premises.id }) }}">Edit</a>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-81

# Changes in this PR

Add the town between Address Line 1 and Postcode in the Property details view of the address. The town is an optional field, so the extra line is only rendered if available, to prevent an empty line showing when not.

## Screenshots of UI changes

### Before

<img width="986" alt="Screenshot 2024-02-26 at 10 49 41" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/30a2ed9f-5f90-4bc8-9d9e-775dc0bec4bd">

### After

<img width="1004" alt="Screenshot 2024-02-26 at 10 16 01" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/317fa428-8b0e-433e-b632-e44cc053718b">


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] ~~Are any changes required to dependent services for this change to work?
  (eg. CAS API)~~ n/a
- [ ] ~~Have they been released to production already?~~ n/a

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
