### PR TITLE
Update npm outdated job to latest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -165,7 +165,8 @@ workflows:
               only:
                 - main
     jobs:
-      - check_outdated:
+      - hmpps/npm_outdated:
+          slack_channel: << pipeline.parameters.alerts-slack-channel >>
           context:
             - hmpps-common-vars
       - hmpps/npm_security_audit:


### PR DESCRIPTION
This should result in a smaller template being used for the Slack alert, reducing noise in the alerts channel.

### Current alert style

<img width="800" alt="Screenshot 2024-07-11 at 12 13 18" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/0cbacae8-4dc8-4d8c-af50-9fa5193e2389">

### Expected alert style after update

<img width="695" alt="Screenshot 2024-07-11 at 12 14 08" src="https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/assets/496382/5809835d-0f24-475c-817c-26f75eaecd1c">

