### PR TITLE
Update e2e tests to match MoJ pagination

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -24,7 +24,7 @@ export default class BookingSearchPage extends Page {
   }
 
   checkForPagination() {
-    cy.get('nav.govuk-pagination').should('exist')
+    cy.get('nav.moj-pagination').should('exist')
   }
 
   checkOrderOfDates(column: number, isAscending: boolean) {
@@ -54,7 +54,7 @@ export default class BookingSearchPage extends Page {
           return
         }
 
-        cy.get('.govuk-pagination__next >a').click()
+        cy.get('.moj-pagination__item--next >a').click()
         cy.then(() => {
           this.checkBookingDetailsAndClickView(premises, booking)
         })

--- a/e2e/tests/stepDefinitions/manage/bookingSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingSearch.ts
@@ -121,9 +121,9 @@ When('I see results for the first page', () => {
 
 When('I navigate to the second page', () => {
   cy.then(function _() {
-    cy.get('a.govuk-pagination__link').eq(1).click()
-    cy.url({ timeout: 10000 }).should('include', '&page=2')
-    cy.get('.govuk-pagination__item').eq(1).should('have.class', 'govuk-pagination__item--current')
+    cy.get('a.moj-pagination__link').contains(/^2$/).click()
+    cy.url({ timeout: 10000 }).should('include', 'page=2')
+    cy.get('.moj-pagination__item').contains(/^2$/).should('have.class', 'moj-pagination__item--active')
   })
 })
 
@@ -136,9 +136,9 @@ Then('I should see different results', () => {
 
 When('I navigate to the first page', () => {
   cy.then(function _() {
-    cy.get('a.govuk-pagination__link').eq(0).click()
-    cy.url({ timeout: 10000 }).should('include', '&page=1')
-    cy.get('.govuk-pagination__item').eq(0).should('have.class', 'govuk-pagination__item--current')
+    cy.get('a.moj-pagination__link').contains(/^1$/).click()
+    cy.url({ timeout: 10000 }).should('include', 'page=1')
+    cy.get('.moj-pagination__item').contains(/^1$/).should('have.class', 'moj-pagination__item--active')
   })
 })
 


### PR DESCRIPTION
# Context

#896 reintroduced the pagination on bookings, and switched the original pagination used from the [GOVUK](https://design-system.service.gov.uk/components/pagination/) to the [MoJ](https://design-patterns.service.justice.gov.uk/components/pagination/) component. Some of the e2e tests had not been updated and are now failing -- this PR updates the e2e tests to matchers that work against the MoJ pagination component.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
