### PR TITLE
CAS-397: Add IPs to allowlist to ensure MOJO access

### DIFF
--- a/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
@@ -86,6 +86,10 @@ generic-service:
     azure-landing-zone-egress-3: "20.26.11.71/32"
     azure-landing-zone-egress-4: "20.26.11.108/32"
     palo-alto-prisma-access-egress: "128.77.75.128/26"
+    palo-alto-prisma-access-egress-2: "128.77.75.64/26"
+    prp-dia-sites-1: "194.33.200.0/21"
+    prp-dia-sites-2: "194.33.216.0/23"
+    prp-dia-sites-3: "194.33.218.0/24"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-temporary-accommodation-ui


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-397

# Changes in this PR

Adds IPs for new subnets for PRP DIA Sites and an extra IP for Palo Alto Prisma Access Egress.

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
