### PR TITLE
BUGFIX/Prevent error when submitting an old release type

### DIFF
--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
@@ -136,6 +136,14 @@ describe('SentenceExpiry', () => {
         releaseTypes: 'Parole cannot be selected alongside the CRD licence or PSS',
       })
     })
+
+    it('returns a single error if an old release type is submitted', () => {
+      const page = new ReleaseType({ releaseTypes: ['licence'] as unknown as Array<ReleaseTypeKey> }, application)
+
+      expect(page.errors()).toEqual({
+        releaseTypes: 'You must specify the release types',
+      })
+    })
   })
 
   describe('response', () => {

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -107,20 +107,19 @@ export default class ReleaseType implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    if (!this.body.releaseTypes?.length) {
+    const submittedReleaseTypes = this.body.releaseTypes?.filter(key => Boolean(releaseTypes[key]))
+
+    if (!submittedReleaseTypes?.length) {
       errors.releaseTypes = 'You must specify the release types'
-    } else if (
-      this.body.releaseTypes?.includes('fixedTermRecall') &&
-      this.body.releaseTypes?.includes('standardRecall')
-    ) {
+    } else if (submittedReleaseTypes.includes('fixedTermRecall') && submittedReleaseTypes.includes('standardRecall')) {
       errors.releaseTypes = 'Select one type of recall licence'
     } else if (
-      this.body.releaseTypes?.includes('parole') &&
-      (this.body.releaseTypes?.includes('crdLicence') || this.body.releaseTypes?.includes('pss'))
+      submittedReleaseTypes.includes('parole') &&
+      (submittedReleaseTypes.includes('crdLicence') || submittedReleaseTypes.includes('pss'))
     ) {
       errors.releaseTypes = 'Parole cannot be selected alongside the CRD licence or PSS'
     } else {
-      this.body.releaseTypes?.forEach((key: ReleaseTypeKey) => {
+      submittedReleaseTypes.forEach((key: ReleaseTypeKey) => {
         if (dateIsBlank(this.body, `${key}StartDate`)) {
           errors[`${key}StartDate`] = `You must specify the ${releaseTypes[key].abbr} start date`
         } else if (!dateAndTimeInputsAreValidDates(this.body, `${key}StartDate`)) {


### PR DESCRIPTION
# Context

If an old release type is submitted during the application (i.e. `license`), the validation may produce a server error as no abbreviation for that release type exists ([issue on Sentry](https://ministryofjustice.sentry.io/issues/5428822122/?environment=prod&project=4504129156218880&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=0)). This fixes the issue by filtering the submitted release types to those that exist in the current list.