### PR TITLE
Change main container max-width from 960px to 1170px

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -1,4 +1,9 @@
 $govuk-global-styles: true
+
+// Width of main container
+$govuk-page-width: 1170px
+$moj-page-width: $govuk-page-width
+
 $path: "/assets/images/"
 
 @import 'govuk/all'


### PR DESCRIPTION
# Context

- https://dsdmoj.atlassian.net/browse/CAS-421

# Changes in this PR

Changing  $govuk-page-width will override govuk default page width https://github.com/alphagov/govuk-frontend/blob/46df0c79fa706e6b22561f11c9943f33dd834230/packages/govuk-frontend/src/govuk/settings/_measurements.scss#L14

Unfortunately moj-frontend does not inherit its page width from govuk-frontend so we have to update it separately so that it overrides the moj-frontend default page width https://github.com/ministryofjustice/moj-frontend/blob/07ab9af94ead09224cc06cb147dabbc52d0922ec/src/moj/settings/_measurements.scss#L6

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
