### PR TITLE
Move subheading to be included in the h1

### DIFF
--- a/server/views/applications/full.njk
+++ b/server/views/applications/full.njk
@@ -25,8 +25,10 @@
     <div class="moj-identity-bar__container">
       <div class="moj-identity-bar__details">
         <span class="moj-identity-bar__title">
-          <span class="govuk-caption-xl">Transitional Accommodation (CAS3) referral</span>
-          <h1 class="govuk-heading-xl">{{ name }}</h1>
+          <h1 class="govuk-heading-xl">
+            <span class="govuk-caption-xl">Transitional Accommodation (CAS3) referral</span>
+            {{ name }}
+          </h1>
         </span>
       </div>
     </div>

--- a/server/views/temporary-accommodation/assessments/full.njk
+++ b/server/views/temporary-accommodation/assessments/full.njk
@@ -21,8 +21,8 @@
         <div class="moj-identity-bar__container">
             <div class="moj-identity-bar__details">
                 <span class="moj-identity-bar__title">
-                    <span class="govuk-caption-xl">Review referral</span>
                     <h1 class="govuk-heading-xl">
+                        <span class="govuk-caption-xl">Review referral</span>
                         {{ name }}
                         {{ assessmentStatusTag(assessment.status) | safe }}
                     </h1>

--- a/server/views/temporary-accommodation/assessments/summary.njk
+++ b/server/views/temporary-accommodation/assessments/summary.njk
@@ -33,9 +33,11 @@
         <div class="moj-identity-bar__container">
             <div class="moj-identity-bar__details">
         <span class="moj-identity-bar__title">
-          <span class="govuk-caption-xl">Referral summary</span>
-          <h1 class="govuk-heading-xl">{{ name }}
-              {{ assessmentStatusTag(assessment.status) | safe }}</h1>
+            <h1 class="govuk-heading-xl">
+                <span class="govuk-caption-xl">Referral summary</span>
+                {{ name }}
+                {{ assessmentStatusTag(assessment.status) | safe }}
+            </h1>
         </span>
             </div>
 


### PR DESCRIPTION
# Context

- https://dsdmoj.atlassian.net/browse/CAS-471

# Changes in this PR

Subheading in the context they are being used would be very important for screenreaders to inform users what page they are viewing.

Example, If this change was not done then screenreaders would only read out "Joe Bloggs Unallocated" instead of  "Referral summary Joe Bloggs "

ref: https://design-system.service.gov.uk/styles/headings/#headings-with-captions
If the caption should be considered part of the page heading, you can also nest the caption within the <h1>.

There should be no visional difference from what users previously saw.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
