### PR TITLE
Replace `exclude-from-print` css class name with govuk util class govuk-\!-display-none-print

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -28,4 +28,3 @@ $path: "/assets/images/"
 @import './pages/temporary-accommodation/dashboard/index'
 @import './pages/temporary-accommodation/bookings/show'
 @import './pages/temporary-accommodation/applications/pages/accommodation-need/sentence-information/sentence-length'
-@import './pages/temporary-accommodation/applications/pages/check-your-answers/review'

--- a/assets/sass/pages/temporary-accommodation/applications/pages/check-your-answers/review.scss
+++ b/assets/sass/pages/temporary-accommodation/applications/pages/check-your-answers/review.scss
@@ -1,6 +1,0 @@
-@media print {
-  /* exclude specific elements when printing */
-  .exclude-from-print {
-    display: none;
-  }
-}

--- a/server/utils/checkYourAnswersUtils/index.test.ts
+++ b/server/utils/checkYourAnswersUtils/index.test.ts
@@ -51,7 +51,7 @@ describe('checkYourAnswersUtils', () => {
           actions: {
             items: [
               {
-                classes: 'exclude-from-print',
+                classes: 'govuk-!-display-none-print',
                 href: paths.applications.pages.show({ id: application.id, task: 'some-task', page: 'some-page' }),
                 text: 'Change',
                 visuallyHiddenText: 'A question',

--- a/server/utils/checkYourAnswersUtils/index.ts
+++ b/server/utils/checkYourAnswersUtils/index.ts
@@ -47,7 +47,7 @@ const summaryListItemForResponse = (
         href: paths.applications.pages.show({ task: task.id, page: pageName, id: application.id }),
         text: 'Change',
         visuallyHiddenText: key,
-        classes: 'exclude-from-print',
+        classes: 'govuk-!-display-none-print',
       },
     ],
   }

--- a/server/views/applications/full.njk
+++ b/server/views/applications/full.njk
@@ -13,7 +13,7 @@
   {{ govukBackLink({
     text: "Back",
     href: backLinkUrl,
-    classes: 'exclude-from-print'
+    classes: 'govuk-!-display-none-print'
   }) }}
 {% endblock %}
 

--- a/server/views/applications/pages/check-your-answers/check-your-answers/review.njk
+++ b/server/views/applications/pages/check-your-answers/check-your-answers/review.njk
@@ -13,7 +13,7 @@
     {{ govukBackLink({
         text: "Back",
         href: paths.applications.show({ id: page.application.id }),
-        classes: 'exclude-from-print'
+        classes: 'govuk-!-display-none-print'
     }) }}
 {% endblock %}
 
@@ -60,7 +60,7 @@
                 {{ govukButton({
                     text: "Continue",
                     preventDoubleClick: true,
-                    classes: 'exclude-from-print'
+                    classes: 'govuk-!-display-none-print'
                 }) }}
             </form>
 

--- a/server/views/components/printButton/macro.njk
+++ b/server/views/components/printButton/macro.njk
@@ -3,7 +3,7 @@
 {% macro printButton() %}
   {{ govukButton({
     text: 'Print this page',
-    classes: 'govuk-button--secondary exclude-from-print',
+    classes: 'govuk-button--secondary govuk-!-display-none-print',
     attributes: { 'data-print-btn': true }
   }) }}
 {% endmacro%}

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -38,6 +38,6 @@
                 }
             ]
         },
-        classes: 'exclude-from-print'
+        classes: 'govuk-!-display-none-print'
     }) }}
 {% endblock %}

--- a/server/views/partials/phaseBanner.njk
+++ b/server/views/partials/phaseBanner.njk
@@ -2,7 +2,7 @@
 
 {{ govukPhaseBanner({
   attributes: { "data-cy-phase-banner": "phase-banner" },
-  classes: "hmpps-header__container exclude-from-print",
+  classes: "hmpps-header__container govuk-!-display-none-print",
   tag: {
     text: "Beta"
   },


### PR DESCRIPTION
# Context
Should be no visible changes to the user and it means we are not having to maintain our own custom classes when they are already being included by govuk frontend by default

- https://dsdmoj.atlassian.net/browse/CAS-476
