### PR TITLE
CAS-269 default referrals sort

### DIFF
--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -206,24 +206,6 @@ context('Apply', () => {
             // Then I see the third page of results
             page.shouldShowPageNumber(3)
 
-            // When I order by Bedspace required
-            cy.task('stubAssessments', { data, pagination })
-            page.sortColumn('Bedspace required')
-
-            // Then I see the first page of results ordered by status ascending
-            page.shouldHaveURLSearchParam('sortBy=arrivedAt')
-            page.shouldShowPageNumber(1)
-            page.checkColumnOrder('Bedspace required', 'ascending')
-
-            // When I navigate to page 3
-            cy.task('stubAssessments', { data, pagination: { ...pagination, pageNumber: 3 } })
-            page.clickPaginationLink(3)
-
-            // Then I see the third page of results ordered by status ascending
-            page.shouldHaveURLSearchParam('sortBy=arrivedAt&sortDirection=asc')
-            page.shouldShowPageNumber(3)
-            page.checkColumnOrder('Bedspace required', 'ascending')
-
             // When I order by Referral received
             cy.task('stubAssessments', { data, pagination })
             page.sortColumn('Referral received')
@@ -233,13 +215,31 @@ context('Apply', () => {
             page.shouldShowPageNumber(1)
             page.checkColumnOrder('Referral received', 'ascending')
 
-            // When I order by Referral received again
-            page.sortColumn('Referral received')
+            // When I navigate to page 3
+            cy.task('stubAssessments', { data, pagination: { ...pagination, pageNumber: 3 } })
+            page.clickPaginationLink(3)
 
-            // Then I see the first page of results ordered by Referral received ascending
-            page.shouldHaveURLSearchParam('sortBy=createdAt&sortDirection=desc')
+            // Then I see the third page of results ordered by Referral received ascending
+            page.shouldHaveURLSearchParam('sortBy=createdAt&sortDirection=asc')
+            page.shouldShowPageNumber(3)
+            page.checkColumnOrder('Referral received', 'ascending')
+
+            // When I order by Bedspace required
+            cy.task('stubAssessments', { data, pagination })
+            page.sortColumn('Bedspace required')
+
+            // Then I see the first page of results ordered by Bedspace required ascending
+            page.shouldHaveURLSearchParam('sortBy=arrivedAt')
             page.shouldShowPageNumber(1)
-            page.checkColumnOrder('Referral received', 'descending')
+            page.checkColumnOrder('Bedspace required', 'ascending')
+
+            // When I order by Bedspace required again
+            page.sortColumn('Bedspace required')
+
+            // Then I see the first page of results ordered by Bedspace required descending
+            page.shouldHaveURLSearchParam('sortBy=arrivedAt&sortDirection=desc')
+            page.shouldShowPageNumber(1)
+            page.checkColumnOrder('Bedspace required', 'descending')
           })
         })
       })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -51,9 +51,9 @@ describe('AssessmentsController', () => {
 
   const tableHeaders = [
     {
-      html: '<a href="?sortBy=name&sortDirection=desc"><button>Name</button></a>',
+      html: '<a href="?sortBy=name"><button>Name</button></a>',
       attributes: {
-        'aria-sort': 'ascending',
+        'aria-sort': 'none',
         'data-cy-sort-field': 'name',
       },
     },
@@ -72,9 +72,9 @@ describe('AssessmentsController', () => {
       },
     },
     {
-      html: '<a href="?sortBy=arrivedAt"><button>Bedspace required</button></a>',
+      html: '<a href="?sortBy=arrivedAt&sortDirection=desc"><button>Bedspace required</button></a>',
       attributes: {
-        'aria-sort': 'none',
+        'aria-sort': 'ascending',
         'data-cy-sort-field': 'arrivedAt',
       },
     },
@@ -144,13 +144,13 @@ describe('AssessmentsController', () => {
 
           expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, status, {
             page: 1,
-            sortBy: 'name',
+            sortBy: 'arrivedAt',
             sortDirection: 'asc',
           })
         })
 
         it('returns the correct page and sorted assessments to the template', async () => {
-          request = createMock<Request>({ session, query: { page: '2', sortBy: 'arrivedAt', sortDirection: 'asc' } })
+          request = createMock<Request>({ session, query: { page: '2', sortBy: 'createdAt', sortDirection: 'desc' } })
           const assessments = assessmentSummaries.build({
             totalResults: 13,
             pageNumber: 2,
@@ -159,19 +159,19 @@ describe('AssessmentsController', () => {
           assessmentsService.getAllForLoggedInUser.mockResolvedValue(assessments)
 
           expectedHeaders = [
+            tableHeaders[0],
+            tableHeaders[1],
             {
-              html: '<a href="?sortBy=name"><button>Name</button></a>',
+              html: '<a href="?sortBy=createdAt&sortDirection=asc"><button>Referral received</button></a>',
               attributes: {
-                'aria-sort': 'none',
-                'data-cy-sort-field': 'name',
+                'aria-sort': 'descending',
+                'data-cy-sort-field': 'createdAt',
               },
             },
-            tableHeaders[1],
-            tableHeaders[2],
             {
-              html: '<a href="?sortBy=arrivedAt&sortDirection=desc"><button>Bedspace required</button></a>',
+              html: '<a href="?sortBy=arrivedAt"><button>Bedspace required</button></a>',
               attributes: {
-                'aria-sort': 'ascending',
+                'aria-sort': 'none',
                 'data-cy-sort-field': 'arrivedAt',
               },
             },
@@ -191,18 +191,18 @@ describe('AssessmentsController', () => {
             tableRows: assessments.data,
             pagination: {
               items: [
-                { text: '1', href: '?page=1&sortBy=arrivedAt&sortDirection=asc' },
-                { text: '2', href: '?page=2&sortBy=arrivedAt&sortDirection=asc', selected: true },
+                { text: '1', href: '?page=1&sortBy=createdAt&sortDirection=desc' },
+                { text: '2', href: '?page=2&sortBy=createdAt&sortDirection=desc', selected: true },
               ],
-              previous: { text: 'Previous', href: '?page=1&sortBy=arrivedAt&sortDirection=asc' },
+              previous: { text: 'Previous', href: '?page=1&sortBy=createdAt&sortDirection=desc' },
             },
             errors: {},
           })
 
           expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, status, {
             page: 2,
-            sortBy: 'arrivedAt',
-            sortDirection: 'asc',
+            sortBy: 'createdAt',
+            sortDirection: 'desc',
           })
         })
 
@@ -221,7 +221,7 @@ describe('AssessmentsController', () => {
             expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, status, {
               crn: searchParameters.crn,
               page: 1,
-              sortBy: 'name',
+              sortBy: 'arrivedAt',
               sortDirection: 'asc',
             })
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -54,28 +54,24 @@ describe('AssessmentsController', () => {
       html: '<a href="?sortBy=name"><button>Name</button></a>',
       attributes: {
         'aria-sort': 'none',
-        'data-cy-sort-field': 'name',
       },
     },
     {
       html: '<a href="?sortBy=crn"><button>CRN</button></a>',
       attributes: {
         'aria-sort': 'none',
-        'data-cy-sort-field': 'crn',
       },
     },
     {
       html: '<a href="?sortBy=createdAt"><button>Referral received</button></a>',
       attributes: {
         'aria-sort': 'none',
-        'data-cy-sort-field': 'createdAt',
       },
     },
     {
       html: '<a href="?sortBy=arrivedAt&sortDirection=desc"><button>Bedspace required</button></a>',
       attributes: {
         'aria-sort': 'ascending',
-        'data-cy-sort-field': 'arrivedAt',
       },
     },
   ]
@@ -110,7 +106,6 @@ describe('AssessmentsController', () => {
           html: '<a href="?sortBy=status"><button>Status</button></a>',
           attributes: {
             'aria-sort': 'none',
-            'data-cy-sort-field': 'status',
           },
         }
 
@@ -165,14 +160,12 @@ describe('AssessmentsController', () => {
               html: '<a href="?sortBy=createdAt&sortDirection=asc"><button>Referral received</button></a>',
               attributes: {
                 'aria-sort': 'descending',
-                'data-cy-sort-field': 'createdAt',
               },
             },
             {
               html: '<a href="?sortBy=arrivedAt"><button>Bedspace required</button></a>',
               attributes: {
                 'aria-sort': 'none',
-                'data-cy-sort-field': 'arrivedAt',
               },
             },
           ]

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -422,7 +422,7 @@ describe('assessmentUtils', () => {
     it('applies some defaults', () => {
       expect(getParams({})).toEqual({
         page: 1,
-        sortBy: 'name',
+        sortBy: 'arrivedAt',
         sortDirection: 'asc',
       })
     })
@@ -430,7 +430,7 @@ describe('assessmentUtils', () => {
     it('returns query values', () => {
       const query = {
         page: '3',
-        sortBy: 'arrivedAt',
+        sortBy: 'createdAt',
         sortDirection: 'desc',
         crn: 'X567345',
       }
@@ -438,7 +438,7 @@ describe('assessmentUtils', () => {
       expect(getParams(query)).toEqual({
         crn: 'X567345',
         page: 3,
-        sortBy: 'arrivedAt',
+        sortBy: 'createdAt',
         sortDirection: 'desc',
       })
     })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -346,31 +346,19 @@ describe('assessmentUtils', () => {
       expect(result).toEqual([
         {
           html: '<a href="?foo=bar&sortBy=name"><button>Name</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'name',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?foo=bar&sortBy=crn&sortDirection=desc"><button>CRN</button></a>',
-          attributes: {
-            'aria-sort': 'ascending',
-            'data-cy-sort-field': 'crn',
-          },
+          attributes: { 'aria-sort': 'ascending' },
         },
         {
           html: '<a href="?foo=bar&sortBy=createdAt"><button>Referral received</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'createdAt',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?foo=bar&sortBy=arrivedAt"><button>Bedspace required</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'arrivedAt',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
       ])
     })
@@ -381,38 +369,23 @@ describe('assessmentUtils', () => {
       expect(result).toEqual([
         {
           html: '<a href="?foo=bar&sortBy=name"><button>Name</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'name',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?foo=bar&sortBy=crn"><button>CRN</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'crn',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?foo=bar&sortBy=createdAt"><button>Referral received</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'createdAt',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?foo=bar&sortBy=arrivedAt"><button>Bedspace required</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'arrivedAt',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?foo=bar&sortBy=status&sortDirection=asc"><button>Status</button></a>',
-          attributes: {
-            'aria-sort': 'descending',
-            'data-cy-sort-field': 'status',
-          },
+          attributes: { 'aria-sort': 'descending' },
         },
       ])
     })

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -234,7 +234,7 @@ export const getParams = (query?: QueryString.ParsedQs): AssessmentSearchParamet
   // Default is page 1, sorted by name ascending
   ...query,
   page: Number(!query.page ? 1 : query.page),
-  sortBy: (query.sortBy || 'name') as AssessmentSortField,
+  sortBy: (query.sortBy || 'arrivedAt') as AssessmentSortField,
   sortDirection: (query.sortDirection || 'asc') as SortDirection,
 })
 

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -69,34 +69,22 @@ describe('bookingSearchUtils', () => {
       const tableHeadings = [
         {
           html: '<a href="?sortBy=name"><button>Name</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'name',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<a href="?sortBy=crn"><button>CRN</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'crn',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           text: 'Address',
         },
         {
           html: '<a href="?sortBy=startDate&sortDirection=desc"><button>Start date</button></a>',
-          attributes: {
-            'aria-sort': 'ascending',
-            'data-cy-sort-field': 'startDate',
-          },
+          attributes: { 'aria-sort': 'ascending' },
         },
         {
           html: '<a href="?sortBy=endDate"><button>End date</button></a>',
-          attributes: {
-            'aria-sort': 'none',
-            'data-cy-sort-field': 'endDate',
-          },
+          attributes: { 'aria-sort': 'none' },
         },
         {
           html: '<span class="govuk-visually-hidden">Actions</span>',
@@ -112,34 +100,22 @@ describe('bookingSearchUtils', () => {
     const tableHeadings = [
       {
         html: '<a href="?sortBy=name"><button>Name</button></a>',
-        attributes: {
-          'aria-sort': 'none',
-          'data-cy-sort-field': 'name',
-        },
+        attributes: { 'aria-sort': 'none' },
       },
       {
         html: '<a href="?sortBy=crn"><button>CRN</button></a>',
-        attributes: {
-          'aria-sort': 'none',
-          'data-cy-sort-field': 'crn',
-        },
+        attributes: { 'aria-sort': 'none' },
       },
       {
         text: 'Address',
       },
       {
         html: '<a href="?sortBy=startDate"><button>Start date</button></a>',
-        attributes: {
-          'aria-sort': 'none',
-          'data-cy-sort-field': 'startDate',
-        },
+        attributes: { 'aria-sort': 'none' },
       },
       {
         html: '<a href="?sortBy=endDate&sortDirection=asc"><button>End date</button></a>',
-        attributes: {
-          'aria-sort': 'descending',
-          'data-cy-sort-field': 'endDate',
-        },
+        attributes: { 'aria-sort': 'descending' },
       },
       {
         html: '<span class="govuk-visually-hidden">Actions</span>',

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -9,10 +9,7 @@ describe('sortHeader', () => {
   it("should return a header when the current view is not sorted by the header's field`", () => {
     expect(sortHeader<SortHeaders>('Some text', 'myField', 'otherField', true, hrefPrefix)).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField' })}"><button>Some text</button></a>`,
-      attributes: {
-        'aria-sort': 'none',
-        'data-cy-sort-field': 'myField',
-      },
+      attributes: { 'aria-sort': 'none' },
     })
   })
 
@@ -22,10 +19,7 @@ describe('sortHeader', () => {
         sortBy: 'myField',
         sortDirection: 'desc',
       })}"><button>Some text</button></a>`,
-      attributes: {
-        'aria-sort': 'ascending',
-        'data-cy-sort-field': 'myField',
-      },
+      attributes: { 'aria-sort': 'ascending' },
     })
   })
 
@@ -35,10 +29,7 @@ describe('sortHeader', () => {
         sortBy: 'myField',
         sortDirection: 'asc',
       })}"><button>Some text</button></a>`,
-      attributes: {
-        'aria-sort': 'descending',
-        'data-cy-sort-field': 'myField',
-      },
+      attributes: { 'aria-sort': 'descending' },
     })
   })
 
@@ -49,10 +40,7 @@ describe('sortHeader', () => {
         sortBy: 'myField',
         sortDirection: 'asc',
       })}"><button>Some text</button></a>`,
-      attributes: {
-        'aria-sort': 'descending',
-        'data-cy-sort-field': 'myField',
-      },
+      attributes: { 'aria-sort': 'descending' },
     })
   })
 
@@ -64,10 +52,7 @@ describe('sortHeader', () => {
         sortBy: 'myField',
         sortDirection: 'asc',
       })}"><button>Some text</button></a>`,
-      attributes: {
-        'aria-sort': 'descending',
-        'data-cy-sort-field': 'myField',
-      },
+      attributes: { 'aria-sort': 'descending' },
     })
   })
 })

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -11,7 +11,7 @@ export const sortHeader = <T extends string>(
   hrefPrefix: string,
 ): TableCell => {
   let sortDirection: SortDirection
-  let ariaSort = 'none'
+  let ariaSort: string
 
   const [basePath, queryString] = hrefPrefix.split('?')
   const qsArgs = qs.parse(queryString)
@@ -37,7 +37,6 @@ export const sortHeader = <T extends string>(
     })}"><button>${text}</button></a>`,
     attributes: {
       'aria-sort': ariaSort,
-      'data-cy-sort-field': targetField,
     },
   }
 }

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -108,11 +108,3 @@
         </div>
     {% endblock %}
 {% endblock %}
-
-{% block extraScripts %}
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-      $(document).ready(function() {
-        window.MOJFrontend.initAll()
-      })
-    </script>
-{% endblock %}

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -70,12 +70,4 @@
         <p>If the booking is missing from every list, <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">contact
                 support</a> for help.</p>
     {% endif %}
-
-    {% block extraScripts %}
-        <script type="text/javascript" nonce="{{ cspNonce }}">
-          $(document).ready(function() {
-            window.MOJFrontend.initAll()
-          })
-        </script>
-    {% endblock %}
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-269

# Changes in this PR

Sets the default sort order for referral screens to 'Bedspace required' ascending.

Also removes unused extra table header cell attributes that are no longer queried by Cypress, and gets rid of some GOVUK-Frontend init scripts which were used for the sortable tables, also no longer used.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [x] Are any changes required to dependent services for this change to work? No
- [x] Have they been released to production already? n/a

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
