### PR TITLE
CHORE: Reuse exported support email to ease updates

### DIFF
--- a/server/views/pages/error.njk
+++ b/server/views/pages/error.njk
@@ -8,7 +8,7 @@
     <div class="govuk-grid-column-two-thirds">
       <h1 class="govuk-heading-l">Sorry, there is a problem with the service</h1>
       <p class="govuk-body">Try again later or contact</p>
-      <p class="govuk-body"><a class="govuk-link" href="mailto:cas3support@digital.justice.gov.uk">cas3support@digital.justice.gov.uk</a> for help.</p>
+      <p class="govuk-body"><a class="govuk-link" href="mailto:{{ PhaseBannerUtils.supportEmail }}">{{ PhaseBannerUtils.supportEmail }}</a> for help.</p>
 
       {% if stack %}
         <h1>{{ message }}</h1>

--- a/server/views/temporary-accommodation/static/accessibilityStatement.njk
+++ b/server/views/temporary-accommodation/static/accessibilityStatement.njk
@@ -37,7 +37,7 @@
       If you find any problems not listed on this page or think we’re not meeting accessibility requirements, email the CAS3 digital team with details of the issue you have experienced.
       </p>
       <p class="govuk-body">
-      Email: <a href="mailto:cas3support@digital.justice.gov.uk" class="govuk-link">cas3support@digital.justice.gov.uk</a>
+      Email: <a href="mailto:{{ PhaseBannerUtils.supportEmail }}" class="govuk-link">{{ PhaseBannerUtils.supportEmail }}</a>
       </p>
       <p class="govuk-body">
       We’ll consider your request and get back to you within 2 working days.

--- a/server/views/temporary-accommodation/static/notAuthorised.njk
+++ b/server/views/temporary-accommodation/static/notAuthorised.njk
@@ -23,7 +23,7 @@
       </p>
       <h2 class="govuk-heading-m">All other issues</h2>
       <p class="govuk-body">
-        Contact <a href="mailto:cas3support@digital.justice.gov.uk">cas3support@digital.justice.gov.uk</a> and describe the problem you are experiencing.
+        Contact <a href="mailto:{{ PhaseBannerUtils.supportEmail }}">{{ PhaseBannerUtils.supportEmail }}</a> and describe the problem you are experiencing.
       </p>
     </div>
   </div>


### PR DESCRIPTION
# Changes in this PR

Replaces hardcoded instances of the support email with the constant set in Phase Banner Utils. This means the support email address can be updated from a single place for the whole service.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
