### PR TITLE
CAS-174 split referral requests

### DIFF
--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -56,4 +56,8 @@ export default class ListPage extends Page {
   clickSubNav(label: string) {
     cy.get('[aria-label="Secondary navigation"] a').contains(label).click()
   }
+
+  shouldHaveActiveSubNavItem(label: string) {
+    cy.get('[aria-label="Secondary navigation"] a').contains(label).should('have.attr', 'aria-current', 'page')
+  }
 }

--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -9,13 +9,8 @@ import { isFullPerson, personName } from '../../../server/utils/personUtils'
 import Page from '../page'
 
 export default class ListPage extends Page {
-  constructor(
-    private readonly unallocatedAssessments: Array<AssessmentSummary>,
-    private readonly inProgressAssessments: Array<AssessmentSummary>,
-    private readonly readyToPlaceAssessments: Array<AssessmentSummary>,
-    private readonly archivedAssessments: Array<AssessmentSummary>,
-  ) {
-    super('Referrals')
+  constructor(pageTitle: string) {
+    super(pageTitle)
   }
 
   clickAssessment(assessment: Assessment) {
@@ -26,27 +21,12 @@ export default class ListPage extends Page {
     }
   }
 
-  shouldShowInProgressAssessments(): void {
-    cy.get('#tab_in-review').click()
-    this.shouldShowAssessments(this.inProgressAssessments, 'in-review')
-  }
-
-  shouldShowUnallocatedAssessments(): void {
-    cy.get('#tab_unallocated').click()
-    this.shouldShowAssessments(this.unallocatedAssessments, 'unallocated')
-  }
-
-  shouldShowReadyToPlaceAssessments(): void {
-    cy.get('#tab_ready-to-place').click()
-    this.shouldShowAssessments(this.readyToPlaceAssessments, 'ready-to-place')
-  }
-
   clickViewArchivedReferrals(): void {
     cy.get('a').contains('View archived referrals').click()
   }
 
-  shouldShowArchivedAssessments(): void {
-    this.archivedAssessments.forEach(assessmentSummary => {
+  shouldShowAssessments(assessments: Array<AssessmentSummary>): void {
+    assessments.forEach(assessmentSummary => {
       cy.get(`a[href*="${paths.assessments.full({ id: assessmentSummary.id })}"]`)
         .parent()
         .parent()
@@ -69,47 +49,11 @@ export default class ListPage extends Page {
                   })
                 : 'N/A',
             )
-          cy.get('td')
-            .eq(2)
-            .contains(
-              assessmentSummary?.arrivalDate
-                ? DateFormats.isoDateToUIDate(assessmentSummary?.arrivalDate, {
-                    format: 'short',
-                  })
-                : 'N/A',
-            )
-          cy.get('td').eq(3).contains(statusName(assessmentSummary.status))
         })
     })
   }
 
-  private shouldShowAssessments(assessments: Array<AssessmentSummary>, containerId: string): void {
-    assessments.forEach(assessmentSummary => {
-      cy.get(`#${containerId}`).within(() => {
-        cy.get(`a[href*="${paths.assessments.full({ id: assessmentSummary.id })}"]`)
-          .parent()
-          .parent()
-          .within(() => {
-            cy.get('th').eq(0).contains(personName(assessmentSummary.person, 'Limited access offender'))
-            cy.get('td').eq(0).contains(assessmentSummary.person.crn)
-            cy.get('td')
-              .eq(1)
-              .contains(
-                DateFormats.isoDateToUIDate(assessmentSummary.createdAt, {
-                  format: 'short',
-                }),
-              )
-            cy.get('td')
-              .eq(2)
-              .contains(
-                assessmentSummary?.arrivalDate
-                  ? DateFormats.isoDateToUIDate(assessmentSummary?.arrivalDate, {
-                      format: 'short',
-                    })
-                  : 'N/A',
-              )
-          })
-      })
-    })
+  clickSubNav(label: string) {
+    cy.get('[aria-label="Secondary navigation"] a').contains(label).click()
   }
 }

--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -25,7 +25,7 @@ export default class ListPage extends Page {
     cy.get('a').contains('View archived referrals').click()
   }
 
-  shouldShowAssessments(assessments: Array<AssessmentSummary>): void {
+  shouldShowAssessments(assessments: Array<AssessmentSummary>, checkStatus = false): void {
     assessments.forEach(assessmentSummary => {
       cy.get(`a[href*="${paths.assessments.full({ id: assessmentSummary.id })}"]`)
         .parent()
@@ -49,6 +49,9 @@ export default class ListPage extends Page {
                   })
                 : 'N/A',
             )
+          if (checkStatus) {
+            cy.get('td').eq(3).contains(statusName(assessmentSummary.status))
+          }
         })
     })
   }

