### PR TITLE
CAS-497: Ensure first ordering action is ascending

### DIFF
--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -85,19 +85,22 @@ context('Booking search', () => {
     // When I visit the Find a provisional booking page
     const page = BookingSearchPage.visit('provisional')
 
-    // And I order results by start date
+    // Then I see the results are ordered by End date descending
+    page.checkColumnOrder('End date', 'descending')
+
+    // When I order results by start date
     page.sortColumn('Start date')
 
-    // Then I see the results are ordered by start date descending
+    // Then I see the results are ordered by start date ascending
     page.shouldHaveURLSearchParam('sortBy=startDate')
-    page.checkColumnOrder('Start date', 'descending')
+    page.checkColumnOrder('Start date', 'ascending')
 
     // When I order the results by start date again
     page.sortColumn('Start date')
 
-    // Then I see the results are ordered by start date ascending
-    page.shouldHaveURLSearchParam('sortBy=startDate&sortDirection=asc')
-    page.checkColumnOrder('Start date', 'ascending')
+    // Then I see the results are ordered by start date descending
+    page.shouldHaveURLSearchParam('sortBy=startDate&sortDirection=desc')
+    page.checkColumnOrder('Start date', 'descending')
   })
 
   it('shows the result of a crn search and clears the search', () => {

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -56,19 +56,19 @@ describe('AssessmentsController', () => {
 
   const tableHeaders = [
     {
-      html: '<a href="?sortBy=name"><button>Name</button></a>',
+      html: '<a href="?sortBy=name&sortDirection=asc"><button>Name</button></a>',
       attributes: {
         'aria-sort': 'none',
       },
     },
     {
-      html: '<a href="?sortBy=crn"><button>CRN</button></a>',
+      html: '<a href="?sortBy=crn&sortDirection=asc"><button>CRN</button></a>',
       attributes: {
         'aria-sort': 'none',
       },
     },
     {
-      html: '<a href="?sortBy=createdAt"><button>Referral received</button></a>',
+      html: '<a href="?sortBy=createdAt&sortDirection=asc"><button>Referral received</button></a>',
       attributes: {
         'aria-sort': 'none',
       },
@@ -108,7 +108,7 @@ describe('AssessmentsController', () => {
         let expectedTemplate = 'temporary-accommodation/assessments/index'
         let expectedHeaders = [...tableHeaders]
         const statusHeader = {
-          html: '<a href="?sortBy=status"><button>Status</button></a>',
+          html: '<a href="?sortBy=status&sortDirection=asc"><button>Status</button></a>',
           attributes: {
             'aria-sort': 'none',
           },
@@ -168,7 +168,7 @@ describe('AssessmentsController', () => {
               },
             },
             {
-              html: '<a href="?sortBy=arrivedAt"><button>Bedspace required</button></a>',
+              html: '<a href="?sortBy=arrivedAt&sortDirection=asc"><button>Bedspace required</button></a>',
               attributes: {
                 'aria-sort': 'none',
               },

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -451,7 +451,7 @@ describe('assessmentUtils', () => {
 
       expect(result).toEqual([
         {
-          html: '<a href="?foo=bar&sortBy=name"><button>Name</button></a>',
+          html: '<a href="?foo=bar&sortBy=name&sortDirection=asc"><button>Name</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
@@ -459,11 +459,11 @@ describe('assessmentUtils', () => {
           attributes: { 'aria-sort': 'ascending' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=createdAt"><button>Referral received</button></a>',
+          html: '<a href="?foo=bar&sortBy=createdAt&sortDirection=asc"><button>Referral received</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=arrivedAt"><button>Bedspace required</button></a>',
+          html: '<a href="?foo=bar&sortBy=arrivedAt&sortDirection=asc"><button>Bedspace required</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
       ])
@@ -474,19 +474,19 @@ describe('assessmentUtils', () => {
 
       expect(result).toEqual([
         {
-          html: '<a href="?foo=bar&sortBy=name"><button>Name</button></a>',
+          html: '<a href="?foo=bar&sortBy=name&sortDirection=asc"><button>Name</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=crn"><button>CRN</button></a>',
+          html: '<a href="?foo=bar&sortBy=crn&sortDirection=asc"><button>CRN</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=createdAt"><button>Referral received</button></a>',
+          html: '<a href="?foo=bar&sortBy=createdAt&sortDirection=asc"><button>Referral received</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=arrivedAt"><button>Bedspace required</button></a>',
+          html: '<a href="?foo=bar&sortBy=arrivedAt&sortDirection=asc"><button>Bedspace required</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -68,11 +68,11 @@ describe('bookingSearchUtils', () => {
     it('returns table headings with start date sorted ascending for provisional or confirmed booking status', () => {
       const tableHeadings = [
         {
-          html: '<a href="?sortBy=name"><button>Name</button></a>',
+          html: '<a href="?sortBy=name&sortDirection=asc"><button>Name</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?sortBy=crn"><button>CRN</button></a>',
+          html: '<a href="?sortBy=crn&sortDirection=asc"><button>CRN</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
@@ -83,7 +83,7 @@ describe('bookingSearchUtils', () => {
           attributes: { 'aria-sort': 'ascending' },
         },
         {
-          html: '<a href="?sortBy=endDate"><button>End date</button></a>',
+          html: '<a href="?sortBy=endDate&sortDirection=asc"><button>End date</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
@@ -99,18 +99,18 @@ describe('bookingSearchUtils', () => {
   it('returns table headings with end date sorted ascending for arrived and departed booking status', () => {
     const tableHeadings = [
       {
-        html: '<a href="?sortBy=name"><button>Name</button></a>',
+        html: '<a href="?sortBy=name&sortDirection=asc"><button>Name</button></a>',
         attributes: { 'aria-sort': 'none' },
       },
       {
-        html: '<a href="?sortBy=crn"><button>CRN</button></a>',
+        html: '<a href="?sortBy=crn&sortDirection=asc"><button>CRN</button></a>',
         attributes: { 'aria-sort': 'none' },
       },
       {
         text: 'Address',
       },
       {
-        html: '<a href="?sortBy=startDate"><button>Start date</button></a>',
+        html: '<a href="?sortBy=startDate&sortDirection=asc"><button>Start date</button></a>',
         attributes: { 'aria-sort': 'none' },
       },
       {

--- a/server/utils/sortHeader.test.ts
+++ b/server/utils/sortHeader.test.ts
@@ -6,36 +6,54 @@ type SortHeaders = 'myField' | 'otherField'
 describe('sortHeader', () => {
   const hrefPrefix = 'http://localhost/example?'
 
-  it("should return a header when the current view is not sorted by the header's field`", () => {
-    expect(sortHeader<SortHeaders>('Some text', 'myField', 'otherField', true, hrefPrefix)).toEqual({
-      html: `<a href="${hrefPrefix}${createQueryString({ sortBy: 'myField' })}"><button>Some text</button></a>`,
-      attributes: { 'aria-sort': 'none' },
+  describe('when the current view is sorted by another field', () => {
+    it('should return a header to sort by this field ascending', () => {
+      const header = sortHeader<SortHeaders>('Some text', 'myField', 'otherField', false, hrefPrefix)
+
+      expect(header).toEqual({
+        html: `<a href="${hrefPrefix}${createQueryString({
+          sortBy: 'myField',
+          sortDirection: 'asc',
+        })}"><button>Some text</button></a>`,
+        attributes: { 'aria-sort': 'none' },
+      })
     })
   })
 
-  it("should return a header when the current view is sorted in ascending order by the header's field`", () => {
-    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', true, hrefPrefix)).toEqual({
-      html: `<a href="${hrefPrefix}${createQueryString({
-        sortBy: 'myField',
-        sortDirection: 'desc',
-      })}"><button>Some text</button></a>`,
-      attributes: { 'aria-sort': 'ascending' },
+  describe('when the current view is sorted by this field ascending', () => {
+    it('should return a header to sort by this field descending', () => {
+      const header = sortHeader<SortHeaders>('Some text', 'myField', 'myField', true, hrefPrefix)
+
+      expect(header).toEqual({
+        html: `<a href="${hrefPrefix}${createQueryString({
+          sortBy: 'myField',
+          sortDirection: 'desc',
+        })}"><button>Some text</button></a>`,
+        attributes: { 'aria-sort': 'ascending' },
+      })
     })
   })
 
-  it("should return a header when the current view is sorted in descending order by the header's field`", () => {
-    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', false, hrefPrefix)).toEqual({
-      html: `<a href="${hrefPrefix}${createQueryString({
-        sortBy: 'myField',
-        sortDirection: 'asc',
-      })}"><button>Some text</button></a>`,
-      attributes: { 'aria-sort': 'descending' },
+  describe('when the current view is sorted by this field descending', () => {
+    it('should return a header to sort by this field ascending', () => {
+      const header = sortHeader<SortHeaders>('Some text', 'myField', 'myField', false, hrefPrefix)
+
+      expect(header).toEqual({
+        html: `<a href="${hrefPrefix}${createQueryString({
+          sortBy: 'myField',
+          sortDirection: 'asc',
+        })}"><button>Some text</button></a>`,
+        attributes: { 'aria-sort': 'descending' },
+      })
     })
   })
 
   it('should override and replace the existing sorting parameters in the hrefPrefix', () => {
     const prefixWithParams = `${hrefPrefix}sortBy=myField&sortDirection=desc`
-    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', false, prefixWithParams)).toEqual({
+
+    const header = sortHeader<SortHeaders>('Some text', 'myField', 'myField', false, prefixWithParams)
+
+    expect(header).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({
         sortBy: 'myField',
         sortDirection: 'asc',
@@ -46,7 +64,10 @@ describe('sortHeader', () => {
 
   it('should retain any non-sorting-related existing parameters in the hrefPrefix apart from page', () => {
     const prefixWithParams = `${hrefPrefix}crn=N999888&page=13`
-    expect(sortHeader<SortHeaders>('Some text', 'myField', 'myField', false, prefixWithParams)).toEqual({
+
+    const header = sortHeader<SortHeaders>('Some text', 'myField', 'myField', false, prefixWithParams)
+
+    expect(header).toEqual({
       html: `<a href="${hrefPrefix}${createQueryString({
         crn: 'N999888',
         sortBy: 'myField',

--- a/server/utils/sortHeader.ts
+++ b/server/utils/sortHeader.ts
@@ -10,23 +10,20 @@ export const sortHeader = <T extends string>(
   currentSortAscending: boolean,
   hrefPrefix: string,
 ): TableCell => {
-  let sortDirection: SortDirection
-  let ariaSort: string
-
-  const [basePath, queryString] = hrefPrefix.split('?')
-  const qsArgs = qs.parse(queryString)
+  const sortDirection: SortDirection = currentSortAscending && currentSortField === targetField ? 'desc' : 'asc'
+  let ariaSort: string = 'none'
 
   if (targetField === currentSortField) {
     if (currentSortAscending) {
-      sortDirection = 'desc'
       ariaSort = 'ascending'
     } else {
-      sortDirection = 'asc'
       ariaSort = 'descending'
     }
-  } else {
-    ariaSort = 'none'
   }
+
+  const [basePath, queryString] = hrefPrefix.split('?')
+
+  const qsArgs = qs.parse(queryString)
 
   return {
     html: `<a href="${basePath}?${createQueryString({


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-497

# Changes in this PR

When clicking on a table header for a column that is not currently ordered, the resulting dataset should always be ordered ascending at first.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
