### PR TITLE
CAS-57 / Default number of days required for bedspace search

### DIFF
--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -33,6 +33,7 @@ Given('I search for a bedspace', () => {
 Given('I attempt to search for a bedspace with required details missing', () => {
   cy.then(function _() {
     const page = Page.verifyOnPage(BedspaceSearchPage)
+    page.clearTextInputByLabel('Number of days required')
     page.clickSubmit()
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
@@ -21,7 +21,7 @@ context('Bedspace Search', () => {
     setupTestUser('assessor')
   })
 
-  it('navigates to the bedspace search page', () => {
+  it('navigates to the bedspace search page with a default number of days', () => {
     // Given I am signed in
     cy.signIn()
 
@@ -35,7 +35,9 @@ context('Bedspace Search', () => {
     page.clickSearchBedspacesLink()
 
     // Then I navigate to the bedspace search page
-    Page.verifyOnPage(BedspaceSearchPage)
+    const searchPage = Page.verifyOnPage(BedspaceSearchPage)
+
+    searchPage.shouldShowTextInputByLabel('Number of days required', '84')
   })
 
   it('shows search results', () => {
@@ -206,6 +208,7 @@ context('Bedspace Search', () => {
 
     // And I miss required fields
     cy.task('stubBedSearchErrors', ['startDate', 'durationDays', 'probationDeliveryUnit'])
+    page.clearTextInputByLabel('Number of days required')
     page.clickSubmit()
 
     // Then I should see error messages relating to those fields

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
@@ -16,7 +16,7 @@ import { DateFormats } from '../../../utils/dateUtils'
 import { addPlaceContext, preservePlaceContext, updatePlaceContextWithArrivalDate } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, setUserInput } from '../../../utils/validation'
-import BedspaceSearchController from './bedspaceSearchController'
+import BedspaceSearchController, { DEFAULT_DURATION_DAYS } from './bedspaceSearchController'
 
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/validation')
@@ -45,7 +45,7 @@ describe('BedspaceSearchController', () => {
   })
 
   describe('index', () => {
-    it('renders the search page when not given a search query', async () => {
+    it('renders the search page with default duration when not given a search query', async () => {
       request.query = {
         'other-parameter': 'other-data',
       }
@@ -65,6 +65,7 @@ describe('BedspaceSearchController', () => {
         allPdus: referenceData.pdus,
         errors: {},
         errorSummary: [],
+        durationDays: DEFAULT_DURATION_DAYS,
       })
     })
 

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -11,6 +11,8 @@ import { addPlaceContext, preservePlaceContext, updatePlaceContextWithArrivalDat
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, setUserInput } from '../../../utils/validation'
 
+export const DEFAULT_DURATION_DAYS = 84
+
 type BedspaceSearchQuery = ObjectWithDateParts<'startDate'> & { probationDeliveryUnit: string; durationDays: string }
 
 export default class BedspaceSearchController {
@@ -64,6 +66,7 @@ export default class BedspaceSearchController {
           startDate,
           errors,
           errorSummary,
+          durationDays: req.query.durationDays || DEFAULT_DURATION_DAYS,
           ...startDatePrefill,
           ...query,
           ...userInput,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-57

# Changes in this PR

Pre-fills the 'Number of days required' to `84` in the bedspace search.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).


## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
