### PR TITLE
BUGFIX: Ignore old release types in Review your answers

### DIFF
--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
@@ -1,6 +1,6 @@
 import { applicationFactory } from '../../../../testutils/factories'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import ReleaseType, { type ReleaseTypeKey, releaseTypes } from './releaseType'
+import ReleaseType, { type ReleaseTypeBody, type ReleaseTypeKey, releaseTypes } from './releaseType'
 
 const body = {
   releaseTypes: ['fixedTermRecall' as const, 'parole' as const],
@@ -31,6 +31,23 @@ describe('SentenceExpiry', () => {
         fixedTermRecallEndDate: '2024-07-09',
         paroleStartDate: '2122-04-01',
         paroleEndDate: '2122-07-18',
+      })
+    })
+
+    it('excludes invalid or old release types', () => {
+      const oldBody = {
+        releaseTypes: ['licence'],
+        'licenceStartDate-year': '2024',
+        'licenceStartDate-month': '1',
+        'licenceStartDate-day': '19',
+        'licenceEndDate-year': '2024',
+        'licenceEndDate-month': '7',
+        'licenceEndDate-day': '9',
+      }
+      const page = new ReleaseType(oldBody as unknown as ReleaseTypeBody, application)
+
+      expect(page.body).toEqual({
+        releaseTypes: [],
       })
     })
   })
@@ -156,6 +173,17 @@ describe('SentenceExpiry', () => {
         'Fixed-term recall end date': '9 July 2024',
         'Parole start date': '1 April 2122',
         'Parole end date': '18 July 2122',
+      })
+    })
+
+    it('does not display invalid release types', () => {
+      const oldBody = {
+        releaseTypes: ['licence'],
+      }
+      const page = new ReleaseType(oldBody as unknown as ReleaseTypeBody, application)
+
+      expect(page.response()).toEqual({
+        'What is the release type?': '',
       })
     })
   })

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -65,17 +65,16 @@ export default class ReleaseType implements TasklistPage {
   ) {}
 
   public set body(value: Partial<ReleaseTypeBody>) {
+    const selectedTypes = value.releaseTypes?.filter(key => Boolean(releaseTypes[key]))
     this._body = {
-      releaseTypes: value.releaseTypes,
-      ...Object.keys(releaseTypes)
-        .filter((key: ReleaseTypeKey) => value.releaseTypes?.includes(key))
-        .reduce((properties, key: ReleaseTypeKey) => {
-          return {
-            ...properties,
-            ...DateFormats.dateAndTimeInputsToIsoString(value, `${key}StartDate`),
-            ...DateFormats.dateAndTimeInputsToIsoString(value, `${key}EndDate`),
-          }
-        }, {}),
+      releaseTypes: selectedTypes,
+      ...selectedTypes?.reduce((properties, key: ReleaseTypeKey) => {
+        return {
+          ...properties,
+          ...DateFormats.dateAndTimeInputsToIsoString(value, `${key}StartDate`),
+          ...DateFormats.dateAndTimeInputsToIsoString(value, `${key}EndDate`),
+        }
+      }, {}),
     }
   }
 
