### PR TITLE
BUGFIX: Ensure years are 4 digits

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -297,6 +297,18 @@ describe('dateAndTimeInputsAreValidDates', () => {
 
     expect(result).toEqual(false)
   })
+
+  it('returns false when the year is not 4 digits', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': '202',
+      'date-month': '01',
+      'date-day': '01',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(false)
+  })
 })
 
 describe('dateIsBlank', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -41,7 +41,13 @@ export class DateFormats {
    * @throws {InvalidDateStringError} If the string is not a valid ISO8601 datetime string
    */
   static isoToDateObj(date: string) {
-    const parsedDate = new Date(date)
+    let parsedDate: Date
+
+    try {
+      parsedDate = new Date(date)
+    } catch (error) {
+      throw new InvalidDateStringError(`Invalid Date: ${date}`)
+    }
 
     if (Number.isNaN(parsedDate.getTime())) {
       throw new InvalidDateStringError(`Invalid Date: ${date}`)
@@ -153,6 +159,10 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   dateInputObj: Partial<ObjectWithDateParts<K>>,
   key: K,
 ): boolean => {
+  const inputYear = dateInputObj?.[`${key}-year`] as string
+
+  if (inputYear && inputYear.length !== 4) return false
+  
   const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)
 
   try {


### PR DESCRIPTION
# Changes in this PR

Ensure date validation considers years with 3 digits invalid, to prevent users accidentally entering incomplete years like `202` instead of `2024`
