### PR TITLE
FIX: Ensure test fixture town isn't regenerated when parsing address

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -181,6 +181,7 @@ export default class PremisesShowPage extends Page {
       id,
       name,
       addressLine1: addressLines[0],
+      town: addressLines[addressLines.length - 2],
       postcode: addressLines[addressLines.length - 1],
       status,
       pdu: pdu.name,


### PR DESCRIPTION
# Context

When running E2E tests which select an active premises to view and act on, the step `'I view an existing active premises'` would set the test suite's active premises based on the data available on the page, but ignoring the town. This meant the town name was regenerated for every test attempt, and therefore failing.

# Changes in this PR

This updates the `parsePremises` method to take into account the town as shown on the page, therefore making this data consistent.

The `town` property is set based on the penultimate line of the address block on the page, with the postcode being the last. The `addressLine2` property is optional, and while not seemingly used in any of the test data, it is safer to ensure the town is parsed as the penultimate line, as it is always set, as is the postcode.


## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
