### PR TITLE
CAS-392: Fix check for past and future dates

### DIFF
--- a/server/utils/bedspaceUtils.ts
+++ b/server/utils/bedspaceUtils.ts
@@ -2,7 +2,7 @@ import { Premises, Room } from '../@types/shared'
 import { BedspaceStatus, ErrorSummary, PageHeadingBarItem, PlaceContext } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { addPlaceContext } from './placeUtils'
-import { DateFormats, dateIsInThePast } from './dateUtils'
+import { DateFormats, dateIsInFuture } from './dateUtils'
 import { insertBespokeError, insertGenericError } from './validation'
 import { SanitisedError } from '../sanitisedError'
 
@@ -29,7 +29,7 @@ export function bedspaceActions(premises: Premises, room: Room, placeContext: Pl
 
 export function bedspaceStatus(room: Room): BedspaceStatus {
   if (room.beds[0].bedEndDate) {
-    if (dateIsInThePast(room.beds[0].bedEndDate)) {
+    if (!dateIsInFuture(room.beds[0].bedEndDate)) {
       return 'archived'
     }
   }

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,4 +1,3 @@
-import { isFuture, isPast } from 'date-fns'
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 import {
   DateFormats,
@@ -10,9 +9,6 @@ import {
   dateIsInFuture,
   dateIsInThePast,
 } from './dateUtils'
-
-jest.mock('date-fns/isPast')
-jest.mock('date-fns/isFuture')
 
 describe('DateFormats', () => {
   describe('dateObjToIsoDate', () => {
@@ -347,29 +343,37 @@ describe('dateIsBlank', () => {
 })
 
 describe('dateIsInThePast', () => {
-  it('returns true if the date is in the past', () => {
-    ;(isPast as jest.Mock).mockReturnValue(true)
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-06-06T14:07:00.000Z'))
+  })
 
+  it('returns true if the date is in the past', () => {
     expect(dateIsInThePast('2020-01-01')).toEqual(true)
   })
 
-  it('returns false if the date is not in the past', () => {
-    ;(isPast as jest.Mock).mockReturnValue(false)
+  it('returns false if the date is today', () => {
+    expect(dateIsInThePast('2024-06-06')).toEqual(false)
+  })
 
-    expect(dateIsInThePast('2020-01-01')).toEqual(false)
+  it('returns false if the date is not in the past', () => {
+    expect(dateIsInThePast('2024-06-07')).toEqual(false)
   })
 })
 
 describe('dateIsInTheFuture', () => {
-  it('returns true if the date is in the future', () => {
-    ;(isFuture as jest.Mock).mockReturnValue(true)
+  beforeEach(() => {
+    jest.useFakeTimers().setSystemTime(new Date('2024-06-06T14:07:00.000Z'))
+  })
 
-    expect(dateIsInFuture('2020-01-01')).toEqual(true)
+  it('returns true if the date is in the future', () => {
+    expect(dateIsInFuture('2024-06-07')).toEqual(true)
+  })
+
+  it('returns false if the date is today', () => {
+    expect(dateIsInFuture('2024-06-06')).toEqual(false)
   })
 
   it('returns false if the date is not in the future', () => {
-    ;(isFuture as jest.Mock).mockReturnValue(false)
-
     expect(dateIsInFuture('2020-01-01')).toEqual(false)
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { differenceInDays, isExists, isFuture, isPast } from 'date-fns'
+import { differenceInDays, isExists } from 'date-fns'
 
 import format from 'date-fns/format'
 import formatISO from 'date-fns/formatISO'
@@ -162,7 +162,7 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
   const inputYear = dateInputObj?.[`${key}-year`] as string
 
   if (inputYear && inputYear.length !== 4) return false
-  
+
   const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)
 
   try {
@@ -195,13 +195,11 @@ export const dateIsBlank = <K extends string | number>(
 export class InvalidDateStringError extends Error {}
 
 export const dateIsInThePast = (dateString: string): boolean => {
-  const date = DateFormats.isoToDateObj(dateString)
-  return isPast(date)
+  return dateString < DateFormats.dateObjToIsoDate(new Date())
 }
 
 export const dateIsInFuture = (dateString: string): boolean => {
-  const date = DateFormats.isoToDateObj(dateString)
-  return isFuture(date)
+  return dateString > DateFormats.dateObjToIsoDate(new Date())
 }
 
 export const dateInputHint = (direction: 'past' | 'future') => {


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-392

# Changes in this PR

The "What is the person's release date?" and "What date is accommodation required from?" questions should have accepted today as an answer, but was not, due to a bug and incorrect testing of the method that checks for a date being in the past.

This PR fixes the tests and the check, and updates the tests and check for future dates, too.

As a result, another change was made to fix another check for a past date that relied on the incorrect implementation.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
