### PR TITLE
CAS-359: fix Local Authority field error highlight

### DIFF
--- a/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
+++ b/server/form-pages/apply/required-referrals/accommodation-referral-details/dtrDetails.ts
@@ -95,9 +95,7 @@ export default class DtrDetails implements TasklistPage {
     return {
       [this.questions.reference]: this.body.reference,
       [this.questions.date]: DateFormats.isoDateToUIDate(this.body.date),
-      [this.questions.localAuthority]: this.body.localAuthorityAreaName
-        ? this.body.localAuthorityAreaName
-        : 'No local authority selected',
+      [this.questions.localAuthority]: this.body.localAuthorityAreaName,
       [this.questions.dutyToReferOutcome]: dutyToReferOutcomes[this.body.dutyToReferOutcome],
       ...(this.body.dutyToReferOutcomeOtherDetails && {
         [this.questions.dutyToReferOutcomeOtherDetails]: this.body.dutyToReferOutcomeOtherDetails,
@@ -129,7 +127,7 @@ export default class DtrDetails implements TasklistPage {
     }
 
     if (!this.body.localAuthorityAreaName) {
-      errors.localAuthorityAreaName = 'Enter a home local authority'
+      errors.localAuthorityAreaName = 'Select a home local authority'
     }
 
     if (!this.body.dutyToReferOutcome) {

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
@@ -39,7 +39,7 @@
             hint: {
                 text: "Provide the home local authority used for the DTR/NOP"
             },
-            items: convertObjectsToSelectOptions(page.getLocalAuthorities(), '', 'name', 'name', 'localAuthorityAreaId'),
+            items: convertObjectsToSelectOptions(page.getLocalAuthorities(), '', 'name', 'name', 'localAuthorityAreaName'),
             fieldName: "localAuthorityAreaName"
         }, fetchContext()) }}
     {% endif %}

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-details.njk
@@ -3,77 +3,74 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ task.title }}</span>
-    {{ page.title }}
-  </h1>
+    <h1 class="govuk-heading-l">
+        <span class="govuk-caption-l">{{ task.title }}</span>
+        {{ page.title }}
+    </h1>
 
-  {{ formPageInput({
-    fieldName: "reference",
-    label: {
-      text: page.questions.reference,
-      classes: "govuk-label--m"
-    }
-  }, fetchContext()) }}
-
-  {{ formPageDateInput( {
-    fieldName: "date",
-    hint: {
-      text: dateInputHint('past')
-    },
-    fieldset: {
-      legend: {
-        text: page.questions.date,
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    items: dateFieldValues('date', errors)
-  }, fetchContext()) }}
-
-  {% if page.getLocalAuthorities() | length %}
-    {{ taSelect(
-      {
+    {{ formPageInput({
+        fieldName: "reference",
         label: {
-          text: "Home local authority",
-          classes: "govuk-label--m"
-        },
+            text: page.questions.reference,
+            classes: "govuk-label--m"
+        }
+    }, fetchContext()) }}
+
+    {{ formPageDateInput({
+        fieldName: "date",
         hint: {
-          text: "Provide the home local authority used for the DTR/NOP"
+            text: dateInputHint('past')
         },
-        items: convertObjectsToSelectOptions(page.getLocalAuthorities(), '', 'name', 'name', 'localAuthorityAreaId'),
-        fieldName: "localAuthorityAreaName"
-      }
-    ) }}
-  {% endif %}
+        fieldset: {
+            legend: {
+                text: page.questions.date,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        items: dateFieldValues('date', errors)
+    }, fetchContext()) }}
 
-  {% set itemsWithDetail = [] %}
-  {% set conditionalHtml %}
-    {{ formPageTextarea({
-      fieldName: "dutyToReferOutcomeOtherDetails",
-      label: {
-        text: "Add details about the reason",
-        classes: "govuk-label--s"
-      }
-    },fetchContext()) }}
-  {% endset %}
+    {% if page.getLocalAuthorities() | length %}
+        {{ taSelect({
+            label: {
+                text: "Home local authority",
+                classes: "govuk-label--m"
+            },
+            hint: {
+                text: "Provide the home local authority used for the DTR/NOP"
+            },
+            items: convertObjectsToSelectOptions(page.getLocalAuthorities(), '', 'name', 'name', 'localAuthorityAreaId'),
+            fieldName: "localAuthorityAreaName"
+        }, fetchContext()) }}
+    {% endif %}
 
-  {% for item in page.items() %}
-    {% set itemsWithDetail = (
-      itemsWithDetail.push(mergeObjects(item, {
-        conditional: { html: conditionalHtml } if item.value === 'rejectedOther' else undefined
-      })), itemsWithDetail)
-    %}
-  {% endfor %}
+    {% set itemsWithDetail = [] %}
+    {% set conditionalHtml %}
+        {{ formPageTextarea({
+            fieldName: "dutyToReferOutcomeOtherDetails",
+            label: {
+                text: "Add details about the reason",
+                classes: "govuk-label--s"
+            }
+        }, fetchContext()) }}
+    {% endset %}
 
-  {{ formPageRadios({
-    fieldset: {
-      legend: {
-        text: page.questions.dutyToReferOutcome,
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    fieldName: "dutyToReferOutcome",
-    items: itemsWithDetail
-  }, fetchContext()) }}
+    {% for item in page.items() %}
+        {% set itemsWithDetail = (
+            itemsWithDetail.push(mergeObjects(item, {
+                conditional: { html: conditionalHtml } if item.value === 'rejectedOther' else undefined
+            })), itemsWithDetail) %}
+    {% endfor %}
+
+    {{ formPageRadios({
+        fieldset: {
+            legend: {
+                text: page.questions.dutyToReferOutcome,
+                classes: "govuk-fieldset__legend--m"
+            }
+        },
+        fieldName: "dutyToReferOutcome",
+        items: itemsWithDetail
+    }, fetchContext()) }}
 
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-359

# Changes in this PR

Ensures the Local Authority field is highlighted when an error is associated with it. Also ensures the previously selected value is shown when coming back to the page to change an answer, or when other errors were shown.

Improve tests by adding a unit test for LA field error. Local Authority field is required, so the logic for displaying a placeholder if not provided is also removed, as is the test related to that. Date tests also updated to stop relying on mocks for date function, instead stubbing the test runner system time. 

## Screenshots of UI changes

### After

<img width="758" alt="Screenshot 2024-06-10 at 15 31 31" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/567f5e1d-e8ab-4fa1-ad9c-595f8400d2c7">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
