### PR TITLE
CHORE/Cleanup unnecessary custom type

### DIFF
--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -367,10 +367,3 @@ export type AssessmentSearchParameters = {
 }
 
 export type BedspaceStatus = 'online' | 'archived'
-
-// TODO: Remove once it exists in generated types
-export type ReferralRejectionBody = {
-  referralRejectionReasonId: string
-  referralRejectionReasonDetail?: string
-  isWithdrawn: boolean
-}

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -408,6 +408,8 @@ describe('AssessmentsController', () => {
       await requestHandler(request, response, next)
 
       expect(assessmentsService.rejectAssessment).toHaveBeenCalledWith(callConfig, assessmentId, {
+        document: {},
+        rejectionRationale: 'default',
         referralRejectionReasonId,
         referralRejectionReasonDetail,
         isWithdrawn: true,
@@ -432,6 +434,8 @@ describe('AssessmentsController', () => {
       await requestHandler(request, response, next)
 
       expect(assessmentsService.rejectAssessment).toHaveBeenCalledWith(callConfig, assessmentId, {
+        document: {},
+        rejectionRationale: 'default',
         referralRejectionReasonId,
         referralRejectionReasonDetail: undefined,
         isWithdrawn: false,

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -192,6 +192,8 @@ export default class AssessmentsController {
         }
 
         await this.assessmentsService.rejectAssessment(callConfig, id, {
+          document: {},
+          rejectionRationale: 'default',
           referralRejectionReasonId,
           referralRejectionReasonDetail: isOtherReason ? referralRejectionReasonDetail : undefined,
           isWithdrawn: ppRequestedWithdrawal === 'yes',

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,7 +1,7 @@
 import nock from 'nock'
 
 import superagent from 'superagent'
-import { TemporaryAccommodationAssessmentStatus as AssessmentStatus } from '../@types/shared'
+import { AssessmentRejection, TemporaryAccommodationAssessmentStatus as AssessmentStatus } from '../@types/shared'
 import config from '../config'
 import paths from '../paths/api'
 import { assessmentFactory, assessmentSummaryFactory, newReferralHistoryUserNoteFactory } from '../testutils/factories'
@@ -180,21 +180,19 @@ describe('AssessmentClient', () => {
 
   describe('rejectAssessment', () => {
     it('posts a new rejection for the assessment', async () => {
-      const referralRejectionReasonBody = {
+      const assessmentRejection: AssessmentRejection = {
+        document: {},
+        rejectionRationale: 'default',
         referralRejectionReasonId: 'rejection-reason-id',
         isWithdrawn: false,
       }
 
       fakeApprovedPremisesApi
-        .post(paths.assessments.rejection({ id: assessmentId }), {
-          document: {},
-          rejectionRationale: 'default',
-          ...referralRejectionReasonBody,
-        })
+        .post(paths.assessments.rejection({ id: assessmentId }), assessmentRejection)
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200)
 
-      await assessmentClient.rejectAssessment(assessmentId, referralRejectionReasonBody)
+      await assessmentClient.rejectAssessment(assessmentId, assessmentRejection)
     })
   })
 

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -8,7 +8,7 @@ import type {
   ReferralHistoryNote as Note,
 } from '@approved-premises/api'
 
-import { AssessmentSearchParameters, PaginatedResponse, ReferralRejectionBody } from '@approved-premises/ui'
+import { AssessmentSearchParameters, PaginatedResponse } from '@approved-premises/ui'
 import { URLSearchParams } from 'url'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -76,14 +76,10 @@ export default class AssessmentClient {
     })
   }
 
-  async rejectAssessment(id: string, referralRejectionBody: ReferralRejectionBody): Promise<void> {
+  async rejectAssessment(id: string, assessmentRejection: AssessmentRejection): Promise<void> {
     await this.restClient.post({
       path: paths.assessments.rejection({ id }),
-      data: {
-        document: {},
-        rejectionRationale: 'default',
-        ...referralRejectionBody,
-      } as AssessmentRejection,
+      data: assessmentRejection,
     })
   }
 

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -1,5 +1,5 @@
 import { AssessmentSearchApiStatus } from '@approved-premises/ui'
-import { TemporaryAccommodationAssessmentStatus } from '@approved-premises/api'
+import { AssessmentRejection, TemporaryAccommodationAssessmentStatus } from '@approved-premises/api'
 import AssessmentClient from '../data/assessmentClient'
 import { CallConfig } from '../data/restClient'
 import {
@@ -122,14 +122,16 @@ describe('AssessmentsService', () => {
 
   describe('rejectAssessment', () => {
     it('calls the rejectAssessment method on the client with rejection details', async () => {
-      const referralRejectionReasonBody = {
+      const assessmentRejection: AssessmentRejection = {
+        document: {},
+        rejectionRationale: 'default',
         referralRejectionReasonId: 'rejection-reason-id',
         isWithdrawn: true,
       }
-      await service.rejectAssessment(callConfig, assessmentId, referralRejectionReasonBody)
+      await service.rejectAssessment(callConfig, assessmentId, assessmentRejection)
 
       expect(AssessmentClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId, referralRejectionReasonBody)
+      expect(assessmentClient.rejectAssessment).toHaveBeenCalledWith(assessmentId, assessmentRejection)
     })
   })
 

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -4,11 +4,11 @@ import type {
   AssessmentUpdateStatus,
   PaginatedResponse,
   ReferenceData,
-  ReferralRejectionBody,
   TableRow,
 } from '@approved-premises/ui'
 import type {
   TemporaryAccommodationAssessment as Assessment,
+  AssessmentRejection,
   NewReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
   TemporaryAccommodationAssessmentStatus,
@@ -62,11 +62,11 @@ export default class AssessmentsService {
   async rejectAssessment(
     callConfig: CallConfig,
     assessmentId: string,
-    referralRejectionBody: ReferralRejectionBody,
+    assessmentRejection: AssessmentRejection,
   ): Promise<void> {
     const assessmentClient = this.assessmentClientFactory(callConfig)
 
-    await assessmentClient.rejectAssessment(assessmentId, referralRejectionBody)
+    await assessmentClient.rejectAssessment(assessmentId, assessmentRejection)
   }
 
   async updateAssessmentStatus(


### PR DESCRIPTION
Rely on existing API-generated type for assessment rejection body instead of custom type, as these offer sufficient overlap.