@@ -85,7 +84,7 @@ export default class ReleaseType implements TasklistPage {
 
   response() {
     const response = {
-      [this.title]: this.body.releaseTypes.map(key => releaseTypes[key].abbr).join('\n'),
+      [this.title]: this.body.releaseTypes?.map(key => releaseTypes[key].abbr).join('\n'),
     }
 
     this.body.releaseTypes?.forEach((key: ReleaseTypeKey) => {
@@ -107,19 +106,20 @@ export default class ReleaseType implements TasklistPage {
   errors() {
     const errors: TaskListErrors<this> = {}
 
-    const submittedReleaseTypes = this.body.releaseTypes?.filter(key => Boolean(releaseTypes[key]))
-
-    if (!submittedReleaseTypes?.length) {
+    if (!this.body.releaseTypes?.length) {
       errors.releaseTypes = 'You must specify the release types'
-    } else if (submittedReleaseTypes.includes('fixedTermRecall') && submittedReleaseTypes.includes('standardRecall')) {
+    } else if (
+      this.body.releaseTypes.includes('fixedTermRecall') &&
+      this.body.releaseTypes.includes('standardRecall')
+    ) {
       errors.releaseTypes = 'Select one type of recall licence'
     } else if (
-      submittedReleaseTypes.includes('parole') &&
-      (submittedReleaseTypes.includes('crdLicence') || submittedReleaseTypes.includes('pss'))
+      this.body.releaseTypes.includes('parole') &&
+      (this.body.releaseTypes.includes('crdLicence') || this.body.releaseTypes.includes('pss'))
     ) {
       errors.releaseTypes = 'Parole cannot be selected alongside the CRD licence or PSS'
     } else {
-      submittedReleaseTypes.forEach((key: ReleaseTypeKey) => {
+      this.body.releaseTypes.forEach((key: ReleaseTypeKey) => {
         if (dateIsBlank(this.body, `${key}StartDate`)) {
           errors[`${key}StartDate`] = `You must specify the ${releaseTypes[key].abbr} start date`
         } else if (!dateAndTimeInputsAreValidDates(this.body, `${key}StartDate`)) {

--- a/server/views/applications/pages/check-your-answers/check-your-answers/review.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers/review.njk
@@ -9,68 +9,67 @@
 {% set pageTitle = page.title + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
-{% block beforeContent%}
-  {{ govukBackLink({
-      text: "Back",
-      href: paths.applications.show({ id: page.application.id }),
-      classes: 'exclude-from-print'
-  }) }}
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.applications.show({ id: page.application.id }),
+        classes: 'exclude-from-print'
+    }) }}
 {% endblock %}
 
 {% block content %}
-  <div class="govuk-grid-row">
-    <div class="govuk-width-container">
-      <h1 class="govuk-heading-xl">
-        {{ page.title }}
-      </h1>
+    <div class="govuk-grid-row">
+        <div class="govuk-width-container">
+            <h1 class="govuk-heading-xl">
+                {{ page.title }}
+            </h1>
 
-      {{ printButton() }}
+            {{ printButton() }}
 
-      <div class="main-box">
-        <h2 class="box-title govuk-heading-m">
-          Person Details
-        </h2>
-        <div class="box-content" data-cy-check-your-answers-section="person-details">
-          {{ personDetails(page.application.person) }}
-        </div>
-      </div>
-
-      {% for section in checkYourAnswersSections(page.application) %}
-        <h2 class="govuk-heading-l">{{ section.title }}</h2>
-        {% for task in section.tasks %}
-          <div class="main-box" data-cy-check-your-answers-section="{{ task.id }}">
-            <h3 class="box-title govuk-heading-m">
-              {{ task.title }}
-            </h3>
-            <div class="box-content">
-              {{
-                govukSummaryList({
-                  rows: task.rows
-                })
-              }}
+            <div class="main-box">
+                <h2 class="box-title govuk-heading-m">
+                    Person Details
+                </h2>
+                <div class="box-content" data-cy-check-your-answers-section="person-details">
+                    {{ personDetails(page.application.person) }}
+                </div>
             </div>
-          </div>
-        {% endfor %}
-      {% endfor %}
 
-      <form action="{{ paths.applications.pages.update({ id: applicationId, task: task.id, page: page.name }) }}?_method=PUT" method="post">
-        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+            {% for section in checkYourAnswersSections(page.application) %}
+                <h2 class="govuk-heading-l">{{ section.title }}</h2>
+                {% for task in section.tasks %}
+                    <div class="main-box" data-cy-check-your-answers-section="{{ task.id }}">
+                        <h3 class="box-title govuk-heading-m">
+                            {{ task.title }}
+                        </h3>
+                        <div class="box-content">
+                            {{ govukSummaryList({
+                                rows: task.rows
+                            }) }}
+                        </div>
+                    </div>
+                {% endfor %}
+            {% endfor %}
 
-        <input type="hidden" name="reviewed" value="1"/>
+            <form action="{{ paths.applications.pages.update({ id: applicationId, task: task.id, page: page.name }) }}?_method=PUT"
+                  method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 
-        {{ govukButton({
-          text: "Continue",
-          preventDoubleClick: true,
-          classes: 'exclude-from-print'
-        }) }}
-      </form>
+                <input type="hidden" name="reviewed" value="1" />
 
+                {{ govukButton({
+                    text: "Continue",
+                    preventDoubleClick: true,
+                    classes: 'exclude-from-print'
+                }) }}
+            </form>
+
+        </div>
     </div>
-  </div>
 
 
 {% endblock %}
 
 {% block extraScripts %}
-  {{ printButtonScript(cspNonce) }}
+    {{ printButtonScript(cspNonce) }}
 {% endblock %}


### PR DESCRIPTION
The change of release types prevented displaying the 'Review your answers' page if an old application contained one of the old release types, 'licence'. This one is now filtered out of the possible answers. If the resulting application has no release type, it will now show as incomplete and a session error would be thrown if accessing the 'Review your answers' page, which is the current outcome for all 'application incomplete' errors.

Original error on Sentry: https://ministryofjustice.sentry.io/issues/4347240074/?alert_rule_id=12729521&alert_type=issue&environment=prod&notification_uuid=a3a3205c-72e6-4769-8a09-d3046c9cd297&project=4504129156218880

