### PR TITLE
Reset errors when download starts

### DIFF
--- a/assets/js/reset-errors.js
+++ b/assets/js/reset-errors.js
@@ -1,0 +1,13 @@
+const removeElementsSelector = '.govuk-error-summary, .govuk-error-message'
+const removeClasses = ['.govuk-form-group--error', '.govuk-select--error']
+
+document
+  .querySelectorAll('form[data-reset-errors-on-submit="true"]')
+  .forEach(e => e.addEventListener('submit', resetErrors))
+
+function resetErrors() {
+  document.querySelectorAll(removeElementsSelector).forEach(e => e.remove())
+  removeClasses.forEach(className => {
+    document.querySelectorAll(className).forEach(e => e.classList.remove(className.slice(1)))
+  })
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/reportNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/reportNew.ts
@@ -23,7 +23,11 @@ export default class ReportNewPage extends Page {
       .should('be.selected')
   }
 
-  completeForm(startDate: string, endDate: string): void {
+  completeForm(startDate: string, endDate: string, probationRegionId?: string): void {
+    if (probationRegionId) {
+      this.getSelectInputByIdAndSelectAnEntry('probationRegionId', probationRegionId)
+    }
+
     this.getLabel('Start date')
     this.getTextInputByIdAndEnterDetails('startDate', startDate)
 
@@ -47,5 +51,11 @@ export default class ReportNewPage extends Page {
     } else if (type === 'referral') {
       cy.get('button').contains('Download referrals report').click()
     }
+  }
+
+  shouldNotShowErrors() {
+    cy.get('.govuk-error-summary').should('not.exist')
+    cy.get('.govuk-form-group--error').should('not.exist')
+    cy.get('.govuk-error-message').should('not.exist')
   }
 }

--- a/server/views/temporary-accommodation/reports/new.njk
+++ b/server/views/temporary-accommodation/reports/new.njk
@@ -11,6 +11,7 @@
 
 {% block extraScripts %}
     <script type="text/javascript" nonce="{{ cspNonce }}" src="/assets/js/datepicker.js"></script>
+    <script type="text/javascript" nonce="{{ cspNonce }}" src="/assets/js/reset-errors.js"></script>
 {% endblock %}
 
 {% block beforeContent %}
@@ -25,7 +26,7 @@
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <form action="{{ paths.reports.create() }}" method="post">
+            <form action="{{ paths.reports.create() }}" method="post" data-reset-errors-on-submit="true">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
                 {{ showErrorSummary(errorSummary) }}


### PR DESCRIPTION
# Context

If a user attempts to download a report but gets an error (missing required field, invalid date, date range too large, end date in future, etc), after correcting the error and attempting the download again, any errors that was on screen remains there, as the response is simply a file download rather than a page reload.

# Changes in this PR

This PR introduces a JS event listener on form submit event for forms with the data attribute `data-reset-errors-on-submit`. The listener then calls a method which removes error elements and classes from the DOM.
