### PR TITLE
CAS-60 show days from now

### DIFF
--- a/cypress_shared/components/bedspaceStatus.ts
+++ b/cypress_shared/components/bedspaceStatus.ts
@@ -12,9 +12,17 @@ export default class bedspaceStatusComponent extends Component {
 
   shouldShowStatusDetails(status: 'Online' | 'Archived'): void {
     this.shouldShowKeyAndValue('Bedspace status', status)
-    this.shouldShowKeyAndValue(
-      'Bedspace end date',
-      this.bedEndDate ? DateFormats.isoDateToUIDate(this.bedEndDate) : 'No end date added',
-    )
+
+    let endDateText = 'No end date added'
+
+    if (this.bedEndDate) {
+      endDateText = DateFormats.isoDateToUIDate(this.bedEndDate)
+
+      if (status === 'Online') {
+        endDateText += ` (${DateFormats.isoDateToDaysFromNow(this.bedEndDate)})`
+      }
+    }
+
+    this.shouldShowKeyAndValue('Bedspace end date', endDateText)
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceEdit.ts
@@ -59,7 +59,9 @@ export default class BedspaceEditPage extends BedspaceEditablePage {
 
   showCannotEditBedspaceEndDate(bedEndDate: string) {
     cy.get('dt').contains('Bedspace end date')
-    cy.get('dd').contains(DateFormats.isoDateToUIDate(bedEndDate))
+    cy.get('dd').contains(
+      `${DateFormats.isoDateToUIDate(bedEndDate)} (${DateFormats.isoDateToDaysFromNow(bedEndDate)})`,
+    )
     cy.get('p').contains('The bedspace end date cannot be edited.')
     cy.get('label').contains('Enter the bedspace end date (optional)').should('not.exist')
   }

--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -105,7 +105,11 @@ describe('BedspaceService', () => {
               },
               {
                 key: { text: 'Bedspace end date' },
-                value: { text: DateFormats.isoDateToUIDate(room1.beds[0].bedEndDate) },
+                value: {
+                  text: `${DateFormats.isoDateToUIDate(room1.beds[0].bedEndDate)} (${DateFormats.isoDateToDaysFromNow(
+                    room1.beds[0].bedEndDate,
+                  )})`,
+                },
               },
               {
                 key: { text: 'Attributes' },
@@ -172,7 +176,9 @@ describe('BedspaceService', () => {
             },
             {
               key: { text: 'Bedspace end date' },
-              value: { text: DateFormats.isoDateToUIDate(bedEndDate) },
+              value: {
+                text: DateFormats.isoDateToUIDate(bedEndDate),
+              },
             },
             {
               key: { text: 'Attributes' },

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -90,6 +90,16 @@ export default class BedspaceService {
   }
 
   summaryListForBedspaceStatus(room: Room): SummaryList {
+    let endDate = 'No end date added'
+
+    if (room.beds[0].bedEndDate) {
+      endDate = DateFormats.isoDateToUIDate(room.beds[0].bedEndDate)
+
+      if (bedspaceStatus(room) === 'online') {
+        endDate += ` (${DateFormats.isoDateToDaysFromNow(room.beds[0].bedEndDate)})`
+      }
+    }
+
     return {
       rows: [
         {
@@ -102,9 +112,7 @@ export default class BedspaceService {
         },
         {
           key: this.textValue('Bedspace end date'),
-          value: this.textValue(
-            room.beds[0].bedEndDate ? DateFormats.isoDateToUIDate(room.beds[0].bedEndDate) : 'No end date added',
-          ),
+          value: this.textValue(endDate),
         },
       ],
     }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -184,6 +184,33 @@ describe('DateFormats', () => {
       expect(result.date.toString()).toEqual('twothousandtwentytwo-20-oo')
     })
   })
+
+  describe('isoDateToDaysFromNow', () => {
+    beforeEach(() => {
+      jest.useFakeTimers()
+      jest.setSystemTime(new Date('2024-04-08T00:01:00.000'))
+    })
+
+    it('returns days ago if the date is in the past', () => {
+      expect(DateFormats.isoDateToDaysFromNow('2024-03-12')).toEqual('27 days ago')
+    })
+
+    it('returns one day ago if the date is yesterday', () => {
+      expect(DateFormats.isoDateToDaysFromNow('2024-04-07')).toEqual('1 day ago')
+    })
+
+    it('returns today if the date is today', () => {
+      expect(DateFormats.isoDateToDaysFromNow('2024-04-08')).toEqual('today')
+    })
+
+    it('returns the number of days if the date is in the future', () => {
+      expect(DateFormats.isoDateToDaysFromNow('2024-04-16')).toEqual('in 8 days')
+    })
+
+    it('returns one day if the date is tomorrow', () => {
+      expect(DateFormats.isoDateToDaysFromNow('2024-04-09')).toEqual('in 1 day')
+    })
+  })
 })
 
 describe('isoToDateAndTimeInputs', () => {
@@ -276,7 +303,9 @@ describe('dateIsBlank', () => {
 })
 
 describe('getYearsSince', () => {
-  jest.useFakeTimers().setSystemTime(new Date('2027-01-01'))
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2027-01-01'))
+  })
 
   it('returns correct years array', () => {
     const years = [{ year: '2023' }, { year: '2024' }, { year: '2025' }, { year: '2026' }, { year: '2027' }]

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { isFuture, isPast } from 'date-fns'
+import { differenceInDays, isFuture, isPast } from 'date-fns'
 
 import format from 'date-fns/format'
 import formatISO from 'date-fns/formatISO'
@@ -118,6 +118,20 @@ export class DateFormats {
       [`${key}-month`]: `${date.getMonth() + 1}`,
       [`${key}-year`]: `${date.getFullYear()}`,
     } as ObjectWithDateParts<K>
+  }
+
+  static isoDateToDaysFromNow(dateString: string) {
+    const difference = differenceInDays(new Date(dateString).setHours(0, 0, 0, 0), new Date().setHours(0, 0, 0, 0))
+    const numDays = Math.abs(difference)
+    const text = `${numDays} ${numDays === 1 ? 'day' : 'days'}`
+
+    if (difference < 0) {
+      return `${text} ago`
+    } else if (difference > 0) {
+      return `in ${text}`
+    } else {
+      return 'today'
+    }
   }
 }
 

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -103,6 +103,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('dateFieldValues', dateFieldValues)
   njkEnv.addGlobal('formatDate', DateFormats.isoDateToUIDate)
   njkEnv.addGlobal('formatDateTime', DateFormats.isoDateTimeToUIDateTime)
+  njkEnv.addGlobal('formatDaysFromNow', DateFormats.isoDateToDaysFromNow)
   njkEnv.addGlobal('parseNaturalNumber', parseNaturalNumber)
   njkEnv.addGlobal('dateInputHint', dateInputHint)
   njkEnv.addGlobal('personName', personName)

--- a/server/views/temporary-accommodation/bedspaces/_editable.njk
+++ b/server/views/temporary-accommodation/bedspaces/_editable.njk
@@ -25,7 +25,7 @@
                 Bedspace end date
             </dt>
             <dd>
-                {{ formatDate(beds[0].bedEndDate) }}
+                {{ formatDate(beds[0].bedEndDate) }} ({{ formatDaysFromNow(beds[0].bedEndDate) }})
             </dd>
         </dl>
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-60

# Changes in this PR

This adds extra descriptive text next to the bedspace end date, showing ` (X days from now)`. 

The new `DateFormats.isoDateToDaysFromNow` method is able to render days in the past, too, as filtering fora future dates only would have been quite prescriptive and opaque. The logic to show only future date is therefore kept separate.

## Screenshots of UI changes

<img width="982" alt="Screenshot 2024-04-08 at 11 34 48" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/d1ff4e3b-3070-48a4-94f2-761a9578b5c7">
