### PR TITLE
Use uppercase for local e2e test usernames

### DIFF
--- a/e2e.local.env
+++ b/e2e.local.env
@@ -1,6 +1,6 @@
-CYPRESS_assessor_username=JimSnowLdap
+CYPRESS_assessor_username=JIMSNOWLDAP
 CYPRESS_assessor_password=secret
-CYPRESS_referrer_username=JimSnowLdap
+CYPRESS_referrer_username=JIMSNOWLDAP
 CYPRESS_referrer_password=secret
 CYPRESS_offender_name="Aadland Bertrand"
 CYPRESS_keyworker_name="Kelby Tabert"


### PR DESCRIPTION
This change is needed after a [recent change to the API](https://github.com/ministryofjustice/hmpps-approved-premises-tools/pull/69) in how it handles nDelius users for CAS1 E2E tests.
