### PR TITLE
CAS-110 bookings CRN search

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -3,5 +3,14 @@
   "singleQuote": true,
   "printWidth": 120,
   "semi": false,
-  "arrowParens": "avoid"
+  "arrowParens": "avoid",
+  "plugins": ["prettier-plugin-jinja-template"],
+  "overrides": [
+    {
+      "files": ["*.njk"],
+      "options": {
+        "parser": "jinja-template"
+      }
+    }
+  ]
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -56,4 +56,8 @@ export default class BookingSearchPage extends Page {
     this.completeTextInputByLabel('Search bookings by CRN (case reference number)', crn)
     this.clickSubmit('Search')
   }
+
+  clearSearch() {
+    cy.get('a').contains('Clear').click()
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -42,8 +42,8 @@ export default class BookingSearchPage extends Page {
     cy.contains(capitaliseStatus(status)).click()
   }
 
-  checkCRNSearchValue(value: string) {
-    this.shouldShowTextInputByLabel('Search bookings by CRN (case reference number)', value)
+  checkCRNSearchValue(value: string, status: string) {
+    this.shouldShowTextInputByLabel(`Search ${status} bookings by CRN (case reference number)`, value)
   }
 
   checkResults(bookings: BookingSearchResults) {
@@ -53,8 +53,8 @@ export default class BookingSearchPage extends Page {
     })
   }
 
-  searchByCRN(crn: string) {
-    this.completeTextInputByLabel('Search bookings by CRN (case reference number)', crn)
+  searchByCRN(crn: string, status: string) {
+    this.completeTextInputByLabel(`Search ${status} bookings by CRN (case reference number)`, crn)
     this.clickSubmit('Search')
   }
 

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -73,4 +73,10 @@ export default class BookingSearchPage extends Page {
     cy.get('p').should('contain', 'Check the other lists.')
     cy.get('main a').contains('contact support').should('have.attr', 'href', `mailto:${supportEmail}`)
   }
+
+  checkNoCRNEntered() {
+    cy.get('main table').should('not.exist')
+    cy.get('h2').should('contain', 'You have not entered any search terms')
+    cy.get('p').should('contain', 'Enter a CRN. This can be found in nDelius.')
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -1,4 +1,4 @@
-import type { Booking, Premises } from '@approved-premises/api'
+import type { Booking, BookingSearchResults, Premises } from '@approved-premises/api'
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
@@ -39,5 +39,20 @@ export default class BookingSearchPage extends Page {
 
   clickOtherBookingStatusLink(status: BookingSearchApiStatus) {
     cy.contains(capitaliseStatus(status)).click()
+  }
+
+  checkCRNSearchValue(value: string) {
+    this.shouldShowTextInputByLabel('Search bookings by CRN (case reference number)', value)
+  }
+
+  checkResults(bookings: BookingSearchResults) {
+    cy.get('main table tbody tr').should('have.length', bookings.resultsCount)
+    bookings.results.forEach(result => {
+      cy.get('main table tbody').should('contain', result.person.crn)
+    })
+  }
+
+  searchByCRN(crn: string) {
+    this.completeTextInputByLabel('Search bookings by CRN (case reference number)', crn)
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -18,8 +18,8 @@ export default class BookingSearchPage extends Page {
   }
 
   checkBookingStatus(status: BookingSearchApiStatus) {
-    const displayStatus = capitaliseStatus(status)
-    cy.get('.moj-side-navigation a[aria-current="location"]').contains(displayStatus)
+    const displayStatus = `${capitaliseStatus(status)} bookings`
+    cy.get('.moj-sub-navigation a[aria-current="page"]').contains(displayStatus)
   }
 
   checkBookingDetailsAndClickView(premises: Premises, booking: Booking) {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -5,6 +5,7 @@ import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 import { capitaliseStatus } from '../../../../server/utils/bookingSearchUtils'
 import { personName } from '../../../../server/utils/personUtils'
+import { supportEmail } from '../../../../server/utils/phaseBannerUtils'
 
 export default class BookingSearchPage extends Page {
   constructor(status: BookingSearchApiStatus = 'provisional') {
@@ -59,5 +60,17 @@ export default class BookingSearchPage extends Page {
 
   clearSearch() {
     cy.get('a').contains('Clear').click()
+  }
+
+  checkNoResults(status: string) {
+    cy.get('main table').should('not.exist')
+    cy.get('p').should('contain', `There are no ${status} bookings to show.`)
+  }
+
+  checkNoResultsByCRN(status: string, crn: string) {
+    cy.get('main table').should('not.exist')
+    cy.get('h2').should('contain', `There are no results for ‘${crn}’ in ${status} bookings.`)
+    cy.get('p').should('contain', 'Check the other lists.')
+    cy.get('main a').contains('contact support').should('have.attr', 'href', `mailto:${supportEmail}`)
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -3,23 +3,23 @@ import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import Page from '../../page'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
-import { convertApiStatusToUiStatus } from '../../../../server/utils/bookingSearchUtils'
+import { capitaliseStatus } from '../../../../server/utils/bookingSearchUtils'
 import { personName } from '../../../../server/utils/personUtils'
 
 export default class BookingSearchPage extends Page {
-  constructor() {
-    super('View bookings')
+  constructor(status: BookingSearchApiStatus = 'provisional') {
+    const title = `${capitaliseStatus(status)} bookings`
+    super(title)
   }
 
   static visit(status: BookingSearchApiStatus): BookingSearchPage {
     cy.visit(paths.bookings.search[status].index({}))
-    return new BookingSearchPage()
+    return new BookingSearchPage(status)
   }
 
   checkBookingStatus(status: BookingSearchApiStatus) {
-    const uiStatus = convertApiStatusToUiStatus(status)
-    const capitalisedStatus = uiStatus.charAt(0).toUpperCase() + uiStatus.slice(1)
-    cy.get('h2').contains(`${capitalisedStatus} bookings`)
+    const displayStatus = capitaliseStatus(status)
+    cy.get('.moj-side-navigation a[aria-current="location"]').contains(displayStatus)
   }
 
   checkBookingDetailsAndClickView(premises: Premises, booking: Booking) {
@@ -38,8 +38,6 @@ export default class BookingSearchPage extends Page {
   }
 
   clickOtherBookingStatusLink(status: BookingSearchApiStatus) {
-    const uiStatus = convertApiStatusToUiStatus(status)
-    const capitalisedStatus = uiStatus.charAt(0).toUpperCase() + uiStatus.slice(1)
-    cy.contains(capitalisedStatus).click()
+    cy.contains(capitaliseStatus(status)).click()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -54,5 +54,6 @@ export default class BookingSearchPage extends Page {
 
   searchByCRN(crn: string) {
     this.completeTextInputByLabel('Search bookings by CRN (case reference number)', crn)
+    this.clickSubmit('Search')
   }
 }

--- a/e2e/tests/bookingSearch.feature
+++ b/e2e/tests/bookingSearch.feature
@@ -4,11 +4,11 @@ Feature: Manage Temporary Accommodation - Booking search
         And I view an existing active premises
         And I'm creating a bedspace
         And I create a bedspace with all necessary details
+        And I'm creating a booking
+        And I create a booking with all necessary details
 
     Scenario: Showing bookings of all statuses
-        Given I'm creating a booking
-        And I create a booking with all necessary details
-        And I'm searching bookings
+        Given I'm searching bookings
         Then I should see a summary of the booking on the provisional bookings page
         And I confirm the booking
         And I'm searching bookings
@@ -19,3 +19,13 @@ Feature: Manage Temporary Accommodation - Booking search
         And I mark the booking as departed
         And I'm searching bookings
         Then I should see a summary of the booking on the departed bookings page
+
+    Scenario: Searching for a booking by CRN
+        Given I'm searching bookings
+        When I search for a CRN that does not exist in provisional bookings
+        Then I should see a message that the provisional booking is not found
+        When I click on the Departed bookings tab
+        Then I should see a message that the departed booking is not found
+        When I click on the Provisional bookings tab
+        And I search for a valid CRN in provisional bookings
+        Then I see the provisional booking I was searching for

--- a/e2e/tests/stepDefinitions/manage/bookingSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingSearch.ts
@@ -1,4 +1,4 @@
-import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
 import Page from '../../../../cypress_shared/pages/page'
 import BookingSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSearch'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
@@ -52,6 +52,55 @@ Then('I should see a summary of the booking on the departed bookings page', () =
     bookingSearchPage.clickOtherBookingStatusLink('departed')
     bookingSearchPage.checkBookingStatus('departed')
 
+    bookingSearchPage.checkBookingDetailsAndClickView(this.premises, this.booking)
+  })
+})
+
+When('I search for a CRN that does not exist in provisional bookings', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'provisional')
+    bookingSearchPage.searchByCRN('N000000', 'provisional')
+  })
+})
+
+Then('I should see a message that the provisional booking is not found', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'provisional')
+    bookingSearchPage.checkNoResultsByCRN('provisional', 'N000000')
+  })
+})
+
+When('I click on the Departed bookings tab', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage)
+    bookingSearchPage.clickOtherBookingStatusLink('departed')
+  })
+})
+
+Then('I should see a message that the departed booking is not found', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'departed')
+    bookingSearchPage.checkNoResultsByCRN('departed', 'N000000')
+  })
+})
+
+When('I click on the Provisional bookings tab', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'departed')
+    bookingSearchPage.clickOtherBookingStatusLink('provisional')
+  })
+})
+
+When('I search for a valid CRN in provisional bookings', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'provisional')
+    bookingSearchPage.searchByCRN(this.booking.person.crn, 'provisional')
+  })
+})
+
+Then('I see the provisional booking I was searching for', () => {
+  cy.then(function _() {
+    const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'provisional')
     bookingSearchPage.checkBookingDetailsAndClickView(this.premises, this.booking)
   })
 })

