### PR TITLE
CAS-60 bedspace end date

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -15,6 +15,7 @@ $path: "/assets/images/"
 @import './components/_probation-region-header'
 @import './components/_attributes-header'
 @import './components/_place-context-header'
+@import './components/_form-row-dl'
 @import './local'
 
 @import './pages/temporary-accommodation/show'

--- a/assets/sass/components/_form-row-dl.scss
+++ b/assets/sass/components/_form-row-dl.scss
@@ -1,0 +1,7 @@
+.form-group-dl {
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0;
+}

--- a/cypress_shared/components/bedspaceStatus.ts
+++ b/cypress_shared/components/bedspaceStatus.ts
@@ -1,0 +1,20 @@
+import Component from './component'
+import { Room } from '../../server/@types/shared'
+import { DateFormats } from '../../server/utils/dateUtils'
+
+export default class bedspaceStatusComponent extends Component {
+  private readonly bedEndDate: string
+
+  constructor(private readonly room: Room) {
+    super()
+    this.bedEndDate = room.beds[0].bedEndDate
+  }
+
+  shouldShowStatusDetails(status: 'Online' | 'Archived'): void {
+    this.shouldShowKeyAndValue('Bedspace status', status)
+    this.shouldShowKeyAndValue(
+      'Bedspace end date',
+      this.bedEndDate ? DateFormats.isoDateToUIDate(this.bedEndDate) : 'No end date added',
+    )
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
@@ -2,6 +2,7 @@ import type { Premises, Room, UpdateRoom } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import BedspaceEditablePage from './bedspaceEditable'
+import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export default class BedspaceEditPage extends BedspaceEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
@@ -54,5 +55,12 @@ export default class BedspaceEditPage extends BedspaceEditablePage {
       })
 
     this.getTextInputByIdAndClear('notes')
+  }
+
+  showCannotEditBedspaceEndDate(bedEndDate: string) {
+    cy.get('dt').contains('Bedspace end date')
+    cy.get('dd').contains(DateFormats.isoDateToUIDate(bedEndDate))
+    cy.get('p').contains('The bedspace end date cannot be edited.')
+    cy.get('label').contains('Enter the bedspace end date (optional)').should('not.exist')
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
@@ -76,4 +76,10 @@ export default class BedspaceEditPage extends BedspaceEditablePage {
       'The bedspace end date must be on or after the date the bedspace was created',
     )
   }
