### PR TITLE
CAS-512: Ensure real dates are entered for application

### DIFF
--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -305,6 +305,30 @@ describe('dateAndTimeInputsAreValidDates', () => {
 
     expect(result).toEqual(false)
   })
+
+  it('returns false when the date is well formatted but does not exist', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': '2024',
+      'date-month': '11',
+      'date-day': '31',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(false)
+  })
+
+  it('returns false when the date is gibberish', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': 'not',
+      'date-month': 'a',
+      'date-day': 'date',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(false)
+  })
 })
 
 describe('dateIsBlank', () => {

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -163,17 +163,12 @@ export const dateAndTimeInputsAreValidDates = <K extends string | number>(
 
   if (inputYear && inputYear.length !== 4) return false
 
-  const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)
-
   try {
-    DateFormats.isoToDateObj(dateString[key])
-  } catch (err) {
-    if (err instanceof InvalidDateStringError) {
-      return false
-    }
+    const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)
+    return dateExists(dateString[key])
+  } catch (e) {
+    return false
   }
-
-  return true
 }
 
 export const dateExists = (dateString: string) => {


### PR DESCRIPTION
This ensures dates are not only correctly formatted (year with 4 digits, month and day as digits), but that they area also real dates: for instance, 31/11/2024 can be parsed as '2024-12-01' but isn't a real date.

# Context

https://dsdmoj.atlassian.net/browse/CAS-512

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
