### PR TITLE
CAS-415/Render rejection details in timeline note

### DIFF
--- a/cypress_shared/pages/assess/summary.ts
+++ b/cypress_shared/pages/assess/summary.ts
@@ -72,4 +72,15 @@ export default class AssessmentSummaryPage extends Page {
           })
       })
   }
+
+  shouldShowNote(title: string, content: string[]) {
+    cy.get('.moj-timeline__item')
+      .contains(title)
+      .closest('.moj-timeline__item')
+      .within(() => {
+        content.forEach(text => {
+          cy.get('.moj-timeline__description').should('contain.text', text)
+        })
+      })
+  }
 }

--- a/e2e/tests/apply-and-place.feature
+++ b/e2e/tests/apply-and-place.feature
@@ -24,3 +24,4 @@ Feature: Apply for and book a Temporary Accommodation bedspace
     And I view the ready to place assessment
     When I reject the assessment with the reason other
     Then I see the assessment has been rejected
+    And I see the rejection reason in the referral notes

--- a/e2e/tests/stepDefinitions/place.ts
+++ b/e2e/tests/stepDefinitions/place.ts
@@ -120,3 +120,15 @@ Then('I see the assessment has been rejected', () => {
     assessmentSummaryPage.shouldShowBanner('This referral has been rejected')
   })
 })
+
+Then('I see the rejection reason in the referral notes', () => {
+  cy.then(function _() {
+    const { assessment } = this
+
+    const assessmentSummaryPage = Page.verifyOnPage(AssessmentSummaryPage, { ...assessment, status: 'rejected' })
+    assessmentSummaryPage.shouldShowNote('Referral marked as rejected', [
+      'Rejection reason: Details about the rejection reason',
+      'Withdrawal requested by the probation practitioner: Yes',
+    ])
+  })
+})


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-415

# Changes in this PR

Renders the rejection details in the referral history timeline view.

## Screenshots of UI changes

### Before

<img width="646" alt="Screenshot 2024-06-20 at 10 37 25" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/aa157e3b-c792-46f1-a949-a2ab11b319a0">

### After

<img width="646" alt="Screenshot 2024-06-20 at 10 36 42" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/b33a7931-6f4e-46d0-a9a1-c42590064e4f">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work? Yes - https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/1966
- [ ] Have they been released to production already? Yes

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
