### PR TITLE
CAS-212 Add sorting for PDU and status columns for properties

### DIFF
--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -395,7 +395,7 @@ export default abstract class Page extends Component {
   }
 
   sortColumn(label: string) {
-    cy.get('main table thead a').contains(label).click()
+    cy.get('main table thead').contains(label).click()
   }
 
   checkColumnOrder(label: string, order: 'ascending' | 'descending' | 'none') {

--- a/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/premises.cy.ts
@@ -37,7 +37,7 @@ context('Premises', () => {
     Page.verifyOnPage(PremisesListPage)
   })
 
-  it('should list all premises', () => {
+  it('should list all premises and sort by PDU or status', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -50,6 +50,21 @@ context('Premises', () => {
 
     // Then I should see all of the premises listed
     page.shouldShowPremises(premisesSummaries)
+
+    // And they should be sorted by PDU ascending
+    page.checkColumnOrder('PDU', 'ascending')
+
+    // When I sort by PDU
+    page.sortColumn('PDU')
+
+    // Then they should be sorted by PDU descending
+    page.checkColumnOrder('PDU', 'descending')
+
+    // When I sort by Status
+    page.sortColumn('Status')
+
+    // Then they should be sorted by Status ascending
+    page.checkColumnOrder('Status', 'ascending')
   })
 
   it('should navigate back from the premises list page to the dashboard', () => {

--- a/server/views/temporary-accommodation/premises/index.njk
+++ b/server/views/temporary-accommodation/premises/index.njk
@@ -10,44 +10,59 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-  {{ breadCrumb('List of properties', []) }}
-  {{ placeContextHeader(placeContext) }}
+    {{ breadCrumb('List of properties', []) }}
+    {{ placeContextHeader(placeContext) }}
 {% endblock %}
 
 {% block content %}
-  {% include "../../_messages.njk" %}
+    {% include "../../_messages.njk" %}
 
-  {{ mojPageHeaderActions({
-    heading: {
-      text: 'List of properties',
-      classes: 'govuk-heading-l'
-    },
-    items: [{
-        text: "Add a property",
-        href: paths.premises.new()
-      }]
-  }) }}
+    {{ mojPageHeaderActions({
+        heading: {
+            text: 'List of properties',
+            classes: 'govuk-heading-l'
+        },
+        items: [{
+            text: "Add a property",
+            href: paths.premises.new()
+        }]
+    }) }}
 
-  {{ govukTable({
-    captionClasses: "govuk-table__caption--m",
-    head: [
-      {
-        text: "Address"
-      },
-      {
-        text: "Bedspaces"
-      },
-      {
-        text: "PDU"
-      },
-      {
-        text: "Status"
-      },
-      {
-        html: '<span class="govuk-visually-hidden">Actions</span>'
-      }
-    ],
-    rows: tableRows
-  }) }} 
+    {{ govukTable({
+        attributes: {
+            'data-module': 'moj-sortable-table'
+        },
+        captionClasses: "govuk-table__caption--m",
+        head: [
+            {
+                text: "Address"
+            },
+            {
+                text: "Bedspaces"
+            },
+            {
+                text: "PDU",
+                attributes: { "aria-sort": "ascending" }
+            },
+            {
+                text: "Status",
+                attributes: { "aria-sort": "none" }
+            },
+            {
+                html: '<span class="govuk-visually-hidden">Actions</span>'
+            }
+        ],
+        rows: tableRows
+    }) }}
 
+{% endblock %}
+
+{% block extraScripts %}
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      $(document).ready(function() {
+        window
+          .MOJFrontend
+          .initAll()
+      })
+    </script>
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-212

# Changes in this PR

Applies the Sortable Table component to the list of premises, with the 'PDU' and 'Status' columns being sortable. The default sort is by PDU ascending.

## Screenshots of UI changes

<img width="980" alt="Screenshot 2024-04-17 at 11 41 16" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/57e62f33-e9ec-4e0d-8aba-57574488ae99">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [x] Are any changes required to dependent services for this change to work? No
- [x] Have they been released to production already? N/a

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
