### PR TITLE
Explicitly override PDU for dev e2e user

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -134,7 +134,7 @@ export default class ApplyHelper {
     private readonly person: Person,
     private readonly offences: Array<ActiveOffence>,
     private readonly environment: 'e2e' | 'integration',
-    private readonly actingUser: TemporaryAccommodationUser,
+    private readonly actingUser?: TemporaryAccommodationUser,
   ) {}
 
   initializeE2e(oasysSectionsLinkedToReoffending: Array<OASysSection>, otherOasysSections: Array<OASysSection>) {

--- a/e2e/tests/stepDefinitions/apply.ts
+++ b/e2e/tests/stepDefinitions/apply.ts
@@ -24,6 +24,16 @@ Given('I start a new application', () => {
     arrivalDate: applicationData.eligibility['accommodation-required-from-date'].accommodationRequiredFromDate,
   })
 
+  // Align PDU to one available to the dev e2e user
+  if (environment === 'dev') {
+    const pdu = {
+      id: '81ec3d88-eecd-49d7-ad90-5dff98080dfb',
+      name: 'East Sussex (includes Brighton and Hove)',
+    }
+    application.data['contact-details']['practitioner-pdu'] = pdu
+    application.data['contact-details']['probation-practitioner'].pdu = pdu
+  }
+
   const apply = new ApplyHelper(application, person, [], 'e2e')
   apply.startApplication()
 


### PR DESCRIPTION
The user the E2E tests are based on is in a different region to the local user used for testing. As the probation region is now tested based on the user's region, the PDU data used for local E2E tests cannot be used for the dev E2E tests.

This PR overrides the default application data when running on dev, in order for the tests to pass.