### PR TITLE
CAS-270 Rename search crn param to crnOrName

### DIFF
--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -83,8 +83,8 @@ export default class ListPage extends Page {
     cy.get('[aria-label="Secondary navigation"] a').contains(label).should('have.attr', 'aria-current', 'page')
   }
 
-  checkCRNSearchValue(value: string, status: string) {
-    this.shouldShowTextInputByLabel(`Search ${status} referrals by CRN (case reference number)`, value)
+  checkCrnOrNameSearchValue(value: string, status: string) {
+    this.shouldShowTextInputByLabel(`Search ${status} referrals with the person’s name or CRN`, value)
   }
 
   checkResults(assessments: AssessmentSummary[]) {
@@ -94,8 +94,8 @@ export default class ListPage extends Page {
     })
   }
 
-  searchByCRN(crn: string, status: string) {
-    this.completeTextInputByLabel(`Search ${status} referrals by CRN (case reference number)`, crn)
+  searchByCrnOrName(crn: string, status: string) {
+    this.completeTextInputByLabel(`Search ${status} referrals with the person’s name or CRN`, crn)
     this.clickSubmit('Search')
   }
 

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -96,31 +96,31 @@ context('Apply', () => {
         const pageTitle = sentence(`${uiStatus} referrals`)
 
         describe(`when viewing ${uiStatus} referrals`, () => {
-          it('shows the result of a CRN search and clears the search', () => {
+          it('shows the result of a CRN or Name search and clears the search', () => {
             // Given there are assessments in the database
             const assessments = assessmentSummaryFactory.buildList(6, { status: factoryStatus })
             const searchedForReferral = assessments[1]
-            const searchCRN = searchedForReferral.person.crn
+            const searchCrnOrName = searchedForReferral.person.crn
             cy.task('stubAssessments', { data: assessments, pagination })
 
             // When I visit the Archived referrals page
             const page = ListPage.visit(status)
 
-            // Then the search by CRN form is empty
-            page.checkCRNSearchValue('', uiStatus)
+            // Then the search by CRN or Name form is empty
+            page.checkCrnOrNameSearchValue('', uiStatus)
 
             // And I see all the results
             page.checkResults(assessments)
 
-            // When I submit a search by CRN
+            // When I submit a search by CRN or Name
             cy.task('stubAssessments', { data: [searchedForReferral] })
-            page.searchByCRN(searchCRN, uiStatus)
+            page.searchByCrnOrName(searchCrnOrName, uiStatus)
             Page.verifyOnPage(ListPage, pageTitle)
 
-            // Then the search by CRN form is populated
-            page.checkCRNSearchValue(searchCRN, uiStatus)
+            // Then the search by CRN or Name form is populated
+            page.checkCrnOrNameSearchValue(searchCrnOrName, uiStatus)
 
-            // Then I see the search result for that CRN
+            // Then I see the search result for that CRN or Name
             page.checkResults([searchedForReferral])
 
             // When I clear the search
@@ -130,36 +130,36 @@ context('Apply', () => {
             // Then I see the list page
             Page.verifyOnPage(ListPage, pageTitle)
 
-            // Then the search by CRN form is populated
-            page.checkCRNSearchValue('', uiStatus)
+            // Then the search by CRN or Name form is populated
+            page.checkCrnOrNameSearchValue('', uiStatus)
 
-            // Then I see the search result for that CRN
+            // Then I see the search result for that CRN or Name
             page.checkResults(assessments)
           })
 
-          it('shows a message if there are no CRN search results', () => {
+          it('shows a message if there are no CRN or Name search results', () => {
             const assessments = assessmentSummaryFactory.buildList(9, { status: factoryStatus })
             const noAssessments: TemporaryAccommodationAssessmentSummary[] = []
-            const searchCRN = 'N0M4TCH'
+            const searchCrnOrName = 'N0M4TCH'
 
             cy.task('stubAssessments', { data: assessments })
 
             // When I visit the Archived referrals page
             const page = ListPage.visit(status)
 
-            // Then the search by CRN form is empty
-            page.checkCRNSearchValue('', uiStatus)
+            // Then the search by CRN or Name form is empty
+            page.checkCrnOrNameSearchValue('', uiStatus)
 
             // And I see all the results
             page.checkResults(assessments)
 
-            // When I submit a search by CRN
+            // When I submit a search by CRN or Name
             cy.task('stubAssessments', { data: noAssessments })
-            page.searchByCRN(searchCRN, uiStatus)
+            page.searchByCrnOrName(searchCrnOrName, uiStatus)
             Page.verifyOnPage(ListPage, pageTitle)
 
-            // Then the search by CRN form is populated
-            page.checkCRNSearchValue(searchCRN, uiStatus)
+            // Then the search by CRN or Name form is populated
+            page.checkCrnOrNameSearchValue(searchCrnOrName, uiStatus)
 
             // Then I see no search results for that CRN
             page.checkResults(noAssessments)

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -365,7 +365,7 @@ export type AssessmentSearchParameters = {
   page?: number
   sortBy?: AssessmentSortField
   sortDirection?: SortDirection
-  crn?: string
+  crnOrName?: string
 }
 
 export type AssessmentUpdatableDateField = 'releaseDate' | 'accommodationRequiredFromDate'

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -202,7 +202,7 @@ describe('AssessmentsController', () => {
           })
         })
 
-        describe('when there is a CRN search parameter', () => {
+        describe('when there is a CRN or Name search parameter', () => {
           it('renders the filtered table view', async () => {
             const assessments = assessmentSummaries.build()
             const searchParameters = assessmentSearchParametersFactory.build()
@@ -215,7 +215,7 @@ describe('AssessmentsController', () => {
             await requestHandler(request, response, next)
 
             expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, status, {
-              crn: searchParameters.crn,
+              crnOrName: searchParameters.crnOrName,
               page: 1,
               sortBy: 'arrivedAt',
               sortDirection: 'asc',
@@ -227,7 +227,7 @@ describe('AssessmentsController', () => {
               tableRows: assessments.data,
               tableHeaders: [],
               pagination: {},
-              crn: searchParameters.crn,
+              crnOrName: searchParameters.crnOrName,
             })
           })
         })

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -85,7 +85,7 @@ export default class AssessmentsController {
             appendQueryString('', params),
             status === 'archived',
           ),
-          crn: params.crn,
+          crnOrName: params.crnOrName,
           pagination: response && pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
         })
       } catch (err) {

--- a/server/testutils/factories/assessmentSearchParameters.ts
+++ b/server/testutils/factories/assessmentSearchParameters.ts
@@ -3,5 +3,8 @@ import { AssessmentSearchParameters } from '@approved-premises/ui'
 import { faker } from '@faker-js/faker/locale/en_GB'
 
 export default Factory.define<AssessmentSearchParameters>(() => ({
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crnOrName: faker.helpers.arrayElement([
+    `C${faker.number.int({ min: 100000, max: 999999 })}`,
+    faker.person.firstName(),
+  ]),
 }))

--- a/server/views/components/search-by-crn-or-name-form/macro.njk
+++ b/server/views/components/search-by-crn-or-name-form/macro.njk
@@ -10,9 +10,28 @@
 
 
 {% macro searchByCrnOrNameForm(params) %}
-    {% set searchLabel = 'Search ' + params.uiStatus + ' ' +  params.type + ' by CRN (case reference number)' %}
+    {% set searchLabel %}
+        {% if params.type === 'referrals' %}
+            {{ 'Search ' + params.uiStatus + ' ' +  params.type + ' with the person’s name or CRN' }}
+        {% else %}
+            {# TODO remove once bookings can be searched using crn or name #}
+            {{ 'Search ' + params.uiStatus + ' ' +  params.type + ' by CRN (case reference number)' }}
+        {% endif%}
+    {% endset %}
+
+    {% set searchHint %}
+        {% if params.type === 'referrals' %}
+            For example, James or XD7364CD
+        {% else %}
+            {# TODO remove once bookings can be searched using crn or name #}
+            For example, XD7364CD
+        {% endif%}
+    {% endset %}
+    
 
     <form action="{{ params.basePath }}" method="get">
+        {# TODO remove once bookings can be searched using crn or name #}
+        {% set fieldName = 'crnOrName' if params.type === 'referrals' else 'crn' %}
 
         {{ govukInput(
             {
@@ -21,10 +40,10 @@
                 text: searchLabel
             },
                 hint: {
-                text: 'For example, XD7364CD'
+                text: searchHint
             },
-                name: 'crn',
-                id: 'crn',
+                name: fieldName,
+                id: fieldName,
                 value: params.crnOrName
             }
         ) }}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -14,7 +14,7 @@
 
 {# TODO Move this HTML to the searchByCrnOrNameResult once HTML can be standardised between referrals and bookings #}
 {% set resultsHtml %}
-    {% if (tableRows|length > 0 ) or (not crn) %}
+    {% if (tableRows|length > 0 ) or (not crnOrName) %}
         <div class="govuk-!-margin-bottom-4">
             {{ mojPagination(pagination) }}
         </div>
@@ -67,7 +67,7 @@
             type: 'referrals',
             basePath: basePath, 
             uiStatus: uiStatus, 
-            crnOrName: crn
+            crnOrName: crnOrName
         })}}
     </div>
 
@@ -77,7 +77,7 @@
         uiStatus: uiStatus,
         tableRows: tableRows,
         resultsHtml: resultsHtml,
-        crnOrName: crn
+        crnOrName: crnOrName
     })}}
 
     {% block archivedLink %}


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-270
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
We are changing how search works and in do so the search param will no longer only search for crn but name as well. This commit is simple renaming the existing param so its clear that its not only for crn

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/2e9b9820-a9fb-4c75-abd8-c02d3ebf21db)

 
![image](https://github.com/user-attachments/assets/a1ad8130-9051-4437-b7d9-ab740dcf01d4)


### After
![image](https://github.com/user-attachments/assets/b11d2956-dace-4679-b773-2beb23611ef7)


![image](https://github.com/user-attachments/assets/697a60bb-e5bf-4c90-80b8-ca1a6da27bc6)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
