### PR TITLE
CAS-215 - fix flakey e2e booking test

### DIFF
--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -31,7 +31,7 @@ Given('I mark the booking as departed', () => {
 
     const departedBooking = bookingFactory.build({
       ...this.booking,
-      status: 'departed',
+      status: 'unknown-departed-or-closed' as BookingStatus,
       departureDate: newDeparture.dateTime,
       departure,
     })


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-215

Repeated instability in CAS3 End-to-End (E2E) tests is producing random failures in several CI pipelines, including the shared `hmpps-approved-premises-api` pipeline. This fix attempts to resolve the instability in the most frequent offender.

# Changes in this PR

During the e2e test run, the in-memory, Cypress representation of a booking has to be updated on each action to match the expected object returned from the API. In this very feature, which tests marking a booking as `departed`, the status of the in-memory booking was set to `departed`. In some cases, the fake date generated for the departure date would actually result in the booking being marked as `closed` instead. An existing pattern in another step simply updates the status of the in-memory booking using the result found on the screen: this approach has been applied to the offending step for consistency.

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