--- a/e2e/tests/stepDefinitions/place.ts
+++ b/e2e/tests/stepDefinitions/place.ts
@@ -17,11 +17,11 @@ Given('I view the list of assessments', () => {
   const dashboardPage = Page.verifyOnPage(DashboardPage)
   dashboardPage.clickReviewAndAssessReferrals()
 
-  Page.verifyOnPage(AssessmentListPage, [], [], [], [])
+  Page.verifyOnPage(AssessmentListPage, 'Referrals unallocated')
 })
 
 Given('I view the assessment', () => {
-  const assessmentListPage = Page.verifyOnPage(AssessmentListPage, [], [], [], [])
+  const assessmentListPage = Page.verifyOnPage(AssessmentListPage, 'Referrals unallocated')
 
   const application = applicationFactory.build({
     person,

--- a/e2e/tests/stepDefinitions/place.ts
+++ b/e2e/tests/stepDefinitions/place.ts
@@ -17,11 +17,11 @@ Given('I view the list of assessments', () => {
   const dashboardPage = Page.verifyOnPage(DashboardPage)
   dashboardPage.clickReviewAndAssessReferrals()
 
-  Page.verifyOnPage(AssessmentListPage, 'Referrals unallocated')
+  Page.verifyOnPage(AssessmentListPage, 'Unallocated referrals')
 })
 
 Given('I view the assessment', () => {
-  const assessmentListPage = Page.verifyOnPage(AssessmentListPage, 'Referrals unallocated')
+  const assessmentListPage = Page.verifyOnPage(AssessmentListPage, 'Unallocated referrals')
 
   const application = applicationFactory.build({
     person,

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -73,7 +73,7 @@ context('Apply', () => {
 
         // Then I should see the list of archived assessments
         const archivedListPage = Page.verifyOnPage(ListPage, 'Archived referrals')
-        archivedListPage.shouldShowAssessments([...rejectedAssessmentSummaries, ...closedAssessmentSummaries])
+        archivedListPage.shouldShowAssessments([...rejectedAssessmentSummaries, ...closedAssessmentSummaries], true)
       })
     })
 

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -49,6 +49,7 @@ context('Apply', () => {
 
         // Then I should see the list of unallocated referrals
         const unallocatedListPage = Page.verifyOnPage(ListPage, 'Unallocated referrals')
+        unallocatedListPage.shouldHaveActiveSubNavItem('Unallocated')
         unallocatedListPage.shouldShowAssessments(unallocatedAssessmentSummaries)
 
         // When I click on 'In review'
@@ -56,6 +57,7 @@ context('Apply', () => {
 
         // Then I should see the list of in review referrals
         const inReviewListPage = Page.verifyOnPage(ListPage, 'In review referrals')
+        unallocatedListPage.shouldHaveActiveSubNavItem('In review')
         inReviewListPage.shouldShowAssessments(inProgressAssessmentSummaries)
 
         // When I click on 'Ready to place'
@@ -63,6 +65,7 @@ context('Apply', () => {
 
         // Then I should see the list of ready to place referrals
         const readyToPlaceListPage = Page.verifyOnPage(ListPage, 'Ready to place referrals')
+        unallocatedListPage.shouldHaveActiveSubNavItem('Ready to place')
         readyToPlaceListPage.shouldShowAssessments(readyToPlaceAssessmentSummaries)
 
         // When I click on the 'View archived assessments' link

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -48,21 +48,21 @@ context('Apply', () => {
         dashboardPage.clickReviewAndAssessReferrals()
 
         // Then I should see the list of unallocated referrals
-        const unallocatedListPage = Page.verifyOnPage(ListPage, 'Referrals unallocated')
+        const unallocatedListPage = Page.verifyOnPage(ListPage, 'Unallocated referrals')
         unallocatedListPage.shouldShowAssessments(unallocatedAssessmentSummaries)
 
         // When I click on 'In review'
         unallocatedListPage.clickSubNav('In review')
 
         // Then I should see the list of in review referrals
-        const inReviewListPage = Page.verifyOnPage(ListPage, 'Referrals in_review')
+        const inReviewListPage = Page.verifyOnPage(ListPage, 'In review referrals')
         inReviewListPage.shouldShowAssessments(inProgressAssessmentSummaries)
 
         // When I click on 'Ready to place'
         inReviewListPage.clickSubNav('Ready to place')
 
         // Then I should see the list of ready to place referrals
-        const readyToPlaceListPage = Page.verifyOnPage(ListPage, 'Referrals ready_to_place')
+        const readyToPlaceListPage = Page.verifyOnPage(ListPage, 'Ready to place referrals')
         readyToPlaceListPage.shouldShowAssessments(readyToPlaceAssessmentSummaries)
 
         // When I click on the 'View archived assessments' link
@@ -91,7 +91,7 @@ context('Apply', () => {
           // Given I visit the referral list page
           const dashboardPage = DashboardPage.visit()
           dashboardPage.clickReviewAndAssessReferrals()
-          const listPage = Page.verifyOnPage(ListPage, 'Referrals unallocated')
+          const listPage = Page.verifyOnPage(ListPage, 'Unallocated referrals')
 
           // When I click on the referral
           listPage.clickAssessment(assessment)
@@ -186,7 +186,7 @@ context('Apply', () => {
           // Given I visit the referral list page
           const dashboardPage = DashboardPage.visit()
           dashboardPage.clickReviewAndAssessReferrals()
-          const listPage = Page.verifyOnPage(ListPage, 'Referrals unallocated')
+          const listPage = Page.verifyOnPage(ListPage, 'Unallocated referrals')
 
           // When I click on the referral
           listPage.clickAssessment(assessment)

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -47,25 +47,30 @@ context('Apply', () => {
         // And I click on the "Review and assess referrals" link
         dashboardPage.clickReviewAndAssessReferrals()
 
-        // Then I should see the list of referrals
-        const listPage = Page.verifyOnPage(
-          ListPage,
-          unallocatedAssessmentSummaries,
-          inProgressAssessmentSummaries,
-          readyToPlaceAssessmentSummaries,
-          [...rejectedAssessmentSummaries, ...closedAssessmentSummaries],
-        )
+        // Then I should see the list of unallocated referrals
+        const unallocatedListPage = Page.verifyOnPage(ListPage, 'Referrals unallocated')
+        unallocatedListPage.shouldShowAssessments(unallocatedAssessmentSummaries)
 
-        // And I should see the list of referrals
-        listPage.shouldShowUnallocatedAssessments()
-        listPage.shouldShowInProgressAssessments()
-        listPage.shouldShowReadyToPlaceAssessments()
+        // When I click on 'In review'
+        unallocatedListPage.clickSubNav('In review')
 
-        // Given I click on the 'View archived assessments' link
-        listPage.clickViewArchivedReferrals()
+        // Then I should see the list of in review referrals
+        const inReviewListPage = Page.verifyOnPage(ListPage, 'Referrals in_review')
+        inReviewListPage.shouldShowAssessments(inProgressAssessmentSummaries)
+
+        // When I click on 'Ready to place'
+        inReviewListPage.clickSubNav('Ready to place')
+
+        // Then I should see the list of ready to place referrals
+        const readyToPlaceListPage = Page.verifyOnPage(ListPage, 'Referrals ready_to_place')
+        readyToPlaceListPage.shouldShowAssessments(readyToPlaceAssessmentSummaries)
+
+        // When I click on the 'View archived assessments' link
+        readyToPlaceListPage.clickViewArchivedReferrals()
 
         // Then I should see the list of archived assessments
-        listPage.shouldShowArchivedAssessments()
+        const archivedListPage = Page.verifyOnPage(ListPage, 'Archived referrals')
+        archivedListPage.shouldShowAssessments([...rejectedAssessmentSummaries, ...closedAssessmentSummaries])
       })
     })
 
@@ -86,7 +91,7 @@ context('Apply', () => {
           // Given I visit the referral list page
           const dashboardPage = DashboardPage.visit()
           dashboardPage.clickReviewAndAssessReferrals()
-          const listPage = Page.verifyOnPage(ListPage, assessmentSummary, [], [], [])
+          const listPage = Page.verifyOnPage(ListPage, 'Referrals unallocated')
 
           // When I click on the referral
           listPage.clickAssessment(assessment)
@@ -181,7 +186,7 @@ context('Apply', () => {
           // Given I visit the referral list page
           const dashboardPage = DashboardPage.visit()
           dashboardPage.clickReviewAndAssessReferrals()
-          const listPage = Page.verifyOnPage(ListPage, assessmentSummary, [], [], [])
+          const listPage = Page.verifyOnPage(ListPage, 'Referrals unallocated')
 
           // When I click on the referral
           listPage.clickAssessment(assessment)

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -33,13 +33,7 @@ context('Apply', () => {
         const rejectedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'rejected' })
         const closedAssessmentSummaries = assessmentSummaryFactory.buildList(2, { status: 'closed' })
 
-        cy.task('stubAssessments', [
-          ...inProgressAssessmentSummaries,
-          ...unallocatedAssessmentSummaries,
-          ...readyToPlaceAssessmentSummaries,
-          ...rejectedAssessmentSummaries,
-          ...closedAssessmentSummaries,
-        ])
+        cy.task('stubAssessments', unallocatedAssessmentSummaries)
 
         // When I visit the dashboard
         const dashboardPage = DashboardPage.visit()
@@ -53,6 +47,7 @@ context('Apply', () => {
         unallocatedListPage.shouldShowAssessments(unallocatedAssessmentSummaries)
 
         // When I click on 'In review'
+        cy.task('stubAssessments', inProgressAssessmentSummaries)
         unallocatedListPage.clickSubNav('In review')
 
         // Then I should see the list of in review referrals
@@ -61,6 +56,7 @@ context('Apply', () => {
         inReviewListPage.shouldShowAssessments(inProgressAssessmentSummaries)
 
         // When I click on 'Ready to place'
+        cy.task('stubAssessments', readyToPlaceAssessmentSummaries)
         inReviewListPage.clickSubNav('Ready to place')
 
         // Then I should see the list of ready to place referrals
@@ -69,6 +65,7 @@ context('Apply', () => {
         readyToPlaceListPage.shouldShowAssessments(readyToPlaceAssessmentSummaries)
 
         // When I click on the 'View archived assessments' link
+        cy.task('stubAssessments', [...closedAssessmentSummaries, ...rejectedAssessmentSummaries])
         readyToPlaceListPage.clickViewArchivedReferrals()
 
         // Then I should see the list of archived assessments

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -324,3 +324,5 @@ export type ApplicationSummaryData = {
     | 'CAS2 (formerly Bail Accommodation Support Services)'
     | null
 }
+
+export type AssessmentSearchApiStatus = 'unallocated' | 'in_review' | 'ready_to_place'

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -8,6 +8,7 @@ import {
   ArrayOfOASysRiskToSelfQuestions,
   ArrayOfOASysSupportingInformationQuestions,
   TemporaryAccommodationAssessment as Assessment,
+  AssessmentStatus,
   Booking,
   Document,
   LocalAuthorityArea,
@@ -325,4 +326,4 @@ export type ApplicationSummaryData = {
     | null
 }
 
-export type AssessmentSearchApiStatus = 'unallocated' | 'in_review' | 'ready_to_place'
+export type AssessmentSearchApiStatus = Extract<AssessmentStatus, 'unallocated' | 'in_review' | 'ready_to_place'>

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -57,7 +57,7 @@ describe('AssessmentsController', () => {
       const requestHandler = assessmentsController.index()
       await requestHandler(request, response, next)
 
-      expect(response.redirect).toHaveBeenCalledWith(paths.assessments.unallocated.pattern)
+      expect(response.redirect).toHaveBeenCalledWith(301, paths.assessments.unallocated.pattern)
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -58,7 +58,9 @@ describe('AssessmentsController', () => {
 
       expect(response.redirect).toHaveBeenCalledWith(paths.assessments.unallocated.pattern)
     })
+  })
 
+  describe('list', () => {
     it.each(['unallocated', 'in_review', 'ready_to_place'])(
       'returns the table rows for assessments with status %s to the template',
       async (status: AssessmentSearchApiStatus) => {
@@ -69,7 +71,7 @@ describe('AssessmentsController', () => {
           archivedTableRows: [],
         })
 
-        const requestHandler = assessmentsController.index(status)
+        const requestHandler = assessmentsController.list(status)
         await requestHandler(request, response, next)
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/index', {

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -53,7 +53,7 @@ describe('AssessmentsController', () => {
   })
 
   describe('index', () => {
-    it('redirects to unallocated assessments if no status is specified', async () => {
+    it('redirects to unallocated referrals', async () => {
       const requestHandler = assessmentsController.index()
       await requestHandler(request, response, next)
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -70,12 +70,14 @@ export const confirmationPageContent: Record<Assessment['status'], { title: stri
 export default class AssessmentsController {
   constructor(private readonly assessmentsService: AssessmentsService) {}
 
-  index(status?: AssessmentSearchApiStatus): RequestHandler {
+  index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      if (!status) {
-        return res.redirect(paths.assessments.unallocated.pattern)
-      }
+      return res.redirect(paths.assessments.unallocated.pattern)
+    }
+  }
 
+  list(status: AssessmentSearchApiStatus): RequestHandler {
+    return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
 
       const { unallocatedTableRows, inProgressTableRows, readyToPlaceTableRows } =

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -80,18 +80,7 @@ export default class AssessmentsController {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
 
-      const { unallocatedTableRows, inProgressTableRows, readyToPlaceTableRows } =
-        await this.assessmentsService.getAllForLoggedInUser(callConfig)
-
-      // TODO: return only required status from service
-      let tableRows: TableRow[]
-      if (status === 'unallocated') {
-        tableRows = unallocatedTableRows
-      } else if (status === 'in_review') {
-        tableRows = inProgressTableRows
-      } else {
-        tableRows = readyToPlaceTableRows
-      }
+      const tableRows = await this.assessmentsService.getAllForLoggedInUser(callConfig, status)
 
       return res.render('temporary-accommodation/assessments/index', {
         status,
@@ -105,7 +94,7 @@ export default class AssessmentsController {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
 
-      const { archivedTableRows } = await this.assessmentsService.getAllForLoggedInUser(callConfig)
+      const archivedTableRows = await this.assessmentsService.getAllForLoggedInUser(callConfig, 'archived')
 
       return res.render('temporary-accommodation/assessments/archive', {
         archivedTableRows,

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -72,7 +72,7 @@ export default class AssessmentsController {
 
   index(): RequestHandler {
     return async (req: Request, res: Response) => {
-      return res.redirect(paths.assessments.unallocated.pattern)
+      return res.redirect(301, paths.assessments.unallocated.pattern)
     }
   }
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
-import { AssessmentSearchApiStatus, TableRow } from '@approved-premises/ui'
+import { AssessmentSearchApiStatus } from '@approved-premises/ui'
 import {
   TemporaryAccommodationAssessment as Assessment,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -35,10 +35,10 @@ describe('AssessmentClient', () => {
     const assessmentSummaries = assessmentSummaryFactory.buildList(5)
 
     it.each([
-      ['unallocated', 'unallocated' as AssessmentStatus],
-      ['in review', 'in_review' as AssessmentStatus],
-      ['ready to place', 'ready_to_place' as AssessmentStatus],
-      ['archived', ['closed', 'rejected'] as AssessmentStatus[]],
+      ['unallocated', 'unallocated' as const],
+      ['in review', 'in_review' as const],
+      ['ready to place', 'ready_to_place' as const],
+      ['archived', ['closed' as const, 'rejected' as const]],
     ])(
       'should get all %s assessments for the current user',
       async (_, apiStatuses: AssessmentStatus | AssessmentStatus[]) => {

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -35,22 +35,19 @@ describe('AssessmentClient', () => {
     const assessmentSummaries = assessmentSummaryFactory.buildList(5)
 
     it.each([
-      ['unallocated', 'unallocated' as const],
-      ['in review', 'in_review' as const],
-      ['ready to place', 'ready_to_place' as const],
+      ['unallocated', ['unallocated' as const]],
+      ['in review', ['in_review' as const]],
+      ['ready to place', ['ready_to_place' as const]],
       ['archived', ['closed' as const, 'rejected' as const]],
-    ])(
-      'should get all %s assessments for the current user',
-      async (_, apiStatuses: AssessmentStatus | AssessmentStatus[]) => {
-        fakeApprovedPremisesApi
-          .get(appendQueryString(paths.assessments.index({}), { statuses: apiStatuses }))
-          .matchHeader('authorization', `Bearer ${callConfig.token}`)
-          .reply(200, assessmentSummaries)
+    ])('should get all %s assessments for the current user', async (_, apiStatuses: AssessmentStatus[]) => {
+      fakeApprovedPremisesApi
+        .get(appendQueryString(paths.assessments.index({}), { statuses: apiStatuses }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, assessmentSummaries)
 
-        const output = await assessmentClient.all(apiStatuses)
-        expect(output).toEqual(assessmentSummaries)
-      },
-    )
+      const output = await assessmentClient.all(apiStatuses)
+      expect(output).toEqual(assessmentSummaries)
+    })
   })
 
   describe('readyToPlaceForCrn', () => {

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -2,6 +2,7 @@ import type {
   TemporaryAccommodationAssessment as Assessment,
   AssessmentAcceptance,
   AssessmentRejection,
+  TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   TemporaryAccommodationAssessmentSummary as AssessmentSummary,
   NewReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
@@ -19,8 +20,10 @@ export default class AssessmentClient {
     this.restClient = new RestClient('assessmentClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async all(): Promise<Array<AssessmentSummary>> {
-    return (await this.restClient.get({ path: paths.assessments.index.pattern })) as Array<AssessmentSummary>
+  async all(statuses: AssessmentStatus | AssessmentStatus[]): Promise<Array<AssessmentSummary>> {
+    return (await this.restClient.get({
+      path: appendQueryString(paths.assessments.index.pattern, { statuses }),
+    })) as Array<AssessmentSummary>
   }
 
   async readyToPlaceForCrn(crn: string): Promise<Array<AssessmentSummary>> {

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -20,7 +20,7 @@ export default class AssessmentClient {
     this.restClient = new RestClient('assessmentClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async all(statuses: AssessmentStatus | AssessmentStatus[]): Promise<Array<AssessmentSummary>> {
+  async all(statuses: AssessmentStatus[]): Promise<Array<AssessmentSummary>> {
     return (await this.restClient.get({
       path: appendQueryString(paths.assessments.index.pattern, { statuses }),
     })) as Array<AssessmentSummary>

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -115,6 +115,9 @@ const paths = {
   },
   assessments: {
     index: assessmentsPath,
+    unallocated: assessmentsPath.path('unallocated'),
+    inReview: assessmentsPath.path('in-review'),
+    readyToPlace: assessmentsPath.path('ready-to-place'),
     archive: assessmentsPath.path('archive'),
     full: assessmentsPath.path(':id'),
     summary: assessmentPath.path(':id/summary'),

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -317,15 +317,15 @@ export default function routes(controllers: Controllers, services: Services, rou
 
   get(paths.bedspaces.search.pattern, bedspaceSearchController.index(), { auditEvent: 'VIEW_SEARCH_BEDSPACES' })
 
-  get(paths.assessments.index.pattern, assessmentsController.index())
+  get(paths.assessments.index.pattern, assessmentsController.index(), { auditEvent: 'REDIRECT_ASSESSMENTS_LIST' })
   get(paths.assessments.unallocated.pattern, assessmentsController.list('unallocated'), {
-    auditEvent: 'VIEW_ASSESSMENTS_LIST',
+    auditEvent: 'VIEW_UNALLOCATED_ASSESSMENTS_LIST',
   })
   get(paths.assessments.inReview.pattern, assessmentsController.list('in_review'), {
-    auditEvent: 'VIEW_ASSESSMENTS_LIST',
+    auditEvent: 'VIEW_IN_REVIEW_ASSESSMENTS_LIST',
   })
   get(paths.assessments.readyToPlace.pattern, assessmentsController.list('ready_to_place'), {
-    auditEvent: 'VIEW_ASSESSMENTS_LIST',
+    auditEvent: 'VIEW_READY_TO_PLACE_ASSESSMENTS_LIST',
   })
   get(paths.assessments.archive.pattern, assessmentsController.archive(), {
     auditEvent: 'VIEW_ARCHIVE_ASSESSMENTS_LIST',

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -317,7 +317,16 @@ export default function routes(controllers: Controllers, services: Services, rou
 
   get(paths.bedspaces.search.pattern, bedspaceSearchController.index(), { auditEvent: 'VIEW_SEARCH_BEDSPACES' })
 
-  get(paths.assessments.index.pattern, assessmentsController.index(), { auditEvent: 'VIEW_ASSESSMENTS_LIST' })
+  get(paths.assessments.index.pattern, assessmentsController.index()),
+    get(paths.assessments.unallocated.pattern, assessmentsController.index('unallocated'), {
+      auditEvent: 'VIEW_ASSESSMENTS_LIST',
+    })
+  get(paths.assessments.inReview.pattern, assessmentsController.index('in_review'), {
+    auditEvent: 'VIEW_ASSESSMENTS_LIST',
+  })
+  get(paths.assessments.readyToPlace.pattern, assessmentsController.index('ready_to_place'), {
+    auditEvent: 'VIEW_ASSESSMENTS_LIST',
+  })
   get(paths.assessments.archive.pattern, assessmentsController.archive(), {
     auditEvent: 'VIEW_ARCHIVE_ASSESSMENTS_LIST',
   })

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -317,14 +317,14 @@ export default function routes(controllers: Controllers, services: Services, rou
 
   get(paths.bedspaces.search.pattern, bedspaceSearchController.index(), { auditEvent: 'VIEW_SEARCH_BEDSPACES' })
 
-  get(paths.assessments.index.pattern, assessmentsController.index()),
-    get(paths.assessments.unallocated.pattern, assessmentsController.index('unallocated'), {
-      auditEvent: 'VIEW_ASSESSMENTS_LIST',
-    })
-  get(paths.assessments.inReview.pattern, assessmentsController.index('in_review'), {
+  get(paths.assessments.index.pattern, assessmentsController.index())
+  get(paths.assessments.unallocated.pattern, assessmentsController.list('unallocated'), {
     auditEvent: 'VIEW_ASSESSMENTS_LIST',
   })
-  get(paths.assessments.readyToPlace.pattern, assessmentsController.index('ready_to_place'), {
+  get(paths.assessments.inReview.pattern, assessmentsController.list('in_review'), {
+    auditEvent: 'VIEW_ASSESSMENTS_LIST',
+  })
+  get(paths.assessments.readyToPlace.pattern, assessmentsController.list('ready_to_place'), {
     auditEvent: 'VIEW_ASSESSMENTS_LIST',
   })
   get(paths.assessments.archive.pattern, assessmentsController.archive(), {

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -44,7 +44,7 @@ describe('AssessmentsService', () => {
         expect(tableRows).toEqual(assessments.map(() => [{ text: `Table row: ${uiStatus}` }]))
 
         expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
-        expect(assessmentClient.all).toHaveBeenCalledWith(uiStatus)
+        expect(assessmentClient.all).toHaveBeenCalledWith([uiStatus])
 
         assessments.forEach(assessment => expect(assessmentTableRows).toHaveBeenCalledWith(assessment, false))
       },

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -1,9 +1,10 @@
-import type { TableRow } from '@approved-premises/ui'
+import type { AssessmentSearchApiStatus, TableRow } from '@approved-premises/ui'
 import type {
   TemporaryAccommodationAssessment as Assessment,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   NewReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
+  TemporaryAccommodationAssessmentStatus,
 } from '../@types/shared'
 import { AssessmentSummary } from '../@types/shared'
 import type { AssessmentClient, RestClientBuilder } from '../data'
@@ -14,46 +15,16 @@ import { assertUnreachable } from '../utils/utils'
 export default class AssessmentsService {
   constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
 
-  async getAllForLoggedInUser(callConfig: CallConfig): Promise<{
-    unallocatedTableRows: Array<TableRow>
-    inProgressTableRows: Array<TableRow>
-    readyToPlaceTableRows: Array<TableRow>
-    archivedTableRows: Array<TableRow>
-  }> {
+  async getAllForLoggedInUser(
+    callConfig: CallConfig,
+    uiStatus: AssessmentSearchApiStatus | 'archived',
+  ): Promise<Array<TableRow>> {
+    const statuses =
+      uiStatus === 'archived' ? (['closed', 'rejected'] as TemporaryAccommodationAssessmentStatus[]) : uiStatus
     const assessmentClient = this.assessmentClientFactory(callConfig)
-    const assessmentSummaries = await assessmentClient.all()
-    const result = {
-      unallocatedTableRows: [] as Array<TableRow>,
-      inProgressTableRows: [] as Array<TableRow>,
-      readyToPlaceTableRows: [] as Array<TableRow>,
-      archivedTableRows: [] as Array<TableRow>,
-    }
+    const assessmentSummaries = await assessmentClient.all(statuses)
 
-    await Promise.all(
-      assessmentSummaries.map(async summary => {
-        switch (summary.status) {
-          case 'unallocated':
-            result.unallocatedTableRows.push(assessmentTableRows(summary))
-            break
-          case 'ready_to_place':
-            result.readyToPlaceTableRows.push(assessmentTableRows(summary))
-            break
-          case 'closed':
-            result.archivedTableRows.push(assessmentTableRows(summary, true))
-            break
-          case 'rejected':
-            result.archivedTableRows.push(assessmentTableRows(summary, true))
-            break
-          case 'in_review':
-            result.inProgressTableRows.push(assessmentTableRows(summary))
-            break
-          default:
-            break
-        }
-      }),
-    )
-
-    return result
+    return assessmentSummaries.map(summary => assessmentTableRows(summary, uiStatus === 'archived'))
   }
 
   findAssessment(callConfig: CallConfig, assessmentId: string): Promise<Assessment> {

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -20,7 +20,7 @@ export default class AssessmentsService {
     uiStatus: AssessmentSearchApiStatus | 'archived',
   ): Promise<Array<TableRow>> {
     const statuses =
-      uiStatus === 'archived' ? (['closed', 'rejected'] as TemporaryAccommodationAssessmentStatus[]) : uiStatus
+      uiStatus === 'archived' ? (['closed', 'rejected'] as TemporaryAccommodationAssessmentStatus[]) : [uiStatus]
     const assessmentClient = this.assessmentClientFactory(callConfig)
     const assessmentSummaries = await assessmentClient.all(statuses)
 

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -64,15 +64,18 @@
           items: [
             {
               text: 'Unallocated',
-              href: paths.assessments.unallocated()
+              href: paths.assessments.unallocated(),
+              active: status == 'unallocated'
             },
             {
               text: 'In review',
-              href: paths.assessments.inReview()
+              href: paths.assessments.inReview(),
+              active: status == 'in_review'
             },
             {
               text: 'Ready to place',
-              href: paths.assessments.readyToPlace()
+              href: paths.assessments.readyToPlace(),
+              active: status == 'ready_to_place'
             }
           ]
         })

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -54,56 +54,51 @@
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">{{ status | replace('_', ' ') | capitalize }} referrals</h1>
+  <h1 class="govuk-heading-l">{{ status | replace('_', ' ') | capitalize }} referrals</h1>
 
-      {{
-        mojSubNavigation({
-          label: 'Secondary navigation',
-          items: [
-            {
-              text: 'Unallocated',
-              href: paths.assessments.unallocated(),
-              active: status == 'unallocated'
-            },
-            {
-              text: 'In review',
-              href: paths.assessments.inReview(),
-              active: status == 'in_review'
-            },
-            {
-              text: 'Ready to place',
-              href: paths.assessments.readyToPlace(),
-              active: status == 'ready_to_place'
-            }
-          ]
-        })
-      }}
+  {{
+    mojSubNavigation({
+      label: 'Secondary navigation',
+      items: [
+        {
+          text: 'Unallocated',
+          href: paths.assessments.unallocated(),
+          active: status == 'unallocated'
+        },
+        {
+          text: 'In review',
+          href: paths.assessments.inReview(),
+          active: status == 'in_review'
+        },
+        {
+          text: 'Ready to place',
+          href: paths.assessments.readyToPlace(),
+          active: status == 'ready_to_place'
+        }
+      ]
+    })
+  }}
 
-      {{
-        govukTable({
-          firstCellIsHeader: true,
-          captionClasses: "govuk-table__caption--m",
-          attributes: {
-            'data-module': 'moj-sortable-table'
-          },
-          head: tableHeaders,
-          rows: tableRows
-        })
-      }}
+  {{
+    govukTable({
+      firstCellIsHeader: true,
+      captionClasses: "govuk-table__caption--m",
+      attributes: {
+        'data-module': 'moj-sortable-table'
+      },
+      head: tableHeaders,
+      rows: tableRows
+    })
+  }}
 
-      {{ 
-        govukButton({
-          text: "View archived referrals",
-          type: "button",
-          href: paths.assessments.archive(),
-          classes: "govuk-button--secondary"
-        }) 
-      }}
-
-    </div>
-  </div>
+  {{
+    govukButton({
+      text: "View archived referrals",
+      type: "button",
+      href: paths.assessments.archive(),
+      classes: "govuk-button--secondary"
+    })
+  }}
 {% endblock %}
 
 {% block extraScripts %}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -56,7 +56,7 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">Referrals {{ status }}</h1>
+      <h1 class="govuk-heading-l">{{ status | replace('_', ' ') | capitalize }} referrals</h1>
 
       {{
         mojSubNavigation({

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -1,8 +1,8 @@
-{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/badge/macro.njk" import mojBadge %}
+{% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 
 {% extends "../../partials/layout.njk" %}
@@ -56,41 +56,45 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-full">
-      <h1 class="govuk-heading-l">Referrals</h1>
+      <h1 class="govuk-heading-l">Referrals {{ status }}</h1>
 
-      {{ 
-        govukTabs({
+      {{
+        mojSubNavigation({
+          label: 'Secondary navigation',
           items: [
             {
-              label: "Unallocated",
-              id: "unallocated",
-              panel: {
-                html: unallocatedTableHtml
-              }
+              text: 'Unallocated',
+              href: paths.assessments.unallocated()
             },
             {
-              label: "In Review",
-              id: "in-review",
-              panel: {
-                html: inProgressTableHtml
-              }
+              text: 'In review',
+              href: paths.assessments.inReview()
             },
             {
-              label: "Ready to place",
-              id: "ready-to-place",
-              panel: {
-                html: readyToPlaceTableHtml
-              }
+              text: 'Ready to place',
+              href: paths.assessments.readyToPlace()
             }
           ]
-      }) 
-    }}
+        })
+      }}
+
+      {{
+        govukTable({
+          firstCellIsHeader: true,
+          captionClasses: "govuk-table__caption--m",
+          attributes: {
+            'data-module': 'moj-sortable-table'
+          },
+          head: tableHeaders,
+          rows: tableRows
+        })
+      }}
 
       {{ 
         govukButton({
           text: "View archived referrals",
           type: "button",
-          href: paths.assessments.archive({}),
+          href: paths.assessments.archive(),
           classes: "govuk-button--secondary"
         }) 
       }}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -1,53 +1,10 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "moj/components/badge/macro.njk" import mojBadge %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
-
 {% extends "../../partials/layout.njk" %}
-
 {% set pageTitle = "Referrals - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
-
-{% set unallocatedTableHtml %}
-  {{ 
-    govukTable({
-      firstCellIsHeader: true,
-      attributes: {
-        'data-module': 'moj-sortable-table'
-      },
-      head: tableHeaders,
-      rows: unallocatedTableRows
-    }) 
-  }}
-{% endset %}
-
-{% set inProgressTableHtml %}
-  {{ 
-    govukTable({
-      firstCellIsHeader: true,
-      attributes: {
-        'data-module': 'moj-sortable-table'
-      },
-      head: tableHeaders,
-      rows: inProgressTableRows
-    }) 
-  }}
-{% endset %}
-
-{% set readyToPlaceTableHtml %}
-  {{ 
-    govukTable({
-      firstCellIsHeader: true,
-      attributes: {
-        'data-module': 'moj-sortable-table'
-      },
-      head: tableHeaders,
-      rows: readyToPlaceTableRows
-    }) 
-  }}
-{% endset %}
 
 {% block beforeContent %}
   {{ breadCrumb('Referrals', []) }}
@@ -104,9 +61,7 @@
 {% block extraScripts %}
   <script type="text/javascript" nonce="{{ cspNonce }}">
     $(document).ready(function () {
-      window
-        .MOJFrontend
-        .initAll()
+      window.MOJFrontend.initAll()
     })
   </script>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-174

The Referrals page (`/review-and-assess`) currently calls the API to fetch _all_ referrals of any status, including referrals that should be shown as archived (statuses `closed` and `rejected`). These referrals are then split into 'Unallocated', 'In review', and 'Ready to place' in the front-end; the same call is used to show the 'Archived referrals' page.

The current page performance is poor, with API queries up to around 6 minutes (!). We expect performance to be drastically improved when the query targets only the relevant status(es) for each of these pages.

This PR splits the 'Unallocated', 'In review' and 'Ready to place' views into 3 separate pages, each requesting a filtered set of referrals from the API. The 'Archived referrals' page now also targets only the specific statuses that are needed to be displayed.

# Changes in this PR

As a result of splitting the data into 3 separate pages, the Tabs GOVUK component is no longer appropriate, and has been replaced with the sub-navigation one. This results in more of the screen real-estate being used, and is consistent with the Bookings search screens.

The title is now also page-specific.

In order to prevent existing bookmarks or links from breaking, a permanent redirect takes users from the previous screen, `/review-and-assess`, to the new 'Unallocated referrals' URL, `/review-and-assess/unallocated`.

## Screenshots of UI changes

### Before

<img width="980" alt="Screenshot 2024-03-05 at 15 35 48" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/ee5817f1-36f3-49fd-a13b-ba6c1dcf913c">

### After

<img width="980" alt="Screenshot 2024-03-05 at 15 34 00" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/a57d31c7-6da1-4f4f-b8ad-ee11f7d10791">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work? Yes: https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1568
- [ ] Have they been released to production already? No

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
