### PR TITLE
Update local e2e person fixture

### DIFF
--- a/cypress_shared/fixtures/person-local.json
+++ b/cypress_shared/fixtures/person-local.json
@@ -1,7 +1,7 @@
 {
   "name": "Aadland Bertrand",
   "crn": "X320741",
-  "dateOfBirth": "2065-07-19",
+  "dateOfBirth": "1987-08-02",
   "nomsNumber": "A1234AI",
   "status": "InCustody",
   "prisonName": "Leeds",
@@ -9,5 +9,5 @@
   "nationality": "",
   "ethnicity": "",
   "sex": "Male",
-  "genderIdentity": "Jedi"
+  "genderIdentity": "Prefer not to say"
 }


### PR DESCRIPTION
This is to match recent updates to seed data in hmpps-probation-integration-services, to ensure locally run E2E tests continue working.

https://github.com/ministryofjustice/hmpps-probation-integration-services/pull/3665

