### PR TITLE
Remove assessment search empty query param validation

### DIFF
--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -109,10 +109,4 @@ export default class ListPage extends Page {
     cy.get('p').should('contain', 'Check the other lists.')
     cy.get('main a').contains('contact support').should('have.attr', 'href', `mailto:${supportEmail}`)
   }
-
-  checkNoCRNEntered() {
-    cy.get('main table').should('not.exist')
-    cy.get('h2').should('contain', 'You have not entered any search terms')
-    cy.get('p').should('contain', 'Enter a CRN. This can be found in nDelius.')
-  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -96,10 +96,4 @@ export default class BookingSearchPage extends Page {
     cy.get('p').should('contain', 'Check the other lists.')
     cy.get('main a').contains('contact support').should('have.attr', 'href', `mailto:${supportEmail}`)
   }
-
-  checkNoCRNEntered() {
-    cy.get('main table').should('not.exist')
-    cy.get('h2').should('contain', 'You have not entered any search terms')
-    cy.get('p').should('contain', 'Enter a CRN. This can be found in nDelius.')
-  }
 }

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -168,22 +168,6 @@ context('Apply', () => {
             page.checkNoResultsByCRN(uiStatus, 'N0M4TCH')
           })
 
-          it('shows an error when submitting a blank CRN', () => {
-            const assessments = assessmentSummaryFactory.buildList(9, { status: factoryStatus })
-
-            cy.task('stubAssessments', { data: assessments })
-
-            // When I visit the referrals page
-            const page = ListPage.visit(status)
-
-            // And I submit a search with a blank CRN
-            page.searchByCRN('  ', uiStatus)
-            Page.verifyOnPage(ListPage, pageTitle)
-
-            // Then I see an error message
-            page.checkNoCRNEntered()
-          })
-
           it('shows pagination and ordering', () => {
             // Given there are assessments in the database
             const data = assessmentSummaryFactory.buildList(6, { status: factoryStatus })

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -180,26 +180,6 @@ context('Booking search', () => {
     page.checkNoResultsByCRN('confirmed', 'N0M4TCH')
   })
 
-  it('shows a message if the user has entered a blank CRN', () => {
-    // Given I am signed in
-    cy.signIn()
-
-    // And there are bookings in the database
-    const { data: bookings } = bookingSearchResultsFactory.build()
-
-    cy.task('stubFindBookings', { bookings, status: 'provisional' })
-
-    // When I visit the Find a provisional booking page
-    const page = BookingSearchPage.visit('provisional')
-
-    // And I submit a search with a blank CRN
-    page.searchByCRN('  ', 'provisional')
-    Page.verifyOnPage(BookingSearchPage, 'provisional')
-
-    // Then I see an error message
-    page.checkNoCRNEntered()
-  })
-
   it('retains the CRN search when ordering, paginating and navigating between booking types', () => {
     // Given I am signed in
     cy.signIn()

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -139,7 +139,6 @@ describe('AssessmentsController', () => {
             tableRows: [[{ text: assessment.createdAt }]],
             tableHeaders: expectedHeaders,
             pagination: {},
-            errors: {},
           })
 
           expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, status, {
@@ -194,7 +193,6 @@ describe('AssessmentsController', () => {
               ],
               previous: { text: 'Previous', href: '?page=1&sortBy=createdAt&sortDirection=desc' },
             },
-            errors: {},
           })
 
           expect(assessmentsService.getAllForLoggedInUser).toHaveBeenCalledWith(callConfig, status, {
@@ -230,42 +228,7 @@ describe('AssessmentsController', () => {
               tableHeaders: [],
               pagination: {},
               crn: searchParameters.crn,
-              errors: {},
             })
-          })
-        })
-
-        describe('when a blank CRN search is submitted', () => {
-          it('renders an error', async () => {
-            const searchParameters = assessmentSearchParametersFactory.build({ crn: '  ' })
-
-            request.query = searchParameters as ParsedQs
-
-            const requestHandler = assessmentsController.list(status)
-            await requestHandler(request, response, next)
-
-            expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'crn', 'empty')
-            expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-              request,
-              response,
-              new Error(),
-              pathFromStatus(status),
-            )
-          })
-        })
-
-        describe('when there is a CRN search error', () => {
-          it('does not call the API to fetch results', async () => {
-            ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({
-              errors: { crn: { text: 'You must enter a CRN', attributes: {} } },
-              errorSummary: [],
-              userInput: {},
-            })
-
-            const requestHandler = assessmentsController.list(status)
-            await requestHandler(request, response, next)
-
-            expect(assessmentsService.getAllForLoggedInUser).not.toHaveBeenCalled()
           })
         })
       },

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -63,8 +63,6 @@ export default class AssessmentsController {
 
   list(status: AssessmentSearchApiStatus): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { errors } = fetchErrorsAndUserInput(req)
-
       const callConfig = extractCallConfig(req)
 
       const params = getParams(req.query)
@@ -75,15 +73,7 @@ export default class AssessmentsController {
           : 'temporary-accommodation/assessments/index'
 
       try {
-        if (params.crn !== undefined && !params.crn.trim().length) {
-          const error = new Error()
-          insertGenericError(error, 'crn', 'empty')
-          throw error
-        }
-
-        const response = errors.crn
-          ? null
-          : await this.assessmentsService.getAllForLoggedInUser(callConfig, status, params)
+        const response = await this.assessmentsService.getAllForLoggedInUser(callConfig, status, params)
 
         return res.render(template, {
           status,
@@ -97,7 +87,6 @@ export default class AssessmentsController {
           ),
           crn: params.crn,
           pagination: response && pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
-          errors,
         })
       } catch (err) {
         return catchValidationErrorOrPropogate(req, res, err, pathFromStatus(status))

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -9,7 +9,7 @@ import { BookingSearchService } from '../../../services'
 import { bookingSearchParametersFactory } from '../../../testutils/factories'
 import extractCallConfig from '../../../utils/restUtils'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import { fetchErrorsAndUserInput } from '../../../utils/validation'
 
 jest.mock('../../../utils/restUtils')
 jest.mock('../../../utils/bookingSearchUtils')
@@ -67,7 +67,6 @@ describe('BookingSearchController', () => {
         uiStatus: 'provisional',
         tableHeadings: [],
         subNavArr: [],
-        errors: {},
         response: paginatedResponse,
         pagination: {},
       })
@@ -87,7 +86,6 @@ describe('BookingSearchController', () => {
         uiStatus: 'active',
         tableHeadings: [],
         subNavArr: [],
-        errors: {},
         response: paginatedResponse,
         pagination: {},
       })
@@ -107,7 +105,6 @@ describe('BookingSearchController', () => {
         uiStatus: 'confirmed',
         tableHeadings: [],
         subNavArr: [],
-        errors: {},
         response: paginatedResponse,
         pagination: {},
       })
@@ -130,7 +127,6 @@ describe('BookingSearchController', () => {
         uiStatus: 'departed',
         tableHeadings: [],
         subNavArr: [],
-        errors: {},
         response: paginatedResponse,
         pagination: {},
       })
@@ -162,36 +158,9 @@ describe('BookingSearchController', () => {
             tableHeadings: [],
             subNavArr: [],
             crn: searchParameters.crn,
-            errors: {},
             response: paginatedResponse,
             pagination: {},
           })
-        },
-      )
-    })
-
-    describe('when an blank CRN search is submitted', () => {
-      it.each(['provisional', 'confirmed', 'active', 'departed'])(
-        'renders an error for %s bookings',
-        async uiStatus => {
-          const status = (uiStatus === 'active' ? 'arrived' : uiStatus) as BookingSearchApiStatus
-          const searchParameters = bookingSearchParametersFactory.build({ crn: '   ' })
-
-          ;(convertApiStatusToUiStatus as jest.MockedFn<typeof convertApiStatusToUiStatus>).mockReturnValue(uiStatus)
-
-          request.query = searchParameters as ParsedQs
-
-          const requestHandler = bookingSearchController.index(status)
-
-          await requestHandler(request, response, next)
-
-          expect(insertGenericError).toHaveBeenCalledWith(new Error(), 'crn', 'empty')
-          expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-            request,
-            response,
-            new Error(),
-            `/bookings/${uiStatus}`,
-          )
         },
       )
     })

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -5,7 +5,7 @@ import { BookingSearchService } from '../../../services'
 import extractCallConfig from '../../../utils/restUtils'
 import { pagination } from '../../../utils/pagination'
 import { convertApiStatusToUiStatus, createSubNavArr, createTableHeadings } from '../../../utils/bookingSearchUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
