### PR TITLE
Cas 249/referral rejection reason

### DIFF
--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -10,4 +10,8 @@ export default class AssessmentRejectionConfirmPage extends Page {
     this.completeTextArea('referralRejectionReasonDetail', 'Details about the rejection reason')
     this.checkRadioByNameAndLabel('isWithdrawn', 'Yes')
   }
+
+  clearRejectionReasonDetail() {
+    this.clearTextInputByLabel('Add details about why the referral is being rejected')
+  }
 }

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -6,7 +6,7 @@ export default class AssessmentRejectionConfirmPage extends Page {
   }
 
   completeForm() {
-    this.checkRadioByNameAndLabel('referralRejectionReason', 'Other (please add)')
+    this.checkRadioByNameAndLabel('referralRejectionReasonId', 'Other (please add)')
     this.completeTextArea('referralRejectionReasonDetail', 'Details about the rejection reason')
     this.checkRadioByNameAndLabel('isWithdrawn', 'Yes')
   }

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -4,4 +4,8 @@ export default class AssessmentRejectionConfirmPage extends Page {
   constructor(title: string) {
     super(title)
   }
+
+  completeForm() {
+    this.checkRadioByNameAndLabel('referralRejectionReason', 'There was not enough time to place them')
+  }
 }

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -8,5 +8,6 @@ export default class AssessmentRejectionConfirmPage extends Page {
   completeForm() {
     this.checkRadioByNameAndLabel('referralRejectionReason', 'Other (please add)')
     this.completeTextArea('referralRejectionReasonDetail', 'Details about the rejection reason')
+    this.checkRadioByNameAndLabel('isWithdrawn', 'Yes')
   }
 }

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -8,7 +8,7 @@ export default class AssessmentRejectionConfirmPage extends Page {
   }
 
   completeForm() {
-    this.checkRadioByNameAndLabel('referralRejectionReasonId', 'Other (please add)')
+    this.checkRadioByNameAndLabel('referralRejectionReasonId', 'Another reason (please add)')
     this.completeTextArea('referralRejectionReasonDetail', 'Details about the rejection reason')
     this.checkRadioByNameAndLabel('isWithdrawn', 'Yes')
   }

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -1,0 +1,7 @@
+import Page from '../page'
+
+export default class AssessmentRejectionConfirmPage extends Page {
+  constructor(title: string) {
+    super(title)
+  }
+}

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -1,8 +1,10 @@
 import Page from '../page'
