### PR TITLE
CAS-296: Get all user profile data from API

### DIFF
--- a/cypress_shared/utils/setupTestUser.ts
+++ b/cypress_shared/utils/setupTestUser.ts
@@ -11,10 +11,9 @@ export function setupTestUserWithoutRole() {
 
 function setupTestWithRoles(roles: Array<UserRole>) {
   cy.task('stubSignIn')
-  cy.task('stubAuthUser')
 
   const probationRegion = referenceDataFactory.probationRegion().build()
-  const actingUser = userFactory.build({ region: probationRegion, roles })
+  const actingUser = userFactory.build({ name: 'john smith', region: probationRegion, roles })
 
   cy.wrap(actingUser).as('actingUser')
   cy.wrap(probationRegion).as('actingUserProbationRegion')

--- a/integration_tests/mockApis/auth.ts
+++ b/integration_tests/mockApis/auth.ts
@@ -118,48 +118,9 @@ const token = () =>
     },
   })
 
-const stubUser = (name: string) =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: {
-        staffId: 231232,
-        username: 'USER1',
-        uuid: 'USER1',
-        active: true,
-        name,
-      },
-    },
-  })
-
-const stubUserRoles = () =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPattern: '/auth/api/user/me/roles',
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: [{ roleCode: 'SOME_USER_ROLE' }],
-    },
-  })
-
 export default {
   getSignInUrl,
   stubAuthPing: ping,
   stubSignIn: (): Promise<[Response, Response, Response, Response, Response, Response]> =>
     Promise.all([favicon(), redirect(), signOut(), manageDetails(), token(), tokenVerification.stubVerifyToken()]),
-  stubAuthUser: (name = 'john smith'): Promise<[Response, Response]> => {
-    return Promise.all([stubUser(name), stubUserRoles()])
-  },
 }

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -70,12 +70,15 @@ context('SignIn', () => {
     cy.request('/').its('body').should('contain', 'Sign in')
 
     cy.task('stubVerifyToken', true)
-    cy.task('stubAuthUser', 'bobby brown')
 
     const probationRegion = referenceDataFactory.probationRegion().build({
       name: 'Another region',
     })
-    const actingUser = userFactory.build({ region: probationRegion, roles: ['assessor', 'referrer'] })
+    const actingUser = userFactory.build({
+      name: 'bobby brown',
+      region: probationRegion,
+      roles: ['assessor', 'referrer'],
+    })
 
     cy.task('stubActingUser', actingUser)
     cy.task('stubGetUserById', actingUser)

--- a/server/data/hmppsAuthClient.test.ts
+++ b/server/data/hmppsAuthClient.test.ts
@@ -2,7 +2,6 @@ import nock from 'nock'
 
 import config from '../config'
 import HmppsAuthClient from './hmppsAuthClient'
-import { CallConfig } from './restClient'
 import TokenStore from './tokenStore'
 
 jest.mock('./tokenStore')
@@ -11,7 +10,6 @@ const tokenStore = new TokenStore(null) as jest.Mocked<TokenStore>
 
 const username = 'Bob'
 const token = { access_token: 'token-1', expires_in: 300 }
-const callConfig = { token: 'some-token' } as CallConfig
 
 describe('hmppsAuthClient', () => {
   let fakeHmppsAuthApi: nock.Scope
@@ -25,32 +23,6 @@ describe('hmppsAuthClient', () => {
   afterEach(() => {
     jest.resetAllMocks()
     nock.cleanAll()
-  })
-
-  describe('getActingUser', () => {
-    it('should return data from api', async () => {
-      const response = { data: 'data' }
-
-      fakeHmppsAuthApi
-        .get('/api/user/me')
-        .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .reply(200, response)
-
-      const output = await hmppsAuthClient.getActingUser(callConfig)
-      expect(output).toEqual(response)
-    })
-  })
-
-  describe('getUserRoles', () => {
-    it('should return data from api', async () => {
-      fakeHmppsAuthApi
-        .get('/api/user/me/roles')
-        .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .reply(200, [{ roleCode: 'role1' }, { roleCode: 'role2' }])
-
-      const output = await hmppsAuthClient.getUserRoles(callConfig)
-      expect(output).toEqual(['role1', 'role2'])
-    })
   })
 
   describe('getSystemClientToken', () => {

--- a/server/data/hmppsAuthClient.ts
+++ b/server/data/hmppsAuthClient.ts
@@ -4,7 +4,6 @@ import superagent from 'superagent'
 import logger from '../../logger'
 import generateOauthClientToken from '../authentication/clientCredentials'
 import config from '../config'
-import RestClient, { CallConfig } from './restClient'
 import type TokenStore from './tokenStore'
 
 const timeoutSpec = config.apis.hmppsAuth.timeout
@@ -42,21 +41,6 @@ export interface UserRole {
 
 export default class HmppsAuthClient {
   constructor(private readonly tokenStore: TokenStore) {}
-
-  private static restClient(callConfig: CallConfig): RestClient {
-    return new RestClient('HMPPS Auth Client', config.apis.hmppsAuth, callConfig)
-  }
-
-  getActingUser(callConfig: CallConfig): Promise<User> {
-    logger.info(`Getting user details: calling HMPPS Auth`)
-    return HmppsAuthClient.restClient(callConfig).get({ path: '/api/user/me' }) as Promise<User>
-  }
-
-  getUserRoles(callConfig: CallConfig): Promise<string[]> {
-    return HmppsAuthClient.restClient(callConfig)
-      .get({ path: '/api/user/me/roles' })
-      .then(roles => (<UserRole[]>roles).map(role => role.roleCode))
-  }
 
   async getSystemClientToken(username?: string): Promise<string> {
     const key = username || '%ANONYMOUS%'

--- a/server/services/index.ts
+++ b/server/services/index.ts
@@ -26,7 +26,6 @@ import ReferenceDataService from './referenceDataService'
 
 export const services = () => {
   const {
-    hmppsAuthClient,
     premisesClientBuilder,
     bookingClientBuilder,
     referenceDataClientBuilder,
@@ -40,7 +39,7 @@ export const services = () => {
     assessmentClientBuilder,
   } = dataAccess()
 
-  const userService = new UserService(hmppsAuthClient, userClientBuilder)
+  const userService = new UserService(userClientBuilder)
   const auditService = new AuditService(config.apis.audit)
   const premisesService = new PremisesService(premisesClientBuilder, referenceDataClientBuilder)
   const personService = new PersonService(personClientBuilder)

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,21 +1,19 @@
-import HmppsAuthClient, { User } from '../data/hmppsAuthClient'
 import { CallConfig } from '../data/restClient'
 import UserClient from '../data/userClient'
 import { userFactory } from '../testutils/factories'
 import UserService from './userService'
+import { convertToTitleCase } from '../utils/utils'
 
-jest.mock('../data/hmppsAuthClient')
 jest.mock('../data/userClient')
 
 const callConfig = { token: 'some-token' } as CallConfig
 
 describe('User service', () => {
-  const hmppsAuthClient = new HmppsAuthClient(null) as jest.Mocked<HmppsAuthClient>
   const userClient = new UserClient(null) as jest.Mocked<UserClient>
 
   const userClientFactory = jest.fn()
 
-  const userService = new UserService(hmppsAuthClient, userClientFactory)
+  const userService = new UserService(userClientFactory)
 
   beforeEach(() => {
     jest.resetAllMocks()
@@ -23,30 +21,26 @@ describe('User service', () => {
   })
 
   describe('getActingUser', () => {
-    it('gets the acting user, collating results from the Community Accommodation API and the HMPPS Auth API', async () => {
+    it('gets the acting user from the Community Accommodation API', async () => {
       const communityAccommodationUser = userFactory.build()
-      const hmppsAuthUser = { name: 'john smith' } as User
 
       userClient.getActingUser.mockResolvedValue(communityAccommodationUser)
       userClient.getUserById.mockResolvedValue(communityAccommodationUser)
-      hmppsAuthClient.getActingUser.mockResolvedValue(hmppsAuthUser)
 
       const result = await userService.getActingUser(callConfig)
 
       expect(result).toEqual({
-        ...communityAccommodationUser,
-        ...hmppsAuthUser,
-        displayName: 'John Smith',
+        name: communityAccommodationUser.name,
+        displayName: convertToTitleCase(communityAccommodationUser.name),
+        id: communityAccommodationUser.id,
+        roles: communityAccommodationUser.roles,
+        service: communityAccommodationUser.service,
+        region: communityAccommodationUser.region,
+        deliusUsername: communityAccommodationUser.deliusUsername,
       })
 
       expect(userClientFactory).toHaveBeenCalledWith(callConfig)
       expect(userClient.getActingUser).toHaveBeenCalledWith()
-    })
-
-    it('propagates errors from the HMPPS Auth API', async () => {
-      hmppsAuthClient.getActingUser.mockRejectedValue(new Error('some error'))
-
-      await expect(userService.getActingUser(callConfig)).rejects.toEqual(new Error('some error'))
     })
 
     it('propagates errors from the Community Accommodation API', async () => {

--- a/server/services/userService.ts
+++ b/server/services/userService.ts
@@ -1,6 +1,5 @@
 import { TemporaryAccommodationUser as User } from '../@types/shared'
 import { RestClientBuilder } from '../data'
-import type HmppsAuthClient from '../data/hmppsAuthClient'
 import { CallConfig } from '../data/restClient'
 import UserClient from '../data/userClient'
 import { convertToTitleCase } from '../utils/utils'
@@ -11,22 +10,17 @@ export type UserDetails = User & {
 }
 
 export default class UserService {
-  constructor(
-    private readonly hmppsAuthClient: HmppsAuthClient,
-    private readonly userClientFactory: RestClientBuilder<UserClient>,
-  ) {}
+  constructor(private readonly userClientFactory: RestClientBuilder<UserClient>) {}
 
   async getActingUser(callConfig: CallConfig): Promise<UserDetails> {
-    const hmppsAuthUser = await this.hmppsAuthClient.getActingUser(callConfig)
-
     const client = this.userClientFactory(callConfig)
 
     const { id } = await client.getActingUser()
     const communityAccommodationUser = await client.getUserById(id)
 
     return {
-      ...hmppsAuthUser,
-      displayName: convertToTitleCase(hmppsAuthUser.name),
+      name: communityAccommodationUser.name,
+      displayName: convertToTitleCase(communityAccommodationUser.name),
       id: communityAccommodationUser.id,
       roles: communityAccommodationUser.roles,
       service: communityAccommodationUser.service,

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -3,11 +3,14 @@ import { Factory } from 'fishery'
 import type { TemporaryAccommodationUser as User } from '@approved-premises/api'
 import referenceData from './referenceData'
 
-export default Factory.define<User>(() => ({
-  id: faker.string.uuid(),
-  roles: [],
-  region: referenceData.probationRegion().build(),
-  service: 'temporary-accommodation',
-  name: faker.person.fullName(),
-  deliusUsername: faker.person.fullName(),
-}))
+export default Factory.define<User>(() => {
+  const name = faker.person.fullName({}).toUpperCase()
+  return {
+    id: faker.string.uuid(),
+    roles: [],
+    region: referenceData.probationRegion().build(),
+    service: 'temporary-accommodation',
+    name,
+    deliusUsername: name.replace(/\s+/g, '.'),
+  }
+})


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-296

From the HMPPS Auth team:

> The endpoint for retrieving and managing user information has been updated. The existing endpoint is now deprecated  and will be decommissioned soon, therefore the service needs to update any reference to the new endpoint.
>
> Current end point: GET {hmpps-auth-api}/auth/api/user/me
> New end point: {hmpps-manage-users-api}/users/me
>
> Note that this also covers any children endpoints, so {hmpps-auth-api}/auth/api/user/me/roles needs to also update to {hmpps-manage-users-api}/users/me/roles.

However, there is no longer any need to use the Auth API to populate the current user's profile data, as all that profile data is coming directly from the API. This means the UI no longer needs to call the HMPPS Auth endpoints for anything else than fetching the auth access token.
