### PR TITLE
Update single question pages to use h1 as legend

### DIFF
--- a/cypress_shared/pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
+++ b/cypress_shared/pages/apply/assess-placement-risks-and-needs/behaviour-in-cas/previousStays.ts
@@ -2,10 +2,12 @@ import type { TemporaryAccommodationApplication } from '@approved-premises/api'
 import paths from '../../../../../server/paths/apply'
 import ApplyPage from '../../applyPage'
 
+import { personName } from '../../../../../server/utils/personUtils'
+
 export default class PreviousStaysPage extends ApplyPage {
   constructor(application: TemporaryAccommodationApplication) {
     super(
-      'Behaviour in previous accommodation',
+      `Has ${personName(application.person)} previously stayed in Community Accommodation Services (CAS)?`,
       application,
       'behaviour-in-cas',
       'previous-stays',

--- a/cypress_shared/pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
+++ b/cypress_shared/pages/apply/requirements-for-placement/food-allergies/foodAllergies.ts
@@ -2,10 +2,12 @@ import type { TemporaryAccommodationApplication } from '@approved-premises/api'
 import paths from '../../../../../server/paths/apply'
 import ApplyPage from '../../applyPage'
 
+import { personName } from '../../../../../server/utils/personUtils'
+
 export default class FoodAllergiesPage extends ApplyPage {
   constructor(application: TemporaryAccommodationApplication) {
     super(
-      'Food allergies',
+      `Does ${personName(application.person)} have any food allergies or dietary requirements?`,
       application,
       'food-allergies',
       'food-allergies',

--- a/server/views/applications/pages/accommodation-need/consent/consent-given.njk
+++ b/server/views/applications/pages/accommodation-need/consent/consent-given.njk
@@ -3,10 +3,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set conditionalHtml %}
     {{ govukNotificationBanner({
@@ -16,6 +16,13 @@
 
   {{ formPageRadios({
     fieldName: "consentGiven",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     items: [
       {
         value: "yes",

--- a/server/views/applications/pages/accommodation-need/eligibility/eligibility-reason.njk
+++ b/server/views/applications/pages/accommodation-need/eligibility/eligibility-reason.njk
@@ -3,13 +3,20 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {{ formPageRadios({
     fieldName: "reason",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     items: page.items()
   }, fetchContext()) }}
 

--- a/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/concerning-arson-behaviour.njk
+++ b/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/concerning-arson-behaviour.njk
@@ -11,13 +11,20 @@
         }, fetchContext()) }}
     {% endset %}
 
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ task.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
     {{ formPageRadios({
         fieldName: "concerningArsonBehaviour",
+        fieldset: {
+            legend: {
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
         hint: {
             text: "This is about behaviour which might introduce risk in an accommodation placement."
         },

--- a/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/concerning-sexual-behaviour.njk
+++ b/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/concerning-sexual-behaviour.njk
@@ -11,13 +11,20 @@
         }, fetchContext()) }}
     {% endset %}
 
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ task.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
     {{ formPageRadios({
         fieldName: "concerningSexualBehaviour",
+        fieldset: {
+            legend: {
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
         hint: {
             text: "This is about sexual behaviour which might introduce risk in an accommodation placement."
         },

--- a/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/history-of-arson-offence.njk
+++ b/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/history-of-arson-offence.njk
@@ -2,13 +2,20 @@
 
 {% block questions %}
 
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ task.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
     {{ formPageRadios({
         fieldName: "historyOfArsonOffence",
+        fieldset: {
+            legend: {
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
         hint: {
             text: "You'll need to explain in the referral how this could affect the accommodation placement."
         },

--- a/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/history-of-sexual-offence.njk
+++ b/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/history-of-sexual-offence.njk
@@ -1,13 +1,20 @@
 {% extends "../../layout.njk" %}
 
 {% block questions %}
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ section.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
     {{ formPageRadios({
         fieldName: "historyOfSexualOffence",
+        fieldset: {
+            legend: {
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
         hint: {
             text: "You'll need to explain in the referral how this could affect the accommodation placement."
         },

--- a/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/registered-sex-offender.njk
+++ b/server/views/applications/pages/accommodation-need/offence-and-behaviour-summary/registered-sex-offender.njk
@@ -2,13 +2,20 @@
 
 {% block questions %}
 
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ task.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
     {{ formPageRadios({
         fieldName: "registeredSexOffender",
+        fieldset: {
+            legend: {
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
         items: [
             {
                 value: "yes",

--- a/server/views/applications/pages/accommodation-need/sentence-information/release-type.njk
+++ b/server/views/applications/pages/accommodation-need/sentence-information/release-type.njk
@@ -32,10 +32,10 @@
 
 {% block questions %}
 
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ task.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
     {% set releaseTypeOptions = [] %}
     {% for option in convertObjectsToCheckboxItems(page.getReleaseTypeOptions(), 'name', 'value', 'releaseTypes') %}
@@ -49,9 +49,13 @@
         fieldName: "releaseTypes",
         fieldset: {
             legend: {
-                text: "Select all that apply",
-                classes: "govuk-fieldset__legend--m"
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
             }
+        },
+        hint: {
+            text: "Select all that apply"
         },
         items: releaseTypeOptions
     }, fetchContext()) }}

--- a/server/views/applications/pages/accommodation-need/sentence-information/sentence-type.njk
+++ b/server/views/applications/pages/accommodation-need/sentence-information/sentence-type.njk
@@ -2,13 +2,20 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
-    <span class="govuk-caption-l">{{ task.title }}</span>
-    {{ page.title }}
-  </h1>
+  {% set pageTitleHTML %}
+      <span class="govuk-caption-l">{{ task.title }}</span>
+      {{ page.title }}
+  {% endset %}
 
   {{ formPageRadios({
     fieldName: "sentenceType",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     hint: {
       text: "Select the option which best describes the situation"
     },

--- a/server/views/applications/pages/assess-placement-risks-and-needs/behaviour-in-cas/previous-stays-details.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/behaviour-in-cas/previous-stays-details.njk
@@ -2,10 +2,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ task.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set itemsWithDetail = [] %}
 
@@ -32,6 +32,13 @@
 
   {{ formPageCheckboxes({
     fieldName: "accommodationTypes",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     hint: {
       text: "Select all that apply"
     },

--- a/server/views/applications/pages/assess-placement-risks-and-needs/behaviour-in-cas/previous-stays.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/behaviour-in-cas/previous-stays.njk
@@ -2,17 +2,18 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
-    {{ page.title }}
-  </h1>
+    {{  page.questions.previousStays }}
+  {% endset %}
 
   {{ formPageRadios({
     fieldName: "previousStays",
     fieldset: {
       legend: {
-        text: page.questions.previousStays,
-        classes: "govuk-fieldset__legend--m"
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
       }
     },
     items: [

--- a/server/views/applications/pages/assess-placement-risks-and-needs/licence-conditions/additional-licence-conditions.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/licence-conditions/additional-licence-conditions.njk
@@ -2,10 +2,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set itemsWithDetail = [] %}
 
@@ -35,6 +35,13 @@
 
   {{ formPageCheckboxes({
     fieldName: "conditions",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     items: itemsWithDetail
   }, fetchContext()) }}
 

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/crs-submitted.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/crs-submitted.njk
@@ -3,10 +3,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ task.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set noHtml %}
     {% set html %}
@@ -21,6 +21,13 @@
 
   {{ formPageRadios({
     fieldName: "crsSubmitted",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     items: [
       {
         value: "yes",

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-submitted.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/dtr-submitted.njk
@@ -3,10 +3,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set noHtml %}
     {% set html %}
@@ -22,6 +22,13 @@
 
   {{ formPageRadios({
     fieldName: "dtrSubmitted",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     items: [
       {
         value: "yes",

--- a/server/views/applications/pages/required-referrals/accommodation-referral-details/other-accommodation-options.njk
+++ b/server/views/applications/pages/required-referrals/accommodation-referral-details/other-accommodation-options.njk
@@ -12,20 +12,30 @@
         },fetchContext()) }}
     {% endset %}
 
-    <h1 class="govuk-heading-l">
+    {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ task.title }}</span>
         {{ page.title }}
-    </h1>
+    {% endset %}
 
-    <p>All accommodation services available through the person's local authority or HMPPS should be explored before an
-        application to Transitional Accommodation (CAS3) is made.</p>
+    {% set guidanceHTML %}
+        <p>
+            All accommodation services available through the person's local authority or HMPPS should be explored before an
+            application to Transitional Accommodation (CAS3) is made.
+        </p>
+    {% endset %}
 
     {{ formPageRadios({
         fieldName: "otherOptions",
         fieldset: {
             legend: {
-                text: page.title,
-                classes: "govuk-fieldset__legend--m"
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
+        formGroup: {
+            beforeInputs: {
+                html: guidanceHTML
             }
         },
         items: [

--- a/server/views/applications/pages/requirements-for-placement/disability-cultural-and-specific-needs/needs.njk
+++ b/server/views/applications/pages/requirements-for-placement/disability-cultural-and-specific-needs/needs.njk
@@ -2,10 +2,10 @@
 
 {% block questions %}
 
-    <h1 class="govuk-heading-l">
-        <span class="govuk-caption-l">{{ section.title }}</span>
-        {{ task.title }}
-    </h1>
+    {% set pageTitleHTML %}
+        <span class="govuk-caption-l">{{ task.title }}</span>
+        {{ page.title }}
+    {% endset %}
 
     {% set itemsWithDetail = [] %}
 
@@ -39,8 +39,9 @@
     {{ formPageCheckboxes({
         fieldset: {
             legend: {
-                text: page.title,
-                classes: "govuk-fieldset__legend--m"
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
             }
         },
         hint: {

--- a/server/views/applications/pages/requirements-for-placement/disability-cultural-and-specific-needs/property-attributes-or-adaptations.njk
+++ b/server/views/applications/pages/requirements-for-placement/disability-cultural-and-specific-needs/property-attributes-or-adaptations.njk
@@ -2,17 +2,19 @@
 {% extends "../../layout.njk" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ task.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
-  <p>For example, a property that:</p>
-  <ul>
-    <li>has ground floor level access</li>
-    <li>has a lift available</li>
-    <li>is wheelchair accessible</li>
-  </ul>
+  {% set hintHTML%}
+    <p class="govuk-hint">For example, a property that:</p>
+    <ul class="govuk-hint">
+      <li>has ground floor level access</li>
+      <li>has a lift available</li>
+      <li>is wheelchair accessible</li>
+    </ul>
+  {% endset %}
 
   {% set propertyAttributesOrAdaptationsDetailHtml %}
     {{ formPageTextarea({
@@ -26,6 +28,16 @@
 
   {{ formPageRadios({
     fieldName: "propertyAttributesOrAdaptations",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
+    hint: {
+      html: hintHTML
+    },
     items: [
       {
         value: "yes",

--- a/server/views/applications/pages/requirements-for-placement/disability-cultural-and-specific-needs/religious-or-cultural-needs.njk
+++ b/server/views/applications/pages/requirements-for-placement/disability-cultural-and-specific-needs/religious-or-cultural-needs.njk
@@ -2,10 +2,10 @@
 {% extends "../../layout.njk" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ task.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set religiousOrCulturalNeedsDetailHtml %}
     {{ formPageTextarea({
@@ -19,6 +19,13 @@
 
   {{ formPageRadios({
     fieldName: "religiousOrCulturalNeeds",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     items: [
       {
         value: "yes",

--- a/server/views/applications/pages/requirements-for-placement/food-allergies/food-allergies.njk
+++ b/server/views/applications/pages/requirements-for-placement/food-allergies/food-allergies.njk
@@ -3,10 +3,10 @@
 {% extends "../../layout.njk" %}
 
 {% block questions %}
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
-    {{ page.title }}
-  </h1>
+    {{ page.questions.foodAllergies }} 
+  {% endset %}
 
   {% set foodAllergiesYesDetailHtml %}
     {{ formPageTextarea({
@@ -32,8 +32,9 @@
     fieldName: "foodAllergies",
     fieldset: {
       legend: {
-        text: page.questions.foodAllergies,
-        classes: "govuk-fieldset__legend--m"
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
       }
     },
     items: [

--- a/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
+++ b/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
@@ -3,10 +3,10 @@
 
 {% block questions %}
 
-  <h1 class="govuk-heading-l">
+  {% set pageTitleHTML %}
     <span class="govuk-caption-l">{{ section.title }}</span>
     {{ page.title }}
-  </h1>
+  {% endset %}
 
   {% set alternativePduDetailHtml %}
     {{ formPageTextarea({
@@ -20,6 +20,13 @@
 
   {{ formPageRadios({
     fieldName: "alternativePdu",
+    fieldset: {
+      legend: {
+        html: pageTitleHTML,
+        isPageHeading: true,
+        classes: "govuk-fieldset__legend--l"
+      }
+    },
     hint: {
       text: "If placement is required in a PDU that's different to the person's current PDU, select 'yes'"
     },


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-500

This is needed for accessibility reasons to ensure that radio button/checkbox options have enough context for the screen reader users to understand what is needed by making the heading part of a fieldset legend.
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->
