### PR TITLE
Fix pages with single date inputs

### DIFF
--- a/server/views/applications/pages/accommodation-need/eligibility/accommodation-required-from-date.njk
+++ b/server/views/applications/pages/accommodation-need/eligibility/accommodation-required-from-date.njk
@@ -2,13 +2,20 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ task.title }}</span>
-    {{ page.title }}
-  </h1>
+{% set pageTitleHTML %}
+  <span class="govuk-caption-l">{{ task.title }}</span>
+  {{ page.title }}
+{% endset %}
 
   {{ formPageDateInput( {
     fieldName: "accommodationRequiredFromDate",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     hint: {
       text: dateInputHint('future')
     },

--- a/server/views/applications/pages/accommodation-need/eligibility/release-date.njk
+++ b/server/views/applications/pages/accommodation-need/eligibility/release-date.njk
@@ -2,10 +2,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ task.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set hintHtml %}
     <p class="govuk-hint">This could include the release date from custody, an Approved Premises, or CAS2 (formerly Bail Accommodation Support Services)</p>
@@ -14,6 +14,13 @@
 
   {{ formPageDateInput( {
     fieldName: "releaseDate",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     hint: {
       html: hintHtml
     },

--- a/server/views/applications/pages/accommodation-need/sentence-information/sentence-expiry.njk
+++ b/server/views/applications/pages/accommodation-need/sentence-information/sentence-expiry.njk
@@ -2,13 +2,20 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ task.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {{ formPageDateInput( {
     fieldName: "sentenceExpiryDate",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     hint: {
       text: dateInputHint('future')
     },

--- a/server/views/temporary-accommodation/assessments/change-date.njk
+++ b/server/views/temporary-accommodation/assessments/change-date.njk
@@ -25,8 +25,6 @@
 
     {{ showErrorSummary(errorSummary) }}
 
-    <h1 class="govuk-heading-l">{{ content.title }}</h1>
-
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             <form action="{{ paths.assessments.updateDate[dateField]({ id: assessment.id }) }}" method="post">
@@ -34,6 +32,13 @@
 
                 {{ formPageDateInput({
                     fieldName: dateField,
+                    fieldset: {
+                        legend: {
+                            text: content.title,
+                            isPageHeading: true,
+                            classes: "govuk-fieldset__legend--l"
+                        }
+                    },
                     items: dateFieldValues(dateField, errors),
                     hint: {
                         html: hintHtml


### PR DESCRIPTION
The current implementation causes a lot of accessibility problems for screen readers as the screenreader does not have context as to what is being asked from the user. All it will read out is "Day", "Month", or "Year"  depending on which input has focus. We should be using IsPageHeading option so that a fieldset is placed around the date field but it also injects an h1 tag inside the fieldsets legend. A screen will then announce the legend to the user so the will have the question and hint

There was an accessibility issue reported as part of an assessment done late 2023 which read:

>Date input fields are not grouped with questions, so screen reader users may find it challenging to associate the date input field with the relevant question (test issue 1.3). This fails WCAG 2.2 success criterion 1.3.1 (A). We plan to fix this by 30/03 2024.

This commit should mean this issue is now fixed across the service.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![Screenshot 2024-07-18 at 16 19 06](https://github.com/user-attachments/assets/e052f438-d54d-4fa8-9d13-24a448db9078)

### After
![Screenshot 2024-07-18 at 16 19 14](https://github.com/user-attachments/assets/d6b9f75c-fe68-4dc4-960c-2cc943ed39f8)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
