### PR TITLE
CAS-233 Implement All regions report download

### DIFF
--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -98,10 +98,10 @@ context('Report', () => {
         expect(requests).to.have.length(1)
       })
 
-      // And the report should be downloded
+      // And the report should be downloaded
       const filePath = path.join(
         Cypress.config('downloadsFolder'),
-        reportForProbationRegionFilename(probationRegion, month, year, type),
+        reportForProbationRegionFilename(probationRegion.name, month, year, type),
       )
 
       cy.readFile(filePath).then(file => {
@@ -145,10 +145,10 @@ context('Report', () => {
         expect(requests).to.have.length(1)
       })
 
-      // And the report should be downloded
+      // And the report should be downloaded
       const filePath = path.join(
         Cypress.config('downloadsFolder'),
-        reportForProbationRegionFilename(probationRegion, month, year, type),
+        reportForProbationRegionFilename(probationRegion.name, month, year, type),
       )
 
       cy.readFile(filePath).then(file => {
@@ -192,10 +192,10 @@ context('Report', () => {
         expect(requests).to.have.length(1)
       })
 
-      // And the report should be downloded
+      // And the report should be downloaded
       const filePath = path.join(
         Cypress.config('downloadsFolder'),
-        reportForProbationRegionFilename(probationRegion, month, year, type),
+        reportForProbationRegionFilename(probationRegion.name, month, year, type),
       )
 
       cy.readFile(filePath).then(file => {
@@ -239,10 +239,10 @@ context('Report', () => {
         expect(requests).to.have.length(1)
       })
 
-      // And the report should be downloded
+      // And the report should be downloaded
       const filePath = path.join(
         Cypress.config('downloadsFolder'),
-        reportForProbationRegionFilename(probationRegion, month, year, type),
+        reportForProbationRegionFilename(probationRegion.name, month, year, type),
       )
 
       cy.readFile(filePath).then(file => {

--- a/server/controllers/temporary-accommodation/manage/reportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.test.ts
@@ -21,7 +21,6 @@ jest.mock('../../../utils/userUtils', () => {
   }
 })
 jest.mock('../../../utils/dateUtils')
-jest.mock('../../../utils/reportUtils')
 
 describe('ReportsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
@@ -88,18 +87,21 @@ describe('ReportsController', () => {
     })
 
     describe('when the user is a reporter', () => {
-      it('renders the form with all regions', async () => {
-        const allRegions = [
+      it('renders the form with all reportable regions', async () => {
+        const regionsReferenceData = [
           probationRegionFactory.build({
             name: 'region-1',
           }),
           probationRegionFactory.build({
             name: 'region-2',
           }),
+          probationRegionFactory.build({
+            name: 'National',
+          }),
         ]
 
         reportService.getReferenceData.mockResolvedValue({
-          probationRegions: allRegions,
+          probationRegions: regionsReferenceData,
         })
 
         const requestHandler = reportsController.new()
@@ -116,7 +118,14 @@ describe('ReportsController', () => {
         expect(filterProbationRegions).not.toHaveBeenCalled()
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/reports/new', {
-          allProbationRegions: allRegions,
+          allProbationRegions: [
+            {
+              id: 'all',
+              name: 'All regions',
+            },
+            regionsReferenceData[0],
+            regionsReferenceData[1],
+          ],
           errors: {},
           errorSummary: [],
           probationRegionId: request.session.probationRegion.id,

--- a/server/controllers/temporary-accommodation/manage/reportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.ts
@@ -6,6 +6,7 @@ import ReportService from '../../../services/reportService'
 import extractCallConfig from '../../../utils/restUtils'
 import { filterProbationRegions, userHasReporterRole } from '../../../utils/userUtils'
 import { getYearsSince, monthsArr } from '../../../utils/dateUtils'
+import { allReportProbationRegions } from '../../../utils/reportUtils'
 
 export default class ReportsController {
   constructor(private readonly reportService: ReportService) {}
@@ -20,7 +21,7 @@ export default class ReportsController {
 
       return res.render('temporary-accommodation/reports/new', {
         allProbationRegions: userHasReporterRole(res.locals.user)
-          ? allProbationRegions
+          ? allReportProbationRegions(allProbationRegions)
           : filterProbationRegions(allProbationRegions, req),
         errors,
         errorSummary: requestErrorSummary,

--- a/server/services/reportService.test.ts
+++ b/server/services/reportService.test.ts
@@ -1,5 +1,6 @@
 import { createMock } from '@golevelup/ts-jest'
 import { Response } from 'express'
+import { ReportType } from '@approved-premises/ui'
 import { ReportClient } from '../data'
 import ReferenceDataClient from '../data/referenceDataClient'
 import { CallConfig } from '../data/restClient'
@@ -58,11 +59,34 @@ describe('ReportService', () => {
       await service.pipeReportForProbationRegion(callConfig, response, probationRegions[0].id, month, year, type)
 
       expect(ReportClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(reportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0], month, year, type)
+      expect(reportForProbationRegionFilename).toHaveBeenCalledWith(probationRegions[0].name, month, year, type)
       expect(reportClient.reportForProbationRegion).toHaveBeenCalledWith(
         response,
         'some-filename',
         probationRegions[0].id,
+        month,
+        year,
+        type,
+      )
+    })
+
+    it('produces a report for all regions', async () => {
+      const response = createMock<Response>()
+      ;(
+        reportForProbationRegionFilename as jest.MockedFunction<typeof reportForProbationRegionFilename>
+      ).mockReturnValue('some-filename')
+
+      const month = '1'
+      const year = '2023'
+      const type: ReportType = 'occupancy'
+
+      await service.pipeReportForProbationRegion(callConfig, response, 'all', month, year, type)
+
+      expect(reportForProbationRegionFilename).toHaveBeenCalledWith('All regions', month, year, type)
+      expect(reportClient.reportForProbationRegion).toHaveBeenCalledWith(
+        response,
+        'some-filename',
+        '',
         month,
         year,
         type,

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -34,13 +34,17 @@ export default class ReportService {
   ): Promise<void> {
     const reportClient = this.reportClientFactory(callConfig)
 
-    const probationRegion = (await this.getReferenceData(callConfig)).probationRegions.find(
-      region => region.id === probationRegionId,
-    )
+    const probationRegionName =
+      probationRegionId === 'all'
+        ? 'All regions'
+        : (await this.getReferenceData(callConfig)).probationRegions.find(region => region.id === probationRegionId)
+            .name
 
-    const filename = reportForProbationRegionFilename(probationRegion, month, year, type)
+    const filename = reportForProbationRegionFilename(probationRegionName, month, year, type)
 
-    await reportClient.reportForProbationRegion(response, filename, probationRegionId, month, year, type)
+    const queryRegionId = probationRegionId === 'all' ? '' : probationRegionId
+
+    await reportClient.reportForProbationRegion(response, filename, queryRegionId, month, year, type)
   }
 
   async getReferenceData(callConfig: CallConfig): Promise<ReportReferenceData> {

--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -1,5 +1,5 @@
 import { probationRegionFactory } from '../testutils/factories'
-import { reportFilename, reportForProbationRegionFilename } from './reportUtils'
+import { allReportProbationRegions, reportFilename, reportForProbationRegionFilename } from './reportUtils'
 
 jest.mock('./validation')
 
@@ -23,7 +23,7 @@ describe('reportUtils', () => {
       const year = '2023'
       const type = 'bedspace-usage'
 
-      const result = reportForProbationRegionFilename(probationRegion, month, year, type)
+      const result = reportForProbationRegionFilename(probationRegion.name, month, year, type)
 
       expect(result).toEqual('bedspace-usage-kent-surrey-sussex-march-2023.xlsx')
     })
@@ -36,7 +36,7 @@ describe('reportUtils', () => {
       const year = '2024'
       const type = 'occupancy'
 
-      const result = reportForProbationRegionFilename(probationRegion, month, year, type)
+      const result = reportForProbationRegionFilename(probationRegion.name, month, year, type)
 
       expect(result).toEqual('occupancy-kent-surrey-sussex-june-2024.xlsx')
     })
@@ -49,9 +49,34 @@ describe('reportUtils', () => {
       const year = '2023'
       const type = 'bookings'
 
-      const result = reportForProbationRegionFilename(probationRegion, month, year, type)
+      const result = reportForProbationRegionFilename(probationRegion.name, month, year, type)
 
       expect(result).toEqual('bookings-kent-surrey-sussex-january-2023.xlsx')
+    })
+  })
+
+  describe('allReportProbationRegions', () => {
+    it("returns regions for report download with 'All regions' option and 'National' filtered out", () => {
+      const regionsReferenceData = [
+        probationRegionFactory.build({
+          name: 'region-1',
+        }),
+        probationRegionFactory.build({
+          name: 'region-2',
+        }),
+        probationRegionFactory.build({
+          name: 'National',
+        }),
+      ]
+
+      expect(allReportProbationRegions(regionsReferenceData)).toEqual([
+        {
+          id: 'all',
+          name: 'All regions',
+        },
+        regionsReferenceData[0],
+        regionsReferenceData[1],
+      ])
     })
   })
 })

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -14,13 +14,11 @@ export const reportFilename = () => {
 }
 
 export const reportForProbationRegionFilename = (
-  probationRegion: ProbationRegion,
+  regionName: ProbationRegion['name'],
   month: string,
   year: string,
   type: ReportType,
 ) => {
-  const regionName = probationRegion.name
-
   const monthName = monthsArr.find(monthObj => monthObj.value === month).name
 
   const concatenatedName = `${type === 'bedspace-usage' ? 'bedspace usage' : type} ${regionName} ${monthName} ${year}`
@@ -50,3 +48,11 @@ export const getApiReportPath = (reportType: ReportType): string => {
 
   return paths.reports.bedspaceUtilisation({})
 }
+
+export const allReportProbationRegions = (regions: Array<ProbationRegion>): Array<ProbationRegion> => [
+  {
+    id: 'all',
+    name: 'All regions',
+  },
+  ...regions.filter(region => region.name !== 'National'),
+]


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-233

# Changes in this PR

Adds the 'All regions' option to the probation region select on the Report download screen, and hides the 'National' option.

## Screenshots of UI changes

### After

<img width="544" alt="Screenshot 2024-04-10 at 11 32 00" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/ca5382dd-1958-4367-ab1a-540bc7db6198">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