--- a/integration_tests/mockApis/bookingSearch.ts
+++ b/integration_tests/mockApis/bookingSearch.ts
@@ -19,4 +19,22 @@ export default {
         jsonBody: args.bookings,
       },
     }),
+  stubFindBookingsByCRN: (args: {
+    bookings: BookingSearchResults
+    status: BookingSearchApiStatus
+    crn: string
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'GET',
+        url: `${paths.bookings.search({})}?status=${args.status}&crn=${args.crn}`,
+      },
+      response: {
+        status: 200,
+        headers: {
+          'Content-Type': 'application/json;charset=UTF-8',
+        },
+        jsonBody: args.bookings,
+      },
+    }),
 }

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -67,7 +67,7 @@ context('Booking search', () => {
     page.checkBookingStatus('departed')
   })
 
-  it('shows the result of a crn search', () => {
+  it('shows the result of a crn search and clears the search', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -97,6 +97,17 @@ context('Booking search', () => {
 
     // Then I see the search result for that CRN
     page.checkResults(searchedForBooking)
+
+    // When I clear the search
+    page.clearSearch()
+
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+
+    // Then the search by CRN form is populated
+    page.checkCRNSearchValue('')
+
+    // Then I see the search result for that CRN
+    page.checkResults(bookings)
   })
 
   it('navigates back to the dashboard from the view bookings page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -168,6 +168,57 @@ context('Booking search', () => {
     page.shouldShowErrorMessagesForFields(['crn'])
   })
 
+  it('retains the CRN search when navigating between booking types', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const bookings = bookingSearchResultsFactory.build()
+
+    ;['provisional', 'confirmed', 'arrived', 'departed'].forEach(status => {
+      cy.task('stubFindBookings', { bookings, status })
+      cy.task('stubFindBookingsByCRN', { bookings, status, crn: 'X321654' })
+    })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // And I submit a search by CRN
+    page.searchByCRN('X321654', 'provisional')
+
+    // Then I see the provisional bookings for the given CRN
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+    page.checkCRNSearchValue('X321654', 'provisional')
+
+    // When I navigate to the confirmed bookings search
+    page.clickOtherBookingStatusLink('confirmed')
+
+    // Then I see the confirmed bookings for the given CRN
+    Page.verifyOnPage(BookingSearchPage, 'confirmed')
+    page.checkCRNSearchValue('X321654', 'confirmed')
+
+    // When I navigate to the active bookings search
+    page.clickOtherBookingStatusLink('arrived')
+
+    // Then I see the active bookings for the given CRN
+    Page.verifyOnPage(BookingSearchPage, 'arrived')
+    page.checkCRNSearchValue('X321654', 'active')
+
+    // When I navigate to the departed bookings search
+    page.clickOtherBookingStatusLink('departed')
+
+    // Then I see the departed bookings for the given CRN
+    Page.verifyOnPage(BookingSearchPage, 'departed')
+    page.checkCRNSearchValue('X321654', 'departed')
+
+    // When I navigate to the provisional bookings search
+    page.clickOtherBookingStatusLink('provisional')
+
+    // Then I see the provisional bookings for the given CRN
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+    page.checkCRNSearchValue('X321654', 'provisional')
+  })
+
   it('navigates back to the dashboard from the view bookings page', () => {
     // Given I am signed in
     cy.signIn()

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -148,7 +148,7 @@ context('Booking search', () => {
     page.checkNoResultsByCRN('confirmed', 'N0M4TCH')
   })
 
-  it('shows an error message if the user has not entered a CRN', () => {
+  it('shows a message if the user has entered a blank CRN', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -165,7 +165,7 @@ context('Booking search', () => {
     Page.verifyOnPage(BookingSearchPage, 'provisional')
 
     // Then I see an error message
-    page.shouldShowErrorMessagesForFields(['crn'])
+    page.checkNoCRNEntered()
   })
 
   it('retains the CRN search when navigating between booking types', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -77,6 +77,7 @@ context('Booking search', () => {
     const searchCRN = searchedForBooking.results[0].person.crn
 
     cy.task('stubFindBookings', { bookings, status: 'provisional' })
+    cy.task('stubFindBookingsByCRN', { bookings: searchedForBooking, status: 'provisional', crn: searchCRN })
 
     // When I visit the Find a provisional booking page
     const page = BookingSearchPage.visit('provisional')
@@ -94,9 +95,8 @@ context('Booking search', () => {
     // Then the search by CRN form is populated
     page.checkCRNSearchValue(searchCRN)
 
-    // TODO: perform actual search
     // Then I see the search result for that CRN
-    // page.checkResults(searchedForBooking)
+    page.checkResults(searchedForBooking)
   })
 
   it('navigates back to the dashboard from the view bookings page', () => {

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -110,6 +110,44 @@ context('Booking search', () => {
     page.checkResults(bookings)
   })
 
+  it('shows a message if there are no CRN search results', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are no bookings matching a CRN search in the database
+    const bookings = bookingSearchResultsFactory.build()
+    const noBookings = { results: [], resultsCount: 0 }
+
+    cy.task('stubFindBookings', { bookings, status: 'confirmed' })
+    cy.task('stubFindBookingsByCRN', {
+      bookings: noBookings,
+      status: 'confirmed',
+      crn: 'N0M4TCH',
+    })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('confirmed')
+
+    // Then the search by CRN form is empty
+    page.checkCRNSearchValue('')
+
+    // And I see all the results
+    page.checkResults(bookings)
+
+    // When I submit a search by CRN
+    page.searchByCRN('N0M4TCH')
+    Page.verifyOnPage(BookingSearchPage, 'confirmed')
+
+    // Then the search by CRN form is populated
+    page.checkCRNSearchValue('N0M4TCH')
+
+    // Then I see no search results for that CRN
+    page.checkResults(noBookings)
+
+    // And I see a message
+    page.checkNoResultsByCRN('confirmed', 'N0M4TCH')
+  })
+
   it('navigates back to the dashboard from the view bookings page', () => {
     // Given I am signed in
     cy.signIn()

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -83,17 +83,17 @@ context('Booking search', () => {
     const page = BookingSearchPage.visit('provisional')
 
     // Then the search by CRN form is empty
-    page.checkCRNSearchValue('')
+    page.checkCRNSearchValue('', 'provisional')
 
     // And I see all the results
     page.checkResults(bookings)
 
     // When I submit a search by CRN
-    page.searchByCRN(searchCRN)
+    page.searchByCRN(searchCRN, 'provisional')
     Page.verifyOnPage(BookingSearchPage, 'provisional')
 
     // Then the search by CRN form is populated
-    page.checkCRNSearchValue(searchCRN)
+    page.checkCRNSearchValue(searchCRN, 'provisional')
 
     // Then I see the search result for that CRN
     page.checkResults(searchedForBooking)
@@ -104,7 +104,7 @@ context('Booking search', () => {
     Page.verifyOnPage(BookingSearchPage, 'provisional')
 
     // Then the search by CRN form is populated
-    page.checkCRNSearchValue('')
+    page.checkCRNSearchValue('', 'provisional')
 
     // Then I see the search result for that CRN
     page.checkResults(bookings)
@@ -129,17 +129,17 @@ context('Booking search', () => {
     const page = BookingSearchPage.visit('confirmed')
 
     // Then the search by CRN form is empty
-    page.checkCRNSearchValue('')
+    page.checkCRNSearchValue('', 'confirmed')
 
     // And I see all the results
     page.checkResults(bookings)
 
     // When I submit a search by CRN
-    page.searchByCRN('N0M4TCH')
+    page.searchByCRN('N0M4TCH', 'confirmed')
     Page.verifyOnPage(BookingSearchPage, 'confirmed')
 
     // Then the search by CRN form is populated
-    page.checkCRNSearchValue('N0M4TCH')
+    page.checkCRNSearchValue('N0M4TCH', 'confirmed')
 
     // Then I see no search results for that CRN
     page.checkResults(noBookings)
@@ -161,7 +161,7 @@ context('Booking search', () => {
     const page = BookingSearchPage.visit('provisional')
 
     // And I submit a search with a blank CRN
-    page.searchByCRN('  ')
+    page.searchByCRN('  ', 'provisional')
     Page.verifyOnPage(BookingSearchPage, 'provisional')
 
     // Then I see an error message

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -148,6 +148,26 @@ context('Booking search', () => {
     page.checkNoResultsByCRN('confirmed', 'N0M4TCH')
   })
 
+  it('shows an error message if the user has not entered a CRN', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const bookings = bookingSearchResultsFactory.build()
+
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // And I submit a search with a blank CRN
+    page.searchByCRN('  ')
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+
+    // Then I see an error message
+    page.shouldShowErrorMessagesForFields(['crn'])
+  })
+
   it('navigates back to the dashboard from the view bookings page', () => {
     // Given I am signed in
     cy.signIn()

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -1,4 +1,5 @@
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
+import { BookingSearchResults } from '@approved-premises/api'
 import Page from '../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import BookingSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSearch'
@@ -64,6 +65,38 @@ context('Booking search', () => {
 
     // Then I navigate to the Find a departed booking page
     page.checkBookingStatus('departed')
+  })
+
+  it('shows the result of a crn search', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const bookings = bookingSearchResultsFactory.build()
+    const searchedForBooking: BookingSearchResults = { results: [bookings.results[2]], resultsCount: 1 }
+    const searchCRN = searchedForBooking.results[0].person.crn
+
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // Then the search by CRN form is empty
+    page.checkCRNSearchValue('')
+
+    // And I see all the results
+    page.checkResults(bookings)
+
+    // When I submit a search by CRN
+    page.searchByCRN(searchCRN)
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+
+    // Then the search by CRN form is populated
+    page.checkCRNSearchValue(searchCRN)
+
+    // TODO: perform actual search
+    // Then I see the search result for that CRN
+    // page.checkResults(searchedForBooking)
   })
 
   it('navigates back to the dashboard from the view bookings page', () => {

--- a/package-lock.json
+++ b/package-lock.json
@@ -108,6 +108,7 @@
         "nodemon": "^3.0.0",
         "openapi-typescript-codegen": "^0.25.0",
         "prettier": "^3.0.0",
+        "prettier-plugin-jinja-template": "^1.3.2",
         "sass": "^1.55.0",
         "shellcheck": "^2.0.0",
         "start-server-and-test": "^2.0.0",
@@ -13567,6 +13568,15 @@
       },
       "engines": {
         "node": ">=6.0.0"
+      }
+    },
+    "node_modules/prettier-plugin-jinja-template": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/prettier-plugin-jinja-template/-/prettier-plugin-jinja-template-1.3.2.tgz",
+      "integrity": "sha512-ROglSKajIA4TRxM5othKfhc+dZrWYaVoJW/0EHlN0WwCXS1FmF/2mtfDkJW4wSTBqu7re1svsYMAu+oMGf6T9Q==",
+      "dev": true,
+      "peerDependencies": {
+        "prettier": "^3.0.0"
       }
     },
     "node_modules/pretty-bytes": {

--- a/package.json
+++ b/package.json
@@ -226,6 +226,7 @@
     "nodemon": "^3.0.0",
     "openapi-typescript-codegen": "^0.25.0",
     "prettier": "^3.0.0",
+    "prettier-plugin-jinja-template": "^1.3.2",
     "sass": "^1.55.0",
     "shellcheck": "^2.0.0",
     "start-server-and-test": "^2.0.0",

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -286,6 +286,10 @@ export interface SubNavObj {
 
 export type BookingSearchApiStatus = 'provisional' | 'confirmed' | 'arrived' | 'departed' | 'closed'
 
+export type BookingSearchParameters = {
+  crn?: string
+}
+
 export type ReportType = 'bookings' | 'bedspace-usage' | 'occupancy' | 'referrals'
 
 export interface OasysPage extends TasklistPage {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -278,7 +278,7 @@ export type OasysImportArrays =
 
 export type JourneyType = 'applications' | 'assessments'
 
-export interface SideNavObj {
+export interface SubNavObj {
   text: string
   href: string
   active: boolean

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -23,7 +23,7 @@ describe('BookingSearchController', () => {
   const bookingSearchController = new BookingSearchController(bookingSearchService)
 
   beforeEach(() => {
-    request = createMock<Request>()
+    request = createMock<Request>({ query: {} })
     ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
     ;(createSubNavArr as jest.MockedFn<typeof createSubNavArr>).mockReturnValue([])
     ;(createTableHeadings as jest.MockedFn<typeof createTableHeadings>).mockReturnValue([])
@@ -38,7 +38,7 @@ describe('BookingSearchController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'provisional')
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'provisional', {})
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
         uiStatus: 'provisional',
@@ -56,7 +56,7 @@ describe('BookingSearchController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'arrived')
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'arrived', {})
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
         uiStatus: 'active',
@@ -74,7 +74,7 @@ describe('BookingSearchController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'confirmed')
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'confirmed', {})
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
         uiStatus: 'confirmed',
@@ -92,7 +92,7 @@ describe('BookingSearchController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'departed')
+      expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'departed', {})
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
         uiStatus: 'departed',
@@ -115,8 +115,11 @@ describe('BookingSearchController', () => {
 
         await requestHandler(request, response, next)
 
-        // TODO: call service with params
-        expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'provisional')
+        expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(
+          callConfig,
+          'provisional',
+          searchParameters,
+        )
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
           uiStatus: 'provisional',

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -50,7 +50,6 @@ describe('BookingSearchController', () => {
         bookingTableRows: [],
         subNavArr: [],
         errors: {},
-        errorSummary: [],
       })
     })
 
@@ -70,7 +69,6 @@ describe('BookingSearchController', () => {
         bookingTableRows: [],
         subNavArr: [],
         errors: {},
-        errorSummary: [],
       })
     })
 
@@ -90,7 +88,6 @@ describe('BookingSearchController', () => {
         bookingTableRows: [],
         subNavArr: [],
         errors: {},
-        errorSummary: [],
       })
     })
 
@@ -110,7 +107,6 @@ describe('BookingSearchController', () => {
         bookingTableRows: [],
         subNavArr: [],
         errors: {},
-        errorSummary: [],
       })
     })
 
@@ -143,7 +139,6 @@ describe('BookingSearchController', () => {
             subNavArr: [],
             crn: searchParameters.crn,
             errors: {},
-            errorSummary: [],
           })
         },
       )

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -3,6 +3,7 @@ import type { NextFunction, Request, Response } from 'express'
 import BookingSearchController from './bookingSearchController'
 import { CallConfig } from '../../../data/restClient'
 import { BookingSearchService } from '../../../services'
+import { bookingSearchParametersFactory } from '../../../testutils/factories'
 import extractCallConfig from '../../../utils/restUtils'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
 
@@ -98,6 +99,32 @@ describe('BookingSearchController', () => {
         tableHeadings: [],
         bookingTableRows: [],
         subNavArr: [],
+      })
+    })
+
+    describe('when there is a CRN search parameter', () => {
+      it('renders the filtered table view for provisional bookings', async () => {
+        const searchParameters = bookingSearchParametersFactory.build()
+
+        bookingSearchService.getTableRowsForFindBooking.mockResolvedValue([])
+        ;(convertApiStatusToUiStatus as jest.MockedFn<typeof convertApiStatusToUiStatus>).mockReturnValue('provisional')
+
+        request.query = searchParameters
+
+        const requestHandler = bookingSearchController.index('provisional')
+
+        await requestHandler(request, response, next)
+
+        // TODO: call service with params
+        expect(bookingSearchService.getTableRowsForFindBooking).toHaveBeenCalledWith(callConfig, 'provisional')
+
+        expect(response.render).toHaveBeenCalledWith('temporary-accommodation/booking-search/results', {
+          uiStatus: 'provisional',
+          tableHeadings: [],
+          bookingTableRows: [],
+          subNavArr: [],
+          crn: searchParameters.crn,
+        })
       })
     })
   })

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -4,7 +4,7 @@ import BookingSearchController from './bookingSearchController'
 import { CallConfig } from '../../../data/restClient'
 import { BookingSearchService } from '../../../services'
 import extractCallConfig from '../../../utils/restUtils'
-import { convertApiStatusToUiStatus, createSideNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
+import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
 
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/bookingSearchUtils')
@@ -24,7 +24,7 @@ describe('BookingSearchController', () => {
   beforeEach(() => {
     request = createMock<Request>()
     ;(extractCallConfig as jest.MockedFn<typeof extractCallConfig>).mockReturnValue(callConfig)
-    ;(createSideNavArr as jest.MockedFn<typeof createSideNavArr>).mockReturnValue([])
+    ;(createSubNavArr as jest.MockedFn<typeof createSubNavArr>).mockReturnValue([])
     ;(createTableHeadings as jest.MockedFn<typeof createTableHeadings>).mockReturnValue([])
   })
 
@@ -43,7 +43,7 @@ describe('BookingSearchController', () => {
         uiStatus: 'provisional',
         tableHeadings: [],
         bookingTableRows: [],
-        sideNavArr: [],
+        subNavArr: [],
       })
     })
 
@@ -61,7 +61,7 @@ describe('BookingSearchController', () => {
         uiStatus: 'active',
         tableHeadings: [],
         bookingTableRows: [],
-        sideNavArr: [],
+        subNavArr: [],
       })
     })
 
@@ -79,7 +79,7 @@ describe('BookingSearchController', () => {
         uiStatus: 'confirmed',
         tableHeadings: [],
         bookingTableRows: [],
-        sideNavArr: [],
+        subNavArr: [],
       })
     })
 
@@ -97,7 +97,7 @@ describe('BookingSearchController', () => {
         uiStatus: 'departed',
         tableHeadings: [],
         bookingTableRows: [],
-        sideNavArr: [],
+        subNavArr: [],
       })
     })
   })

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -5,7 +5,9 @@ import extractCallConfig from '../../../utils/restUtils'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
 
 // TODO: replace with type generated from API
-export type BookingSearchParameters = Record<string, string>
+export type BookingSearchParameters = {
+  crn?: string
+}
 
 export default class BookingSearchController {
   constructor(private readonly bookingSearchService: BookingSearchService) {}
@@ -16,7 +18,7 @@ export default class BookingSearchController {
 
       const params = req.query as BookingSearchParameters
 
-      const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status)
+      const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status, params)
 
       return res.render(`temporary-accommodation/booking-search/results`, {
         uiStatus: convertApiStatusToUiStatus(status),

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -4,12 +4,17 @@ import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import extractCallConfig from '../../../utils/restUtils'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
 
+// TODO: replace with type generated from API
+export type BookingSearchParameters = Record<string, string>
+
 export default class BookingSearchController {
   constructor(private readonly bookingSearchService: BookingSearchService) {}
 
   index(status: BookingSearchApiStatus): RequestHandler {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
+
+      const params = req.query as BookingSearchParameters
 
       const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status)
 
@@ -18,6 +23,7 @@ export default class BookingSearchController {
         subNavArr: createSubNavArr(status),
         tableHeadings: createTableHeadings(status),
         bookingTableRows,
+        crn: params.crn,
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -28,7 +28,7 @@ export default class BookingSearchController {
 
         return res.render(`temporary-accommodation/booking-search/results`, {
           uiStatus: convertApiStatusToUiStatus(status),
-          subNavArr: createSubNavArr(status),
+          subNavArr: createSubNavArr(status, params.crn),
           tableHeadings: createTableHeadings(status),
           bookingTableRows,
           crn: params.crn,

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -3,25 +3,46 @@ import { BookingSearchService } from 'server/services'
 import type { BookingSearchApiStatus, BookingSearchParameters } from '@approved-premises/ui'
 import extractCallConfig from '../../../utils/restUtils'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
+import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import paths from '../../../paths/temporary-accommodation/manage'
 
 export default class BookingSearchController {
   constructor(private readonly bookingSearchService: BookingSearchService) {}
 
   index(status: BookingSearchApiStatus): RequestHandler {
     return async (req: Request, res: Response) => {
+      const { errors, errorSummary } = fetchErrorsAndUserInput(req)
+
       const callConfig = extractCallConfig(req)
 
       const params = req.query as BookingSearchParameters
 
-      const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status, params)
+      try {
+        if (params.crn !== undefined && !params.crn.trim().length) {
+          const error = new Error()
+          insertGenericError(error, 'crn', 'empty')
+          throw error
+        }
 
-      return res.render(`temporary-accommodation/booking-search/results`, {
-        uiStatus: convertApiStatusToUiStatus(status),
-        subNavArr: createSubNavArr(status),
-        tableHeadings: createTableHeadings(status),
-        bookingTableRows,
-        crn: params.crn,
-      })
+        const bookingTableRows = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status, params)
+
+        return res.render(`temporary-accommodation/booking-search/results`, {
+          uiStatus: convertApiStatusToUiStatus(status),
+          subNavArr: createSubNavArr(status),
+          tableHeadings: createTableHeadings(status),
+          bookingTableRows,
+          crn: params.crn,
+          errors,
+          errorSummary,
+        })
+      } catch (err) {
+        return catchValidationErrorOrPropogate(
+          req,
+          res,
+          err,
+          paths.bookings.search[convertApiStatusToUiStatus(status)].index(),
+        )
+      }
     }
   }
 }

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -1,13 +1,8 @@
 import type { Request, RequestHandler, Response } from 'express'
 import { BookingSearchService } from 'server/services'
-import type { BookingSearchApiStatus } from '@approved-premises/ui'
+import type { BookingSearchApiStatus, BookingSearchParameters } from '@approved-premises/ui'
 import extractCallConfig from '../../../utils/restUtils'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
-
-// TODO: replace with type generated from API
-export type BookingSearchParameters = {
-  crn?: string
-}
 
 export default class BookingSearchController {
   constructor(private readonly bookingSearchService: BookingSearchService) {}

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -11,7 +11,7 @@ export default class BookingSearchController {
 
   index(status: BookingSearchApiStatus): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { errors, errorSummary } = fetchErrorsAndUserInput(req)
+      const { errors } = fetchErrorsAndUserInput(req)
 
       const callConfig = extractCallConfig(req)
 
@@ -33,7 +33,6 @@ export default class BookingSearchController {
           bookingTableRows,
           crn: params.crn,
           errors,
-          errorSummary,
         })
       } catch (err) {
         return catchValidationErrorOrPropogate(

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -2,7 +2,7 @@ import type { Request, RequestHandler, Response } from 'express'
 import { BookingSearchService } from 'server/services'
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import extractCallConfig from '../../../utils/restUtils'
-import { convertApiStatusToUiStatus, createSideNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
+import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
 
 export default class BookingSearchController {
   constructor(private readonly bookingSearchService: BookingSearchService) {}
@@ -15,7 +15,7 @@ export default class BookingSearchController {
 
       return res.render(`temporary-accommodation/booking-search/results`, {
         uiStatus: convertApiStatusToUiStatus(status),
-        sideNavArr: createSideNavArr(status),
+        subNavArr: createSubNavArr(status),
         tableHeadings: createTableHeadings(status),
         bookingTableRows,
       })

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -17,12 +17,11 @@ import type {
   Nonarrival,
   Turnaround,
 } from '@approved-premises/api'
-import type { BookingSearchApiStatus } from '@approved-premises/ui'
+import type { BookingSearchApiStatus, BookingSearchParameters } from '@approved-premises/ui'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 import { appendQueryString } from '../utils/utils'
 import RestClient, { CallConfig } from './restClient'
-import { BookingSearchParameters } from '../controllers/temporary-accommodation/manage/bookingSearchController'
 
 export default class BookingClient {
   restClient: RestClient

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -22,6 +22,7 @@ import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
 import { appendQueryString } from '../utils/utils'
 import RestClient, { CallConfig } from './restClient'
+import { BookingSearchParameters } from '../controllers/temporary-accommodation/manage/bookingSearchController'
 
 export default class BookingClient {
   restClient: RestClient
@@ -122,8 +123,8 @@ export default class BookingClient {
     return response as Turnaround
   }
 
-  async search(status: BookingSearchApiStatus): Promise<BookingSearchResults> {
-    const path = appendQueryString(paths.bookings.search({ status }), { status })
+  async search(status: BookingSearchApiStatus, params: BookingSearchParameters): Promise<BookingSearchResults> {
+    const path = appendQueryString(paths.bookings.search({ status }), { status, ...params })
 
     const response = await this.restClient.get({ path })
 

--- a/server/services/bookingSearchService.test.ts
+++ b/server/services/bookingSearchService.test.ts
@@ -35,7 +35,7 @@ describe('BookingService', () => {
 
       bookingClient.search.mockResolvedValue(bookings)
 
-      const rows = await service.getTableRowsForFindBooking(callConfig, 'provisional')
+      const rows = await service.getTableRowsForFindBooking(callConfig, 'provisional', {})
 
       expect(rows).toEqual([
         [
@@ -123,7 +123,7 @@ describe('BookingService', () => {
       const bookings = bookingSearchResultsFactory.build({ resultsCount: 0, results: [] })
       bookingClient.search.mockResolvedValue(bookings)
 
-      const rows = await service.getTableRowsForFindBooking(callConfig, 'provisional')
+      const rows = await service.getTableRowsForFindBooking(callConfig, 'provisional', {})
 
       expect(rows).toEqual([])
     })

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -1,10 +1,9 @@
-import type { BookingSearchApiStatus, TableRow } from '@approved-premises/ui'
+import type { BookingSearchApiStatus, BookingSearchParameters, TableRow } from '@approved-premises/ui'
 import type { RestClientBuilder } from '../data'
 import BookingClient from '../data/bookingClient'
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from '../utils/dateUtils'
-import { BookingSearchParameters } from '../controllers/temporary-accommodation/manage/bookingSearchController'
 
 export default class BookingSearchService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -4,13 +4,18 @@ import BookingClient from '../data/bookingClient'
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from '../utils/dateUtils'
+import { BookingSearchParameters } from '../controllers/temporary-accommodation/manage/bookingSearchController'
 
 export default class BookingSearchService {
   constructor(private readonly bookingClientFactory: RestClientBuilder<BookingClient>) {}
 
-  async getTableRowsForFindBooking(callConfig: CallConfig, status: BookingSearchApiStatus): Promise<Array<TableRow>> {
+  async getTableRowsForFindBooking(
+    callConfig: CallConfig,
+    status: BookingSearchApiStatus,
+    params: BookingSearchParameters,
+  ): Promise<Array<TableRow>> {
     const bookingClient = this.bookingClientFactory(callConfig)
-    const bookingSummaries = await bookingClient.search(status)
+    const bookingSummaries = await bookingClient.search(status, params)
 
     const { results } = bookingSummaries
 

--- a/server/testutils/factories/bookingSearchParameters.ts
+++ b/server/testutils/factories/bookingSearchParameters.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { faker } from '@faker-js/faker/locale/en_GB'
+import { BookingSearchParameters } from '../../controllers/temporary-accommodation/manage/bookingSearchController'
+
+export default Factory.define<BookingSearchParameters>(() => ({
+  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+}))

--- a/server/testutils/factories/bookingSearchParameters.ts
+++ b/server/testutils/factories/bookingSearchParameters.ts
@@ -1,6 +1,6 @@
 import { Factory } from 'fishery'
 import { faker } from '@faker-js/faker/locale/en_GB'
-import { BookingSearchParameters } from '../../controllers/temporary-accommodation/manage/bookingSearchController'
+import { BookingSearchParameters } from '@approved-premises/ui'
 
 export default Factory.define<BookingSearchParameters>(() => ({
   crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -11,6 +11,7 @@ import bedSearchParametersFactory from './bedSearchParameters'
 import bedSearchResultFactory from './bedSearchResult'
 import bedSearchResultsFactory from './bedSearchResults'
 import bookingFactory from './booking'
+import bookingSearchParametersFactory from './bookingSearchParameters'
 import bookingSearchResultFactory from './bookingSearchResult'
 import bookingSearchResultBedSummaryFactory from './bookingSearchResultBedSummary'
 import bookingSearchResultBookingSummaryFactory from './bookingSearchResultBookingSummary'
@@ -81,6 +82,7 @@ export {
   bedSearchResultFactory,
   bedSearchResultsFactory,
   bookingFactory,
+  bookingSearchParametersFactory,
   bookingSearchResultBedSummaryFactory,
   bookingSearchResultBookingSummaryFactory,
   bookingSearchResultFactory,

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -2,7 +2,7 @@ import paths from '../paths/temporary-accommodation/manage'
 import {
   capitaliseStatus,
   convertApiStatusToUiStatus,
-  createSideNavArr,
+  createSubNavArr,
   createTableHeadings,
 } from './bookingSearchUtils'
 
@@ -11,28 +11,28 @@ describe('bookingSearchUtils', () => {
     it('returns side nav with given status selected', () => {
       const sideNavArr = [
         {
-          text: 'Provisional',
+          text: 'Provisional bookings',
           href: paths.bookings.search.provisional.index({}),
           active: true,
         },
         {
-          text: 'Confirmed',
+          text: 'Confirmed bookings',
           href: paths.bookings.search.confirmed.index({}),
           active: false,
         },
         {
-          text: 'Active',
+          text: 'Active bookings',
           href: paths.bookings.search.active.index({}),
           active: false,
         },
         {
-          text: 'Departed',
+          text: 'Departed bookings',
           href: paths.bookings.search.departed.index({}),
           active: false,
         },
       ]
 
-      expect(createSideNavArr('provisional')).toEqual(sideNavArr)
+      expect(createSubNavArr('provisional')).toEqual(sideNavArr)
     })
   })
 

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -1,5 +1,10 @@
 import paths from '../paths/temporary-accommodation/manage'
-import { convertApiStatusToUiStatus, createSideNavArr, createTableHeadings } from './bookingSearchUtils'
+import {
+  capitaliseStatus,
+  convertApiStatusToUiStatus,
+  createSideNavArr,
+  createTableHeadings,
+} from './bookingSearchUtils'
 
 describe('bookingSearchUtils', () => {
   describe('createSideNavArr', () => {
@@ -110,5 +115,14 @@ describe('convertApiStatusToUiStatus', () => {
     expect(convertApiStatusToUiStatus('confirmed')).toEqual('confirmed')
     expect(convertApiStatusToUiStatus('arrived')).toEqual('active')
     expect(convertApiStatusToUiStatus('departed')).toEqual('departed')
+  })
+})
+
+describe('capitaliseStatus', () => {
+  it('returns the capitalised version of the given api status', () => {
+    expect(capitaliseStatus('provisional')).toEqual('Provisional')
+    expect(capitaliseStatus('confirmed')).toEqual('Confirmed')
+    expect(capitaliseStatus('arrived')).toEqual('Active')
+    expect(capitaliseStatus('departed')).toEqual('Departed')
   })
 })

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -34,6 +34,33 @@ describe('bookingSearchUtils', () => {
 
       expect(createSubNavArr('provisional')).toEqual(sideNavArr)
     })
+
+    it('appends the CRN parameter if given', () => {
+      const sideNavArr = [
+        {
+          text: 'Provisional bookings',
+          href: `${paths.bookings.search.provisional.index({})}?crn=X222555`,
+          active: true,
+        },
+        {
+          text: 'Confirmed bookings',
+          href: `${paths.bookings.search.confirmed.index({})}?crn=X222555`,
+          active: false,
+        },
+        {
+          text: 'Active bookings',
+          href: `${paths.bookings.search.active.index({})}?crn=X222555`,
+          active: false,
+        },
+        {
+          text: 'Departed bookings',
+          href: `${paths.bookings.search.departed.index({})}?crn=X222555`,
+          active: false,
+        },
+      ]
+
+      expect(createSubNavArr('provisional', 'X222555')).toEqual(sideNavArr)
+    })
   })
 
   describe('createTableHeadings', () => {

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -1,27 +1,27 @@
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
-import { SideNavObj, TableCell } from '../@types/ui/index'
+import { SubNavObj, TableCell } from '../@types/ui/index'
 import paths from '../paths/temporary-accommodation/manage'
 
-export function createSideNavArr(status: BookingSearchApiStatus): Array<SideNavObj> {
+export function createSubNavArr(status: BookingSearchApiStatus): Array<SubNavObj> {
   const uiStatus = convertApiStatusToUiStatus(status)
   return [
     {
-      text: 'Provisional',
+      text: 'Provisional bookings',
       href: paths.bookings.search.provisional.index({}),
       active: uiStatus === 'provisional',
     },
     {
-      text: 'Confirmed',
+      text: 'Confirmed bookings',
       href: paths.bookings.search.confirmed.index({}),
       active: uiStatus === 'confirmed',
     },
     {
-      text: 'Active',
+      text: 'Active bookings',
       href: paths.bookings.search.active.index({}),
       active: uiStatus === 'active',
     },
     {
-      text: 'Departed',
+      text: 'Departed bookings',
       href: paths.bookings.search.departed.index({}),
       active: uiStatus === 'departed',
     },

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -69,3 +69,8 @@ export function convertApiStatusToUiStatus(status: BookingSearchApiStatus): stri
       return status
   }
 }
+
+export function capitaliseStatus(status: BookingSearchApiStatus) {
+  const uiStatus = convertApiStatusToUiStatus(status)
+  return uiStatus.charAt(0).toUpperCase() + uiStatus.slice(1)
+}

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -1,31 +1,15 @@
 import type { BookingSearchApiStatus } from '@approved-premises/ui'
 import { SubNavObj, TableCell } from '../@types/ui/index'
 import paths from '../paths/temporary-accommodation/manage'
+import { appendQueryString } from './utils'
 
-export function createSubNavArr(status: BookingSearchApiStatus): Array<SubNavObj> {
+export function createSubNavArr(status: BookingSearchApiStatus, crn?: string): Array<SubNavObj> {
   const uiStatus = convertApiStatusToUiStatus(status)
-  return [
-    {
-      text: 'Provisional bookings',
-      href: paths.bookings.search.provisional.index({}),
-      active: uiStatus === 'provisional',
-    },
-    {
-      text: 'Confirmed bookings',
-      href: paths.bookings.search.confirmed.index({}),
-      active: uiStatus === 'confirmed',
-    },
-    {
-      text: 'Active bookings',
-      href: paths.bookings.search.active.index({}),
-      active: uiStatus === 'active',
-    },
-    {
-      text: 'Departed bookings',
-      href: paths.bookings.search.departed.index({}),
-      active: uiStatus === 'departed',
-    },
-  ]
+  return ['provisional', 'confirmed', 'active', 'departed'].map((bookingStatus: BookingSearchApiStatus) => ({
+    text: `${capitaliseStatus(bookingStatus)} bookings`,
+    href: appendQueryString(paths.bookings.search[bookingStatus].index({}), { crn }),
+    active: uiStatus === bookingStatus,
+  }))
 }
 
 export function createTableHeadings(status: BookingSearchApiStatus): Array<TableCell> {

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -22,7 +22,7 @@
   }}
 
   <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
-    <form action="" method="get">
+    <form action="{{ paths.bookings.search[uiStatus].index() }}" method="get">
       {{
         govukInput({
           classes: 'moj-search__input',
@@ -44,7 +44,7 @@
       <div class="govuk-button-group">
         {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
 
-        <a class="govuk-link" id="clear-search-button" data-ga-action="click" data-ga-value="1" href="">Clear</a>
+        <a class="govuk-link" href="{{ paths.bookings.search[uiStatus].index() }}">Clear</a>
       </div>
     </form>
   </div>

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -2,7 +2,6 @@
 {%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
-
 {% set pageTitle = "View bookings - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
@@ -11,44 +10,37 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">View bookings</h1>
+  <h1 class="govuk-heading-l">{{ uiStatus | capitalize }} bookings</h1>
 
   <div class="govuk-grid-row">
-
-  <div class="govuk-grid-column-one-third">
-
-    {{ mojSideNavigation({
-      label: 'Side navigation',
-      items: sideNavArr
-    }) }}
-
+    <div class="govuk-grid-column-one-third">
+      {{
+        mojSideNavigation({
+        label: 'Side navigation',
+        items: sideNavArr
+        })
+      }}
     </div>
 
     <div class="govuk-grid-column-two-thirds">
-
-    <h2>{{ uiStatus | capitalize }} bookings</h2>
-
-    {{ govukTable({
-    captionClasses: "govuk-table__caption--m",
-    attributes: {
-    'data-module': 'moj-sortable-table'
-    },
-    head: tableHeadings,
-    rows: bookingTableRows
-  }) }}
-
+      {{
+        govukTable({
+        captionClasses: "govuk-table__caption--m",
+        attributes: {
+        'data-module': 'moj-sortable-table'
+        },
+        head: tableHeadings,
+        rows: bookingTableRows
+        })
+      }}
     </div>
+  </div>
 
-</div>
-
-{% block extraScripts %}
-  <script type="text/javascript" nonce="{{ cspNonce }}">
-  $(document).ready(function () {
-  window
-      .MOJFrontend
-      .initAll() })
-
-</script>
-{% endblock %}
-
+  {% block extraScripts %}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      $(document).ready(function () {
+        window.MOJFrontend.initAll()
+      })
+    </script>
+  {% endblock %}
 {% endblock %}

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -31,7 +31,7 @@
         {
           label: {
             classes: 'govuk-label--m',
-            text: 'Search bookings by CRN (case reference number)'
+            text: 'Search ' + uiStatus + ' bookings by CRN (case reference number)'
           },
           hint: {
             text: 'For example, XD7364CD'

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -1,5 +1,5 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{%- from "moj/components/side-navigation/macro.njk" import mojSideNavigation -%}
+{%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% set pageTitle = "View bookings - " + applicationName %}
@@ -12,29 +12,23 @@
 {% block content %}
   <h1 class="govuk-heading-l">{{ uiStatus | capitalize }} bookings</h1>
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      {{
-        mojSideNavigation({
-        label: 'Side navigation',
-        items: sideNavArr
-        })
-      }}
-    </div>
+  {{
+    mojSubNavigation({
+    label: 'Secondary navigation',
+    items: subNavArr
+    })
+  }}
 
-    <div class="govuk-grid-column-two-thirds">
-      {{
-        govukTable({
-        captionClasses: "govuk-table__caption--m",
-        attributes: {
-        'data-module': 'moj-sortable-table'
-        },
-        head: tableHeadings,
-        rows: bookingTableRows
-        })
-      }}
-    </div>
-  </div>
+  {{
+    govukTable({
+    captionClasses: "govuk-table__caption--m",
+    attributes: {
+    'data-module': 'moj-sortable-table'
+    },
+    head: tableHeadings,
+    rows: bookingTableRows
+    })
+  }}
 
   {% block extraScripts %}
     <script type="text/javascript" nonce="{{ cspNonce }}">

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -1,9 +1,10 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
+{% from "../components/ta-input/macro.njk" import taInput %}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% set pageTitle = "View bookings - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
@@ -21,25 +22,24 @@
     })
   }}
 
+  {{ showErrorSummary(errorSummary) }}
+
   <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
     <form action="{{ paths.bookings.search[uiStatus].index() }}" method="get">
-      {{
-        govukInput({
-          classes: 'moj-search__input',
+
+      {{ taInput(
+        {
           label: {
             classes: 'govuk-label--m',
             text: 'Search bookings by CRN (case reference number)'
           },
-          autocomplete: 'off',
           hint: {
-            classes: 'moj-search__hint',
             text: 'For example, XD7364CD'
           },
-          id: 'crn',
-          name: 'crn',
-          value: crn
-        })
-      }}
+          fieldName: 'crn'
+        },
+        fetchContext()
+      ) }}
 
       <div class="govuk-button-group">
         {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -15,14 +15,14 @@
 {% block content %}
   <h1 class="govuk-heading-l">{{ uiStatus | capitalize }} bookings</h1>
 
+  {{ showErrorSummary(errorSummary) }}
+
   {{
     mojSubNavigation({
     label: 'Secondary navigation',
     items: subNavArr
     })
   }}
-
-  {{ showErrorSummary(errorSummary) }}
 
   <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
     <form action="{{ paths.bookings.search[uiStatus].index() }}" method="get">

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -49,16 +49,24 @@
     </form>
   </div>
 
-  {{
-    govukTable({
-    captionClasses: "govuk-table__caption--m",
-    attributes: {
-    'data-module': 'moj-sortable-table'
-    },
-    head: tableHeadings,
-    rows: bookingTableRows
-    })
-  }}
+  {% if (bookingTableRows|length > 0) or (not crn) %}
+    {{
+      govukTable({
+        captionClasses: "govuk-table__caption--m",
+        attributes: {
+          'data-module': 'moj-sortable-table'
+        },
+        head: tableHeadings,
+        rows: bookingTableRows
+      })
+    }}
+  {% else %}
+    <h2>There are no results for ‘{{ crn }}’ in {{ uiStatus }} bookings.</h2>
+
+    <p>Check the other lists.</p>
+
+    <p>If the booking is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact support</a> for help.</p>
+  {% endif %}
 
   {% block extraScripts %}
     <script type="text/javascript" nonce="{{ cspNonce }}">

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -1,7 +1,7 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
-{% from "../components/ta-input/macro.njk" import taInput %}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
@@ -13,9 +13,9 @@
 {% endblock %}
 
 {% block content %}
-  <h1 class="govuk-heading-l">{{ uiStatus | capitalize }} bookings</h1>
+  {% set context = fetchContext() %}
 
-  {{ showErrorSummary(errorSummary) }}
+  <h1 class="govuk-heading-l">{{ uiStatus | capitalize }} bookings</h1>
 
   {{
     mojSubNavigation({
@@ -27,7 +27,7 @@
   <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
     <form action="{{ paths.bookings.search[uiStatus].index() }}" method="get">
 
-      {{ taInput(
+      {{ govukInput(
         {
           label: {
             classes: 'govuk-label--m',
@@ -36,9 +36,10 @@
           hint: {
             text: 'For example, XD7364CD'
           },
-          fieldName: 'crn'
-        },
-        fetchContext()
+          name: 'crn',
+          id: 'crn',
+          value: crn
+        }
       ) }}
 
       <div class="govuk-button-group">
@@ -49,7 +50,11 @@
     </form>
   </div>
 
-  {% if (bookingTableRows|length > 0) or (not crn) %}
+  {% if context.errors.crn %}
+    <h2>You have not entered any search terms</h2>
+
+    <p>Enter a CRN. This can be found in nDelius.</p>
+  {% elif (bookingTableRows|length > 0) or (not crn) %}
     {{
       govukTable({
         captionClasses: "govuk-table__caption--m",

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -1,4 +1,6 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
 {%- from "moj/components/sub-navigation/macro.njk" import mojSubNavigation -%}
 {% extends "../../partials/layout.njk" %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
@@ -18,6 +20,34 @@
     items: subNavArr
     })
   }}
+
+  <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
+    <form action="" method="get">
+      {{
+        govukInput({
+          classes: 'moj-search__input',
+          label: {
+            classes: 'govuk-label--m',
+            text: 'Search bookings by CRN (case reference number)'
+          },
+          autocomplete: 'off',
+          hint: {
+            classes: 'moj-search__hint',
+            text: 'For example, XD7364CD'
+          },
+          id: 'crn',
+          name: 'crn',
+          value: crn
+        })
+      }}
+
+      <div class="govuk-button-group">
+        {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
+
+        <a class="govuk-link" id="clear-search-button" data-ga-action="click" data-ga-value="1" href="">Clear</a>
+      </div>
+    </form>
+  </div>
 
   {{
     govukTable({


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-110

This adds CRN search to the bookings search. The layout of the Bookings search screens is updated to accommodate the new search functionality.

# Changes in this PR

- Add search box to search by CRN
- Clicking 'Clear' clears the search and loads all results
- Move side navigation to horizontal tab bar
- Use full width for search results


## Screenshots of UI changes

### Before

<img width="980" alt="Screenshot 2024-02-29 at 15 50 49" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/40321a43-d724-4c62-9545-3801c2d6405c">

### After

<img width="980" alt="Screenshot 2024-02-29 at 15 50 09" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/0cd689bb-f293-49ae-96bb-89b9c26ba4b9">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work? Yes: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1545
- [ ] Have they been released to production already? No

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