+
+  shouldShowErrorMessageForBookingConflict(bookingPath: string) {
+    cy.get('.govuk-error-summary').should('contain', `This bedspace end date conflicts with an existing booking`)
+    cy.get('a').contains('an existing booking').should('have.attr', 'href', bookingPath)
+    cy.get(`[data-cy-error-bedEndDate]`).should('contain', 'This bedspace end date conflicts with an existing booking')
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
@@ -63,4 +63,17 @@ export default class BedspaceEditPage extends BedspaceEditablePage {
     cy.get('p').contains('The bedspace end date cannot be edited.')
     cy.get('label').contains('Enter the bedspace end date (optional)').should('not.exist')
   }
+
+  shouldShowErrorMessageForEndDateBeforeCreationDate(createdAt: string) {
+    cy.get('.govuk-error-summary').should(
+      'contain',
+      `The bedspace end date must be on or after the date the bedspace was created (${DateFormats.isoDateToUIDate(
+        createdAt,
+      )})`,
+    )
+    cy.get(`[data-cy-error-bedEndDate]`).should(
+      'contain',
+      'The bedspace end date must be on or after the date the bedspace was created',
+    )
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
@@ -7,7 +7,9 @@ export default abstract class BedspaceEditablePage extends Page {
     this.getTextInputByIdAndEnterDetails('name', newOrUpdateRoom.name)
 
     this.getLegend('Enter the bedspace end date (optional)')
-    this.completeDateInputs('bedEndDate', newOrUpdateRoom.bedEndDate)
+    if (newOrUpdateRoom.bedEndDate) {
+      this.completeDateInputs('bedEndDate', newOrUpdateRoom.bedEndDate)
+    }
 
     newOrUpdateRoom.characteristicIds.forEach(characteristicId => {
       this.checkCheckboxByNameAndValue('characteristicIds[]', characteristicId)

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
@@ -6,8 +6,8 @@ export default abstract class BedspaceEditablePage extends Page {
     this.getLabel('Enter a bedspace reference')
     this.getTextInputByIdAndEnterDetails('name', newOrUpdateRoom.name)
 
-    this.getLegend('Enter the bedspace end date (optional)')
-    if (newOrUpdateRoom.bedEndDate) {
+    if (this.bedEndDateIsEditable() && newOrUpdateRoom.bedEndDate) {
+      this.getLegend('Enter the bedspace end date (optional)')
       this.completeDateInputs('bedEndDate', newOrUpdateRoom.bedEndDate)
     }
 
@@ -23,5 +23,9 @@ export default abstract class BedspaceEditablePage extends Page {
 
   assignCharacteristics(alias: string): void {
     this.getCheckboxItemsAsReferenceData('Does the bedspace have any of the following attributes?', alias)
+  }
+
+  bedEndDateIsEditable() {
+    return Boolean(cy.get('body').then($body => $body.find('input[name^=bedEndDate]').length > 0))
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEditable.ts
@@ -6,6 +6,9 @@ export default abstract class BedspaceEditablePage extends Page {
     this.getLabel('Enter a bedspace reference')
     this.getTextInputByIdAndEnterDetails('name', newOrUpdateRoom.name)
 
+    this.getLegend('Enter the bedspace end date (optional)')
+    this.completeDateInputs('bedEndDate', newOrUpdateRoom.bedEndDate)
+
     newOrUpdateRoom.characteristicIds.forEach(characteristicId => {
       this.checkCheckboxByNameAndValue('characteristicIds[]', characteristicId)
     })

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -6,6 +6,7 @@ import BookingListingComponent from '../../../components/bookingListing'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import LostBedListingComponent from '../../../components/lostBedListing'
 import Page from '../../page'
+import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export default class BedspaceShowPage extends Page {
   private readonly locationHeaderComponent: LocationHeaderComponent
@@ -66,14 +67,28 @@ export default class BedspaceShowPage extends Page {
     })
 
     cy.root().should('not.contain', 'This bedspace is in an archived property.')
+
+    this.shouldShowKeyAndValue('Bedspace status', 'Online')
   }
 
-  shouldShowAsArchived(): void {
+  shouldShowAsArchived(premiseIsArchived = true): void {
     cy.get('.moj-page-header-actions').within(() => {
       cy.root().should('not.contain', 'Actions')
     })
 
-    cy.root().should('contain', 'This bedspace is in an archived property.')
+    if (premiseIsArchived) {
+      cy.root().should('contain', 'This bedspace is in an archived property.')
+    }
+
+    this.shouldShowKeyAndValue('Bedspace status', 'Archived')
+  }
+
+  shouldShowBedspaceEndDate(endDate: string | null): void {
+    if (!endDate) {
+      this.shouldShowKeyAndValue('Bedspace end date', 'No end date added')
+    } else {
+      this.shouldShowKeyAndValue('Bedspace end date', DateFormats.isoDateToUIDate(this.room.beds[0].bedEndDate))
+    }
   }
 
   clickBedspaceEditLink(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -4,12 +4,15 @@ import { Premises } from '../../../../server/@types/shared'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingListingComponent from '../../../components/bookingListing'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import BedspaceStatusComponent from '../../../components/bedspaceStatus'
 import LostBedListingComponent from '../../../components/lostBedListing'
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 
 export default class BedspaceShowPage extends Page {
   private readonly locationHeaderComponent: LocationHeaderComponent
+
+  private readonly bedspaceStatusComponent: BedspaceStatusComponent
 
   private readonly premises: Premises
 
@@ -21,6 +24,7 @@ export default class BedspaceShowPage extends Page {
 
     this.premises = premises
     this.locationHeaderComponent = new LocationHeaderComponent({ premises })
+    this.bedspaceStatusComponent = new BedspaceStatusComponent(room)
   }
 
   static visit(premises: Premises, room: Room): BedspaceShowPage {
@@ -68,7 +72,7 @@ export default class BedspaceShowPage extends Page {
 
     cy.root().should('not.contain', 'This bedspace is in an archived property.')
 
-    this.shouldShowKeyAndValue('Bedspace status', 'Online')
+    this.bedspaceStatusComponent.shouldShowStatusDetails('Online')
   }
 
   shouldShowAsArchived(premiseIsArchived = true): void {
@@ -80,7 +84,7 @@ export default class BedspaceShowPage extends Page {
       cy.root().should('contain', 'This bedspace is in an archived property.')
     }
 
-    this.shouldShowKeyAndValue('Bedspace status', 'Archived')
+    this.bedspaceStatusComponent.shouldShowStatusDetails('Archived')
   }
 
   shouldShowBedspaceEndDate(endDate: string | null): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -4,10 +4,13 @@ import { PlaceContext } from '../../../../server/@types/ui'
 import errorLookups from '../../../../server/i18n/en/errors.json'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
+import BedspaceStatusComponent from '../../../components/bedspaceStatus'
 import BookingEditablePage from './bookingEditable'
 
 export default class BookingNewPage extends BookingEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
+
+  private readonly bedspaceStatusComponent: BedspaceStatusComponent
 
   constructor(
     private readonly premises: Premises,
@@ -16,6 +19,7 @@ export default class BookingNewPage extends BookingEditablePage {
     super('Book bedspace', premises, room)
 
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.bedspaceStatusComponent = new BedspaceStatusComponent(room)
   }
 
   static visit(premises: Premises, room: Room): BookingNewPage {
@@ -47,8 +51,9 @@ export default class BookingNewPage extends BookingEditablePage {
 
   shouldShowBookingDetails(): void {
     this.locationHeaderComponent.shouldShowLocationDetails()
+    this.bedspaceStatusComponent.shouldShowStatusDetails('Online')
 
-    cy.get('p').should('contain', this.turnaroundText())
+    cy.contains('p', this.turnaroundText())
   }
 
   shouldShowPrefilledBookingDetails(newBooking: NewBooking): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -138,7 +138,7 @@ export default class PremisesShowPage extends Page {
 
   clickBedpaceViewLink(room: Room): void {
     cy.get('h4')
-      .contains(room.name)
+      .contains(`Bedspace name: ${room.name}`)
       .parents('[data-cy-bedspace]')
       .within(() => {
         cy.get('a').contains('View').click()

--- a/e2e/tests/stepDefinitions/manage/bedspace.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspace.ts
@@ -4,7 +4,7 @@ import BedspaceEditPage from '../../../../cypress_shared/pages/temporary-accommo
 import BedspaceNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceNew'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
 import PremisesShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/premisesShow'
-import { newRoomFactory, roomFactory, updateRoomFactory } from '../../../../server/testutils/factories'
+import { bedFactory, newRoomFactory, roomFactory, updateRoomFactory } from '../../../../server/testutils/factories'
 
 Given("I'm creating a bedspace", () => {
   cy.get('@premises').then(premises => {
@@ -25,8 +25,9 @@ Given('I create a bedspace with all necessary details', () => {
     cy.then(function _() {
       const room = roomFactory.forEnvironment(this.characteristics).build({
         id: 'unknown',
+        beds: [bedFactory.build({ bedEndDate: undefined })],
       })
-      const newRoom = newRoomFactory.fromRoom(room).build()
+      const newRoom = newRoomFactory.fromRoom(room).build({ bedEndDate: undefined })
 
       cy.wrap(room).as('room')
       page.completeForm(newRoom)
@@ -55,7 +56,7 @@ Given('I edit the bedspace details', () => {
         id: this.room.id,
         name: this.room.name,
       })
-      const updateRoom = updateRoomFactory.fromRoom(updatedRoom).build()
+      const updateRoom = updateRoomFactory.fromRoom(updatedRoom).build({ bedEndDate: updatedRoom.beds[0].bedEndDate })
 
       cy.wrap(updatedRoom).as('room')
       page.completeForm(updateRoom)

--- a/integration_tests/mockApis/room.ts
+++ b/integration_tests/mockApis/room.ts
@@ -94,10 +94,22 @@ export default {
         jsonBody: args.room,
       },
     }),
-  stubRoomUpdateErrors: (args: { premisesId: string; room: Room; params: Array<string> }): SuperAgentRequest =>
-    stubFor(
-      errorStub(args.params, paths.premises.rooms.update({ premisesId: args.premisesId, roomId: args.room.id }), 'PUT'),
-    ),
+  stubRoomUpdateConflictError: (args: { premisesId: string; room: Room; detail: string }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'PUT',
+        url: paths.premises.rooms.update({ premisesId: args.premisesId, roomId: args.room.id }),
+      },
+      response: {
+        status: 409,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          title: 'Conflict',
+          status: 409,
+          detail: args.detail,
+        },
+      },
+    }),
   verifyRoomUpdate: async (args: { premisesId: string; room: Room }) =>
     (
       await getMatchingRequests({

--- a/integration_tests/mockApis/room.ts
+++ b/integration_tests/mockApis/room.ts
@@ -59,8 +59,29 @@ export default {
         url: paths.premises.rooms.create({ premisesId }),
       })
     ).body.requests,
-  stubRoomCreateErrors: (args: { premisesId: string; params: Array<string> }): SuperAgentRequest =>
-    stubFor(errorStub(args.params, paths.premises.rooms.create({ premisesId: args.premisesId }), 'POST')),
+  stubRoomCreateErrors: (args: {
+    premisesId: string
+    errors: Array<{ field: keyof Room; type?: string }>
+  }): SuperAgentRequest =>
+    stubFor({
+      request: {
+        method: 'POST',
+        url: paths.premises.rooms.create({ premisesId: args.premisesId }),
+      },
+      response: {
+        status: 400,
+        headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+        jsonBody: {
+          title: 'Bad Request',
+          status: 400,
+          detail: 'There is a problem with your request',
+          'invalid-params': args.errors.map(error => ({
+            propertyName: `$.${error.field}`,
+            errorType: error.type || 'empty',
+          })),
+        },
+      },
+    }),
   stubRoomUpdate: (args: { premisesId: string; room: Room }): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/mockApis/room.ts
+++ b/integration_tests/mockApis/room.ts
@@ -3,7 +3,6 @@ import { Room } from '@approved-premises/api'
 import paths from '../../server/paths/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { characteristics } from '../../wiremock/referenceDataStubs'
-import { errorStub } from '../../wiremock/utils'
 import booking from './booking'
 import lostBed from './lostBed'
 

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -134,6 +134,7 @@ context('Bedspace', () => {
       expect(requestBody.name).equal(newRoom.name)
       expect(requestBody.characteristicIds).members(newRoom.characteristicIds)
       expect(requestBody.notes.replaceAll('\r\n', '\n')).equal(newRoom.notes)
+      expect(requestBody.bedEndDate).equal(newRoom.bedEndDate)
     })
 
     // And I should be redirected to the show bedspace page
@@ -191,7 +192,9 @@ context('Bedspace', () => {
 
     // And there is a premises and a room in the database
     const premises = premisesFactory.build()
-    const room = roomFactory.build()
+    const room = roomFactory.build({
+      beds: [bedFactory.build({ bedEndDate: undefined })],
+    })
 
     const premisesId = premises.id
 
@@ -364,7 +367,7 @@ context('Bedspace', () => {
     describe('when the bedspace has no end date', () => {
       it('shows the bedspace as Online', () => {
         // And there is a bedspace with no end date for the premises
-        const bed = bedFactory.build()
+        const bed = bedFactory.build({ bedEndDate: undefined })
         const room = roomFactory.build({ beds: [bed] })
         cy.task('stubSingleRoom', { premisesId: premises.id, room })
 

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -211,7 +211,7 @@ context('Bedspace', () => {
           cy.task('stubRoomUpdateConflictError', {
             premisesId: premises.id,
             room,
-            detail: `The bedspace end date must be on or after the bedspace createdAt date: ${createdAt}`,
+            detail: `Bedspace end date cannot be prior to the Bedspace creation date: ${createdAt}`,
           })
           page.clickSubmit()
 
@@ -224,7 +224,8 @@ context('Bedspace', () => {
           cy.task('stubRoomUpdateConflictError', {
             premisesId: premises.id,
             room,
-            detail: 'Conflict booking exists for the room: 82c03c63-321a-45dd-811d-be87a41f5780',
+            detail:
+              'Conflict booking exists for the room with end date 2024-04-14: 82c03c63-321a-45dd-811d-be87a41f5780',
           })
           page.clickSubmit()
 

--- a/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspace.cy.ts
@@ -142,25 +142,48 @@ context('Bedspace', () => {
     bedspaceShowPage.shouldShowBanner('Bedspace created')
   })
 
-  it('shows errors when the API returns an error', () => {
-    // Given I am signed in
-    cy.signIn()
+  describe('shows errors', () => {
+    it('when no bedspace reference is entered', () => {
+      // Given I am signed in
+      cy.signIn()
 
-    // And there is reference data in the database
-    cy.task('stubRoomReferenceData')
+      // And there is reference data in the database
+      cy.task('stubRoomReferenceData')
 
-    // When I visit the new bedspace page
-    const premises = premisesFactory.build()
-    cy.task('stubSinglePremises', premises)
+      // When I visit the new bedspace page
+      const premises = premisesFactory.build()
+      cy.task('stubSinglePremises', premises)
 
-    const page = BedspaceNewPage.visit(premises)
+      const page = BedspaceNewPage.visit(premises)
 
-    // And I miss required fields
-    cy.task('stubRoomCreateErrors', { premisesId: premises.id, params: ['name'] })
-    page.clickSubmit()
+      // And I miss required fields
+      cy.task('stubRoomCreateErrors', { premisesId: premises.id, errors: [{ field: 'name' }] })
+      page.clickSubmit()
 
-    // Then I should see error messages relating to those fields
-    page.shouldShowErrorMessagesForFields(['name'])
+      // Then I should see error messages relating to those fields
+      page.shouldShowErrorMessagesForFields(['name'])
+    })
+
+    it('when an invalid bedspace end date is entered', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is reference data in the database
+      cy.task('stubRoomReferenceData')
+
+      // When I visit the new bedspace page
+      const premises = premisesFactory.build()
+      cy.task('stubSinglePremises', premises)
+
+      const page = BedspaceNewPage.visit(premises)
+
+      // And I enter an invalid date
+      cy.task('stubRoomCreateErrors', { premisesId: premises.id, errors: [{ field: 'bedEndDate', type: 'invalid' }] })
+      page.clickSubmit()
+
+      // Then I should see error messages relating to those fields
+      page.shouldShowErrorMessagesForFields(['bedEndDate'], 'invalid')
+    })
   })
 
   it('navigates back from the new bedspace page to the show premises page', () => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -361,3 +361,5 @@ export type AssessmentSearchParameters = {
   sortDirection?: SortDirection
   crn?: string
 }
+
+export type BedspaceStatus = 'online' | 'archived'

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -15,7 +15,7 @@ import {
   roomFactory,
   updateRoomFactory,
 } from '../../../testutils/factories'
-import { bedspaceActions, insertConflictErrors } from '../../../utils/bedspaceUtils'
+import { bedspaceActions, insertEndDateErrors } from '../../../utils/bedspaceUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BedspacesController from './bedspacesController'
@@ -317,10 +317,10 @@ describe('BedspacesController', () => {
       const room = roomFactory.build()
 
       const err = {
-        status: 409,
+        status: 400,
         data: {
-          title: 'Conflict',
-          detail: 'The bedspace end date must be on or after the bedspace createdAt date: 2024-03-27',
+          title: 'Bad Request',
+          detail: 'Bedspace end date cannot be prior to the Bedspace creation date: 2024-03-28',
         },
       }
 
@@ -335,7 +335,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(insertConflictErrors).toHaveBeenCalledWith(err, premisesId, room.id)
+      expect(insertEndDateErrors).toHaveBeenCalledWith(err, premisesId, room.id)
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,
@@ -353,7 +353,7 @@ describe('BedspacesController', () => {
         status: 409,
         data: {
           title: 'Conflict',
-          detail: 'Conflict booking exists for the room: 82c03c63-321a-45dd-811d-be87a41f5780',
+          detail: 'Conflict booking exists for the room with end date 2024-07-07: 82c03c63-321a-45dd-811d-be87a41f5780',
         },
       }
 
@@ -368,7 +368,7 @@ describe('BedspacesController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(insertConflictErrors).toHaveBeenCalledWith(err, premisesId, room.id)
+      expect(insertEndDateErrors).toHaveBeenCalledWith(err, premisesId, room.id)
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -224,6 +224,7 @@ describe('BedspacesController', () => {
       request.body = {
         name: room.name,
         notes: room.notes,
+        ...DateFormats.isoToDateAndTimeInputs(room.beds[0].bedEndDate, 'bedEndDate'),
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
@@ -232,11 +233,17 @@ describe('BedspacesController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.updateRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id, {
-        name: room.name,
-        notes: room.notes,
-        characteristicIds: [],
-      })
+      expect(bedspaceService.updateRoom).toHaveBeenCalledWith(
+        callConfig,
+        premises.id,
+        room.id,
+        expect.objectContaining({
+          name: room.name,
+          notes: room.notes,
+          characteristicIds: [],
+          bedEndDate: room.beds[0].bedEndDate,
+        }),
+      )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Bedspace updated')
       expect(response.redirect).toHaveBeenCalledWith(

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.test.ts
@@ -20,6 +20,7 @@ import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import BedspacesController from './bedspacesController'
 import { preservePlaceContext } from '../../../utils/placeUtils'
+import { DateFormats } from '../../../utils/dateUtils'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
@@ -92,17 +93,23 @@ describe('BedspacesController', () => {
       request.body = {
         name: room.name,
         notes: room.notes,
+        ...DateFormats.isoToDateAndTimeInputs(room.beds[0].bedEndDate, 'bedEndDate'),
       }
 
       bedspaceService.createRoom.mockResolvedValue(room)
 
       await requestHandler(request, response, next)
 
-      expect(bedspaceService.createRoom).toHaveBeenCalledWith(callConfig, premisesId, {
-        name: room.name,
-        characteristicIds: [],
-        notes: room.notes,
-      })
+      expect(bedspaceService.createRoom).toHaveBeenCalledWith(
+        callConfig,
+        premisesId,
+        expect.objectContaining({
+          name: room.name,
+          characteristicIds: [],
+          notes: room.notes,
+          bedEndDate: room.beds[0].bedEndDate,
+        }),
+      )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Bedspace created')
       expect(response.redirect).toHaveBeenCalledWith(paths.premises.bedspaces.show({ premisesId, roomId: room.id }))

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -4,7 +4,7 @@ import type { NewRoom, UpdateRoom } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { AssessmentsService, BookingService, PremisesService } from '../../../services'
 import BedspaceService from '../../../services/bedspaceService'
-import { bedspaceActions, insertConflictErrors } from '../../../utils/bedspaceUtils'
+import { bedspaceActions, insertEndDateErrors } from '../../../utils/bedspaceUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { preservePlaceContext } from '../../../utils/placeUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -118,8 +118,12 @@ export default class BedspacesController {
 
         res.redirect(paths.premises.bedspaces.show({ premisesId, roomId }))
       } catch (err) {
-        if (err.status === 409) {
-          insertConflictErrors(err, premisesId, roomId)
+        if (
+          err.status === 409 ||
+          (err.status === 400 &&
+            err.data.detail.match('Bedspace end date cannot be prior to the Bedspace creation date'))
+        ) {
+          insertEndDateErrors(err, premisesId, roomId)
         }
         catchValidationErrorOrPropogate(req, res, err, paths.premises.bedspaces.edit({ premisesId, roomId }))
       }

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -7,7 +7,12 @@ import BedspaceService from '../../../services/bedspaceService'
 import { bedspaceActions } from '../../../utils/bedspaceUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { preservePlaceContext } from '../../../utils/placeUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import {
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  insertBespokeError,
+  insertGenericError,
+} from '../../../utils/validation'
 import { DateFormats } from '../../../utils/dateUtils'
 
 export default class BedspacesController {
@@ -118,6 +123,22 @@ export default class BedspacesController {
 
         res.redirect(paths.premises.bedspaces.show({ premisesId, roomId }))
       } catch (err) {
+        if (err.status === 409) {
+          if (err.data.detail.match('The bedspace end date must be on or after the bedspace createdAt date:')) {
+            const createdAt = err.data.detail.split(':')[1].trim()
+            insertBespokeError(err, {
+              errorTitle: 'There is a problem',
+              errorSummary: [
+                {
+                  text: `The bedspace end date must be on or after the date the bedspace was created (${DateFormats.isoDateToUIDate(
+                    createdAt,
+                  )})`,
+                },
+              ],
+            })
+            insertGenericError(err, 'bedEndDate', 'beforeCreatedAt')
+          }
+        }
         catchValidationErrorOrPropogate(req, res, err, paths.premises.bedspaces.edit({ premisesId, roomId }))
       }
     }

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -93,6 +93,7 @@ export default class BedspacesController {
       const callConfig = extractCallConfig(req)
 
       const { name } = req.body
+      const { bedEndDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'bedEndDate')
 
       const room = await this.bedspaceService.getRoom(callConfig, premisesId, roomId)
 
@@ -102,6 +103,7 @@ export default class BedspacesController {
         characteristicIds: [],
         ...req.body,
         name: newRoomName,
+        bedEndDate,
       }
 
       try {

--- a/server/controllers/temporary-accommodation/manage/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspacesController.ts
@@ -8,6 +8,7 @@ import { bedspaceActions } from '../../../utils/bedspaceUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { preservePlaceContext } from '../../../utils/placeUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import { DateFormats } from '../../../utils/dateUtils'
 
 export default class BedspacesController {
   constructor(
@@ -41,10 +42,12 @@ export default class BedspacesController {
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { premisesId } = req.params
+      const { bedEndDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'bedEndDate')
 
       const newRoom: NewRoom = {
         characteristicIds: [],
         ...req.body,
+        bedEndDate,
       }
 
       try {

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -106,6 +106,22 @@ describe('BookingsController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/new', {
         premises,
         room,
+        bedspaceStatus: {
+          rows: [
+            {
+              key: 'Bedspace status',
+              value: {
+                html: '<span class="govuk-tag govuk-tag--green">Online</span>',
+              },
+            },
+            {
+              key: 'Bedspace end date',
+              value: {
+                text: DateFormats.isoDateToUIDate(room.beds[0].bedEndDate),
+              },
+            },
+          ],
+        },
         errors: {},
         errorSummary: [],
         crn: 'some-crn',

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -48,10 +48,12 @@ export default class BookingsController {
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
       const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspaceStatus = this.bedspacesService.summaryListForBedspaceStatus(room)
 
       return res.render('temporary-accommodation/bookings/new', {
         premises,
         room,
+        bedspaceStatus,
         errors,
         errorSummary,
         errorTitle,

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -132,7 +132,8 @@
       "empty": "Enter text to save as a note"
     },
     "bedEndDate": {
-      "invalid": "The bedspace end date is an invalid date"
+      "invalid": "The bedspace end date is an invalid date",
+      "beforeCreatedAt": "The bedspace end date must be on or after the date the bedspace was created"
     }
   },
   "bookingCancellation": {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -58,8 +58,12 @@
       "expectedNumber": "The duration is not a valid number of days",
       "mustBeAtLeast1": "The duration is not a valid number of days"
     },
-    "moveOnCategoryId": { "empty": "You must choose a move on category" },
-    "destinationProvider": { "empty": "You must enter a destination provider" },
+    "moveOnCategoryId": {
+      "empty": "You must choose a move on category"
+    },
+    "destinationProvider": {
+      "empty": "You must enter a destination provider"
+    },
     "newDepartureDate": {
       "empty": "You must enter a new departure date",
       "invalid": "The departure date is an invalid date",
@@ -80,8 +84,12 @@
     "reason": {
       "empty": "You must choose a reason"
     },
-    "numberOfBeds": { "empty": "You must enter the number of beds lost" },
-    "referenceNumber": { "empty": "You must enter a reference number" },
+    "numberOfBeds": {
+      "empty": "You must enter the number of beds lost"
+    },
+    "referenceNumber": {
+      "empty": "You must enter a reference number"
+    },
     "addressLine1": {
       "empty": "You must enter an address"
     },
@@ -122,6 +130,9 @@
     },
     "message": {
       "empty": "Enter text to save as a note"
+    },
+    "bedEndDate": {
+      "invalid": "The bedspace end date is an invalid date"
     }
   },
   "bookingCancellation": {

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -133,7 +133,8 @@
     },
     "bedEndDate": {
       "invalid": "The bedspace end date is an invalid date",
-      "beforeCreatedAt": "The bedspace end date must be on or after the date the bedspace was created"
+      "beforeCreatedAt": "The bedspace end date must be on or after the date the bedspace was created",
+      "conflict": "This bedspace end date conflicts with an existing booking"
     }
   },
   "bookingCancellation": {

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -60,6 +60,7 @@ describe('BedspaceService', () => {
         name: 'ABC',
         characteristics: [characteristicFactory.build({ name: 'Characteristic 3' })],
         notes: 'Some more notes',
+        beds: [bedFactory.build({ bedEndDate: undefined })],
       })
 
       roomClient.all.mockResolvedValue([room1, room2])
@@ -104,7 +105,7 @@ describe('BedspaceService', () => {
               },
               {
                 key: { text: 'Bedspace end date' },
-                value: { text: 'No end date added' },
+                value: { text: DateFormats.isoDateToUIDate(room1.beds[0].bedEndDate) },
               },
               {
                 key: { text: 'Attributes' },

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -1,10 +1,12 @@
+import { addDays } from 'date-fns'
 import ReferenceDataClient from '../data/referenceDataClient'
 import { CallConfig } from '../data/restClient'
 import RoomClient from '../data/roomClient'
-import { characteristicFactory, newRoomFactory, roomFactory } from '../testutils/factories'
+import { bedFactory, characteristicFactory, newRoomFactory, roomFactory } from '../testutils/factories'
 import { filterCharacteristics, formatCharacteristics } from '../utils/characteristicUtils'
 import { formatLines } from '../utils/viewUtils'
 import BedspaceService from './bedspaceService'
+import { DateFormats } from '../utils/dateUtils'
 
 jest.mock('../data/roomClient')
 jest.mock('../data/referenceDataClient')
@@ -74,6 +76,14 @@ describe('BedspaceService', () => {
           summaryList: {
             rows: [
               {
+                key: { text: 'Bedspace status' },
+                value: { html: '<span class="govuk-tag govuk-tag--green">Online</span>' },
+              },
+              {
+                key: { text: 'Bedspace end date' },
+                value: { text: 'No end date added' },
+              },
+              {
                 key: { text: 'Attributes' },
                 value: { text: 'Some attributes' },
               },
@@ -88,6 +98,14 @@ describe('BedspaceService', () => {
           room: room1,
           summaryList: {
             rows: [
+              {
+                key: { text: 'Bedspace status' },
+                value: { html: '<span class="govuk-tag govuk-tag--green">Online</span>' },
+              },
+              {
+                key: { text: 'Bedspace end date' },
+                value: { text: 'No end date added' },
+              },
               {
                 key: { text: 'Attributes' },
                 value: { text: 'Some attributes' },
@@ -125,12 +143,14 @@ describe('BedspaceService', () => {
 
   describe('getSingleBedspaceDetails', () => {
     it('returns a room and a summary list, for the given premises ID and room ID', async () => {
+      const bedEndDate = DateFormats.dateObjToIsoDate(addDays(new Date(), -14))
       const room = roomFactory.build({
         characteristics: [
           characteristicFactory.build({ name: 'Characteristic 1' }),
           characteristicFactory.build({ name: 'Characteristic 2' }),
         ],
         notes: 'Some notes',
+        beds: [bedFactory.build({ bedEndDate })],
       })
 
       roomClient.find.mockResolvedValue(room)
@@ -145,6 +165,14 @@ describe('BedspaceService', () => {
         room,
         summaryList: {
           rows: [
+            {
+              key: { text: 'Bedspace status' },
+              value: { html: `<span class="govuk-tag govuk-tag--grey">Archived</span>` },
+            },
+            {
+              key: { text: 'Bedspace end date' },
+              value: { text: DateFormats.isoDateToUIDate(bedEndDate) },
+            },
             {
               key: { text: 'Attributes' },
               value: { text: 'Some attributes' },

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -89,7 +89,7 @@ export default class BedspaceService {
     return { characteristics }
   }
 
-  private summaryListForRoom(room: Room): SummaryList {
+  summaryListForBedspaceStatus(room: Room): SummaryList {
     return {
       rows: [
         {
@@ -106,6 +106,14 @@ export default class BedspaceService {
             room.beds[0].bedEndDate ? DateFormats.isoDateToUIDate(room.beds[0].bedEndDate) : 'No end date added',
           ),
         },
+      ],
+    }
+  }
+
+  private summaryListForRoom(room: Room): SummaryList {
+    return {
+      rows: [
+        ...this.summaryListForBedspaceStatus(room).rows,
         {
           key: this.textValue('Attributes'),
           value: formatCharacteristics(room.characteristics),

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -5,6 +5,8 @@ import { CallConfig } from '../data/restClient'
 import RoomClient from '../data/roomClient'
 import { filterCharacteristics, formatCharacteristics } from '../utils/characteristicUtils'
 import { formatLines } from '../utils/viewUtils'
+import { DateFormats } from '../utils/dateUtils'
+import { bedspaceStatus } from '../utils/bedspaceUtils'
 
 export type BedspaceReferenceData = {
   characteristics: Array<Characteristic>
@@ -90,6 +92,20 @@ export default class BedspaceService {
   private summaryListForRoom(room: Room): SummaryList {
     return {
       rows: [
+        {
+          key: this.textValue('Bedspace status'),
+          value: this.htmlValue(
+            bedspaceStatus(room) === 'online'
+              ? `<span class="govuk-tag govuk-tag--green">Online</span>`
+              : `<span class="govuk-tag govuk-tag--grey">Archived</span>`,
+          ),
+        },
+        {
+          key: this.textValue('Bedspace end date'),
+          value: this.textValue(
+            room.beds[0].bedEndDate ? DateFormats.isoDateToUIDate(room.beds[0].bedEndDate) : 'No end date added',
+          ),
+        },
         {
           key: this.textValue('Attributes'),
           value: formatCharacteristics(room.characteristics),

--- a/server/testutils/factories/bed.ts
+++ b/server/testutils/factories/bed.ts
@@ -2,8 +2,10 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
 import { Bed } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
 
 export default Factory.define<Bed>(() => ({
   id: faker.string.uuid(),
   name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+  bedEndDate: DateFormats.dateObjToIsoDate(faker.date.future({ years: 1 })),
 }))

--- a/server/testutils/factories/newRoom.ts
+++ b/server/testutils/factories/newRoom.ts
@@ -3,6 +3,7 @@ import { Factory } from 'fishery'
 import type { NewRoom, Room } from '@approved-premises/api'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
+import { DateFormats } from '../../utils/dateUtils'
 
 class NewRoomFactory extends Factory<NewRoom> {
   /* istanbul ignore next */
@@ -20,4 +21,5 @@ export default NewRoomFactory.define(() => ({
     characteristic => characteristic.id,
   ),
   notes: faker.lorem.lines(),
+  bedEndDate: DateFormats.dateObjToIsoDate(faker.date.future({ years: 1 })),
 }))

--- a/server/testutils/factories/newRoom.ts
+++ b/server/testutils/factories/newRoom.ts
@@ -1,6 +1,7 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 import type { NewRoom, Room } from '@approved-premises/api'
+import { addYears } from 'date-fns'
 import { unique } from '../../utils/utils'
 import referenceDataFactory from './referenceData'
 import { DateFormats } from '../../utils/dateUtils'
@@ -21,5 +22,5 @@ export default NewRoomFactory.define(() => ({
     characteristic => characteristic.id,
   ),
   notes: faker.lorem.lines(),
-  bedEndDate: DateFormats.dateObjToIsoDate(faker.date.future({ years: 1 })),
+  bedEndDate: DateFormats.dateObjToIsoDate(addYears(faker.date.future({ years: 1 }), 2)),
 }))

--- a/server/utils/bedspaceUtils.test.ts
+++ b/server/utils/bedspaceUtils.test.ts
@@ -1,7 +1,7 @@
 import { addDays } from 'date-fns'
 import paths from '../paths/temporary-accommodation/manage'
 import { bedFactory, placeContextFactory, premisesFactory, roomFactory } from '../testutils/factories'
-import { bedspaceActions, bedspaceStatus, insertConflictErrors } from './bedspaceUtils'
+import { bedspaceActions, bedspaceStatus, insertEndDateErrors } from './bedspaceUtils'
 import { addPlaceContext } from './placeUtils'
 import { DateFormats } from './dateUtils'
 import * as validation from './validation'
@@ -123,14 +123,15 @@ describe('bedspaceUtils', () => {
 
     it('inserts an error for a date before created at conflict', () => {
       const error = {
+        status: 400,
         data: {
-          detail: 'The bedspace end date must be on or after the bedspace createdAt date: 2024-04-14',
+          detail: 'Bedspace end date cannot be prior to the Bedspace creation date: 2024-04-14',
         },
         stack: '',
         message: '',
       }
 
-      insertConflictErrors(error, 'premiseId', 'roomId')
+      insertEndDateErrors(error, 'premiseId', 'roomId')
 
       expect(validation.insertBespokeError).toHaveBeenCalledWith(error, {
         errorTitle: 'There is a problem',
@@ -145,14 +146,15 @@ describe('bedspaceUtils', () => {
 
     it('inserts an error for an existing booking conflict', () => {
       const error = {
+        status: 409,
         data: {
-          detail: 'Conflict booking exists for the room: bookingId',
+          detail: 'Conflict booking exists for the room with end date 2024-05-27: bookingId',
         },
         stack: '',
         message: '',
       }
 
-      insertConflictErrors(error, 'premiseId', 'roomId')
+      insertEndDateErrors(error, 'premiseId', 'roomId')
 
       expect(validation.insertBespokeError).toHaveBeenCalledWith(error, {
         errorTitle: 'There is a problem',

--- a/server/utils/bedspaceUtils.ts
+++ b/server/utils/bedspaceUtils.ts
@@ -37,12 +37,12 @@ export function bedspaceStatus(room: Room): BedspaceStatus {
   return 'online'
 }
 
-export function insertConflictErrors(err: SanitisedError, premisesId: Premises['id'], roomId: Room['id']) {
+export function insertEndDateErrors(err: SanitisedError, premisesId: Premises['id'], roomId: Room['id']) {
   const { detail } = err.data as { detail: string }
   const errorSummary: ErrorSummary[] = []
   let errorType: string
 
-  if (detail.match('The bedspace end date must be on or after the bedspace createdAt date:')) {
+  if (detail.match('Bedspace end date cannot be prior to the Bedspace creation date')) {
     const createdAt = detail.split(':')[1].trim()
     errorSummary.push({
       text: `The bedspace end date must be on or after the date the bedspace was created (${DateFormats.isoDateToUIDate(
@@ -52,7 +52,7 @@ export function insertConflictErrors(err: SanitisedError, premisesId: Premises['
     errorType = 'beforeCreatedAt'
   }
 
-  if (detail.match('Conflict booking exists for the room:')) {
+  if (detail.match('Conflict booking exists for the room with end date')) {
     const bookingId = detail.split(':')[1].trim()
     errorSummary.push({
       html: `This bedspace end date conflicts with <a href="${paths.bookings.show({

--- a/server/utils/bedspaceUtils.ts
+++ b/server/utils/bedspaceUtils.ts
@@ -1,10 +1,11 @@
 import { Premises, Room } from '../@types/shared'
-import { PageHeadingBarItem, PlaceContext } from '../@types/ui'
+import { BedspaceStatus, PageHeadingBarItem, PlaceContext } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { addPlaceContext } from './placeUtils'
+import { dateIsInThePast } from './dateUtils'
 
 export function bedspaceActions(premises: Premises, room: Room, placeContext: PlaceContext): Array<PageHeadingBarItem> {
-  if (premises.status === 'archived') {
+  if (premises.status === 'archived' || bedspaceStatus(room) === 'archived') {
     return null
   }
   const items = [
@@ -22,4 +23,14 @@ export function bedspaceActions(premises: Premises, room: Room, placeContext: Pl
   })
 
   return items
+}
+
+export function bedspaceStatus(room: Room): BedspaceStatus {
+  if (room.beds[0].bedEndDate) {
+    if (dateIsInThePast(room.beds[0].bedEndDate)) {
+      return 'archived'
+    }
+  }
+
+  return 'online'
 }

--- a/server/utils/bedspaceUtils.ts
+++ b/server/utils/bedspaceUtils.ts
@@ -1,8 +1,10 @@
 import { Premises, Room } from '../@types/shared'
-import { BedspaceStatus, PageHeadingBarItem, PlaceContext } from '../@types/ui'
+import { BedspaceStatus, ErrorSummary, PageHeadingBarItem, PlaceContext } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { addPlaceContext } from './placeUtils'
-import { dateIsInThePast } from './dateUtils'
+import { DateFormats, dateIsInThePast } from './dateUtils'
+import { insertBespokeError, insertGenericError } from './validation'
+import { SanitisedError } from '../sanitisedError'
 
 export function bedspaceActions(premises: Premises, room: Room, placeContext: PlaceContext): Array<PageHeadingBarItem> {
   if (premises.status === 'archived' || bedspaceStatus(room) === 'archived') {
@@ -33,4 +35,40 @@ export function bedspaceStatus(room: Room): BedspaceStatus {
   }
 
   return 'online'
+}
+
+export function insertConflictErrors(err: SanitisedError, premisesId: Premises['id'], roomId: Room['id']) {
+  const { detail } = err.data as { detail: string }
+  const errorSummary: ErrorSummary[] = []
+  let errorType: string
+
+  if (detail.match('The bedspace end date must be on or after the bedspace createdAt date:')) {
+    const createdAt = detail.split(':')[1].trim()
+    errorSummary.push({
+      text: `The bedspace end date must be on or after the date the bedspace was created (${DateFormats.isoDateToUIDate(
+        createdAt,
+      )})`,
+    })
+    errorType = 'beforeCreatedAt'
+  }
+
+  if (detail.match('Conflict booking exists for the room:')) {
+    const bookingId = detail.split(':')[1].trim()
+    errorSummary.push({
+      html: `This bedspace end date conflicts with <a href="${paths.bookings.show({
+        premisesId,
+        roomId,
+        bookingId,
+      })}">an existing booking</a>`,
+    })
+    errorType = 'conflict'
+  }
+
+  if (errorSummary.length && errorType) {
+    insertBespokeError(err, {
+      errorTitle: 'There is a problem',
+      errorSummary,
+    })
+    insertGenericError(err, 'bedEndDate', errorType)
+  }
 }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -4,7 +4,6 @@ import { isFuture, isPast } from 'date-fns'
 
 import format from 'date-fns/format'
 import formatISO from 'date-fns/formatISO'
-import parseISO from 'date-fns/parseISO'
 
 export class DateFormats {
   /**
@@ -42,7 +41,7 @@ export class DateFormats {
    * @throws {InvalidDateStringError} If the string is not a valid ISO8601 datetime string
    */
   static isoToDateObj(date: string) {
-    const parsedDate = parseISO(date)
+    const parsedDate = new Date(date)
 
     if (Number.isNaN(parsedDate.getTime())) {
       throw new InvalidDateStringError(`Invalid Date: ${date}`)

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -152,7 +152,7 @@
                     html: keyCharacteristicsHtml
                   }
                 } if keyCharacteristicsHtml else undefined,
-                { 
+                {
                   key: {
                     text: "Number of bedspaces"
                   },

--- a/server/views/temporary-accommodation/bedspaces/_editable.njk
+++ b/server/views/temporary-accommodation/bedspaces/_editable.njk
@@ -2,52 +2,69 @@
 {% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
 {% from "govuk/components/textarea/macro.njk" import govukTextarea %}
 {% from "../components/ta-input/macro.njk" import taInput %}
+{% from "../components/ta-date-input/macro.njk" import taDateInput %}
 
 {{ taInput(
-  {
-    label: {
-      text: 'Enter a bedspace reference',
-      classes: "govuk-label--m"
+    {
+        label: {
+        text: 'Enter a bedspace reference',
+        classes: "govuk-label--m"
     },
+        hint: {
+        text: "This will be used to identify the bedspace when making bookings and reporting on the service"
+    },
+        fieldName: "name"
+    },
+    fetchContext()
+) }}
+
+{{ taDateInput({
+    fieldset: {
+        legend: {
+            text: "Enter the bedspace end date (optional)",
+            classes: "govuk-fieldset__legend--m"
+        }
+    },
+    fieldName: "bedEndDate",
     hint: {
-      text: "This will be used to identify the bedspace when making bookings and reporting on the service"
+        html: '<p>This is the last date the bedspace can be used by the service. It\'ll then be archived. You cannot edit the date after adding it.</p><p class="govuk-hint">For example, 27 3 2025</p>'
     },
-    fieldName: "name"
-  },
-  fetchContext()
+    items: dateFieldValues('bedEndDate', errors)
+},
+    fetchContext()
 ) }}
 
 {{ govukCheckboxes({
-  fieldset: {
-    legend: {
-      text: "Does the bedspace have any of the following attributes?",
-      classes: "govuk-fieldset__legend--m"
-    }
-  },
-  hint: {
-    text: "Select all that apply"
-  },
-  items: convertObjectsToCheckboxItems(allCharacteristics, 'name', 'id', 'characteristicIds'),
-  id: "characteristicIds",
-  name: "characteristicIds[]",
-  errorMessage: errors.characteristicIds
+    fieldset: {
+        legend: {
+            text: "Does the bedspace have any of the following attributes?",
+            classes: "govuk-fieldset__legend--m"
+        }
+    },
+    hint: {
+        text: "Select all that apply"
+    },
+    items: convertObjectsToCheckboxItems(allCharacteristics, 'name', 'id', 'characteristicIds'),
+    id: "characteristicIds",
+    name: "characteristicIds[]",
+    errorMessage: errors.characteristicIds
 }) }}
 
 {{ govukTextarea({
-  label: {
-    text: "Please provide any further bedspace details",
-    classes: "govuk-label--m"
-  },
-  hint: {
-    text: "This information will be used to help find a suitable bedspace for the person on probation"
-  },
-  id: "notes",
-  name: "notes",
-  value: notes,
-  errorMessage: errors.notes
+    label: {
+        text: "Please provide any further bedspace details",
+        classes: "govuk-label--m"
+    },
+    hint: {
+        text: "This information will be used to help find a suitable bedspace for the person on probation"
+    },
+    id: "notes",
+    name: "notes",
+    value: notes,
+    errorMessage: errors.notes
 }) }}
 
 {{ govukButton({
-  text: "Submit",
-  preventDoubleClick: true
+    text: "Submit",
+    preventDoubleClick: true
 }) }}

--- a/server/views/temporary-accommodation/bedspaces/_editable.njk
+++ b/server/views/temporary-accommodation/bedspaces/_editable.njk
@@ -20,7 +20,7 @@
 
 {% if beds[0].bedEndDate %}
     <div class="govuk-form-group">
-        <dl>
+        <dl class="form-group-dl">
             <dt class="govuk-fieldset__legend govuk-fieldset__legend--m">
                 Bedspace end date
             </dt>

--- a/server/views/temporary-accommodation/bedspaces/_editable.njk
+++ b/server/views/temporary-accommodation/bedspaces/_editable.njk
@@ -18,21 +18,36 @@
     fetchContext()
 ) }}
 
-{{ taDateInput({
-    fieldset: {
-        legend: {
-            text: "Enter the bedspace end date (optional)",
-            classes: "govuk-fieldset__legend--m"
-        }
+{% if beds[0].bedEndDate %}
+    <div class="govuk-form-group">
+        <dl>
+            <dt class="govuk-fieldset__legend govuk-fieldset__legend--m">
+                Bedspace end date
+            </dt>
+            <dd>
+                {{ formatDate(beds[0].bedEndDate) }}
+            </dd>
+        </dl>
+
+        <p>The bedspace end date cannot be edited.</p>
+    </div>
+{% else %}
+    {{ taDateInput({
+        fieldset: {
+            legend: {
+                text: "Enter the bedspace end date (optional)",
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        fieldName: "bedEndDate",
+        hint: {
+            html: '<p>This is the last date the bedspace can be used by the service. It\'ll then be archived. You cannot edit the date after adding it.</p><p class="govuk-hint">For example, 27 3 2025</p>'
+        },
+        items: dateFieldValues('bedEndDate', errors)
     },
-    fieldName: "bedEndDate",
-    hint: {
-        html: '<p>This is the last date the bedspace can be used by the service. It\'ll then be archived. You cannot edit the date after adding it.</p><p class="govuk-hint">For example, 27 3 2025</p>'
-    },
-    items: dateFieldValues('bedEndDate', errors)
-},
-    fetchContext()
-) }}
+        fetchContext()
+    ) }}
+{% endif %}
 
 {{ govukCheckboxes({
     fieldset: {

--- a/server/views/temporary-accommodation/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/bedspaces/show.njk
@@ -15,87 +15,92 @@
 {% set bodyClasses = "temporary-accommodation-bedspaces-show" %}
 
 {% block beforeContent %}
-  {{ breadCrumb('View a bedspace', [
-    {title: 'List of properties', href: addPlaceContext(paths.premises.index())},
-    {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))}
-  ]) }}
-  {{ placeContextHeader(placeContext) }}
+    {{ breadCrumb('View a bedspace', [
+        {title: 'List of properties', href: addPlaceContext(paths.premises.index())},
+        {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))}
+    ]) }}
+    {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
-  {% include "../../_messages.njk" %}
+    {% include "../../_messages.njk" %}
 
-  {% if premises.status === 'archived' %}
-    {% if not successMessages.length %}
-      {% set archivedBannerHtml %}
-        <p class="govuk-notification-banner__heading">This bedspace is in an archived property.</p>
-        <p class="govuk-body">You cannot make a new booking.</p>
-      {% endset %}
+    {% if premises.status === 'archived' %}
+        {% if not successMessages.length %}
+            {% set archivedBannerHtml %}
+                <p class="govuk-notification-banner__heading">This bedspace is in an archived property.</p>
+                <p class="govuk-body">You cannot make a new booking.</p>
+            {% endset %}
 
-      {{ govukNotificationBanner({
-        html: archivedBannerHtml
-      }) }}
+            {{ govukNotificationBanner({
+                html: archivedBannerHtml
+            }) }}
+        {% endif %}
     {% endif %}
-  {% endif %}
 
-  {{ mojPageHeaderActions({
-    heading: {
-      text: 'View a bedspace',
-      classes: 'govuk-heading-l'
-    },
-    items: actions
-  }) }}
+    {{ mojPageHeaderActions({
+        heading: {
+            text: 'View a bedspace',
+            classes: 'govuk-heading-l'
+        },
+        items: actions
+    }) }}
 
-  <div class="govuk-grid-row">
-    <div class="govuk-grid-column-one-third">
-      {{ locationHeader({ premises: premises }) }}
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-one-third">
+            {{ locationHeader({ premises: premises }) }}
+        </div>
+        <div class="govuk-grid-column-one-third">
+            <div class="attributes-header details">
+                <h2>Property attributes</h2>
+                <ul>
+                    {% for characteristic in premisesCharacteristics %}
+                        <li>{{ characteristic }}</li>
+                    {% endfor %}
+                </ul>
+            </div>
+        </div>
     </div>
-    <div class="govuk-grid-column-one-third">
-      <div class="attributes-header details">
-        <h2>Property attributes</h2>
-        <ul>
-          {% for characteristic in premisesCharacteristics %}
-          <li>{{ characteristic }}</li>
-          {% endfor %}
-        </ul>
-      </div>
+
+
+    <div class="edit-bar">
+        <div class="edit-bar__container">
+            <div class="edit-bar__title">
+                <h2 class="govuk-label govuk-label--m">Bedspace name: {{ bedspace.room.name }}</h2>
+            </div>
+            <div class="edit-bar__action">
+                <a href="{{ paths.premises.bedspaces.edit({ premisesId: premises.id, roomId: bedspace.room.id }) }}">Edit</a>
+            </div>
+        </div>
     </div>
-  </div>
 
 
-  <div class="edit-bar">
-    <div class="edit-bar__container">
-      <div class="edit-bar__title">
-        <h2 class="govuk-label govuk-label--m">{{ bedspace.room.name }}</h2>
-      </div>
-      <div class="edit-bar__action">
-        <a href="{{ paths.premises.bedspaces.edit({ premisesId: premises.id, roomId: bedspace.room.id }) }}">Edit</a>
-      </div>
-    </div>
-  </div>
+    {{ govukSummaryList({
+        rows: bedspace.summaryList.rows,
+        classes: 'govuk-summary-list--no-border details'
+    }) }}
 
+    <h2>Bookings</h2>
 
-  {{ govukSummaryList({
-    rows: bedspace.summaryList.rows,
-    classes: 'govuk-summary-list--no-border details'
-  }) }}
-
-  <h2>Bookings</h2>
-
-  {% for listingEntry in listingEntries %}
-    {% if listingEntry.type === 'booking'%}
-      {{ bookingListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
-    {% elif listingEntry.type === 'lost-bed' %}
-      {{ lostBedListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
-    {% endif %}
-  {% endfor %}
+    {% for listingEntry in listingEntries %}
+        {% if listingEntry.type === 'booking' %}
+            {{ bookingListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
+            {% elif listingEntry.type === 'lost-bed' %}
+            {{ lostBedListing(listingEntry.body, addPlaceContext(listingEntry.path)) }}
+        {% endif %}
+    {% endfor %}
 
 {% endblock %}
 
 {% block extraScripts %}
-  {% if actions %}
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-      new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
-    </script>
-  {% endif %}
+    {% if actions %}
+        <script type="text/javascript" nonce="{{ cspNonce }}">
+          new MOJFrontend.ButtonMenu({
+            container: $('.moj-button-menu'),
+            mq: '(min-width: 200em)',
+            buttonText: 'Actions',
+            menuClasses: 'moj-button-menu__wrapper--right',
+          })
+        </script>
+    {% endif %}
 {% endblock %}

--- a/server/views/temporary-accommodation/bookings/_editable.njk
+++ b/server/views/temporary-accommodation/bookings/_editable.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
 {% from "../components/ta-input/macro.njk" import taInput %}
 {% from "../components/ta-date-input/macro.njk" import taDateInput %}
 {% from "../components/place-context-value/macro.njk" import placeContextValue %}
@@ -7,58 +8,63 @@
 
 {{ taInput(
     {
-      label: {
+        label: {
         text: "What is the person's CRN",
         classes: "govuk-label--m"
-      },
-      hint: {
+    },
+        hint: {
         text: "Enter the CRN for the person you are booking the bedspace for"
-      },
-      classes: "govuk-input--width-10",
-      fieldName: "crn"
+    },
+        classes: "govuk-input--width-10",
+        fieldName: "crn"
     },
     fetchContext()
-  )
-}}
+) }}
+
+<h2>Bedspace status summary</h2>
+
+{{ govukSummaryList({
+    rows: bedspaceStatus.rows,
+    classes: 'govuk-summary-list--no-border details'
+}) }}
 
 {{ taDateInput(
     {
-      fieldset: {
+        fieldset: {
         legend: {
-          text: "What is the start date?",
-          classes: "govuk-fieldset__legend--m"
+            text: "What is the start date?",
+            classes: "govuk-fieldset__legend--m"
         }
-      },
-      fieldName: "arrivalDate",
-      items: dateFieldValues('arrivalDate', errors)
+    },
+        fieldName: "arrivalDate",
+        items: dateFieldValues('arrivalDate', errors)
     },
     fetchContext()
-  )
-}}
+) }}
 
 {{ taDateInput(
     {
-      fieldset: {
+        fieldset: {
         legend: {
-          text: "What is the end date?",
-          classes: "govuk-fieldset__legend--m"
+            text: "What is the end date?",
+            classes: "govuk-fieldset__legend--m"
         }
-      },
-      hint: {
+    },
+        hint: {
         html: "<span id='departureDate-hint'></span>"
-      },
-      fieldName: "departureDate",
-      items: dateFieldValues('departureDate', errors)
+    },
+        fieldName: "departureDate",
+        items: dateFieldValues('departureDate', errors)
     },
     fetchContext()
-  )
-}}
+) }}
 
 {% if not disableTurnarounds %}
-  <p>There will be a turnaround time of {{ premises.turnaroundWorkingDayCount }} working {{ 'day' if premises.turnaroundWorkingDayCount === 1 else 'days' }} after this booking</p>
+    <p>There will be a turnaround time of {{ premises.turnaroundWorkingDayCount }}
+        working {{ 'day' if premises.turnaroundWorkingDayCount === 1 else 'days' }} after this booking</p>
 {% endif %}
 
 {{ govukButton({
-  text: "Continue",
-  preventDoubleClick: true
+    text: "Continue",
+    preventDoubleClick: true
 }) }}

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -12,85 +12,90 @@
 {% set bodyClasses = "temporary-accommodation-premises-show" %}
 
 {% block beforeContent %}
-  {{ breadCrumb('View a property', [
-    {title: 'List of properties', href: addPlaceContext(paths.premises.index())}
-  ]) }}
-  {{ placeContextHeader(placeContext) }}
+    {{ breadCrumb('View a property', [
+        {title: 'List of properties', href: addPlaceContext(paths.premises.index())}
+    ]) }}
+    {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
-  {% include "../../_messages.njk" %}
+    {% include "../../_messages.njk" %}
 
-  {% if premises.status === 'archived' %}
-    {% if not successMessages.length %}
-      {% set archivedBannerHtml %}
-        <p class="govuk-notification-banner__heading">This is an archived property.</p>
-        <p class="govuk-body">You cannot create a new bedspace, or make a new booking.</p>
-      {% endset %}
+    {% if premises.status === 'archived' %}
+        {% if not successMessages.length %}
+            {% set archivedBannerHtml %}
+                <p class="govuk-notification-banner__heading">This is an archived property.</p>
+                <p class="govuk-body">You cannot create a new bedspace, or make a new booking.</p>
+            {% endset %}
 
-      {{ govukNotificationBanner({
-        html: archivedBannerHtml
-      }) }}
+            {{ govukNotificationBanner({
+                html: archivedBannerHtml
+            }) }}
+        {% endif %}
     {% endif %}
-  {% endif %}
 
-  <h1 class="govuk-heading-l">View a property</h1>
+    <h1 class="govuk-heading-l">View a property</h1>
 
-  {{ mojPageHeaderActions({
-    heading: {
-      text: premises.addressLine1 + ', ' + premises.postcode,
-      classes: 'govuk-heading-m',
-      level: 2
-    },
-    items: actions
-  }) }}
-
-  <div data-cy-premises="true">
-    <div class="edit-bar">
-      <div class="edit-bar__container">
-        <div class="edit-bar__title">
-          <h3>{{ premises.name }}</h3>
-        </div>
-        <div class="edit-bar__action">
-          <a href="{{ paths.premises.edit({ premisesId: premises.id }) }}">Edit</a>
-        </div>
-      </div>
-    </div>
-
-    {{ govukSummaryList({
-      rows: summaryList.rows,
-      classes: 'govuk-summary-list--no-border details'
+    {{ mojPageHeaderActions({
+        heading: {
+            text: premises.addressLine1 + ', ' + premises.postcode,
+            classes: 'govuk-heading-m',
+            level: 2
+        },
+        items: actions
     }) }}
-  </div>
 
-  <h3>Bedspace details</h3>
-
-  {% for bedspace in bedspaces %}
-    <div data-cy-bedspace="true">
-      <div class="edit-bar">
-        <div class="edit-bar__container">
-          <div class="edit-bar__title">
-            <h4>{{ bedspace.room.name }}</h4>
-          </div>
-          <div class="edit-bar__action">
-            <a href="{{ addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: bedspace.room.id })) }}">View</a>
-          </div>
+    <div data-cy-premises="true">
+        <div class="edit-bar">
+            <div class="edit-bar__container">
+                <div class="edit-bar__title">
+                    <h3>{{ premises.name }}</h3>
+                </div>
+                <div class="edit-bar__action">
+                    <a href="{{ paths.premises.edit({ premisesId: premises.id }) }}">Edit</a>
+                </div>
+            </div>
         </div>
-      </div>
 
-      {{ govukSummaryList({
-        rows: bedspace.summaryList.rows,
-        classes: 'govuk-summary-list--no-border details'
-      }) }}
+        {{ govukSummaryList({
+            rows: summaryList.rows,
+            classes: 'govuk-summary-list--no-border details'
+        }) }}
     </div>
-  {% endfor %}
+
+    <h3>Bedspace details</h3>
+
+    {% for bedspace in bedspaces %}
+        <div data-cy-bedspace="true">
+            <div class="edit-bar">
+                <div class="edit-bar__container">
+                    <div class="edit-bar__title">
+                        <h4>Bedspace name: {{ bedspace.room.name }}</h4>
+                    </div>
+                    <div class="edit-bar__action">
+                        <a href="{{ addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: bedspace.room.id })) }}">View</a>
+                    </div>
+                </div>
+            </div>
+
+            {{ govukSummaryList({
+                rows: bedspace.summaryList.rows,
+                classes: 'govuk-summary-list--no-border details'
+            }) }}
+        </div>
+    {% endfor %}
 
 {% endblock %}
 
 {% block extraScripts %}
-  {% if actions %}
-    <script type="text/javascript" nonce="{{ cspNonce }}">
-      new MOJFrontend.ButtonMenu({container: $('.moj-button-menu'), mq: "(min-width: 200em)", buttonText: "Actions", menuClasses: "moj-button-menu__wrapper--right"});
-    </script>
-  {% endif %}
+    {% if actions %}
+        <script type="text/javascript" nonce="{{ cspNonce }}">
+          new MOJFrontend.ButtonMenu({
+            container: $('.moj-button-menu'),
+            mq: '(min-width: 200em)',
+            buttonText: 'Actions',
+            menuClasses: 'moj-button-menu__wrapper--right',
+          })
+        </script>
+    {% endif %}
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-60

Availability reporting for bedspaces suffers from the overuse of 'voids' to makr bedspace when they are no longer available. Those 'voids' are typically used when the bedspace is not available for a finite period of time; during this time the room is still classed as 'available' in reporting. 

To enable users to archive bedspace when they are no longer available at all, and therefore provide more accurate reporting of availability, they need to be able to set an 'end date' for the bedspace. In practice, this means:

- Once a bedspace has reached its end date, it is automatically archived and cannot be booked
- A bedspace can be created with or without an end date
- An end date can be added when editing a bedspace. Once added, the bedspace end date can no longer be edited
- A bedspace end date cannot:
  - conflict with an existing booking
  - be set to before the creation date of the bedspace

The bedpsace status is then derived from the set end date and shown in various places around the service. The status shows as 'Online' if the bedspace end date is not set or set in the future, and shows as 'Archived' if it is set today or in the past.

# Changes in this PR

## Screenshots of UI changes



### Before

### After
<img width="980" alt="Screenshot 2024-03-27 at 18 50 39" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/788cba06-7a9e-4ffb-9711-c491baf240f9">

<img width="980" alt="Screenshot 2024-03-27 at 18 50 01" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/cbec0c9b-40be-43bf-a9c3-0ebb18aee237">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work? Yes, change of response for conflicts with existing booking or creation date.
- [ ] Have they been released to production already? No

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
