### PR TITLE
CAS-525: PDU as first class field

### DIFF
--- a/server/controllers/apply/applicationsController.test.ts
+++ b/server/controllers/apply/applicationsController.test.ts
@@ -340,7 +340,7 @@ describe('applicationsController', () => {
     })
   })
 
-  describe('submit', () => {
+  describe('confirm', () => {
     it('renders the application submission confirmation page', async () => {
       const requestHandler = applicationsController.confirm()
       await requestHandler(request, response, next)

--- a/server/utils/applications/getApplicationData.test.ts
+++ b/server/utils/applications/getApplicationData.test.ts
@@ -39,6 +39,7 @@ describe('getApplicationSubmissionData', () => {
       hasHistoryOfArson: false,
       isConcerningArsonBehaviour: true,
       prisonReleaseTypes: ['Fixed-term recall', 'Parole'],
+      probationDeliveryUnitId: applicationDataJson['contact-details']['probation-practitioner'].pdu.id,
     })
   })
 })

--- a/server/utils/applications/getApplicationData.ts
+++ b/server/utils/applications/getApplicationData.ts
@@ -19,6 +19,7 @@ import {
   isRegisteredSexOffenderFromApplication,
   needsAccessiblePropertyFromApplication,
   personReleaseDateFromApplication,
+  probationDeliveryUnitIdFromApplication,
   releaseTypesFromApplication,
 } from './reportDataFromApplication'
 
@@ -49,5 +50,6 @@ export const getApplicationSubmissionData = (application: Application): SubmitAp
     hasHistoryOfArson: hasHistoryOfArsonFromApplication(application),
     isConcerningArsonBehaviour: isConcerningArsonBehaviourFromApplication(application),
     prisonReleaseTypes: releaseTypesFromApplication(application),
+    probationDeliveryUnitId: probationDeliveryUnitIdFromApplication(application),
   }
 }

--- a/server/utils/applications/reportDataFromApplication.test.ts
+++ b/server/utils/applications/reportDataFromApplication.test.ts
@@ -11,9 +11,10 @@ import {
   isRegisteredSexOffenderFromApplication,
   needsAccessiblePropertyFromApplication,
   personReleaseDateFromApplication,
+  probationDeliveryUnitIdFromApplication,
   releaseTypesFromApplication,
 } from './reportDataFromApplication'
-import { applicationFactory } from '../../testutils/factories'
+import { applicationFactory, pduFactory } from '../../testutils/factories'
 import { SessionDataError } from '../errors'
 
 describe('reportDataFromApplication', () => {
@@ -372,6 +373,31 @@ describe('reportDataFromApplication', () => {
       })
 
       expect(releaseTypesFromApplication(application)).toEqual([])
+    })
+  })
+
+  describe('probationDeliveryUnitIdFromApplication', () => {
+    it("returns the probation practitioner's PDU id", () => {
+      const pdu = pduFactory.build()
+      const application = applicationFactory.build({
+        data: {
+          'contact-details': {
+            'probation-practitioner': {
+              pdu,
+            },
+          },
+        },
+      })
+
+      expect(probationDeliveryUnitIdFromApplication(application)).toEqual(pdu.id)
+    })
+
+    it("throws an error if the probation practitioner's PDU is not present", () => {
+      const application = applicationFactory.build()
+
+      expect(() => probationDeliveryUnitIdFromApplication(application)).toThrow(
+        new SessionDataError('No probation practitioner PDU'),
+      )
     })
   })
 })

--- a/server/utils/applications/reportDataFromApplication.ts
+++ b/server/utils/applications/reportDataFromApplication.ts
@@ -175,6 +175,16 @@ const releaseTypesFromApplication = (application: Application): Array<string> =>
   return releaseTypesData.map(key => releaseTypes[key].abbr)
 }
 
+const probationDeliveryUnitIdFromApplication = (application: Application): string => {
+  const pduId = (application.data as Record<string, unknown>)?.['contact-details']?.['probation-practitioner']?.pdu?.id
+
+  if (!pduId) {
+    throw new SessionDataError('No probation practitioner PDU')
+  }
+
+  return pduId
+}
+
 export {
   dutyToReferSubmissionDateFromApplication,
   dutyToReferLocalAuthorityAreaNameFromApplication,
@@ -190,4 +200,5 @@ export {
   hasHistoryOfArsonFromApplication,
   isConcerningArsonBehaviourFromApplication,
   releaseTypesFromApplication,
+  probationDeliveryUnitIdFromApplication,
 }


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-525

# Changes in this PR

Sends the PDU id of the Probation practitioner as the `probationDeliveryUnitId` alongside the rest of the application data and first-class fields.

- [ ] **NOTE: the API types created from linked BE ticket below will need to be merged into this for CI to pass.**

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?, Yes: https://dsdmoj.atlassian.net/browse/CAS-438
- [ ] Have they been released to production already? No

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
