### PR TITLE
CAS-413: Remove Residents Palo Alto IP range

### DIFF
--- a/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
@@ -64,8 +64,7 @@ generic-service:
     groups:
       - internal
       - prisons
-    palo-alto-prisma-access-egress: "128.77.75.128/26"
-    palo-alto-prisma-access-egress-2: "128.77.75.64/26"
+    palo-alto-prisma-access-corporate: "128.77.75.64/26"
 
 generic-prometheus-alerts:
   targetApplication: hmpps-temporary-accommodation-ui


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-413

# Changes in this PR

Remove the Palo Alto Residents IP range from the allowlist. Rename the remaining Palo Alto range for clarity (details of all ranges in Jira ticket).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
