### PR TITLE
CAS-264 referrals CRN search

### DIFF
--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -8,6 +8,7 @@ import { DateFormats } from '../../../server/utils/dateUtils'
 import { isFullPerson, personName } from '../../../server/utils/personUtils'
 import Page from '../page'
 import type { AssessmentSearchApiStatus } from '../../../server/@types/ui'
+import { supportEmail } from '../../../server/utils/phaseBannerUtils'
 
 export default class ListPage extends Page {
   constructor(pageTitle: string) {
@@ -99,5 +100,12 @@ export default class ListPage extends Page {
 
   clearSearch() {
     cy.get('a').contains('Clear').click()
+  }
+
+  checkNoResultsByCRN(status: string, crn: string) {
+    cy.get('main table').should('not.exist')
+    cy.get('h2').should('contain', `There are no results for ‘${crn}’ in ${status} referrals.`)
+    cy.get('p').should('contain', 'Check the other lists.')
+    cy.get('main a').contains('contact support').should('have.attr', 'href', `mailto:${supportEmail}`)
   }
 }

--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -16,7 +16,7 @@ export default class ListPage extends Page {
     super(pageTitle)
   }
 
-  static visit(status: AssessmentSearchApiStatus | 'archive'): ListPage {
+  static visit(status: AssessmentSearchApiStatus): ListPage {
     cy.visit(pathFromStatus(status))
 
     let pageTitle = 'Archived referrals'

--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -9,6 +9,7 @@ import { isFullPerson, personName } from '../../../server/utils/personUtils'
 import Page from '../page'
 import type { AssessmentSearchApiStatus } from '../../../server/@types/ui'
 import { supportEmail } from '../../../server/utils/phaseBannerUtils'
+import { pathFromStatus } from '../../../server/utils/assessmentUtils'
 
 export default class ListPage extends Page {
   constructor(pageTitle: string) {
@@ -16,7 +17,7 @@ export default class ListPage extends Page {
   }
 
   static visit(status: AssessmentSearchApiStatus | 'archive'): ListPage {
-    cy.visit(paths.assessments[status]())
+    cy.visit(pathFromStatus(status))
 
     let pageTitle = 'Archived referrals'
 

--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -108,4 +108,10 @@ export default class ListPage extends Page {
     cy.get('p').should('contain', 'Check the other lists.')
     cy.get('main a').contains('contact support').should('have.attr', 'href', `mailto:${supportEmail}`)
   }
+
+  checkNoCRNEntered() {
+    cy.get('main table').should('not.exist')
+    cy.get('h2').should('contain', 'You have not entered any search terms')
+    cy.get('p').should('contain', 'Enter a CRN. This can be found in nDelius.')
+  }
 }

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -1,3 +1,4 @@
+import { AssessmentSummary, TemporaryAccommodationAssessmentSummary } from '@approved-premises/api'
 import AssessmentConfirmPage from '../../../../cypress_shared/pages/assess/confirm'
 import AssessmentFullPage from '../../../../cypress_shared/pages/assess/full'
 import ListPage from '../../../../cypress_shared/pages/assess/list'
@@ -157,7 +158,7 @@ context('Apply', () => {
           const searchCRN = searchedForReferral.person.crn
           cy.task('stubAssessments', { data: assessments, pagination })
 
-          // When I visit the Unallocated referrals page
+          // When I visit the Archived referrals page
           const page = ListPage.visit('archive')
 
           // Then the search by CRN form is empty
@@ -189,6 +190,37 @@ context('Apply', () => {
 
           // Then I see the search result for that CRN
           page.checkResults(assessments)
+        })
+
+        it('shows a message if there are no CRN search results', () => {
+          const assessments = assessmentSummaryFactory.buildList(9, { status: 'rejected' })
+          const noAssessments: TemporaryAccommodationAssessmentSummary[] = []
+          const searchCRN = 'N0M4TCH'
+
+          cy.task('stubAssessments', { data: assessments })
+
+          // When I visit the Archived referrals page
+          const page = ListPage.visit('archive')
+
+          // Then the search by CRN form is empty
+          page.checkCRNSearchValue('', 'archived')
+
+          // And I see all the results
+          page.checkResults(assessments)
+
+          // When I submit a search by CRN
+          cy.task('stubAssessments', { data: noAssessments })
+          page.searchByCRN(searchCRN, 'archived')
+          Page.verifyOnPage(ListPage, 'Archived referrals')
+
+          // Then the search by CRN form is populated
+          page.checkCRNSearchValue(searchCRN, 'archived')
+
+          // Then I see no search results for that CRN
+          page.checkResults(noAssessments)
+
+          // And I see a message
+          page.checkNoResultsByCRN('archived', 'N0M4TCH')
         })
 
         it('shows pagination and ordering', () => {

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -1,4 +1,4 @@
-import { AssessmentSummary, TemporaryAccommodationAssessmentSummary } from '@approved-premises/api'
+import { TemporaryAccommodationAssessmentSummary } from '@approved-premises/api'
 import AssessmentConfirmPage from '../../../../cypress_shared/pages/assess/confirm'
 import AssessmentFullPage from '../../../../cypress_shared/pages/assess/full'
 import ListPage from '../../../../cypress_shared/pages/assess/list'
@@ -221,6 +221,22 @@ context('Apply', () => {
 
           // And I see a message
           page.checkNoResultsByCRN('archived', 'N0M4TCH')
+        })
+
+        it('shows an error when submitting a blank CRN', () => {
+          const assessments = assessmentSummaryFactory.buildList(9, { status: 'rejected' })
+
+          cy.task('stubAssessments', { data: assessments })
+
+          // When I visit the Archived referrals page
+          const page = ListPage.visit('archive')
+
+          // And I submit a search with a blank CRN
+          page.searchByCRN('  ', 'archived')
+          Page.verifyOnPage(ListPage, 'Archived referrals')
+
+          // Then I see an error message
+          page.checkNoCRNEntered()
         })
 
         it('shows pagination and ordering', () => {

--- a/integration_tests/tsconfig.json
+++ b/integration_tests/tsconfig.json
@@ -2,8 +2,15 @@
   "compilerOptions": {
     "target": "es5",
     "noEmit": true,
-    "lib": ["es5", "dom", "es2015.promise"],
-    "types": ["cypress", "cypress-axe"],
+    "lib": [
+      "es5",
+      "dom",
+      "es2015.promise"
+    ],
+    "types": [
+      "cypress",
+      "cypress-axe"
+    ],
     "esModuleInterop": true,
     "resolveJsonModule": true,
     "moduleResolution": "node",
@@ -11,9 +18,19 @@
     "skipLibCheck": true,
     "experimentalDecorators": true,
     "paths": {
-      "@approved-premises/ui": ["../server/@types/ui/index.d.ts"],
-      "@approved-premises/api": ["../server/@types/shared/index.d.ts"]
+      "@approved-premises/ui": [
+        "../server/@types/ui/index.d.ts"
+      ],
+      "@approved-premises/api": [
+        "../server/@types/shared/index.d.ts"
+      ]
     }
   },
-  "include": ["**/*.ts", "../cypress_shared/**/*.ts"]
+  "include": [
+    "**/*.ts",
+    "../cypress_shared/**/*.ts"
+  ],
+  "files": [
+    "../server/@types/express/index.d.ts"
+  ]
 }

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -44,6 +44,8 @@ type FlashMessage = string | ErrorMessages | Array<ErrorSummary> | Record<string
 
 export declare global {
   namespace Express {
+    import CookieSessionRequest = CookieSessionInterfaces.CookieSessionRequest
+
     interface User {
       username: string
       token: string
@@ -53,8 +55,13 @@ export declare global {
     interface Request {
       verified?: boolean
       id: string
+      user?: User
+      session?: CookieSessionRequest['session']
+
       logout(done: (err: unknown) => void): void
+
       flash(type: string, message: FlashMessage): number
+
       flash(type: string): FlashMessage
     }
   }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -357,4 +357,5 @@ export type AssessmentSearchParameters = {
   page?: number
   sortBy?: AssessmentSortField
   sortDirection?: SortDirection
+  crn?: string
 }

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -351,7 +351,9 @@ export type ApplicationSummaryData = {
     | null
 }
 
-export type AssessmentSearchApiStatus = Extract<AssessmentStatus, 'unallocated' | 'in_review' | 'ready_to_place'>
+export type AssessmentSearchApiStatus =
+  | Extract<AssessmentStatus, 'unallocated' | 'in_review' | 'ready_to_place'>
+  | 'archived'
 
 export type AssessmentSearchParameters = {
   page?: number

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -101,12 +101,30 @@ describe('AssessmentsController', () => {
   })
 
   describe('list', () => {
-    describe.each(['unallocated', 'in_review', 'ready_to_place'])(
+    describe.each(['unallocated', 'in_review', 'ready_to_place', 'archived'])(
       'when viewing assessments with status %s',
       (status: AssessmentSearchApiStatus) => {
+        let expectedTemplate = 'temporary-accommodation/assessments/index'
+        let expectedHeaders = [...tableHeaders]
+        const statusHeader = {
+          html: '<a href="?sortBy=status"><button>Status</button></a>',
+          attributes: {
+            'aria-sort': 'none',
+            'data-cy-sort-field': 'status',
+          },
+        }
+
+        beforeEach(() => {
+          if (status === 'archived') {
+            expectedTemplate = 'temporary-accommodation/assessments/archive'
+            expectedHeaders.push(statusHeader)
+          }
+        })
+
         it('returns the pagination and table rows to the template', async () => {
           const assessment = assessmentSummaryFactory.build()
           const assessments = assessmentSummaries.build({ data: [assessment], totalResults: 1 })
+
           assessmentsService.getAllForLoggedInUser.mockResolvedValue({
             ...assessments,
             data: assessments.data.map(summary => [{ text: summary.createdAt }]),
@@ -115,11 +133,11 @@ describe('AssessmentsController', () => {
           const requestHandler = assessmentsController.list(status)
           await requestHandler(request, response, next)
 
-          expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/index', {
+          expect(response.render).toHaveBeenCalledWith(expectedTemplate, {
             status,
             basePath: pathFromStatus(status),
             tableRows: [[{ text: assessment.createdAt }]],
-            tableHeaders,
+            tableHeaders: expectedHeaders,
             pagination: {},
             errors: {},
           })
@@ -140,30 +158,36 @@ describe('AssessmentsController', () => {
           })
           assessmentsService.getAllForLoggedInUser.mockResolvedValue(assessments)
 
+          expectedHeaders = [
+            {
+              html: '<a href="?sortBy=name"><button>Name</button></a>',
+              attributes: {
+                'aria-sort': 'none',
+                'data-cy-sort-field': 'name',
+              },
+            },
+            tableHeaders[1],
+            tableHeaders[2],
+            {
+              html: '<a href="?sortBy=arrivedAt&sortDirection=desc"><button>Bedspace required</button></a>',
+              attributes: {
+                'aria-sort': 'ascending',
+                'data-cy-sort-field': 'arrivedAt',
+              },
+            },
+          ]
+
+          if (status === 'archived') {
+            expectedHeaders.push(statusHeader)
+          }
+
           const requestHandler = assessmentsController.list(status)
           await requestHandler(request, response, next)
 
-          expect(response.render).toHaveBeenLastCalledWith('temporary-accommodation/assessments/index', {
+          expect(response.render).toHaveBeenLastCalledWith(expectedTemplate, {
             status,
             basePath: pathFromStatus(status),
-            tableHeaders: [
-              {
-                html: '<a href="?sortBy=name"><button>Name</button></a>',
-                attributes: {
-                  'aria-sort': 'none',
-                  'data-cy-sort-field': 'name',
-                },
-              },
-              tableHeaders[1],
-              tableHeaders[2],
-              {
-                html: '<a href="?sortBy=arrivedAt&sortDirection=desc"><button>Bedspace required</button></a>',
-                attributes: {
-                  'aria-sort': 'ascending',
-                  'data-cy-sort-field': 'arrivedAt',
-                },
-              },
-            ],
+            tableHeaders: expectedHeaders,
             tableRows: assessments.data,
             pagination: {
               items: [
@@ -201,7 +225,7 @@ describe('AssessmentsController', () => {
               sortDirection: 'asc',
             })
 
-            expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/index', {
+            expect(response.render).toHaveBeenCalledWith(expectedTemplate, {
               status,
               basePath: pathFromStatus(status),
               tableRows: assessments.data,
@@ -248,157 +272,6 @@ describe('AssessmentsController', () => {
         })
       },
     )
-  })
-
-  describe('archive', () => {
-    const archivedTableHeaders = [
-      ...tableHeaders,
-      {
-        html: '<a href="?sortBy=status"><button>Status</button></a>',
-        attributes: {
-          'aria-sort': 'none',
-          'data-cy-sort-field': 'status',
-        },
-      },
-    ]
-
-    it('returns the paginated table rows to the archived template', async () => {
-      const assessment = assessmentSummaryFactory.build()
-      const assessments = assessmentSummaries.build({ data: [assessment], totalResults: 1 })
-      assessmentsService.getAllForLoggedInUser.mockResolvedValue({
-        ...assessments,
-        data: assessments.data.map(summary => [{ text: summary.createdAt }]),
-      })
-
-      const requestHandler = assessmentsController.archive()
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenLastCalledWith('temporary-accommodation/assessments/archive', {
-        tableHeaders: archivedTableHeaders,
-        archivedTableRows: [[{ text: assessment.createdAt }]],
-        pagination: {},
-        errors: {},
-      })
-
-      expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, 'archived', {
-        page: 1,
-        sortBy: 'name',
-        sortDirection: 'asc',
-      })
-    })
-
-    it('returns the correct page and sorted results to the template', async () => {
-      request = createMock<Request>({ session, query: { page: '2', sortBy: 'status', sortDirection: 'asc' } })
-      const assessments = assessmentSummaries.build({
-        totalResults: 13,
-        pageNumber: 2,
-        totalPages: 2,
-      })
-      assessmentsService.getAllForLoggedInUser.mockResolvedValue(assessments)
-
-      const requestHandler = assessmentsController.archive()
-      await requestHandler(request, response, next)
-
-      expect(response.render).toHaveBeenLastCalledWith('temporary-accommodation/assessments/archive', {
-        archivedTableRows: assessments.data,
-        tableHeaders: [
-          {
-            html: '<a href="?sortBy=name"><button>Name</button></a>',
-            attributes: {
-              'aria-sort': 'none',
-              'data-cy-sort-field': 'name',
-            },
-          },
-          tableHeaders[1],
-          tableHeaders[2],
-          tableHeaders[3],
-          {
-            html: '<a href="?sortBy=status&sortDirection=desc"><button>Status</button></a>',
-            attributes: {
-              'aria-sort': 'ascending',
-              'data-cy-sort-field': 'status',
-            },
-          },
-        ],
-        pagination: {
-          items: [
-            { text: '1', href: '?page=1&sortBy=status&sortDirection=asc' },
-            { text: '2', href: '?page=2&sortBy=status&sortDirection=asc', selected: true },
-          ],
-          previous: { text: 'Previous', href: '?page=1&sortBy=status&sortDirection=asc' },
-        },
-        errors: {},
-      })
-
-      expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, 'archived', {
-        page: 2,
-        sortBy: 'status',
-        sortDirection: 'asc',
-      })
-    })
-
-    describe('when there is a CRN search parameter', () => {
-      it('renders the filtered table view for archived referrals', async () => {
-        const assessments = assessmentSummaries.build()
-        const searchParameters = assessmentSearchParametersFactory.build()
-
-        jest.spyOn(assessmentUtils, 'createTableHeadings').mockReturnValue([])
-        assessmentsService.getAllForLoggedInUser.mockResolvedValue(assessments)
-        request.query = searchParameters as ParsedQs
-
-        const requestHandler = assessmentsController.archive()
-        await requestHandler(request, response, next)
-
-        expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, 'archived', {
-          crn: searchParameters.crn,
-          page: 1,
-          sortBy: 'name',
-          sortDirection: 'asc',
-        })
-
-        expect(response.render).toHaveBeenLastCalledWith('temporary-accommodation/assessments/archive', {
-          archivedTableRows: assessments.data,
-          tableHeaders: [],
-          pagination: {},
-          crn: searchParameters.crn,
-          errors: {},
-        })
-      })
-    })
-
-    describe('when a blank CRN search is submitted', () => {
-      it('renders an error for archived referrals', async () => {
-        const searchParameters = assessmentSearchParametersFactory.build({ crn: '  ' })
-
-        request.query = searchParameters as ParsedQs
-
-        const requestHandler = assessmentsController.archive()
-        await requestHandler(request, response, next)
-
-        expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'crn', 'empty')
-        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-          request,
-          response,
-          new Error(),
-          `/review-and-assess/archive`,
-        )
-      })
-    })
-
-    describe('when there is a CRN search error', () => {
-      it('does not call the API to fetch results', async () => {
-        ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({
-          errors: { crn: { text: 'You must enter a CRN', attributes: {} } },
-          errorSummary: [],
-          userInput: {},
-        })
-
-        const requestHandler = assessmentsController.archive()
-        await requestHandler(request, response, next)
-
-        expect(assessmentsService.getAllForLoggedInUser).not.toHaveBeenCalled()
-      })
-    })
   })
 
   describe('summary', () => {

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -87,6 +87,7 @@ describe('AssessmentsController', () => {
   })
 
   afterEach(() => {
+    jest.clearAllMocks()
     jest.restoreAllMocks()
   })
 
@@ -212,7 +213,7 @@ describe('AssessmentsController', () => {
           })
         })
 
-        describe('when an blank CRN search is submitted', () => {
+        describe('when a blank CRN search is submitted', () => {
           it('renders an error', async () => {
             const searchParameters = assessmentSearchParametersFactory.build({ crn: '  ' })
 
@@ -228,6 +229,21 @@ describe('AssessmentsController', () => {
               new Error(),
               pathFromStatus(status),
             )
+          })
+        })
+
+        describe('when there is a CRN search error', () => {
+          it('does not call the API to fetch results', async () => {
+            ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({
+              errors: { crn: { text: 'You must enter a CRN', attributes: {} } },
+              errorSummary: [],
+              userInput: {},
+            })
+
+            const requestHandler = assessmentsController.list(status)
+            await requestHandler(request, response, next)
+
+            expect(assessmentsService.getAllForLoggedInUser).not.toHaveBeenCalled()
           })
         })
       },
@@ -350,7 +366,7 @@ describe('AssessmentsController', () => {
       })
     })
 
-    describe('when an blank CRN search is submitted', () => {
+    describe('when a blank CRN search is submitted', () => {
       it('renders an error for archived referrals', async () => {
         const searchParameters = assessmentSearchParametersFactory.build({ crn: '  ' })
 
@@ -366,6 +382,21 @@ describe('AssessmentsController', () => {
           new Error(),
           `/review-and-assess/archive`,
         )
+      })
+    })
+
+    describe('when there is a CRN search error', () => {
+      it('does not call the API to fetch results', async () => {
+        ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({
+          errors: { crn: { text: 'You must enter a CRN', attributes: {} } },
+          errorSummary: [],
+          userInput: {},
+        })
+
+        const requestHandler = assessmentsController.archive()
+        await requestHandler(request, response, next)
+
+        expect(assessmentsService.getAllForLoggedInUser).not.toHaveBeenCalled()
       })
     })
   })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -71,19 +71,21 @@ export default class AssessmentsController {
           throw error
         }
 
-        const response = await this.assessmentsService.getAllForLoggedInUser(callConfig, status, params)
+        const response = errors.crn
+          ? null
+          : await this.assessmentsService.getAllForLoggedInUser(callConfig, status, params)
 
         return res.render('temporary-accommodation/assessments/index', {
           status,
           basePath: pathFromStatus(status),
-          tableRows: response.data,
+          tableRows: response?.data,
           tableHeaders: createTableHeadings(
             params.sortBy,
             params.sortDirection === 'asc',
             appendQueryString('', params),
           ),
           crn: params.crn,
-          pagination: pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
+          pagination: response && pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
           errors,
         })
       } catch (err) {
@@ -107,7 +109,9 @@ export default class AssessmentsController {
           throw error
         }
 
-        const response = await this.assessmentsService.getAllForLoggedInUser(callConfig, 'archived', params)
+        const response = errors.crn
+          ? null
+          : await this.assessmentsService.getAllForLoggedInUser(callConfig, 'archived', params)
 
         return res.render('temporary-accommodation/assessments/archive', {
           tableHeaders: createTableHeadings(
@@ -116,10 +120,10 @@ export default class AssessmentsController {
             appendQueryString('', params),
             true,
           ),
-          archivedTableRows: response.data,
+          archivedTableRows: response?.data,
           errors,
           crn: params.crn,
-          pagination: pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
+          pagination: response && pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
         })
       } catch (err) {
         return catchValidationErrorOrPropogate(req, res, err, paths.assessments.archive({}))

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -64,6 +64,11 @@ export default class AssessmentsController {
 
       const params = getParams(req.query)
 
+      const template =
+        status === 'archived'
+          ? 'temporary-accommodation/assessments/archive'
+          : 'temporary-accommodation/assessments/index'
+
       try {
         if (params.crn !== undefined && !params.crn.trim().length) {
           const error = new Error()
@@ -75,7 +80,7 @@ export default class AssessmentsController {
           ? null
           : await this.assessmentsService.getAllForLoggedInUser(callConfig, status, params)
 
-        return res.render('temporary-accommodation/assessments/index', {
+        return res.render(template, {
           status,
           basePath: pathFromStatus(status),
           tableRows: response?.data,
@@ -83,6 +88,7 @@ export default class AssessmentsController {
             params.sortBy,
             params.sortDirection === 'asc',
             appendQueryString('', params),
+            status === 'archived',
           ),
           crn: params.crn,
           pagination: response && pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
@@ -90,43 +96,6 @@ export default class AssessmentsController {
         })
       } catch (err) {
         return catchValidationErrorOrPropogate(req, res, err, pathFromStatus(status))
-      }
-    }
-  }
-
-  archive(): RequestHandler {
-    return async (req: Request, res: Response) => {
-      const { errors } = fetchErrorsAndUserInput(req)
-
-      const callConfig = extractCallConfig(req)
-
-      const params = getParams(req.query)
-
-      try {
-        if (params.crn !== undefined && !params.crn.trim().length) {
-          const error = new Error()
-          insertGenericError(error, 'crn', 'empty')
-          throw error
-        }
-
-        const response = errors.crn
-          ? null
-          : await this.assessmentsService.getAllForLoggedInUser(callConfig, 'archived', params)
-
-        return res.render('temporary-accommodation/assessments/archive', {
-          tableHeaders: createTableHeadings(
-            params.sortBy,
-            params.sortDirection === 'asc',
-            appendQueryString('', params),
-            true,
-          ),
-          archivedTableRows: response?.data,
-          errors,
-          crn: params.crn,
-          pagination: response && pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
-        })
-      } catch (err) {
-        return catchValidationErrorOrPropogate(req, res, err, paths.assessments.archive({}))
       }
     }
   }

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -110,6 +110,7 @@ export default class AssessmentsController {
           true,
         ),
         archivedTableRows: response.data,
+        crn: params.crn,
         pagination: pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
       })
     }

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -1,7 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
-import { BookingSearchService } from 'server/services'
 import { BookingSearchSortField } from '@approved-premises/api'
 import type { BookingSearchApiStatus, BookingSearchParameters } from '@approved-premises/ui'
+import { BookingSearchService } from '../../../services'
 import extractCallConfig from '../../../utils/restUtils'
 import { pagination } from '../../../utils/pagination'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -327,7 +327,7 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.assessments.readyToPlace.pattern, assessmentsController.list('ready_to_place'), {
     auditEvent: 'VIEW_READY_TO_PLACE_ASSESSMENTS_LIST',
   })
-  get(paths.assessments.archive.pattern, assessmentsController.archive(), {
+  get(paths.assessments.archive.pattern, assessmentsController.list('archived'), {
     auditEvent: 'VIEW_ARCHIVE_ASSESSMENTS_LIST',
   })
   get(paths.assessments.full.pattern, assessmentsController.full(), {

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -1,4 +1,5 @@
 import { AssessmentSearchApiStatus } from '@approved-premises/ui'
+import { TemporaryAccommodationAssessmentStatus } from '@approved-premises/api'
 import AssessmentClient from '../data/assessmentClient'
 import { CallConfig } from '../data/restClient'
 import {
@@ -33,7 +34,9 @@ describe('AssessmentsService', () => {
     it.each(['unallocated', 'in_review', 'ready_to_place'])(
       'returns paginated %s assessments summaries formatted for presentation in a table',
       async (uiStatus: AssessmentSearchApiStatus) => {
-        const assessments = assessmentSummaryFactory.params({ status: uiStatus }).buildList(2)
+        const assessments = assessmentSummaryFactory
+          .params({ status: uiStatus as TemporaryAccommodationAssessmentStatus })
+          .buildList(2)
         const response = assessmentSummaries.build({ data: assessments, totalResults: 2 })
 
         assessmentClient.all.mockResolvedValue(response)

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -22,7 +22,7 @@ export default class AssessmentsService {
 
   async getAllForLoggedInUser(
     callConfig: CallConfig,
-    uiStatus: AssessmentSearchApiStatus | 'archived',
+    uiStatus: AssessmentSearchApiStatus,
     params?: AssessmentSearchParameters,
   ): Promise<PaginatedResponse<TableRow>> {
     const statuses =

--- a/server/testutils/factories/assessmentSearchParameters.ts
+++ b/server/testutils/factories/assessmentSearchParameters.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { AssessmentSearchParameters } from '@approved-premises/ui'
+import { faker } from '@faker-js/faker/locale/en_GB'
+
+export default Factory.define<AssessmentSearchParameters>(() => ({
+  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -5,6 +5,7 @@ import applicationFactory from './application'
 import applicationSummaryFactory from './applicationSummary'
 import arrivalFactory from './arrival'
 import assessmentFactory from './assessment'
+import assessmentSearchParametersFactory from './assessmentSearchParameters'
 import assessmentSummaryFactory from './assessmentSummary'
 import bedFactory from './bed'
 import bedSearchParametersFactory from './bedSearchParameters'
@@ -76,6 +77,7 @@ export {
   applicationSummaryFactory,
   arrivalFactory,
   assessmentFactory,
+  assessmentSearchParametersFactory,
   assessmentSummaryFactory,
   bedFactory,
   bedSearchParametersFactory,

--- a/server/utils/applications/getSummaryDataFromApplication.ts
+++ b/server/utils/applications/getSummaryDataFromApplication.ts
@@ -1,4 +1,4 @@
-import { EligibilityReasonsT } from 'server/form-pages/apply/accommodation-need/eligibility/eligibilityReason'
+import { EligibilityReasonsT } from '../../form-pages/apply/accommodation-need/eligibility/eligibilityReason'
 import { TemporaryAccommodationApplication as Application } from '../../@types/shared'
 import { ApplicationSummaryData, YesOrNo } from '../../@types/ui'
 

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -449,7 +449,7 @@ describe('assessmentUtils', () => {
       ['/review-and-assess/unallocated', 'unallocated'],
       ['/review-and-assess/in-review', 'in_review'],
       ['/review-and-assess/ready-to-place', 'ready_to_place'],
-      ['/review-and-assess/archive', 'archive'],
+      ['/review-and-assess/archive', 'archived'],
     ])('returns %s for status %s', (path, status: AssessmentSearchApiStatus) => {
       expect(pathFromStatus(status)).toEqual(path)
     })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -1,3 +1,4 @@
+import { AssessmentSearchApiStatus } from '@approved-premises/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import {
   assessmentFactory,
@@ -13,6 +14,7 @@ import {
   assessmentTableRows,
   createTableHeadings,
   getParams,
+  pathFromStatus,
   statusChangeMessage,
   timelineItems,
 } from './assessmentUtils'
@@ -439,6 +441,17 @@ describe('assessmentUtils', () => {
         sortBy: 'arrivedAt',
         sortDirection: 'desc',
       })
+    })
+  })
+
+  describe('pathFromStatus', () => {
+    it.each([
+      ['/review-and-assess/unallocated', 'unallocated'],
+      ['/review-and-assess/in-review', 'in_review'],
+      ['/review-and-assess/ready-to-place', 'ready_to_place'],
+      ['/review-and-assess/archive', 'archive'],
+    ])('returns %s for status %s', (path, status: AssessmentSearchApiStatus) => {
+      expect(pathFromStatus(status)).toEqual(path)
     })
   })
 })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -430,9 +430,11 @@ describe('assessmentUtils', () => {
         page: '3',
         sortBy: 'arrivedAt',
         sortDirection: 'desc',
+        crn: 'X567345',
       }
 
       expect(getParams(query)).toEqual({
+        crn: 'X567345',
         page: 3,
         sortBy: 'arrivedAt',
         sortDirection: 'desc',

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -238,11 +238,12 @@ export const getParams = (query?: QueryString.ParsedQs): AssessmentSearchParamet
   sortDirection: (query.sortDirection || 'asc') as SortDirection,
 })
 
-export const pathFromStatus = (status: AssessmentSearchApiStatus | 'archive') => {
+export const pathFromStatus = (status: AssessmentSearchApiStatus) => {
   let pathStatus: string = status
 
   if (status === 'in_review') pathStatus = 'inReview'
   if (status === 'ready_to_place') pathStatus = 'readyToPlace'
+  if (status === 'archived') pathStatus = 'archive'
 
   return paths.assessments[pathStatus]({})
 }

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -9,7 +9,13 @@ import {
   ReferralHistoryUserNote as UserNote,
 } from '@approved-premises/api'
 import QueryString from 'qs'
-import { AssessmentSearchParameters, MessageContents, TableRow, TimelineItem } from '../@types/ui'
+import {
+  AssessmentSearchApiStatus,
+  AssessmentSearchParameters,
+  MessageContents,
+  TableRow,
+  TimelineItem,
+} from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { DateFormats } from './dateUtils'
 import { personName } from './personUtils'
@@ -231,3 +237,12 @@ export const getParams = (query?: QueryString.ParsedQs): AssessmentSearchParamet
   sortBy: (query.sortBy || 'name') as AssessmentSortField,
   sortDirection: (query.sortDirection || 'asc') as SortDirection,
 })
+
+export const pathFromStatus = (status: AssessmentSearchApiStatus | 'archive') => {
+  let pathStatus: string = status
+
+  if (status === 'in_review') pathStatus = 'inReview'
+  if (status === 'ready_to_place') pathStatus = 'readyToPlace'
+
+  return paths.assessments[pathStatus]({})
+}

--- a/server/views/temporary-accommodation/assessments/archive.njk
+++ b/server/views/temporary-accommodation/assessments/archive.njk
@@ -55,13 +55,22 @@
                 {{ mojPagination(pagination) }}
             </div>
 
-            {{ govukTable({
-                firstCellIsHeader: true,
-                head: tableHeaders,
-                rows: archivedTableRows
-            }) }}
+            {% if (archivedTableRows|length > 0) or (not crn) %}
+                {{ govukTable({
+                    firstCellIsHeader: true,
+                    head: tableHeaders,
+                    rows: archivedTableRows
+                }) }}
 
-            {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}
+                {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}
+            {% else %}
+                <h2>There are no results for ‘{{ crn }}’ in archived referrals.</h2>
+
+                <p>Check the other lists.</p>
+
+                <p>If the referral is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact
+                        support</a> for help.</p>
+            {% endif %}
         </div>
     </div>
 {% endblock %}

--- a/server/views/temporary-accommodation/assessments/archive.njk
+++ b/server/views/temporary-accommodation/assessments/archive.njk
@@ -1,90 +1,13 @@
-{% from "govuk/components/table/macro.njk" import govukTable %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
-{% from "govuk/components/input/macro.njk" import govukInput %}
-{% from "govuk/components/tag/macro.njk" import govukTag %}
-{% from "moj/components/badge/macro.njk" import mojBadge %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
-{%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 
-{% extends "../../partials/layout.njk" %}
-
-{% set pageTitle = "Archived referrals - " + applicationName %}
-{% set mainClasses = "app-container govuk-body" %}
+{% extends "./index.njk" %}
 
 {% block beforeContent %}
-
     {{ govukBackLink({
         text: "Back",
         href: paths.assessments.index()
     }) }}
-
 {% endblock %}
 
-{% block content %}
-    {% set context = fetchContext() %}
-
-    <h1 class="govuk-heading-l">Archived referrals</h1>
-
-    <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
-        <form action="{{ paths.assessments.archive() }}" method="get">
-
-            {{ govukInput(
-                {
-                    label: {
-                    classes: 'govuk-label--m',
-                    text: 'Search archived referrals by CRN (case reference number)'
-                },
-                    hint: {
-                    text: 'For example, XD7364CD'
-                },
-                    name: 'crn',
-                    id: 'crn',
-                    value: crn
-                }
-            ) }}
-
-            <div class="govuk-button-group">
-                {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
-
-                <a class="govuk-link" href="{{ paths.assessments.archive() }}">Clear</a>
-            </div>
-        </form>
-    </div>
-
-    {% if context.errors.crn %}
-        <h2>You have not entered any search terms</h2>
-
-        <p>Enter a CRN. This can be found in nDelius.</p>
-
-        {% elif (tableRows|length > 0) or (not crn) %}
-
-        <div class="govuk-!-margin-bottom-4">
-            {{ mojPagination(pagination) }}
-        </div>
-
-        {{ govukTable({
-            firstCellIsHeader: true,
-            head: tableHeaders,
-            rows: tableRows
-        }) }}
-
-        {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}
-    {% else %}
-        <h2>There are no results for ‘{{ crn }}’ in archived referrals.</h2>
-
-        <p>Check the other lists.</p>
-
-        <p>If the referral is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact
-                support</a> for help.</p>
-    {% endif %}
-{% endblock %}
-
-{% block extraScripts %}
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-      $(document).ready(function() {
-        window
-          .MOJFrontend
-          .initAll()
-      })
-    </script>
-{% endblock %}
+{% block tabs %}{% endblock %}
+{% block archivedLink %}{% endblock %}

--- a/server/views/temporary-accommodation/assessments/archive.njk
+++ b/server/views/temporary-accommodation/assessments/archive.njk
@@ -21,58 +21,60 @@
 {% endblock %}
 
 {% block content %}
-    <div class="govuk-grid-row">
-        <div class="govuk-grid-column-full">
-            <h1 class="govuk-heading-l">Archived referrals</h1>
+    {% set context = fetchContext() %}
 
-            <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
-                <form action="{{ paths.assessments.archive() }}" method="get">
+    <h1 class="govuk-heading-l">Archived referrals</h1>
 
-                    {{ govukInput(
-                        {
-                            label: {
-                            classes: 'govuk-label--m',
-                            text: 'Search archived referrals by CRN (case reference number)'
-                        },
-                            hint: {
-                            text: 'For example, XD7364CD'
-                        },
-                            name: 'crn',
-                            id: 'crn',
-                            value: crn
-                        }
-                    ) }}
+    <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
+        <form action="{{ paths.assessments.archive() }}" method="get">
 
-                    <div class="govuk-button-group">
-                        {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
+            {{ govukInput(
+                {
+                    label: {
+                    classes: 'govuk-label--m',
+                    text: 'Search archived referrals by CRN (case reference number)'
+                },
+                    hint: {
+                    text: 'For example, XD7364CD'
+                },
+                    name: 'crn',
+                    id: 'crn',
+                    value: crn
+                }
+            ) }}
 
-                        <a class="govuk-link" href="{{ paths.assessments.archive() }}">Clear</a>
-                    </div>
-                </form>
+            <div class="govuk-button-group">
+                {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
+
+                <a class="govuk-link" href="{{ paths.assessments.archive() }}">Clear</a>
             </div>
-
-            <div class="govuk-!-margin-bottom-4">
-                {{ mojPagination(pagination) }}
-            </div>
-
-            {% if (archivedTableRows|length > 0) or (not crn) %}
-                {{ govukTable({
-                    firstCellIsHeader: true,
-                    head: tableHeaders,
-                    rows: archivedTableRows
-                }) }}
-
-                {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}
-            {% else %}
-                <h2>There are no results for ‘{{ crn }}’ in archived referrals.</h2>
-
-                <p>Check the other lists.</p>
-
-                <p>If the referral is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact
-                        support</a> for help.</p>
-            {% endif %}
-        </div>
+        </form>
     </div>
+
+    <div class="govuk-!-margin-bottom-4">
+                {{ mojPagination(pagination) }}
+            </div>{% if context.errors.crn %}
+        <h2>You have not entered any search terms</h2>
+
+        <p>Enter a CRN. This can be found in nDelius.</p>
+
+        {% elif (archivedTableRows|length > 0) or (not crn) %}
+
+        {{ govukTable({
+            firstCellIsHeader: true,
+            head: tableHeaders,
+            rows: archivedTableRows
+        }) }}
+
+        {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}
+    {% else %}
+        <h2>There are no results for ‘{{ crn }}’ in archived referrals.</h2>
+
+        <p>Check the other lists.</p>
+
+        <p>If the referral is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact
+                support</a> for help.</p>
+    {% endif %}
 {% endblock %}
 
 {% block extraScripts %}

--- a/server/views/temporary-accommodation/assessments/archive.njk
+++ b/server/views/temporary-accommodation/assessments/archive.njk
@@ -1,6 +1,6 @@
-{% from "govuk/components/tabs/macro.njk" import govukTabs %}
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "govuk/components/tag/macro.njk" import govukTag %}
 {% from "moj/components/badge/macro.njk" import mojBadge %}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
@@ -24,6 +24,32 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-full">
             <h1 class="govuk-heading-l">Archived referrals</h1>
+
+            <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
+                <form action="{{ paths.assessments.archive() }}" method="get">
+
+                    {{ govukInput(
+                        {
+                            label: {
+                            classes: 'govuk-label--m',
+                            text: 'Search archived referrals by CRN (case reference number)'
+                        },
+                            hint: {
+                            text: 'For example, XD7364CD'
+                        },
+                            name: 'crn',
+                            id: 'crn',
+                            value: crn
+                        }
+                    ) }}
+
+                    <div class="govuk-button-group">
+                        {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
+
+                        <a class="govuk-link" href="{{ paths.assessments.archive() }}">Clear</a>
+                    </div>
+                </form>
+            </div>
 
             <div class="govuk-!-margin-bottom-4">
                 {{ mojPagination(pagination) }}

--- a/server/views/temporary-accommodation/assessments/archive.njk
+++ b/server/views/temporary-accommodation/assessments/archive.njk
@@ -51,19 +51,21 @@
         </form>
     </div>
 
-    <div class="govuk-!-margin-bottom-4">
-                {{ mojPagination(pagination) }}
-            </div>{% if context.errors.crn %}
+    {% if context.errors.crn %}
         <h2>You have not entered any search terms</h2>
 
         <p>Enter a CRN. This can be found in nDelius.</p>
 
-        {% elif (archivedTableRows|length > 0) or (not crn) %}
+        {% elif (tableRows|length > 0) or (not crn) %}
+
+        <div class="govuk-!-margin-bottom-4">
+            {{ mojPagination(pagination) }}
+        </div>
 
         {{ govukTable({
             firstCellIsHeader: true,
             head: tableHeaders,
-            rows: archivedTableRows
+            rows: tableRows
         }) }}
 
         {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -20,26 +20,28 @@
 
     <h1 class="govuk-heading-l">{{ title }}</h1>
 
-    {{ mojSubNavigation({
-        label: 'Secondary navigation',
-        items: [
-            {
-                text: 'Unallocated',
-                href: paths.assessments.unallocated(),
-                active: status == 'unallocated'
-            },
-            {
-                text: 'In review',
-                href: paths.assessments.inReview(),
-                active: status == 'in_review'
-            },
-            {
-                text: 'Ready to place',
-                href: paths.assessments.readyToPlace(),
-                active: status == 'ready_to_place'
-            }
-        ]
-    }) }}
+    {% block tabs %}
+        {{ mojSubNavigation({
+            label: 'Secondary navigation',
+            items: [
+                {
+                    text: 'Unallocated',
+                    href: paths.assessments.unallocated(),
+                    active: status == 'unallocated'
+                },
+                {
+                    text: 'In review',
+                    href: paths.assessments.inReview(),
+                    active: status == 'in_review'
+                },
+                {
+                    text: 'Ready to place',
+                    href: paths.assessments.readyToPlace(),
+                    active: status == 'ready_to_place'
+                }
+            ]
+        }) }}
+    {% endblock %}
 
     <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
         <form action="{{ basePath }}" method="get">
@@ -95,15 +97,16 @@
                 support</a> for help.</p>
     {% endif %}
 
-
-    <div class="govuk-!-margin-top-9">
-        {{ govukButton({
-            text: "View archived referrals",
-            type: "button",
-            href: paths.assessments.archive(),
-            classes: "govuk-button--secondary"
-        }) }}
-    </div>
+    {% block archivedLink %}
+        <div class="govuk-!-margin-top-9">
+            {{ govukButton({
+                text: "View archived referrals",
+                type: "button",
+                href: paths.assessments.archive(),
+                classes: "govuk-button--secondary"
+            }) }}
+        </div>
+    {% endblock %}
 {% endblock %}
 
 {% block extraScripts %}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -1,10 +1,14 @@
 {% from "govuk/components/table/macro.njk" import govukTable %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/input/macro.njk" import govukInput %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {%- from "moj/components/pagination/macro.njk" import mojPagination -%}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
 {% extends "../../partials/layout.njk" %}
-{% set pageTitle = "Referrals - " + applicationName %}
+
+{% set uiStatus = status | replace('_', ' ') %}
+{% set title = (uiStatus + ' referrals') | sentenceCase %}
+{% set pageTitle = title + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -12,7 +16,9 @@
 {% endblock %}
 
 {% block content %}
-    <h1 class="govuk-heading-l">{{ status | replace('_', ' ') | capitalize }} referrals</h1>
+    {% set context = fetchContext() %}
+
+    <h1 class="govuk-heading-l">{{ title }}</h1>
 
     {{ mojSubNavigation({
         label: 'Secondary navigation',
@@ -35,26 +41,69 @@
         ]
     }) }}
 
-    <div class="govuk-!-margin-bottom-4">
-        {{ mojPagination(pagination) }}
+    <div class="govuk-template govuk-!-padding-8 govuk-!-padding-bottom-static-3 govuk-!-margin-bottom-8">
+        <form action="{{ basePath }}" method="get">
+
+            {{ govukInput(
+                {
+                    label: {
+                    classes: 'govuk-label--m',
+                    text: 'Search ' + uiStatus + ' referrals by CRN (case reference number)'
+                },
+                    hint: {
+                    text: 'For example, XD7364CD'
+                },
+                    name: 'crn',
+                    id: 'crn',
+                    value: crn
+                }
+            ) }}
+
+            <div class="govuk-button-group">
+                {{ govukButton({ text: "Search", attributes: { id: 'search-button' }, preventDoubleClick: true}) }}
+
+                <a class="govuk-link" href="{{ basePath }}">Clear</a>
+            </div>
+        </form>
     </div>
 
-    {{ govukTable({
-        firstCellIsHeader: true,
-        head: tableHeaders,
-        rows: tableRows
-    }) }}
+    {% if context.errors.crn %}
+        <h2>You have not entered any search terms</h2>
 
-    <div class="govuk-!-margin-bottom-9">
+        <p>Enter a CRN. This can be found in nDelius.</p>
+
+        {% elif (tableRows|length > 0) or (not crn) %}
+
+        <div class="govuk-!-margin-bottom-4">
+            {{ mojPagination(pagination) }}
+        </div>
+
+        {{ govukTable({
+            firstCellIsHeader: true,
+            head: tableHeaders,
+            rows: tableRows
+        }) }}
+
         {{ mojPagination(pagination) | replace('Pagination navigation', 'Pagination navigation after results') }}
-    </div>
 
-    {{ govukButton({
-        text: "View archived referrals",
-        type: "button",
-        href: paths.assessments.archive(),
-        classes: "govuk-button--secondary"
-    }) }}
+    {% else %}
+        <h2>There are no results for ‘{{ crn }}’ in {{ uiStatus }} referrals.</h2>
+
+        <p>Check the other lists.</p>
+
+        <p>If the referral is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact
+                support</a> for help.</p>
+    {% endif %}
+
+
+    <div class="govuk-!-margin-top-9">
+        {{ govukButton({
+            text: "View archived referrals",
+            type: "button",
+            href: paths.assessments.archive(),
+            classes: "govuk-button--secondary"
+        }) }}
+    </div>
 {% endblock %}
 
 {% block extraScripts %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-264

# Changes in this PR

This introduces a CRN search for the Referrals screen. The designs and functionality are largely based on the CRN search [recently added to the Bookings search](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/882).

As both the `archive()` and `list()` methods of the Assessments controller effectively do the same thing, they have been combined into one to avoid excessive code duplication. The tests (unit & cypress) are now run parameterised for all 4 statuses. The template for the Archived view has also been mostly stripped to simply extend the template for the other statuses.

Finally, some typescript compilation errors when running `tsc -p integration_tests` required updating the extended type declaration for `express`. The `Request` now includes optional `user` and `session` to ensure those properties are recognised and parsed appropriately.

## Screenshots of UI changes

### Before

<img width="980" alt="Screenshot 2024-03-19 at 15 38 44" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/a3ea2a90-0cde-4684-8b77-62ee20e15c7a">


### After

<img width="980" alt="Screenshot 2024-03-19 at 15 38 09" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/1e17ff0c-b255-44ac-ad5d-a26dcfcc92c0">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [x] Are any changes required to dependent services for this change to work? No
- [x] Have they been released to production already? n/a

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
