### PR TITLE
CAS-306 Return booking error for bedspace end date conflict

### DIFF
--- a/cypress_shared/components/bedspaceConflictError.ts
+++ b/cypress_shared/components/bedspaceConflictError.ts
@@ -16,8 +16,8 @@ export default class BedspaceConflictErrorComponent extends Component {
 
   shouldShowDateConflictErrorMessages(
     fields: Array<string>,
-    conflictingEntity: Booking | LostBed,
-    conflictingEntityType: 'booking' | 'lost-bed',
+    conflictingEntity: Booking | LostBed | null,
+    conflictingEntityType: 'booking' | 'lost-bed' | 'bedspace-end-date',
   ): void {
     fields.forEach(field => {
       cy.get(`[data-cy-error-${field}]`).should('contain', errorLookups.generic[field].conflict)
@@ -29,15 +29,16 @@ export default class BedspaceConflictErrorComponent extends Component {
     cy.get('.govuk-error-summary h2').should('contain', title)
     cy.get('.govuk-error-summary ul').should('contain', message)
 
-    cy.get('.govuk-error-summary a').click()
+    if (conflictingEntity) {
+      cy.get('.govuk-error-summary a').click()
 
-    if (conflictingEntityType === 'booking') {
-      Page.verifyOnPage(BookingShowPage, this.premises, this.room, conflictingEntity as Booking)
-    } else {
-      Page.verifyOnPage(LostBedShowPage, this.premises, this.room, conflictingEntity as LostBed)
+      if (conflictingEntityType === 'booking') {
+        Page.verifyOnPage(BookingShowPage, this.premises, this.room, conflictingEntity as Booking)
+      } else {
+        Page.verifyOnPage(LostBedShowPage, this.premises, this.room, conflictingEntity as LostBed)
+      }
+      cy.go('back')
     }
-
-    cy.go('back')
   }
 
   private getTitle(fields: Array<string>): string {
@@ -49,7 +50,14 @@ export default class BedspaceConflictErrorComponent extends Component {
     return 'The turnaround time could not be changed'
   }
 
-  private getMessage(fields: Array<string>, conflictingEntityType: 'booking' | 'lost-bed'): string {
+  private getMessage(
+    fields: Array<string>,
+    conflictingEntityType: 'booking' | 'lost-bed' | 'bedspace-end-date',
+  ): string {
+    if (conflictingEntityType === 'bedspace-end-date') {
+      return 'This booking conflicts with the bedspace end date.'
+    }
+
     const noun = conflictingEntityType === 'booking' ? 'booking' : 'void'
 
     if (this.source === 'booking' || this.source === 'lost-bed') {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingEditable.ts
@@ -13,8 +13,8 @@ export default abstract class BookingEditablePage extends Page {
   }
 
   shouldShowDateConflictErrorMessages(
-    conflictingEntity: Booking | LostBed,
-    conflictingEntityType: 'booking' | 'lost-bed',
+    conflictingEntity: Booking | LostBed | null,
+    conflictingEntityType: 'booking' | 'lost-bed' | 'bedspace-end-date',
   ): void {
     this.bedspaceConflictErrorComponent.shouldShowDateConflictErrorMessages(
       ['arrivalDate', 'departureDate'],

--- a/integration_tests/mockApis/booking.ts
+++ b/integration_tests/mockApis/booking.ts
@@ -40,7 +40,7 @@ export default {
   stubBookingCreateConflictError: (args: {
     premisesId: string
     conflictingEntityId: string
-    conflictingEntityType: 'booking' | 'lost-bed'
+    conflictingEntityType: 'booking' | 'lost-bed' | 'bedspace-end-date'
   }) =>
     stubFor({
       request: {

--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -461,6 +461,23 @@ describe('bookingUtils', () => {
       })
     })
 
+    it('generates a bespoke error when there is a conflict with the bedspace end date', () => {
+      const err = {
+        data: {
+          detail: `BedSpace is archived from 2024-06-06 which overlaps with the desired dates`,
+        },
+      }
+
+      expect(generateConflictBespokeError(err as SanitisedError, premisesId, roomId, 'plural')).toEqual({
+        errorTitle: 'This bedspace is not available for the dates entered',
+        errorSummary: [
+          {
+            text: 'This booking conflicts with the bedspace end date.',
+          },
+        ],
+      })
+    })
+
     it('generates a bespoke error for a single date', () => {
       const err = {
         data: {

--- a/wiremock/utils.ts
+++ b/wiremock/utils.ts
@@ -51,10 +51,23 @@ const errorStub = (fields: Array<string>, pattern: string, method: string) => {
   }
 }
 
-const bedspaceConflictResponseBody = (entityId: string | LostBed, entityType: 'booking' | 'lost-bed') => ({
-  title: 'Conflict',
-  status: 409,
-  detail: `${entityType === 'booking' ? 'Booking' : 'Lost Bed'}: ${entityId}`,
-})
+const bedspaceConflictResponseBody = (
+  entityId: string | LostBed,
+  entityType: 'booking' | 'lost-bed' | 'bedspace-end-date',
+) => {
+  let detail: string
+
+  if (entityType === 'bedspace-end-date') {
+    detail = 'BedSpace is archived from 2024-06-06 which overlaps with the desired dates'
+  } else {
+    detail = `${entityType === 'booking' ? 'Booking' : 'Lost Bed'}: ${entityId}`
+  }
+
+  return {
+    title: 'Conflict',
+    status: 409,
+    detail,
+  }
+}
 
 export { getCombinations, errorStub, bedspaceConflictResponseBody }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-306

# Changes in this PR

Render a specific error when the user attempts to create a booking that clashes with the selected bedspace's end date.

## Screenshots of UI changes

### After

<img width="980" alt="Screenshot 2024-04-16 at 17 51 56" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/63362447-2c96-43ab-8dfd-ce127843d999">

<img width="980" alt="Screenshot 2024-04-16 at 17 52 14" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/83c96abb-f0d4-4af4-bc06-6ad13a57d5ed">


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [x] Are any changes required to dependent services for this change to work? No
- [x] Have they been released to production already? n/a

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
