### PR TITLE
Simplify e2e alert template

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -18,28 +18,6 @@ parameters:
     default: 18.16-browsers
 
 jobs:
-  check_outdated:
-    executor:
-      name: hmpps/node
-      tag: << pipeline.parameters.node-version >>
-    steps:
-      - checkout
-      - restore_cache:
-          key: dependency-cache-{{ checksum "package-lock.json" }}
-      - run:
-          name: install-npm
-          command: 'npm ci --no-audit'
-      - run:
-          name: Check version
-          command: 'npm --version'
-      - run:
-          name: Run check
-          command: 'npm outdated typescript govuk-frontend'
-      - slack/notify:
-          event: fail
-          channel: << pipeline.parameters.alerts-slack-channel >>
-          template: basic_fail_1
-
   e2e_environment_test:
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,7 +72,35 @@ jobs:
       - slack/notify:
           event: fail
           channel: << pipeline.parameters.alerts-slack-channel >>
-          template: basic_fail_1
+          custom: |
+            {
+              "blocks": [
+                {
+                  "type": "context",
+                  "elements": [
+                    {
+                      "type": "mrkdwn",
+                      "text": ":circleci-${CCI_STATUS}: CircleCI job *${CIRCLE_JOB}* ${CCI_STATUS}"
+                    }
+                  ]
+                },
+                {
+                  "type": "section",
+                  "text": {
+                    "type": "mrkdwn",
+                    "text": "*${CIRCLE_PROJECT_REPONAME}* Author: *${CIRCLE_USERNAME}*"
+                  },
+                  "accessory": {
+                    "type": "button",
+                    "text": {
+                      "type": "plain_text",
+                      "text": "View job"
+                    },
+                    "url": "${CIRCLE_BUILD_URL}"
+                  }
+                }
+              ]
+            }
 
 workflows:
   version: 2


### PR DESCRIPTION
An attempt to simplify the template used for Slack notifications for CircleCI e2e test failures. This new templates follows [the one from the Ministry of Justice CircleCI orb](https://github.com/ministryofjustice/hmpps-circleci-orb/blob/main/src/files/slack_failed.tpl.json) more closely, but replaces one of the duplicated job statuses with the Author of the ref.

This also fully removes the `check_outdated` job, which is no longer referenced anywhere in the config.
