### PR TITLE
Use `Cypress.env` instead of `process.env`

### DIFF
--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -30,7 +30,7 @@ export default abstract class Page extends Component {
 
   checkOnPage(): void {
     cy.get('h1').contains(this.title)
-    if (!process.env.SKIP_AXE) {
+    if (!Cypress.env('SKIP_AXE')) {
       cy.injectAxe()
       cy.configureAxe({
         rules: [


### PR DESCRIPTION
I was a bit previous with #961 - I forgot that Cypress ran in a browser context, not backend Node!
