### PR TITLE
CAS-282: Trim date input entry to ensure correct parsing

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -122,6 +122,18 @@ describe('DateFormats', () => {
       expect(result.date).toEqual('2022-01-01')
     })
 
+    it('trims the entered month, day and year of whitespace', () => {
+      const obj: ObjectWithDateParts<'date'> = {
+        'date-year': '  2024',
+        'date-month': '11  ',
+        'date-day': '  5  ',
+      }
+
+      const result = DateFormats.dateAndTimeInputsToIsoString(obj, 'date')
+
+      expect(result.date).toEqual('2024-11-05')
+    })
+
     it('returns the date with a time if passed one', () => {
       const obj: ObjectWithDateParts<'date'> = {
         'date-year': '2022',

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -83,9 +83,9 @@ export class DateFormats {
     const dayKey = `${key}-day`
     const timeKey = `${key}-time`
 
-    const year = dateInputObj[yearKey] as string
-    const month = `0${dateInputObj[monthKey]}`.slice(-2)
-    const day = `0${dateInputObj[dayKey]}`.slice(-2)
+    const year = (dateInputObj[yearKey] || '').trim() as string
+    const month = `0${(dateInputObj[monthKey] || '').trim()}`.slice(-2)
+    const day = `0${(dateInputObj[dayKey] || '').trim()}`.slice(-2)
     const time = dateInputObj[timeKey] as string
 
     let date: string


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-282

The text entered in date inputs is not currently trimmed of whitespace before being converted to an ISO date string. As a result, if a space is entered _after_ a part of the date (day or month), the resulting ISO date is incorrectly formatted (e.g. `2024-1 -3 `), causing errors down the line.

# Changes in this PR

Any date part entered in a date input is trimmed before being converted to an ISO date string.
