### PR TITLE
Fix error if optional LAA name not present

### DIFF
--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -86,6 +86,7 @@ describe('reportDataFromApplication', () => {
       const application = applicationFactory.build({
         data: {
           'accommodation-referral-details': {
+            'dtr-submitted': { dtrSubmitted: 'yes' },
             'dtr-details': { localAuthorityAreaName: 'A local authority area name' },
           },
         },
@@ -94,17 +95,27 @@ describe('reportDataFromApplication', () => {
       expect(dutyToReferLocalAuthorityAreaNameFromApplication(application)).toEqual('A local authority area name')
     })
 
-    it('throws an error if the Duty to Refer Local Authority Area Name data is not present', () => {
+    it('returns an empty string if the Duty to Refer has not been submitted', () => {
       const application = applicationFactory.build({
         data: {
           'accommodation-referral-details': {
-            'dtr-details': {},
+            'dtr-submitted': { dtrSubmitted: 'no' },
           },
         },
       })
 
+      expect(dutyToReferLocalAuthorityAreaNameFromApplication(application)).toEqual('')
+    })
+
+    it('throws an error if the Duty to Refer Local Authority Area Name data is not present', () => {
+      const application = applicationFactory.build({
+        data: {
+          'accommodation-referral-details': {},
+        },
+      })
+
       expect(() => dutyToReferLocalAuthorityAreaNameFromApplication(application)).toThrow(
-        new SessionDataError('No duty to refer local authority area name data'),
+        new SessionDataError('No duty to refer submitted data'),
       )
     })
   })

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -34,13 +34,13 @@ const dutyToReferSubmissionDateFromApplication = (application: Application): str
 }
 
 const dutyToReferLocalAuthorityAreaNameFromApplication = (application: Application) => {
+  if (!isDutyToReferSubmittedFromApplication(application)) {
+    return ''
+  }
+
   const dutyToReferLocalAuthorityAreaName: string = (application.data as Record<string, unknown>)?.[
     'accommodation-referral-details'
   ]?.['dtr-details']?.localAuthorityAreaName
-
-  if (!dutyToReferLocalAuthorityAreaName) {
-    throw new SessionDataError('No duty to refer local authority area name data')
-  }
 
   return dutyToReferLocalAuthorityAreaName
 }


### PR DESCRIPTION
LAA is Local Authority Area. This field is currently optional, and the error should only be thrown if the Duty to Refer details have not been submitted.

# Context

https://dsdmoj.atlassian.net/browse/CAS-266

# Changes in this PR

If Duty to Refer has not been submitted, an empty string should be returned for the Local Authority Area Name first-class field.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
