### PR TITLE
Minor fixes to how GOV.UK Button is used

### DIFF
--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -3,7 +3,6 @@
 {%- from "moj/components/timeline/macro.njk" import mojTimeline -%}
 {% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../partials/breadCrumb.njk" import breadCrumb %}
-{% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../components/person-details/macro.njk" import personDetails %}
 {%- from "govuk/components/summary-list/macro.njk" import govukSummaryList -%}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}

--- a/server/views/temporary-accommodation/reports/new.njk
+++ b/server/views/temporary-accommodation/reports/new.njk
@@ -94,7 +94,7 @@
                     text: "Download booking data",
                     name: "reportType",
                     value: 'booking',
-                    classes: 'govuk-input govuk-!-width-one-half',
+                    classes: 'govuk-!-width-one-half',
                     preventDoubleClick: true
                 }) }}
 
@@ -104,7 +104,7 @@
                     text: "Download bedspace usage",
                     name: "reportType",
                     value: 'bedUsage',
-                    classes: 'govuk-input govuk-!-width-one-half',
+                    classes: 'govuk-!-width-one-half',
                     preventDoubleClick: true
                 }) }}
 
@@ -114,7 +114,7 @@
                     text: "Download occupancy report",
                     name: "reportType",
                     value: 'bedOccupancy',
-                    classes: 'govuk-input govuk-!-width-one-half',
+                    classes: 'govuk-!-width-one-half',
                     preventDoubleClick: true
                 }) }}
 
@@ -124,7 +124,7 @@
                     text: "Download referrals report",
                     name: "reportType",
                     value: 'referral',
-                    classes: 'govuk-input govuk-!-width-one-half',
+                    classes: 'govuk-!-width-one-half',
                     preventDoubleClick: true
                 }) }}
 


### PR DESCRIPTION
# Context

GOV.UK buttons should be styled consistently 

# Changes in this PR

I noticed that the report button styling was not consistent with the rest of the application. I discovered that `govuk-input` class was incorrectly added to them. This meant that the buttons would have a thicker border around them like text inputs and it also changed how the button looked like when the mouse hovered over it. This change would more than likely have broken the contrast accessibility for these buttons.

I also spotted an unnecessary import of GOV.UK Buttons in the same file which I added as a new commit

## Screenshots of UI changes

### Before


https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/3441519/c2c8f915-9525-4516-835a-2ca64fa3d768



### After


https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/3441519/f1e5f4e7-11d2-4b3b-b87e-41d73bc2b357



# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