+import { TemporaryAccommodationAssessment as Assessment } from '../../../server/@types/shared'
+import { personName } from '../../../server/utils/personUtils'
 
 export default class AssessmentRejectionConfirmPage extends Page {
-  constructor(title: string) {
-    super(title)
+  constructor(private readonly assessment: Assessment) {
+    super(`Reject ${personName(assessment.application.person)}'s referral`)
   }
 
   completeForm() {

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -10,7 +10,7 @@ export default class AssessmentRejectionConfirmPage extends Page {
   completeForm() {
     this.checkRadioByNameAndLabel('referralRejectionReasonId', 'Another reason (please add)')
     this.completeTextArea('referralRejectionReasonDetail', 'Details about the rejection reason')
-    this.checkRadioByNameAndLabel('isWithdrawn', 'Yes')
+    this.checkRadioByNameAndLabel('ppRequestedWithdrawal', 'Yes')
   }
 
   clearRejectionReasonDetail() {

--- a/cypress_shared/pages/assess/confirmRejection.ts
+++ b/cypress_shared/pages/assess/confirmRejection.ts
@@ -6,6 +6,7 @@ export default class AssessmentRejectionConfirmPage extends Page {
   }
 
   completeForm() {
-    this.checkRadioByNameAndLabel('referralRejectionReason', 'There was not enough time to place them')
+    this.checkRadioByNameAndLabel('referralRejectionReason', 'Other (please add)')
+    this.completeTextArea('referralRejectionReasonDetail', 'Details about the rejection reason')
   }
 }

--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -192,7 +192,7 @@ export default abstract class Page extends Component {
   }
 
   clearTextInputByLabel(label: string): void {
-    cy.get('label').contains(label).parent().find('input').clear()
+    cy.get('label').contains(label).parent().find('input, textarea').clear()
   }
 
   completeDateInputs(prefix: string, date: string): void {

--- a/e2e/tests/apply-and-place.feature
+++ b/e2e/tests/apply-and-place.feature
@@ -1,10 +1,12 @@
 Feature: Apply for and book a Temporary Accommodation bedspace
+
   Scenario: Creating an application
     Given I am logged in as a referrer
     When I start a new application
     And I fill in and complete an application
     And I see a confirmation of the application
     Then I can see the full submitted application
+
   Scenario: Booking a bedspace from an assessment
     Given I am logged in as an assessor
     When I view an existing active premises
@@ -15,3 +17,10 @@ Feature: Apply for and book a Temporary Accommodation bedspace
     And I view the assessment
     And I mark the assessment as ready to place
     Then I can place the assessment
+
+  Scenario: Rejecting an assessment
+    Given I am logged in as an assessor
+    When I view the list of ready to place assessments
+    And I view the ready to place assessment
+    When I reject the assessment with the reason other
+    Then I see the assessment has been rejected

--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -5,6 +5,7 @@ import api from '../../server/paths/api'
 import { getMatchingRequests, stubFor } from '../../wiremock'
 import { errorStub } from '../../wiremock/utils'
 import { MockPagination } from './bookingSearch'
+import { referralRejectionReasons } from '../../wiremock/referenceDataStubs'
 
 export default {
   stubAssessments: (args: { data: Array<AssessmentSummary>; pagination?: MockPagination }): SuperAgentRequest =>
@@ -75,6 +76,7 @@ export default {
         url: api.assessments.allocation({ id: assessmentId }),
       })
     ).body.requests,
+  stubReferralRejectionReasons: (): SuperAgentRequest => stubFor(referralRejectionReasons),
   stubRejectAssessment: (assessment: Assessment): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -348,6 +348,7 @@ context('Apply', () => {
           assessment.application.document = applicationTranslatedDocument
 
           cy.task('stubFindAssessment', assessment)
+          cy.task('stubReferralRejectionReasons')
 
           // Given I visit the assessment page
           const assessmentPage = AssessmentSummaryPage.visit(assessment)
@@ -359,6 +360,7 @@ context('Apply', () => {
           const rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
 
           // When I complete the form
+          rejectionConfirmationPage.completeForm()
           // rejectionConfirmationPage.clickSubmit()
           //
           // cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -342,7 +342,7 @@ context('Apply', () => {
         })
       })
 
-      it.only('allows rejecting an assessment', () => {
+      it('allows rejecting an assessment', () => {
         cy.fixture('applicationTranslatedDocument.json').then(applicationTranslatedDocument => {
           const assessment = assessmentFactory.build({ status: 'unallocated' })
           assessment.application.document = applicationTranslatedDocument
@@ -359,14 +359,16 @@ context('Apply', () => {
           // Then I am taken to the confirmation page
           const rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
 
+          cy.task('stubRejectAssessment', assessment)
+          cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
+
           // When I complete the form
           rejectionConfirmationPage.completeForm()
-          cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
           rejectionConfirmationPage.clickSubmit()
 
           // Then I am taken to the summary page and a banner is shown
-          // Page.verifyOnPage(AssessmentSummaryPage, { ...assessment, status: 'rejected' })
-          // assessmentPage.shouldShowBanner('This referral has been rejected')
+          Page.verifyOnPage(AssessmentSummaryPage, { ...assessment, status: 'rejected' })
+          assessmentPage.shouldShowBanner('This referral has been rejected')
         })
       })
 

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -357,7 +357,7 @@ context('Apply', () => {
           assessmentPage.clickAction('Reject')
 
           // Then I am taken to the confirmation page
-          const rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
+          const rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, assessment)
 
           cy.task('stubRejectAssessment', assessment)
           cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
@@ -387,7 +387,7 @@ context('Apply', () => {
           assessmentPage.clickAction('Reject')
 
           // Then I am taken to the confirmation page
-          let rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
+          let rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, assessment)
 
           cy.task('stubRejectAssessment', assessment)
           cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
@@ -396,7 +396,7 @@ context('Apply', () => {
           rejectionConfirmationPage.clickSubmit()
 
           // Then I see errors
-          rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
+          rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, assessment)
           rejectionConfirmationPage.shouldShowErrorMessagesForFields(['referralRejectionReasonId', 'isWithdrawn'])
 
           // When I complete the form but clear the details
@@ -405,7 +405,7 @@ context('Apply', () => {
           rejectionConfirmationPage.clickSubmit()
 
           // Then I see one error
-          rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
+          rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, assessment)
           rejectionConfirmationPage.shouldShowErrorMessagesForFields(['referralRejectionReasonDetail'])
         })
       })

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -397,7 +397,10 @@ context('Apply', () => {
 
           // Then I see errors
           rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, assessment)
-          rejectionConfirmationPage.shouldShowErrorMessagesForFields(['referralRejectionReasonId', 'isWithdrawn'])
+          rejectionConfirmationPage.shouldShowErrorMessagesForFields([
+            'referralRejectionReasonId',
+            'ppRequestedWithdrawal',
+          ])
 
           // When I complete the form but clear the details
           rejectionConfirmationPage.completeForm()

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -361,11 +361,10 @@ context('Apply', () => {
 
           // When I complete the form
           rejectionConfirmationPage.completeForm()
-          // rejectionConfirmationPage.clickSubmit()
-          //
-          // cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
-          //
-          // // Then I am taken to the summary page and a banner is shown
+          cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
+          rejectionConfirmationPage.clickSubmit()
+
+          // Then I am taken to the summary page and a banner is shown
           // Page.verifyOnPage(AssessmentSummaryPage, { ...assessment, status: 'rejected' })
           // assessmentPage.shouldShowBanner('This referral has been rejected')
         })

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -15,6 +15,7 @@ import {
   referralHistoryUserNoteFactory,
 } from '../../../../server/testutils/factories'
 import { MockPagination } from '../../../mockApis/bookingSearch'
+import AssessmentRejectionConfirmPage from '../../../../cypress_shared/pages/assess/confirmRejection'
 
 const pagination: MockPagination = {
   totalResults: 23,
@@ -338,6 +339,33 @@ context('Apply', () => {
           cy.task('verifyCloseAssessment', assessment.id).then(requests => {
             expect(requests).to.have.length(1)
           })
+        })
+      })
+
+      it.only('allows rejecting an assessment', () => {
+        cy.fixture('applicationTranslatedDocument.json').then(applicationTranslatedDocument => {
+          const assessment = assessmentFactory.build({ status: 'unallocated' })
+          assessment.application.document = applicationTranslatedDocument
+
+          cy.task('stubFindAssessment', assessment)
+
+          // Given I visit the assessment page
+          const assessmentPage = AssessmentSummaryPage.visit(assessment)
+
+          // When I click on the Update status to 'Reject' button
+          assessmentPage.clickAction('Reject')
+
+          // Then I am taken to the confirmation page
+          const rejectionConfirmationPage = Page.verifyOnPage(AssessmentRejectionConfirmPage, 'Reject referral')
+
+          // When I complete the form
+          // rejectionConfirmationPage.clickSubmit()
+          //
+          // cy.task('stubFindAssessment', { ...assessment, status: 'rejected' })
+          //
+          // // Then I am taken to the summary page and a banner is shown
+          // Page.verifyOnPage(AssessmentSummaryPage, { ...assessment, status: 'rejected' })
+          // assessmentPage.shouldShowBanner('This referral has been rejected')
         })
       })
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -22,6 +22,7 @@ import {
   PrisonCaseNote,
   SortDirection,
   TemporaryAccommodationApplication,
+  TemporaryAccommodationAssessmentStatus,
   User,
 } from '@approved-premises/api'
 import { CallConfig } from '../../data/restClient'
@@ -352,6 +353,8 @@ export type ApplicationSummaryData = {
 export type AssessmentSearchApiStatus =
   | Extract<AssessmentStatus, 'unallocated' | 'in_review' | 'ready_to_place'>
   | 'archived'
+
+export type AssessmentUpdateStatus = Exclude<TemporaryAccommodationAssessmentStatus, 'rejected'>
 
 export type AssessmentSearchParameters = {
   page?: number

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -367,3 +367,10 @@ export type AssessmentSearchParameters = {
 }
 
 export type BedspaceStatus = 'online' | 'archived'
+
+// TODO: Remove once it exists in generated types
+export type ReferralRejectionBody = {
+  referralRejectionReasonId: string
+  referralRejectionReasonDetail?: string
+  isWithdrawn: boolean
+}

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -120,6 +120,9 @@ export type RadioItem =
       text: string
       value: string
       checked?: boolean
+      conditional?: {
+        html: string
+      }
     }
   | {
       divider: string

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -310,6 +310,19 @@ describe('AssessmentsController', () => {
     })
   })
 
+  describe('confirmRejection', () => {
+    it('calls render with the assessment id', async () => {
+      const assessmentId = 'some-assessment-id'
+      const requestHandler = assessmentsController.confirmRejection()
+      request.params = { id: assessmentId }
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/confirm-rejection', {
+        id: assessmentId,
+      })
+    })
+  })
+
   describe('confirm', () => {
     it.each([
       'null' as const,
@@ -317,7 +330,6 @@ describe('AssessmentsController', () => {
       'in_review' as const,
       'ready_to_place' as const,
       'closed' as const,
-      'rejected' as const,
     ])('calls render with a confirmation message for the %s status', async status => {
       const assessmentId = 'some-assessment-id'
       const requestHandler = assessmentsController.confirm()

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -336,7 +336,7 @@ describe('AssessmentsController', () => {
     it('calls the rejectAssessment method on the service with rejection details', async () => {
       const assessmentId = 'assessment-id'
       const referralRejectionReasonId = 'rejection-reason-id'
-      const isWithdrawn = true
+      const isWithdrawn = 'yes'
 
       jest.spyOn(assessmentUtils, 'statusChangeMessage').mockReturnValue('some info message')
 
@@ -350,7 +350,7 @@ describe('AssessmentsController', () => {
         callConfig,
         assessmentId,
         referralRejectionReasonId,
-        isWithdrawn,
+        true,
       )
       expect(assessmentUtils.statusChangeMessage).toHaveBeenCalledWith(assessmentId, 'rejected')
       expect(response.redirect).toHaveBeenCalledWith(paths.assessments.summary({ id: assessmentId }))

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -346,7 +346,7 @@ describe('AssessmentsController', () => {
         referralRejectionReasonId: {
           text: 'Select a reason for rejecting this referral',
         },
-        isWithdrawn: {
+        ppRequestedWithdrawal: {
           text: 'Select yes if the probation practitioner asked for the referral to be withdrawn',
         },
       }
@@ -388,7 +388,7 @@ describe('AssessmentsController', () => {
       const referralRejectionReasons = [
         referenceDataFactory.build({ id: 'reason-one-id' }),
         referenceDataFactory.build({ id: 'reason-two-id' }),
-        referenceDataFactory.build({ id: 'other-reason-id', name: 'Another reason' }),
+        referenceDataFactory.build({ id: 'other-reason-id', name: 'Another reason (please add)' }),
       ]
       assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
     })
@@ -397,18 +397,19 @@ describe('AssessmentsController', () => {
       const assessmentId = 'assessment-id'
       const referralRejectionReasonId = 'other-reason-id'
       const referralRejectionReasonDetail = 'Some details'
-      const isWithdrawn = 'yes'
+      const ppRequestedWithdrawal = 'yes'
 
       jest.spyOn(assessmentUtils, 'statusChangeMessage').mockReturnValue('some info message')
 
       const requestHandler = assessmentsController.reject()
       request.params = { id: assessmentId }
-      request.body = { referralRejectionReasonId, referralRejectionReasonDetail, isWithdrawn }
+      request.body = { referralRejectionReasonId, referralRejectionReasonDetail, ppRequestedWithdrawal }
 
       await requestHandler(request, response, next)
 
       expect(assessmentsService.rejectAssessment).toHaveBeenCalledWith(callConfig, assessmentId, {
-        ...request.body,
+        referralRejectionReasonId,
+        referralRejectionReasonDetail,
         isWithdrawn: true,
       })
       expect(assessmentUtils.statusChangeMessage).toHaveBeenCalledWith(assessmentId, 'rejected')
@@ -420,13 +421,13 @@ describe('AssessmentsController', () => {
       const assessmentId = 'assessment-id'
       const referralRejectionReasonId = 'reason-one-id'
       const referralRejectionReasonDetail = 'Some details'
-      const isWithdrawn = 'no'
+      const ppRequestedWithdrawal = 'no'
 
       jest.spyOn(assessmentUtils, 'statusChangeMessage').mockReturnValue('some info message')
 
       const requestHandler = assessmentsController.reject()
       request.params = { id: assessmentId }
-      request.body = { referralRejectionReasonId, referralRejectionReasonDetail, isWithdrawn }
+      request.body = { referralRejectionReasonId, referralRejectionReasonDetail, ppRequestedWithdrawal }
 
       await requestHandler(request, response, next)
 
@@ -448,7 +449,7 @@ describe('AssessmentsController', () => {
 
       expect(insertGenericError).toHaveBeenCalledTimes(2)
       expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'referralRejectionReasonId', 'empty')
-      expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'isWithdrawn', 'empty')
+      expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'ppRequestedWithdrawal', 'empty')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
         request,
         response,
@@ -460,16 +461,11 @@ describe('AssessmentsController', () => {
     it('redirects to the reject confirmation page with an error if more details are not provided', async () => {
       const requestHandler = assessmentsController.reject()
       const assessmentId = 'other-reason-id'
-      const referralRejectionReasons = [
-        referenceDataFactory.build({ id: 'reason-id', name: 'A reason' }),
-        referenceDataFactory.build({ id: 'other-reason-id', name: 'Another reason' }),
-      ]
-      assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
 
       request.params = { id: assessmentId }
       request.body = {
         referralRejectionReasonId: 'other-reason-id',
-        isWithdrawn: 'no',
+        ppRequestedWithdrawal: 'no',
         referralRejectionReasonDetail: '   ',
       }
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -388,7 +388,7 @@ describe('AssessmentsController', () => {
       const referralRejectionReasons = [
         referenceDataFactory.build({ id: 'reason-one-id' }),
         referenceDataFactory.build({ id: 'reason-two-id' }),
-        referenceDataFactory.build({ id: 'other-reason-id', name: 'Other reason' }),
+        referenceDataFactory.build({ id: 'other-reason-id', name: 'Another reason' }),
       ]
       assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
     })
@@ -462,7 +462,7 @@ describe('AssessmentsController', () => {
       const assessmentId = 'other-reason-id'
       const referralRejectionReasons = [
         referenceDataFactory.build({ id: 'reason-id', name: 'A reason' }),
-        referenceDataFactory.build({ id: 'other-reason-id', name: 'Some other reason' }),
+        referenceDataFactory.build({ id: 'other-reason-id', name: 'Another reason' }),
       ]
       assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -316,21 +316,22 @@ describe('AssessmentsController', () => {
 
   describe('confirmRejection', () => {
     it('calls render with the assessment id and the rejection reasons', async () => {
-      const assessmentId = 'some-assessment-id'
+      const assessment = assessmentFactory.build()
       const referralRejectionReasons = referenceDataFactory.buildList(3)
 
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
+      assessmentsService.findAssessment.mockResolvedValue(assessment)
       assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
 
       const requestHandler = assessmentsController.confirmRejection()
 
-      request.params = { id: assessmentId }
+      request.params = { id: assessment.id }
 
       await requestHandler(request, response, next)
 
       expect(assessmentsService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/confirm-rejection', {
-        id: assessmentId,
+        assessment,
         referralRejectionReasons,
         referralRejectionReasonOtherMatch,
         errors: {},
@@ -339,7 +340,7 @@ describe('AssessmentsController', () => {
     })
 
     it('calls render with errors', async () => {
-      const assessmentId = 'some-assessment-id'
+      const assessment = assessmentFactory.build()
       const referralRejectionReasons = referenceDataFactory.buildList(3)
       const errors = {
         referralRejectionReasonId: {
@@ -362,17 +363,18 @@ describe('AssessmentsController', () => {
         errorSummary,
         userInput: undefined,
       })
+      assessmentsService.findAssessment.mockResolvedValue(assessment)
       assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
 
       const requestHandler = assessmentsController.confirmRejection()
 
-      request.params = { id: assessmentId }
+      request.params = { id: assessment.id }
 
       await requestHandler(request, response, next)
 
       expect(assessmentsService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/confirm-rejection', {
-        id: assessmentId,
+        assessment,
         referralRejectionReasons,
         referralRejectionReasonOtherMatch,
         errors,

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -12,6 +12,7 @@ import {
   assessmentSummaryFactory,
   newReferralHistoryUserNoteFactory,
   probationRegionFactory,
+  referenceDataFactory,
 } from '../../../testutils/factories'
 import * as assessmentUtils from '../../../utils/assessmentUtils'
 import { preservePlaceContext } from '../../../utils/placeUtils'
@@ -311,14 +312,22 @@ describe('AssessmentsController', () => {
   })
 
   describe('confirmRejection', () => {
-    it('calls render with the assessment id', async () => {
+    it('calls render with the assessment id and the rejection reasons', async () => {
       const assessmentId = 'some-assessment-id'
+      const referralRejectionReasons = referenceDataFactory.buildList(3)
+
+      assessmentsService.getReferenceData.mockResolvedValue({ referralRejectionReasons })
+
       const requestHandler = assessmentsController.confirmRejection()
+
       request.params = { id: assessmentId }
+
       await requestHandler(request, response, next)
 
+      expect(assessmentsService.getReferenceData).toHaveBeenCalledWith(callConfig)
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/assessments/confirm-rejection', {
         id: assessmentId,
+        referralRejectionReasons,
       })
     })
   })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -323,6 +323,32 @@ describe('AssessmentsController', () => {
     })
   })
 
+  describe('reject', () => {
+    it('calls the rejectAssessment method on the service with rejection details', async () => {
+      const assessmentId = 'assessment-id'
+      const referralRejectionReasonId = 'rejection-reason-id'
+      const isWithdrawn = true
+
+      jest.spyOn(assessmentUtils, 'statusChangeMessage').mockReturnValue('some info message')
+
+      const requestHandler = assessmentsController.reject()
+      request.params = { id: assessmentId }
+      request.body = { referralRejectionReasonId, isWithdrawn }
+
+      await requestHandler(request, response, next)
+
+      expect(assessmentsService.rejectAssessment).toHaveBeenCalledWith(
+        callConfig,
+        assessmentId,
+        referralRejectionReasonId,
+        isWithdrawn,
+      )
+      expect(assessmentUtils.statusChangeMessage).toHaveBeenCalledWith(assessmentId, 'rejected')
+      expect(response.redirect).toHaveBeenCalledWith(paths.assessments.summary({ id: assessmentId }))
+      expect(request.flash).toHaveBeenCalledWith('success', 'some info message')
+    })
+  })
+
   describe('confirm', () => {
     it.each([
       'null' as const,

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -1,7 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 import { AssessmentSearchApiStatus } from '@approved-premises/ui'
 import {
-  TemporaryAccommodationAssessment as Assessment,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   NewReferralHistoryUserNote as NewNote,
 } from '../../../@types/shared'
@@ -20,7 +19,7 @@ import { appendQueryString } from '../../../utils/utils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import { pagination } from '../../../utils/pagination'
 
-export const confirmationPageContent: Record<Assessment['status'], { title: string; text: string }> = {
+export const confirmationPageContent: Record<Exclude<AssessmentStatus, 'rejected'>, { title: string; text: string }> = {
   in_review: {
     title: 'Mark this referral as in review',
     text: '<p class="govuk-body">Mark this referral as in review if you or a HPT colleague are working on this referral.</p>',
@@ -30,11 +29,6 @@ export const confirmationPageContent: Record<Assessment['status'], { title: stri
     text: `<p class="govuk-body">Mark this referral as ready to place to find a suitable bedspace.</p>
       <p class="govuk-body">Some regions will require approval before a bedspace is booked. Other regions require an address before approvals can be given. Check with your manager if you are unsure.</p>
       <p class="govuk-body">Once a person has been placed the referral should be archived.</p>`,
-  },
-  rejected: {
-    title: 'Confirm rejection',
-    text: `<p class="govuk-body">You will need to email the community probation practitioner to let them know their referral has been rejected.</p>
-      <p class="govuk-body">Once a referral has been rejected it cannot be undone.</p>`,
   },
   closed: {
     title: 'Archive this referral',
@@ -132,6 +126,14 @@ export default class AssessmentsController {
       return res.render('temporary-accommodation/assessments/full', {
         assessment,
         actions: assessmentActions(assessment),
+      })
+    }
+  }
+
+  confirmRejection(): RequestHandler {
+    return async (req: Request, res: Response) => {
+      return res.render('temporary-accommodation/assessments/confirm-rejection', {
+        id: req.params.id,
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -160,7 +160,7 @@ export default class AssessmentsController {
       const { referralRejectionReasons } = await this.assessmentsService.getReferenceData(callConfig)
 
       const { id } = req.params
-      const { referralRejectionReasonId, referralRejectionReasonDetail, isWithdrawn } = req.body
+      const { referralRejectionReasonId, referralRejectionReasonDetail, ppRequestedWithdrawal } = req.body
 
       try {
         let error: Error
@@ -182,9 +182,9 @@ export default class AssessmentsController {
           }
         }
 
-        if (!isWithdrawn) {
+        if (!ppRequestedWithdrawal) {
           error = error || new Error()
-          insertGenericError(error, 'isWithdrawn', 'empty')
+          insertGenericError(error, 'ppRequestedWithdrawal', 'empty')
         }
 
         if (error) {
@@ -194,7 +194,7 @@ export default class AssessmentsController {
         await this.assessmentsService.rejectAssessment(callConfig, id, {
           referralRejectionReasonId,
           referralRejectionReasonDetail: isOtherReason ? referralRejectionReasonDetail : undefined,
-          isWithdrawn: isWithdrawn === 'yes',
+          isWithdrawn: ppRequestedWithdrawal === 'yes',
         })
 
         req.flash('success', statusChangeMessage(id, 'rejected'))

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -132,8 +132,13 @@ export default class AssessmentsController {
 
   confirmRejection(): RequestHandler {
     return async (req: Request, res: Response) => {
+      const callConfig = extractCallConfig(req)
+
+      const { referralRejectionReasons } = await this.assessmentsService.getReferenceData(callConfig)
+
       return res.render('temporary-accommodation/assessments/confirm-rejection', {
         id: req.params.id,
+        referralRejectionReasons,
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -139,10 +139,11 @@ export default class AssessmentsController {
 
       const callConfig = extractCallConfig(req)
 
+      const assessment = await this.assessmentsService.findAssessment(callConfig, req.params.id)
       const { referralRejectionReasons } = await this.assessmentsService.getReferenceData(callConfig)
 
       return res.render('temporary-accommodation/assessments/confirm-rejection', {
-        id: req.params.id,
+        assessment,
         referralRejectionReasons,
         referralRejectionReasonOtherMatch,
         errors,

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -42,7 +42,7 @@ export const confirmationPageContent: Record<AssessmentUpdateStatus, { title: st
   },
 }
 
-export const referralRejectionReasonOtherMatch = 'Another reason'
+export const referralRejectionReasonOtherMatch = 'Another reason (please add)'
 
 export default class AssessmentsController {
   constructor(private readonly assessmentsService: AssessmentsService) {}

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -42,7 +42,7 @@ export const confirmationPageContent: Record<AssessmentUpdateStatus, { title: st
   },
 }
 
-export const referralRejectionReasonOtherMatch = 'other'
+export const referralRejectionReasonOtherMatch = 'Another reason'
 
 export default class AssessmentsController {
   constructor(private readonly assessmentsService: AssessmentsService) {}

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -150,7 +150,7 @@ export default class AssessmentsController {
       const { id } = req.params
       const { referralRejectionReasonId, isWithdrawn } = req.body
 
-      await this.assessmentsService.rejectAssessment(callConfig, id, referralRejectionReasonId, isWithdrawn)
+      await this.assessmentsService.rejectAssessment(callConfig, id, referralRejectionReasonId, isWithdrawn === 'yes')
 
       req.flash('success', statusChangeMessage(id, 'rejected'))
       res.redirect(paths.assessments.summary({ id }))

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -180,12 +180,20 @@ describe('AssessmentClient', () => {
 
   describe('rejectAssessment', () => {
     it('posts a new rejection for the assessment', async () => {
+      const referralRejectionReasonId = 'rejection-reason-id'
+      const isWithdrawn = false
+
       fakeApprovedPremisesApi
-        .post(paths.assessments.rejection({ id: assessmentId }), { document: {}, rejectionRationale: 'default' })
+        .post(paths.assessments.rejection({ id: assessmentId }), {
+          document: {},
+          rejectionRationale: 'default',
+          referralRejectionReasonId,
+          isWithdrawn,
+        })
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200)
 
-      await assessmentClient.rejectAssessment(assessmentId)
+      await assessmentClient.rejectAssessment(assessmentId, referralRejectionReasonId, isWithdrawn)
     })
   })
 

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -180,20 +180,21 @@ describe('AssessmentClient', () => {
 
   describe('rejectAssessment', () => {
     it('posts a new rejection for the assessment', async () => {
-      const referralRejectionReasonId = 'rejection-reason-id'
-      const isWithdrawn = false
+      const referralRejectionReasonBody = {
+        referralRejectionReasonId: 'rejection-reason-id',
+        isWithdrawn: false,
+      }
 
       fakeApprovedPremisesApi
         .post(paths.assessments.rejection({ id: assessmentId }), {
           document: {},
           rejectionRationale: 'default',
-          referralRejectionReasonId,
-          isWithdrawn,
+          ...referralRejectionReasonBody,
         })
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200)
 
-      await assessmentClient.rejectAssessment(assessmentId, referralRejectionReasonId, isWithdrawn)
+      await assessmentClient.rejectAssessment(assessmentId, referralRejectionReasonBody)
     })
   })
 

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -76,10 +76,15 @@ export default class AssessmentClient {
     })
   }
 
-  async rejectAssessment(id: string): Promise<void> {
+  async rejectAssessment(id: string, referralRejectionReasonId: string, isWithdrawn: boolean): Promise<void> {
     await this.restClient.post({
       path: paths.assessments.rejection({ id }),
-      data: { document: {}, rejectionRationale: 'default' } as AssessmentRejection,
+      data: {
+        document: {},
+        rejectionRationale: 'default',
+        referralRejectionReasonId,
+        isWithdrawn,
+      } as AssessmentRejection,
     })
   }
 

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -8,7 +8,7 @@ import type {
   ReferralHistoryNote as Note,
 } from '@approved-premises/api'
 
-import { AssessmentSearchParameters, PaginatedResponse } from '@approved-premises/ui'
+import { AssessmentSearchParameters, PaginatedResponse, ReferralRejectionBody } from '@approved-premises/ui'
 import { URLSearchParams } from 'url'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -76,14 +76,13 @@ export default class AssessmentClient {
     })
   }
 
-  async rejectAssessment(id: string, referralRejectionReasonId: string, isWithdrawn: boolean): Promise<void> {
+  async rejectAssessment(id: string, referralRejectionBody: ReferralRejectionBody): Promise<void> {
     await this.restClient.post({
       path: paths.assessments.rejection({ id }),
       data: {
         document: {},
         rejectionRationale: 'default',
-        referralRejectionReasonId,
-        isWithdrawn,
+        ...referralRejectionBody,
       } as AssessmentRejection,
     })
   }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -145,7 +145,7 @@
     "referralRejectionReasonDetail": {
       "empty": "Add details about the reason for the rejection"
     },
-    "isWithdrawn": {
+    "ppRequestedWithdrawal": {
       "empty": "Select yes if the probation practitioner asked for the referral to be withdrawn"
     }
   },

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -138,6 +138,15 @@
       "invalid": "The bedspace end date is an invalid date",
       "beforeCreatedAt": "The bedspace end date must be on or after the date the bedspace was created",
       "conflict": "This bedspace end date conflicts with an existing booking"
+    },
+    "referralRejectionReasonId": {
+      "empty": "Select a reason for rejecting this referral"
+    },
+    "referralRejectionReasonDetail": {
+      "empty": "Add details about the reason for the rejection"
+    },
+    "isWithdrawn": {
+      "empty": "Select yes if the probation practitioner asked for the referral to be withdrawn"
     }
   },
   "bookingCancellation": {

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -121,6 +121,8 @@ const paths = {
     archive: assessmentsPath.path('archive'),
     full: assessmentsPath.path(':id'),
     summary: assessmentPath.path(':id/summary'),
+    confirmRejection: assessmentPath.path('rejected'),
+    reject: assessmentPath.path('rejected'),
     confirm: assessmentPath.path(':status'),
     update: assessmentPath.path(':status'),
     notes: { create: assessmentPath.path('/notes') },

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -336,6 +336,9 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.assessments.summary.pattern, assessmentsController.summary(), {
     auditEvent: 'VIEW_ASSESSMENT_SUMMARY',
   })
+  get(paths.assessments.confirmRejection.pattern, assessmentsController.confirmRejection(), {
+    auditEvent: 'VIEW_ASSESSMENT_REJECTION_CONFIRM',
+  })
   get(paths.assessments.confirm.pattern, assessmentsController.confirm(), {
     auditEvent: 'VIEW_ASSESSMENT_STATUS_CHANGE_CONFIRM',
   })

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -339,6 +339,15 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.assessments.confirmRejection.pattern, assessmentsController.confirmRejection(), {
     auditEvent: 'VIEW_ASSESSMENT_REJECTION_CONFIRM',
   })
+  post(paths.assessments.reject.pattern, assessmentsController.reject(), {
+    auditEvent: 'REJECT_ASSESSMENT',
+    redirectAuditEventSpecs: [
+      {
+        path: paths.assessments.full.pattern,
+        auditEvent: 'REJECT_ASSESSMENT_SUCCESS',
+      },
+    ],
+  })
   get(paths.assessments.confirm.pattern, assessmentsController.confirm(), {
     auditEvent: 'VIEW_ASSESSMENT_STATUS_CHANGE_CONFIRM',
   })

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -105,7 +105,7 @@ describe('AssessmentsService', () => {
   })
 
   describe('getReferenceData', () => {
-    it('should return the reference data needed to create departures', async () => {
+    it('should return the reference data needed to reject referrals', async () => {
       const referralRejectionReasons = referenceDataFactory.buildList(5)
 
       referenceDataClient.getReferenceData.mockResolvedValue(referralRejectionReasons)

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -122,10 +122,14 @@ describe('AssessmentsService', () => {
 
   describe('rejectAssessment', () => {
     it('calls the rejectAssessment method on the client with rejection details', async () => {
-      await service.rejectAssessment(callConfig, assessmentId, 'rejection-reason-id', true)
+      const referralRejectionReasonBody = {
+        referralRejectionReasonId: 'rejection-reason-id',
+        isWithdrawn: true,
+      }
+      await service.rejectAssessment(callConfig, assessmentId, referralRejectionReasonBody)
 
       expect(AssessmentClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId, 'rejection-reason-id', true)
+      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId, referralRejectionReasonBody)
     })
   })
 

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -97,6 +97,15 @@ describe('AssessmentsService', () => {
     })
   })
 
+  describe('rejectAssessment', () => {
+    it('calls the rejectAssessment method on the client with rejection details', async () => {
+      await service.rejectAssessment(callConfig, assessmentId, 'rejection-reason-id', true)
+
+      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId, 'rejection-reason-id', true)
+    })
+  })
+
   describe('updateAssessment', () => {
     it("calls the unallocateAssessment method on the client when the new status is 'unallocated'", async () => {
       await service.updateAssessmentStatus(callConfig, assessmentId, 'unallocated')
@@ -110,13 +119,6 @@ describe('AssessmentsService', () => {
 
       expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
       expect(assessmentClient.allocateAssessment).toHaveBeenCalledWith(assessmentId)
-    })
-
-    it("calls the rejectAssessment method on the client when the new status is 'rejected'", async () => {
-      await service.updateAssessmentStatus(callConfig, assessmentId, 'rejected')
-
-      expect(asessmentClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId)
     })
 
     it("calls the acceptAssessment method on the client when the new status is 'ready_to_place'", async () => {

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -1,12 +1,12 @@
 import type {
   AssessmentSearchApiStatus,
   AssessmentSearchParameters,
+  AssessmentUpdateStatus,
   PaginatedResponse,
   TableRow,
 } from '@approved-premises/ui'
 import type {
   TemporaryAccommodationAssessment as Assessment,
-  TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   NewReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
   TemporaryAccommodationAssessmentStatus,
@@ -42,7 +42,22 @@ export default class AssessmentsService {
     return assessmentClient.find(assessmentId)
   }
 
-  async updateAssessmentStatus(callConfig: CallConfig, assessmentId: string, status: AssessmentStatus): Promise<void> {
+  async rejectAssessment(
+    callConfig: CallConfig,
+    assessmentId: string,
+    referralRejectionReasonId: string,
+    isWithdrawn: boolean,
+  ): Promise<void> {
+    const assessmentClient = this.assessmentClientFactory(callConfig)
+
+    await assessmentClient.rejectAssessment(assessmentId, referralRejectionReasonId, isWithdrawn)
+  }
+
+  async updateAssessmentStatus(
+    callConfig: CallConfig,
+    assessmentId: string,
+    status: AssessmentUpdateStatus,
+  ): Promise<void> {
     const assessmentClient = this.assessmentClientFactory(callConfig)
 
     switch (status) {
@@ -51,9 +66,6 @@ export default class AssessmentsService {
         break
       case 'in_review':
         await assessmentClient.allocateAssessment(assessmentId)
-        break
-      case 'rejected':
-        await assessmentClient.rejectAssessment(assessmentId)
         break
       case 'ready_to_place':
         await assessmentClient.acceptAssessment(assessmentId)

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -3,6 +3,7 @@ import type {
   AssessmentSearchParameters,
   AssessmentUpdateStatus,
   PaginatedResponse,
+  ReferenceData,
   TableRow,
 } from '@approved-premises/ui'
 import type {
@@ -12,13 +13,20 @@ import type {
   TemporaryAccommodationAssessmentStatus,
 } from '../@types/shared'
 import { AssessmentSummary } from '../@types/shared'
-import type { AssessmentClient, RestClientBuilder } from '../data'
+import type { AssessmentClient, ReferenceDataClient, RestClientBuilder } from '../data'
 import { CallConfig } from '../data/restClient'
 import { assessmentTableRows } from '../utils/assessmentUtils'
 import { assertUnreachable } from '../utils/utils'
 
+export type AssessmentReferenceData = {
+  referralRejectionReasons: Array<ReferenceData>
+}
+
 export default class AssessmentsService {
-  constructor(private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>) {}
+  constructor(
+    private readonly assessmentClientFactory: RestClientBuilder<AssessmentClient>,
+    private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
+  ) {}
 
   async getAllForLoggedInUser(
     callConfig: CallConfig,
@@ -40,6 +48,14 @@ export default class AssessmentsService {
     const assessmentClient = this.assessmentClientFactory(callConfig)
 
     return assessmentClient.find(assessmentId)
+  }
+
+  async getReferenceData(callConfig: CallConfig): Promise<AssessmentReferenceData> {
+    const referenceDataClient = this.referenceDataClientFactory(callConfig)
+
+    return {
+      referralRejectionReasons: await referenceDataClient.getReferenceData('referral-rejection-reasons'),
+    }
   }
 
   async rejectAssessment(

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -4,6 +4,7 @@ import type {
   AssessmentUpdateStatus,
   PaginatedResponse,
   ReferenceData,
+  ReferralRejectionBody,
   TableRow,
 } from '@approved-premises/ui'
 import type {
@@ -61,12 +62,11 @@ export default class AssessmentsService {
   async rejectAssessment(
     callConfig: CallConfig,
     assessmentId: string,
-    referralRejectionReasonId: string,
-    isWithdrawn: boolean,
+    referralRejectionBody: ReferralRejectionBody,
   ): Promise<void> {
     const assessmentClient = this.assessmentClientFactory(callConfig)
 
-    await assessmentClient.rejectAssessment(assessmentId, referralRejectionReasonId, isWithdrawn)
+    await assessmentClient.rejectAssessment(assessmentId, referralRejectionBody)
   }
 
   async updateAssessmentStatus(

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -58,7 +58,7 @@ export const services = () => {
   const bedspaceSearchService = new BedspaceSearchService(bedClientBuilder, referenceDataClientBuilder)
   const bookingSearchService = new BookingSearchService(bookingClientBuilder)
   const turnaroundService = new TurnaroundService(bookingClientBuilder)
-  const assessmentsService = new AssessmentsService(assessmentClientBuilder)
+  const assessmentsService = new AssessmentsService(assessmentClientBuilder, referenceDataClientBuilder)
   const referenceDataService = new ReferenceDataService(referenceDataClientBuilder)
 
   return {

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -319,7 +319,9 @@ describe('assessmentUtils', () => {
 
       expect(statusChangeMessage(assessment.id, assessment.status)).toEqual({
         title: 'This referral has been rejected',
-        html: `<a class="govuk-link" href="${paths.assessments.index({})}">Return to the referrals dashboard</a>`,
+        html: `It's been moved to archived referrals. You now need to email the probation practitioner to tell them it's been rejected.<br><br><a class="govuk-link" href="${paths.assessments.index(
+          {},
+        )}">Return to the referrals dashboard</a>`,
       })
     })
 

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -311,17 +311,16 @@ describe('assessmentUtils', () => {
 
   describe('referralRejectionReasonIsOther', () => {
     const rejectionReasons = [
-      referenceDataFactory.build({ id: 'another-id', name: 'Another reason' }),
+      referenceDataFactory.build({ id: 'another-reason-id', name: 'Another reason' }),
       referenceDataFactory.build({ id: 'other-id', name: 'Other' }),
       referenceDataFactory.build({ id: 'valid-id', name: 'A valid reason' }),
     ]
 
     it.each([
-      [true, 'other-id', 'other'],
-      [true, 'another-id', 'Another reason'],
-      [false, 'valid-id', 'other'],
-      [false, 'does-not-exist', 'other'],
-    ])(`returns %s} if the referral rejection id %s reason matches '%s'`, (expected, id, match) => {
+      [true, 'another-reason-id', 'Another reason'],
+      [false, 'other-id', 'Another reason'],
+      [false, 'does-not-exist', 'Another reason'],
+    ])(`returns %s if the referral rejection id %s reason matches '%s'`, (expected, id, match) => {
       expect(referralRejectionReasonIsOther(id, match, rejectionReasons)).toEqual(expected)
     })
   })

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -5,6 +5,7 @@ import {
   assessmentSummaryFactory,
   personFactory,
   placeContextFactory,
+  referenceDataFactory,
   referralHistorySystemNoteFactory,
   referralHistoryUserNoteFactory,
   restrictedPersonFactory,
@@ -15,6 +16,7 @@ import {
   createTableHeadings,
   getParams,
   pathFromStatus,
+  referralRejectionReasonIsOther,
   statusChangeMessage,
   timelineItems,
 } from './assessmentUtils'
@@ -304,6 +306,23 @@ describe('assessmentUtils', () => {
           },
         },
       ])
+    })
+  })
+
+  describe('referralRejectionReasonIsOther', () => {
+    const rejectionReasons = [
+      referenceDataFactory.build({ id: 'another-id', name: 'Another reason' }),
+      referenceDataFactory.build({ id: 'other-id', name: 'Other' }),
+      referenceDataFactory.build({ id: 'valid-id', name: 'A valid reason' }),
+    ]
+
+    it.each([
+      [true, 'other-id', 'other'],
+      [true, 'another-id', 'Another reason'],
+      [false, 'valid-id', 'other'],
+      [false, 'does-not-exist', 'other'],
+    ])(`returns %s} if the referral rejection id %s reason matches '%s'`, (expected, id, match) => {
+      expect(referralRejectionReasonIsOther(id, match, rejectionReasons)).toEqual(expected)
     })
   })
 

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -13,6 +13,7 @@ import {
   AssessmentSearchApiStatus,
   AssessmentSearchParameters,
   MessageContents,
+  ReferenceData,
   TableRow,
   TimelineItem,
 } from '../@types/ui'
@@ -154,6 +155,12 @@ export const timelineItems = (assessment: Assessment): Array<TimelineItem> => {
     }
   })
 }
+
+export const referralRejectionReasonIsOther = (
+  id: string,
+  match: string,
+  referralRejectionReasons: Array<ReferenceData>,
+) => Boolean(referralRejectionReasons.find(reason => reason.id === id)?.name.match(new RegExp(match, 'i')))
 
 export const statusChangeMessage = (assessmentId: string, status: AssessmentStatus): MessageContents => {
   switch (status) {

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -172,7 +172,9 @@ export const statusChangeMessage = (assessmentId: string, status: AssessmentStat
     case 'rejected':
       return {
         title: 'This referral has been rejected',
-        html: `<a class="govuk-link" href="${paths.assessments.index({})}">Return to the referrals dashboard</a>`,
+        html: `It's been moved to archived referrals. You now need to email the probation practitioner to tell them it's been rejected.<br><br><a class="govuk-link" href="${paths.assessments.index(
+          {},
+        )}">Return to the referrals dashboard</a>`,
       }
     case 'unallocated':
       return {

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -160,7 +160,7 @@ export const referralRejectionReasonIsOther = (
   id: string,
   match: string,
   referralRejectionReasons: Array<ReferenceData>,
-) => Boolean(referralRejectionReasons.find(reason => reason.id === id)?.name.match(new RegExp(match, 'i')))
+) => Boolean(referralRejectionReasons.find(reason => reason.id === id)?.name === match)
 
 export const statusChangeMessage = (assessmentId: string, status: AssessmentStatus): MessageContents => {
   switch (status) {

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -130,10 +130,10 @@ describe('formUtils', () => {
       ])
     })
 
-    it('adds conditional reveals to items', () => {
+    it('adds conditional reveals to items with matching text', () => {
       const result = convertObjectsToRadioItems(objects, 'name', 'id', 'field', {}, [
         {
-          match: 'def',
+          match: 'DE',
           html: '<p>Conditional HTML</p>',
         },
       ])

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -133,7 +133,7 @@ describe('formUtils', () => {
     it('adds conditional reveals to items with matching text', () => {
       const result = convertObjectsToRadioItems(objects, 'name', 'id', 'field', {}, [
         {
-          match: 'DE',
+          match: 'def',
           html: '<p>Conditional HTML</p>',
         },
       ])

--- a/server/utils/formUtils.test.ts
+++ b/server/utils/formUtils.test.ts
@@ -129,6 +129,31 @@ describe('formUtils', () => {
         },
       ])
     })
+
+    it('adds conditional reveals to items', () => {
+      const result = convertObjectsToRadioItems(objects, 'name', 'id', 'field', {}, [
+        {
+          match: 'def',
+          html: '<p>Conditional HTML</p>',
+        },
+      ])
+
+      expect(result).toEqual([
+        {
+          text: 'abc',
+          value: '123',
+          checked: false,
+        },
+        {
+          text: 'def',
+          value: '345',
+          checked: false,
+          conditional: {
+            html: '<p>Conditional HTML</p>',
+          },
+        },
+      ])
+    })
   })
 
   describe('convertKeyValuePairToCheckBoxItems', () => {

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -23,20 +23,38 @@ export const dateFieldValues = (fieldName: string, context: Record<string, unkno
   ]
 }
 
+export type ConditionalDefinition = {
+  match: string
+  html: string
+}
+
 export const convertObjectsToRadioItems = (
   items: Array<Record<string, string>>,
   textKey: string,
   valueKey: string,
   fieldName: string,
   context: Record<string, unknown>,
+  conditionals: Array<ConditionalDefinition> = [],
 ): Array<RadioItem> => {
-  return items.map(item => {
-    return {
-      text: item[textKey],
-      value: item[valueKey],
-      checked: context[fieldName] === item[valueKey],
+  const radios = items.map(
+    item =>
+      ({
+        text: item[textKey],
+        value: item[valueKey],
+        checked: context[fieldName] === item[valueKey],
+      }) as RadioItem,
+  )
+
+  conditionals.forEach(conditional => {
+    const { match, html } = conditional
+    const target = radios.find(radio => 'text' in radio && radio.text.match(match))
+
+    if (target && 'text' in target) {
+      target.conditional = { html }
     }
   })
+
+  return radios
 }
 
 export const convertObjectsToSelectOptions = (

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -47,7 +47,7 @@ export const convertObjectsToRadioItems = (
 
   conditionals.forEach(conditional => {
     const { match, html } = conditional
-    const target = radios.find(radio => 'text' in radio && radio.text.match(match))
+    const target = radios.find(radio => 'text' in radio && radio.text.match(new RegExp(match, 'i')))
 
     if (target && 'text' in target) {
       target.conditional = { html }

--- a/server/utils/formUtils.ts
+++ b/server/utils/formUtils.ts
@@ -47,7 +47,7 @@ export const convertObjectsToRadioItems = (
 
   conditionals.forEach(conditional => {
     const { match, html } = conditional
-    const target = radios.find(radio => 'text' in radio && radio.text.match(new RegExp(match, 'i')))
+    const target = radios.find(radio => 'text' in radio && radio.text === match)
 
     if (target && 'text' in target) {
       target.conditional = { html }

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -9,6 +9,7 @@ import type { ErrorMessages, PersonStatus } from '@approved-premises/ui'
 import { statusTag as assessmentStatusTag } from './assessmentStatusUtils'
 import { DateFormats, dateInputHint } from './dateUtils'
 import {
+  ConditionalDefinition,
   convertObjectsToCheckboxItems,
   convertObjectsToRadioItems,
   convertObjectsToSelectOptions,
@@ -120,8 +121,9 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
       textKey: string,
       valueKey: string,
       fieldName: string,
+      conditionals?: Array<ConditionalDefinition>,
     ) {
-      return convertObjectsToRadioItems(items, textKey, valueKey, fieldName, this.ctx)
+      return convertObjectsToRadioItems(items, textKey, valueKey, fieldName, this.ctx, conditionals)
     },
   )
 

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -28,7 +28,7 @@
 
     <h1 class="govuk-heading-l">Reject referral</h1>
 
-    <form action="?_method=PUT" method="post">
+    <form action="{{ paths.assessments.reject({ id: id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
         {{ taRadios(
@@ -42,11 +42,11 @@
                 hint: {
                 text: 'This helps the organisation understand why CAS3 referrals are rejected.'
             },
-                items: convertObjectsToRadioItems( referralRejectionReasons, 'name', 'id', 'referralRejectionReason', [{
+                items: convertObjectsToRadioItems( referralRejectionReasons, 'name', 'id', 'referralRejectionReasonId', [{
                 match: 'Other',
                 html: conditionalHtml
             }]),
-                fieldName: "referralRejectionReason"
+                fieldName: "referralRejectionReasonId"
             }, fetchContext()
         ) }}
 

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../components/ta-radios/macro.njk" import taRadios %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -19,9 +20,22 @@
     <form action="?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {% for reason in referralRejectionReasons %}
-            {{ reason.id }} / {{ reason.name }}<br />
-        {% endfor %}
+        {{ taRadios(
+            {
+                fieldset: {
+                legend: {
+                    text: "Why are you rejecting this referral?",
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+                hint: {
+                text: 'This helps the organisation understand why CAS3 referrals are rejected.'
+            },
+                items: convertObjectsToRadioItems(referralRejectionReasons, 'name', 'id', 'status'),
+                fieldName: "referralRejectionReason"
+            }, fetchContext()
+        ) }}
+
         {{ govukButton({
             text: "Save and continue",
             preventDoubleClick: true

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -2,6 +2,7 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../components/ta-radios/macro.njk" import taRadios %}
 {% from "../components/ta-textarea/macro.njk" import taTextarea %}
+{% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -28,8 +29,11 @@
 
     <h1 class="govuk-heading-l">Reject referral</h1>
 
+    {{ showErrorSummary(errorSummary) }}
+
     <form action="{{ paths.assessments.reject({ id: id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
 
         {{ taRadios(
             {
@@ -43,7 +47,7 @@
                 text: 'This helps the organisation understand why CAS3 referrals are rejected.'
             },
                 items: convertObjectsToRadioItems( referralRejectionReasons, 'name', 'id', 'referralRejectionReasonId', [{
-                match: 'Other',
+                match: referralRejectionReasonOtherMatch,
                 html: conditionalHtml
             }]),
                 fieldName: "referralRejectionReasonId"

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -50,6 +50,28 @@
             }, fetchContext()
         ) }}
 
+        {{ taRadios(
+            {
+                fieldset: {
+                legend: {
+                    text: "Did the probation practitioner ask for it to be withdrawn?",
+                    classes: "govuk-fieldset__legend--m"
+                }
+            },
+                items: [
+                {
+                    value: "yes",
+                    text: "Yes"
+                },
+                {
+                    value: "no",
+                    text: "No"
+                }
+            ],
+                fieldName: "isWithdrawn"
+            }, fetchContext()
+        ) }}
+
         {{ govukButton({
             text: "Save and continue",
             preventDoubleClick: true

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -1,0 +1,28 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../partials/layout.njk" %}
+
+{% set pageTitle = "Reject referral - " + applicationName %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.assessments.summary({ id: id })
+    }) }}
+{% endblock %}
+
+{% block content %}
+    <h1 class="govuk-heading-l">Reject referral</h1>
+
+    <form action="?_method=PUT" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+        {{ govukButton({
+            text: "Save and continue",
+            preventDoubleClick: true
+        }) }}
+
+    </form>
+{% endblock %}

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.assessments.summary({ id: id })
+        href: paths.assessments.summary({ id: assessment.id })
     }) }}
 {% endblock %}
 
@@ -27,11 +27,11 @@
         }, fetchContext()) }}
     {% endset %}
 
-    <h1 class="govuk-heading-l">Reject referral</h1>
+    <h1 class="govuk-heading-l">Reject {{ personName(assessment.application.person) }}'s referral</h1>
 
     {{ showErrorSummary(errorSummary) }}
 
-    <form action="{{ paths.assessments.reject({ id: id }) }}" method="post">
+    <form action="{{ paths.assessments.reject({ id: assessment.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
 

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -17,6 +17,7 @@
 {% endblock %}
 
 {% block content %}
+    {% set context = fetchContext() %}
     {% set conditionalHtml %}
         {{ taTextarea({
             fieldName: 'referralRejectionReasonDetail',
@@ -24,8 +25,10 @@
                 text: "Add details about why the referral is being rejected",
                 classes: "govuk-label--s"
             }
-        }, fetchContext()) }}
+        }, context) }}
     {% endset %}
+
+    {{ context.isWithdrawn }}
 
     <h1 class="govuk-heading-l">Reject {{ personName(assessment.application.person) }}'s referral</h1>
 
@@ -51,7 +54,7 @@
                 html: conditionalHtml
             }]),
                 fieldName: "referralRejectionReasonId"
-            }, fetchContext()
+            }, context
         ) }}
 
         {{ taRadios(
@@ -65,15 +68,17 @@
                 items: [
                 {
                     value: "yes",
-                    text: "Yes"
+                    text: "Yes",
+                    checked: context.isWithdrawn === 'yes'
                 },
                 {
                     value: "no",
-                    text: "No"
+                    text: "No",
+                    checked: context.isWithdrawn === 'no'
                 }
             ],
                 fieldName: "isWithdrawn"
-            }, fetchContext()
+            }, context
         ) }}
 
         {{ govukButton({

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -28,8 +28,6 @@
         }, context) }}
     {% endset %}
 
-    {{ context.isWithdrawn }}
-
     <h1 class="govuk-heading-l">Reject {{ personName(assessment.application.person) }}'s referral</h1>
 
     {{ showErrorSummary(errorSummary) }}
@@ -71,15 +69,15 @@
                         {
                             value: "yes",
                             text: "Yes",
-                            checked: context.isWithdrawn === 'yes'
+                            checked: context.ppRequestedWithdrawal === 'yes'
                         },
                         {
                             value: "no",
                             text: "No",
-                            checked: context.isWithdrawn === 'no'
+                            checked: context.ppRequestedWithdrawal === 'no'
                         }
                     ],
-                        fieldName: "isWithdrawn"
+                        fieldName: "ppRequestedWithdrawal"
                     }, context
                 ) }}
 

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -1,6 +1,7 @@
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../components/ta-radios/macro.njk" import taRadios %}
+{% from "../components/ta-textarea/macro.njk" import taTextarea %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -15,6 +16,16 @@
 {% endblock %}
 
 {% block content %}
+    {% set conditionalHtml %}
+        {{ taTextarea({
+            fieldName: 'referralRejectionReasonDetail',
+            label: {
+                text: "Add details about why the referral is being rejected",
+                classes: "govuk-label--s"
+            }
+        }, fetchContext()) }}
+    {% endset %}
+
     <h1 class="govuk-heading-l">Reject referral</h1>
 
     <form action="?_method=PUT" method="post">
@@ -31,7 +42,10 @@
                 hint: {
                 text: 'This helps the organisation understand why CAS3 referrals are rejected.'
             },
-                items: convertObjectsToRadioItems(referralRejectionReasons, 'name', 'id', 'status'),
+                items: convertObjectsToRadioItems( referralRejectionReasons, 'name', 'id', 'referralRejectionReason', [{
+                match: 'Other',
+                html: conditionalHtml
+            }]),
                 fieldName: "referralRejectionReason"
             }, fetchContext()
         ) }}

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -19,6 +19,9 @@
     <form action="?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
+        {% for reason in referralRejectionReasons %}
+            {{ reason.id }} / {{ reason.name }}<br />
+        {% endfor %}
         {{ govukButton({
             text: "Save and continue",
             preventDoubleClick: true

--- a/server/views/temporary-accommodation/assessments/confirm-rejection.njk
+++ b/server/views/temporary-accommodation/assessments/confirm-rejection.njk
@@ -34,57 +34,61 @@
 
     {{ showErrorSummary(errorSummary) }}
 
-    <form action="{{ paths.assessments.reject({ id: assessment.id }) }}" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.assessments.reject({ id: assessment.id }) }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
 
-        {{ taRadios(
-            {
-                fieldset: {
-                legend: {
-                    text: "Why are you rejecting this referral?",
-                    classes: "govuk-fieldset__legend--m"
-                }
-            },
-                hint: {
-                text: 'This helps the organisation understand why CAS3 referrals are rejected.'
-            },
-                items: convertObjectsToRadioItems( referralRejectionReasons, 'name', 'id', 'referralRejectionReasonId', [{
-                match: referralRejectionReasonOtherMatch,
-                html: conditionalHtml
-            }]),
-                fieldName: "referralRejectionReasonId"
-            }, context
-        ) }}
+                {{ taRadios(
+                    {
+                        fieldset: {
+                        legend: {
+                            text: "Why are you rejecting this referral?",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                        hint: {
+                        text: 'This helps the organisation understand why CAS3 referrals are rejected.'
+                    },
+                        items: convertObjectsToRadioItems( referralRejectionReasons, 'name', 'id', 'referralRejectionReasonId', [{
+                        match: referralRejectionReasonOtherMatch,
+                        html: conditionalHtml
+                    }]),
+                        fieldName: "referralRejectionReasonId"
+                    }, context
+                ) }}
 
-        {{ taRadios(
-            {
-                fieldset: {
-                legend: {
-                    text: "Did the probation practitioner ask for it to be withdrawn?",
-                    classes: "govuk-fieldset__legend--m"
-                }
-            },
-                items: [
-                {
-                    value: "yes",
-                    text: "Yes",
-                    checked: context.isWithdrawn === 'yes'
-                },
-                {
-                    value: "no",
-                    text: "No",
-                    checked: context.isWithdrawn === 'no'
-                }
-            ],
-                fieldName: "isWithdrawn"
-            }, context
-        ) }}
+                {{ taRadios(
+                    {
+                        fieldset: {
+                        legend: {
+                            text: "Did the probation practitioner ask for it to be withdrawn?",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                        items: [
+                        {
+                            value: "yes",
+                            text: "Yes",
+                            checked: context.isWithdrawn === 'yes'
+                        },
+                        {
+                            value: "no",
+                            text: "No",
+                            checked: context.isWithdrawn === 'no'
+                        }
+                    ],
+                        fieldName: "isWithdrawn"
+                    }, context
+                ) }}
 
-        {{ govukButton({
-            text: "Save and continue",
-            preventDoubleClick: true
-        }) }}
+                {{ govukButton({
+                    text: "Save and continue",
+                    preventDoubleClick: true
+                }) }}
 
-    </form>
+            </form>
+        </div>
+    </div>
 {% endblock %}

--- a/wiremock/referenceDataStubs.ts
+++ b/wiremock/referenceDataStubs.ts
@@ -8,6 +8,7 @@ import lostBedReasonsJson from './stubs/lost-bed-reasons.json'
 import moveOnCategoriesJson from './stubs/move-on-categories.json'
 import pdusJson from './stubs/pdus.json'
 import probationRegionsJson from './stubs/probation-regions.json'
+import rejectionReasonsJson from './stubs/referral-rejection-reasons.json'
 
 const departureReasons = {
   request: {
@@ -149,6 +150,20 @@ const pdus = {
   },
 }
 
+const referralRejectionReasons = {
+  request: {
+    method: 'GET',
+    urlPath: '/reference-data/referral-rejection-reasons',
+  },
+  response: {
+    status: 200,
+    headers: {
+      'Content-Type': 'application/json;charset=UTF-8',
+    },
+    jsonBody: rejectionReasonsJson,
+  },
+}
+
 export {
   departureReasons,
   moveOnCategories,
@@ -160,4 +175,5 @@ export {
   localAuthorities,
   probationRegions,
   pdus,
+  referralRejectionReasons,
 }

--- a/wiremock/stubs/referral-rejection-reasons.json
+++ b/wiremock/stubs/referral-rejection-reasons.json
@@ -31,13 +31,25 @@
   },
   {
     "id": "155ee6dc-ac2a-40d2-a350-90b63fb34a06",
-    "name": "There’s no capacity",
+    "name": "The PDU has no available bedspaces at all",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "b19ba749-408f-48c0-907c-11eace2dcf67",
+    "name": "No single occupancy bedspace is available",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "311de468-078b-4c39-ae42-8d41575b7726",
+    "name": "No suitable bedspace is available (not because of single occupancy)",
     "serviceScope": "temporary-accommodation",
     "isActive": true
   },
   {
     "id": "85799bf8-8b64-4903-9ab8-b08a77f1a9d3",
-    "name": "Other (please add)",
+    "name": "Another reason (please add)",
     "serviceScope": "temporary-accommodation",
     "isActive": true
   }

--- a/wiremock/stubs/referral-rejection-reasons.json
+++ b/wiremock/stubs/referral-rejection-reasons.json
@@ -1,0 +1,44 @@
+[
+  {
+    "id": "21b8569c-ef2e-4059-8676-323098d16aa5",
+    "name": "They have no recourse to public funds (NRPF)",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "11506230-49a8-48b5-bdf5-20f51324e8a5",
+    "name": "They’re not eligible (not because of NRPF)",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "a1c7d402-77b5-4335-a67b-eba6a71c70bf",
+    "name": "There was not enough time to place them",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "88c3b8d5-77c8-4c52-84f0-ec9073e4df50",
+    "name": "There was not enough time on their licence or post-sentence supervision (PSS)",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "90e9d919-9a39-45cd-b405-7039b5640668",
+    "name": "Their risk or needs cannot be safely managed in CAS3",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "155ee6dc-ac2a-40d2-a350-90b63fb34a06",
+    "name": "There’s no capacity",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  },
+  {
+    "id": "85799bf8-8b64-4903-9ab8-b08a77f1a9d3",
+    "name": "Other (please add)",
+    "serviceScope": "temporary-accommodation",
+    "isActive": true
+  }
+]


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-249

# Changes in this PR

Adds a form capturing the reason for rejection when rejecting a referral. The list of possible reasons is fetched as `ReferenceData` from the API. Selecting 'Another reason' shows a free text field to add more details.

Note: the order the rejection reason options comes back in is currently being worked on in the API, to ensure the ‘other’ option is returned last.

## Screenshots of UI changes

### New rejection confirmation page

<img width="705" alt="Screenshot 2024-04-30 at 17 07 51" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/6140940d-1277-4831-bfa9-fcb4e3ec0da9">

### New success banner

<img width="996" alt="Screenshot 2024-04-30 at 17 08 03" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/d8f19ca4-f49c-4dd9-97c1-304d1ece57a5">


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work? Yes: [CAS-336](https://dsdmoj.atlassian.net/browse/CAS-336) and [CAS-348](https://dsdmoj.atlassian.net/browse/CAS-348)
- [ ] Have they been released to production already? CAS-336: yes, CAS-348: no

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->


[CAS-336]: https://dsdmoj.atlassian.net/browse/CAS-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[CAS-348]: https://dsdmoj.atlassian.net/browse/CAS-348?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