+import { catchValidationErrorOrPropogate } from '../../../utils/validation'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { appendQueryString } from '../../../utils/utils'
 
@@ -14,19 +14,11 @@ export default class BookingSearchController {
 
   index(status: BookingSearchApiStatus): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { errors } = fetchErrorsAndUserInput(req)
-
       const callConfig = extractCallConfig(req)
 
       const params = req.query as BookingSearchParameters
 
       try {
-        if (params.crn !== undefined && !params.crn.trim().length) {
-          const error = new Error()
-          insertGenericError(error, 'crn', 'empty')
-          throw error
-        }
-
         const response = await this.bookingSearchService.getTableRowsForFindBooking(callConfig, status, params)
 
         // the params are defaulted downstream, inspect to find out what they are
@@ -40,7 +32,6 @@ export default class BookingSearchController {
           pagination: pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
           response,
           crn: params.crn,
-          errors,
         })
       } catch (err) {
         return catchValidationErrorOrPropogate(

--- a/server/views/components/search-by-crn-or-name-results/macro.njk
+++ b/server/views/components/search-by-crn-or-name-results/macro.njk
@@ -2,7 +2,6 @@
 
 
 {# params - Type of Object - Description #}
-{# errors - Object - Errors object from the view, soon to be removed #}
 {# resultsHtml - String - HTML string containing the pagination and results. Currently parent view is responsible for this. We will look to moving that logic into this component #}
 {# crnOrName - String - Either a CRN or Name which the user would like to search for #}
 {# uiStatus - String - Specific status the record would be in #}
@@ -10,12 +9,7 @@
 
 
 {% macro searchByCrnOrNameResults(params) %}
-    {% if params.errors.crn %}
-        <h2>You have not entered any search terms</h2>
-
-        <p>Enter a CRN. This can be found in nDelius.</p>
-
-    {% elif (params.resultsHtml| trim |length > 0) or (not params.crnOrName) %}
+    {% if (params.resultsHtml| trim |length > 0) %}
         {{ params.resultsHtml | safe | trim | indent(8)}}
 
     {% else %}

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -14,7 +14,7 @@
 
 {# TODO Move this HTML to the searchByCrnOrNameResult once HTML can be standardised between referrals and bookings #}
 {% set resultsHtml %}
-    {% if tableRows|length > 0 %}
+    {% if (tableRows|length > 0 ) or (not crn) %}
         <div class="govuk-!-margin-bottom-4">
             {{ mojPagination(pagination) }}
         </div>

--- a/server/views/temporary-accommodation/assessments/index.njk
+++ b/server/views/temporary-accommodation/assessments/index.njk
@@ -14,7 +14,7 @@
 
 {# TODO Move this HTML to the searchByCrnOrNameResult once HTML can be standardised between referrals and bookings #}
 {% set resultsHtml %}
-    {% if (not context.errors.prn) and ((tableRows|length > 0) or (not crn)) %}
+    {% if tableRows|length > 0 %}
         <div class="govuk-!-margin-bottom-4">
             {{ mojPagination(pagination) }}
         </div>

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -11,7 +11,7 @@
 
 {# TODO Move this HTML to the searchByCrnOrNameResult once HTML can be standardised between referrals and bookings #}
 {% set resultsHtml %}
-    {% if response.data|length > 0 %}
+    {% if (response.data|length > 0) or (not crn) %}
         {{ govukTable({
             captionClasses: "govuk-table__caption--m",
             head: tableHeadings,

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -11,7 +11,7 @@
 
 {# TODO Move this HTML to the searchByCrnOrNameResult once HTML can be standardised between referrals and bookings #}
 {% set resultsHtml %}
-    {% if (not context.errors.prn) and ((response.data|length > 0) or (not crn)) %}
+    {% if response.data|length > 0 %}
         {{ govukTable({
             captionClasses: "govuk-table__caption--m",
             head: tableHeadings,


### PR DESCRIPTION
# Context

This was removed because it introduced a new "validation" pattern in the service and didn't match what GOV.UK design system recommends. On the off chance the user removes a previous search terms and submits the form they would get this copy telling them that they cant search without text when it could just be seen as "clearing" the search filter

