### PR TITLE
Reinstate 1 retry for e2e tests

### DIFF
--- a/cypress.config.e2e.ts
+++ b/cypress.config.e2e.ts
@@ -47,5 +47,5 @@ export default defineConfig({
     supportFile: false,
   },
   numTestsKeptInMemory: 0,
-  retries: 0,
+  retries: 1,
 })


### PR DESCRIPTION
A change to 0 was accidentally committed in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/commit/1db0a64040f6a5df71fc5f7b00da32d3e0a44cd6#diff-54d38379cbaaec941931336685d71e180b81ffd296265af1e89344d6230c2795R50

