### PR TITLE
Add bedspace reference to booking screens

### DIFF
--- a/cypress_shared/components/locationHeader.ts
+++ b/cypress_shared/components/locationHeader.ts
@@ -9,11 +9,15 @@ export default class LocationHeaderComponent extends Component {
     super()
   }
 
-  shouldShowLocationDetails(): void {
+  shouldShowLocationDetails(showBedspaceId: boolean = false): void {
     const { premises } = this.details
+    const { room } = this.details
 
     cy.get('.location-header').within(() => {
       if (premises && !this.hideAddress) {
+        if (showBedspaceId) {
+          cy.get('h2').contains('Property address').siblings('p').should('contain', room.name)
+        }
         cy.get('h2')
           .contains('Property address')
           .siblings('p')

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
@@ -27,7 +27,7 @@ export default class BookingCancellationNewPage extends BookingCancellationEdita
 
   shouldShowBookingDetails(): void {
     this.popDetailsHeaderComponent.shouldShowPopDetails()
-    this.locationHeaderComponent.shouldShowLocationDetails()
+    this.locationHeaderComponent.shouldShowLocationDetails(true)
     this.bookingInfoComponent.shouldShowBookingDetails()
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirm.ts
@@ -25,6 +25,6 @@ export default class BookingConfirmPage extends Page {
 
   shouldShowBookingDetails(): void {
     this.popDetailsHeaderComponent.shouldShowPopDetails()
-    this.locationHeaderComponent.shouldShowLocationDetails()
+    this.locationHeaderComponent.shouldShowLocationDetails(true)
   }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -50,7 +50,7 @@ export default class BookingNewPage extends BookingEditablePage {
   }
 
   shouldShowBookingDetails(): void {
-    this.locationHeaderComponent.shouldShowLocationDetails()
+    this.locationHeaderComponent.shouldShowLocationDetails(true)
     this.bedspaceStatusComponent.shouldShowStatusDetails('Online')
 
     cy.contains('p', this.turnaroundText())

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingTurnaroundNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingTurnaroundNew.ts
@@ -38,7 +38,7 @@ export default class BookingTurnaroundNewPage extends Page {
 
   shouldShowBookingDetails(): void {
     this.popDetailsHeaderComponent.shouldShowPopDetails()
-    this.locationHeaderComponent.shouldShowLocationDetails()
+    this.locationHeaderComponent.shouldShowLocationDetails(true)
     this.bookingInfoComponent.shouldShowBookingDetails()
 
     this.shouldShowTextInputByLabel(workingDaysLabel, `${this.booking.turnaround.workingDays}`)

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedNew.ts
@@ -18,7 +18,7 @@ export default class LostBedNewPage extends LostBedEditablePage {
   }
 
   shouldShowBedspaceDetails(): void {
-    this.locationHeaderComponent.shouldShowLocationDetails()
+    this.locationHeaderComponent.shouldShowLocationDetails(true)
   }
 
   completeForm(newLostBed: NewLostBed): void {

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -10,10 +10,10 @@
     {% if not hideAddress %}
       <h2>Property address</h2>
       <p>
-            {{ room.name }}<br />
-            {{ premises.addressLine1 }}<br/>
-            {% if premises.town.length %}{{ premises.town }}{% endif %}<br />
-            {{ premises.postcode }}
+            {% if room.name.length %}{{ room.name }}<br/>{% endif %}
+            {{ premises.addressLine1 }}
+            {% if premises.town.length %}<br/>{{ premises.town }}{% endif %}
+            <br />{{ premises.postcode }}
       </p>
     {% endif %}
   {% endif %}

--- a/server/views/temporary-accommodation/components/location-header/macro.njk
+++ b/server/views/temporary-accommodation/components/location-header/macro.njk
@@ -4,13 +4,17 @@
 
 <div class="location-header">
   {% set premises = locationDetails.premises %}
+      {% set room = locationDetails.room %}
 
   {% if premises %}
     {% if not hideAddress %}
       <h2>Property address</h2>
-      <p>{{ premises.addressLine1 }}
-            {% if premises.town.length %}<br/>{{ premises.town }}{% endif %}
-            <br />{{ premises.postcode }}</p>
+      <p>
+            {{ room.name }}<br />
+            {{ premises.addressLine1 }}<br/>
+            {% if premises.town.length %}{{ premises.town }}{% endif %}<br />
+            {{ premises.postcode }}
+      </p>
     {% endif %}
   {% endif %}
 </div>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-171

# Changes in this PR

Adds the bedspace reference with the property address on booking screens.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
