### PR TITLE
CAS-489: Auto-complete field for placement in another PDU

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -265,7 +265,11 @@
   "placement-location": {
     "alternative-pdu": {
       "alternativePdu": "yes",
-      "alternativePduDetail": "Some PDU, for reasons X, Y, Z"
+      "pduId": "616497bf-3e6b-40e2-830b-8bfaeeaec157",
+      "pduName": "County Durham and Darlington"
+    },
+    "alternative-pdu-reason": {
+      "reason": "Reasons X, Y, Z"
     }
   },
   "disability-cultural-and-specific-needs": {

--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -233,7 +233,9 @@
           "id": "placement-location",
           "content": [
             {
-              "Is placement required in an alternative PDU?": "Yes - Some PDU, for reasons X, Y, Z"
+              "Is placement required in an alternative PDU?": "Yes",
+              "PDU for placement": "County Durham and Darlington",
+              "Reason for choosing an alternative PDU": "Reasons X, Y, Z"
             }
           ]
         },

--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -41,6 +41,7 @@ import {
   AdditionalLicenceConditionsPage,
   AdjudicationsPage,
   AlternativePduPage,
+  AlternativePduReasonPage,
   AntiSocialBehaviourPage,
   ApprovalsForSpecificRisksPage,
   BackupContactPage,
@@ -649,6 +650,16 @@ export default class ApplyHelper {
   }
 
   private completePlacementLocation() {
+    if (this.environment === 'integration') {
+      const pdu = referenceDataFactory.pdu().build({
+        id: this.application.data['placement-location']['alternative-pdu'].pduId,
+        name: this.application.data['placement-location']['alternative-pdu'].pduName,
+      })
+      cy.task('stubPdus', {
+        pdus: [pdu, ...referenceDataFactory.pdu().buildList(5)],
+      })
+    }
+
     // Given I click on the safeguarding and support task
     Page.verifyOnPage(TaskListPage, this.application).clickTask('placement-location')
 
@@ -657,7 +668,11 @@ export default class ApplyHelper {
     alternativePduPage.completeForm()
     alternativePduPage.clickSubmit()
 
-    this.pages.placementLocation = [alternativePduPage]
+    const alternativePduReasonPage = new AlternativePduReasonPage(this.application)
+    alternativePduReasonPage.completeForm()
+    alternativePduReasonPage.clickSubmit()
+
+    this.pages.placementLocation = [alternativePduPage, alternativePduReasonPage]
 
     // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(TaskListPage, this.application)

--- a/cypress_shared/pages/apply/index.ts
+++ b/cypress_shared/pages/apply/index.ts
@@ -36,6 +36,7 @@ import ReligiousOrCulturalNeedsPage from './requirements-for-placement/disabilit
 import FoodAllergiesPage from './requirements-for-placement/food-allergies/foodAllergies'
 import MoveOnPlanPage from './requirements-for-placement/move-on-plan/moveOnPlan'
 import AlternativePduPage from './requirements-for-placement/placement-location/alternativePdu'
+import AlternativePduReasonPage from './requirements-for-placement/placement-location/alternativePduReason'
 import CaringResponsibilitiesPage from './requirements-for-placement/safeguarding-and-support/caringResponsibilities'
 import LocalConnectionsPage from './requirements-for-placement/safeguarding-and-support/localConnections'
 import SafeguardingAndVulnerabilityPage from './requirements-for-placement/safeguarding-and-support/safeguardingAndVulnerability'
@@ -58,6 +59,7 @@ export {
   AdditionalLicenceConditionsPage,
   AdjudicationsPage,
   AlternativePduPage,
+  AlternativePduReasonPage,
   AntiSocialBehaviourPage,
   ApprovalsForSpecificRisksPage,
   BackupContactPage,

--- a/cypress_shared/pages/apply/requirements-for-placement/placement-location/alternativePdu.ts
+++ b/cypress_shared/pages/apply/requirements-for-placement/placement-location/alternativePdu.ts
@@ -19,7 +19,9 @@ export default class AlternativePduPage extends ApplyPage {
     this.checkRadioButtonFromPageBody('alternativePdu')
 
     if (this.tasklistPage.body.alternativePdu === 'yes') {
-      this.selectSelectOptionFromPageBody('pduId')
+      const pduName = this.tasklistPage.body.pduName as string
+      this.completeTextInputByLabel('Select a PDU', pduName.slice(0, 3))
+      cy.get('li[role="option"]').contains(pduName).click()
     }
   }
 }

--- a/cypress_shared/pages/apply/requirements-for-placement/placement-location/alternativePduReason.ts
+++ b/cypress_shared/pages/apply/requirements-for-placement/placement-location/alternativePduReason.ts
@@ -2,13 +2,13 @@ import type { TemporaryAccommodationApplication } from '@approved-premises/api'
 import paths from '../../../../../server/paths/apply'
 import ApplyPage from '../../applyPage'
 
-export default class AlternativePduPage extends ApplyPage {
+export default class AlternativePduReasonPage extends ApplyPage {
   constructor(application: TemporaryAccommodationApplication) {
     super(
-      'Is placement required in an alternative PDU (probation delivery unit)?',
+      'Provide a reason for choosing a different PDU (probation delivery unit)',
       application,
       'placement-location',
-      'alternative-pdu',
+      'alternative-pdu-reason',
       paths.applications.show({
         id: application.id,
       }),
@@ -16,10 +16,6 @@ export default class AlternativePduPage extends ApplyPage {
   }
 
   completeForm() {
-    this.checkRadioButtonFromPageBody('alternativePdu')
-
-    if (this.tasklistPage.body.alternativePdu === 'yes') {
-      this.selectSelectOptionFromPageBody('pduId')
-    }
+    this.completeTextInputFromPageBody('reason')
   }
 }

--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -16,11 +16,11 @@ const stubLocalAuthorities = (localAuthorities: Array<LocalAuthorityArea>) =>
     },
   })
 
-const stubPdus = (args: { pdus: Array<ProbationDeliveryUnit>; probationRegionId: string }) =>
+const stubPdus = (args: { pdus: Array<ProbationDeliveryUnit>; probationRegionId?: string }) =>
   stubFor({
     request: {
       method: 'GET',
-      url: `/reference-data/probation-delivery-units?probationRegionId=${args.probationRegionId}`,
+      url: `/reference-data/probation-delivery-units${args.probationRegionId ? `?probationRegionId=${args.probationRegionId}` : ''}`,
     },
     response: {
       status: 200,

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -259,6 +259,7 @@ export type GroupedListofBookings = {
   [K in 'arrivingToday' | 'departingToday' | 'upcomingArrivals' | 'upcomingDepartures']: Array<Booking>
 }
 
+export type GetPdusOptions = { regional?: boolean }
 export type DataServices = Partial<{
   personService: {
     getPrisonCaseNotes: (callConfig: CallConfig, crn: string) => Promise<Array<PrisonCaseNote>>
@@ -276,7 +277,7 @@ export type DataServices = Partial<{
   }
   referenceDataService: {
     getLocalAuthorities: (CallConfig: CallConfig) => Promise<Array<LocalAuthorityArea>>
-    getRegionPdus: (CallConfig: CallConfig) => Promise<Array<ProbationDeliveryUnit>>
+    getPdus: (CallConfig: CallConfig, options: GetPdusOptions = {}) => Promise<Array<ProbationDeliveryUnit>>
   }
 }>
 

--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.test.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.test.ts
@@ -30,9 +30,9 @@ describe('PractitionerPdu', () => {
   describe('initialize', () => {
     it('returns the page with PDUs fetched from the API', async () => {
       const pdus = referenceDataFactory.pdu().buildList(10)
-      const getRegionPdusMock = jest.fn().mockResolvedValue(pdus)
+      const getPdusMock = jest.fn().mockResolvedValue(pdus)
       const referenceDataService = createMock<ReferenceDataService>({
-        getRegionPdus: getRegionPdusMock,
+        getPdus: getPdusMock,
       })
 
       const page = await PractitionerPdu.initialize(
@@ -45,7 +45,7 @@ describe('PractitionerPdu', () => {
         mockSessionUser,
       )
 
-      expect(getRegionPdusMock).toHaveBeenCalledWith(callConfig)
+      expect(getPdusMock).toHaveBeenCalledWith(callConfig, { regional: true })
       expect(page).toBeInstanceOf(PractitionerPdu)
       expect(page.pdus).toEqual(pdus)
     })
@@ -111,11 +111,7 @@ describe('PractitionerPdu', () => {
 
   describe('getRegionPdus', () => {
     it('returns the PDUs formatted for use in a select element', () => {
-      const pdus = [
-        referenceDataFactory.pdu().build(),
-        referenceDataFactory.pdu().build(),
-        referenceDataFactory.pdu().build(),
-      ]
+      const pdus = referenceDataFactory.pdu().buildList(3)
 
       const page = new PractitionerPdu({ id: pdus[1].id, name: pdus[1].name }, application, mockSessionUser, pdus)
 

--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
@@ -36,7 +36,7 @@ export default class PractitionerPdu implements TasklistPage {
     dataServices: DataServices,
     session?: Partial<SessionData>,
   ) {
-    const pdus = await dataServices.referenceDataService.getRegionPdus(callConfig)
+    const pdus = await dataServices.referenceDataService.getPdus(callConfig, { regional: true })
     return new PractitionerPdu(body, application, session, pdus)
   }
 

--- a/server/form-pages/apply/requirements-for-placement/placement-location/alternativePdu.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/placement-location/alternativePdu.test.ts
@@ -1,61 +1,153 @@
-import { applicationFactory } from '../../../../testutils/factories'
-import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
-import { yesOrNoResponseWithDetail } from '../../../utils'
-import AlternativePdu from './alternativePdu'
-
-jest.mock('../../../utils')
-
-const body = { alternativePdu: 'yes' as const, alternativePduDetail: 'Detail' }
+import { createMock } from '@golevelup/ts-jest'
+import { applicationFactory, referenceDataFactory } from '../../../../testutils/factories'
+import { itShouldHavePreviousValue } from '../../../shared-examples'
+import AlternativePdu, { AlternativePduBody } from './alternativePdu'
+import { ReferenceDataService } from '../../../../services'
+import { CallConfig } from '../../../../data/restClient'
 
 describe('AlternativePdu', () => {
   const application = applicationFactory.build()
+  const pdus = referenceDataFactory.pdu().buildList(3)
+  const body: AlternativePduBody = { alternativePdu: 'yes', pduId: pdus[1].id, pduName: pdus[1].name }
 
-  describe('body', () => {
-    it('sets the body', () => {
-      const page = new AlternativePdu(body, application)
+  describe('initialize', () => {
+    it('returns the page with all PDUs fetched from the API', async () => {
+      const callConfig = { token: 'some-token' } as CallConfig
+      const getPdusMock = jest.fn().mockResolvedValue(pdus)
+      const referenceDataService = createMock<ReferenceDataService>({
+        getPdus: getPdusMock,
+      })
 
-      expect(page.body).toEqual(body)
+      const page = await AlternativePdu.initialize({} as AlternativePduBody, application, callConfig, {
+        referenceDataService,
+      })
+
+      expect(getPdusMock).toHaveBeenCalledWith(callConfig)
+      expect(page).toBeInstanceOf(AlternativePdu)
+      expect(page.pdus).toEqual(pdus)
     })
   })
 
-  itShouldHavePreviousValue(new AlternativePdu({}, application), 'dashboard')
-  itShouldHaveNextValue(new AlternativePdu({}, application), '')
+  describe('body', () => {
+    it('sets the body to the existing value', () => {
+      const page = new AlternativePdu(body, application, pdus)
+
+      expect(page.body).toEqual(body)
+    })
+
+    it('sets the body based on the value submitted and the PDUs from the API', () => {
+      const page = new AlternativePdu({}, application, pdus)
+
+      page.body = { alternativePdu: 'yes', pduId: pdus[0].id }
+
+      expect(page.body).toEqual({
+        alternativePdu: 'yes',
+        pduId: pdus[0].id,
+        pduName: pdus[0].name,
+      })
+    })
+
+    it('clears any previously selected PDU if the answer is no', () => {
+      const page = new AlternativePdu(body, application, pdus)
+
+      page.body = { ...body, alternativePdu: 'no' }
+
+      expect(page.body).toEqual({
+        alternativePdu: 'no',
+      })
+    })
+  })
+
+  itShouldHavePreviousValue(new AlternativePdu({}, application, pdus), 'dashboard')
+
+  describe('next', () => {
+    it('returns the alternative PDU reason page ID if the answer is yes', () => {
+      const page = new AlternativePdu(body, application, pdus)
+
+      expect(page.next()).toEqual('alternative-pdu-reason')
+    })
+
+    it('returns a blank string for the task list if the answer is no', () => {
+      const page = new AlternativePdu({ alternativePdu: 'no' }, application, pdus)
+
+      expect(page.next()).toEqual('')
+    })
+  })
 
   describe('errors', () => {
-    it('returns an empty object if the alternative PDU fields are populated', () => {
-      const page = new AlternativePdu(body, application)
+    it('returns no error if the alternative PDU fields are populated', () => {
+      const page = new AlternativePdu(body, application, pdus)
+
       expect(page.errors()).toEqual({})
     })
 
-    it('returns an empty object if the alternative PDU answer is no', () => {
-      const page = new AlternativePdu({ alternativePdu: 'no' }, application)
+    it('returns no error if the alternative PDU answer is no', () => {
+      const page = new AlternativePdu({ alternativePdu: 'no' }, application, pdus)
+
       expect(page.errors()).toEqual({})
     })
 
-    it('returns an error if the alternative PDU answer not populated', () => {
-      const page = new AlternativePdu({ ...body, alternativePdu: undefined }, application)
+    it('returns an error if the alternative PDU answer is not populated', () => {
+      const page = new AlternativePdu({ ...body, alternativePdu: undefined }, application, pdus)
+
       expect(page.errors()).toEqual({
         alternativePdu: 'You must specify if placement is required in an alternative PDU',
       })
     })
 
-    it('returns an error if the alternative PDU answer is yes but details are not populated', () => {
-      const page = new AlternativePdu({ ...body, alternativePduDetail: undefined }, application)
+    it('returns an error if the alternative PDU answer is yes but PDU is not selected', () => {
+      const page = new AlternativePdu({ alternativePdu: 'yes', pduId: undefined }, application, pdus)
+
       expect(page.errors()).toEqual({
-        alternativePduDetail: 'You must provide the alternative PDU and the reason it is preferred',
+        pduId: 'You must select a PDU',
       })
     })
   })
 
   describe('response', () => {
-    it('returns a translated version of the response', () => {
-      ;(yesOrNoResponseWithDetail as jest.Mock).mockReturnValue('Response with optional detail')
+    it('returns a translated version of the response when answered yes', () => {
+      const page = new AlternativePdu(body, application, pdus)
 
-      const page = new AlternativePdu(body, application)
       expect(page.response()).toEqual({
-        'Is placement required in an alternative PDU?': 'Response with optional detail',
+        'Is placement required in an alternative PDU?': 'Yes',
+        'PDU for placement': pdus[1].name,
       })
-      expect(yesOrNoResponseWithDetail).toHaveBeenCalledWith('alternativePdu', body)
+    })
+
+    it('returns a translated version of the response when answered no', () => {
+      const page = new AlternativePdu({ alternativePdu: 'no' }, application, pdus)
+
+      expect(page.response()).toEqual({
+        'Is placement required in an alternative PDU?': 'No',
+      })
+    })
+  })
+
+  describe('getAllPdus', () => {
+    it('returns the PDUs formatted for use in a select element', () => {
+      const page = new AlternativePdu(body, application, pdus)
+
+      const renderedPdus = page.getAllPdus()
+
+      expect(renderedPdus).toEqual([
+        {
+          value: '',
+          text: 'Select an option',
+        },
+        {
+          value: pdus[0].id,
+          text: pdus[0].name,
+        },
+        {
+          value: pdus[1].id,
+          text: pdus[1].name,
+          selected: true,
+        },
+        {
+          value: pdus[2].id,
+          text: pdus[2].name,
+        },
+      ])
     })
   })
 })

--- a/server/form-pages/apply/requirements-for-placement/placement-location/alternativePduReason.test.ts
+++ b/server/form-pages/apply/requirements-for-placement/placement-location/alternativePduReason.test.ts
@@ -1,0 +1,45 @@
+import { applicationFactory } from '../../../../testutils/factories'
+import AlternativePduReason, { AlternativePduReasonBody } from './alternativePduReason'
+import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
+
+describe('alternativePduReason', () => {
+  const application = applicationFactory.build()
+  const body: AlternativePduReasonBody = { reason: 'Some reason for requesting placement in an alternative PDU' }
+
+  describe('body', () => {
+    it('sets the body', () => {
+      const page = new AlternativePduReason(body, application)
+
+      expect(page.body).toEqual(body)
+    })
+  })
+
+  itShouldHavePreviousValue(new AlternativePduReason(body, application), 'alternative-pdu')
+  itShouldHaveNextValue(new AlternativePduReason(body, application), '')
+
+  describe('response', () => {
+    it('returns a translated version of the response', () => {
+      const page = new AlternativePduReason(body, application)
+
+      expect(page.response()).toEqual({
+        'Reason for choosing an alternative PDU': body.reason,
+      })
+    })
+  })
+
+  describe('errors', () => {
+    it('returns no errors if the answer has been provided', () => {
+      const page = new AlternativePduReason(body, application)
+
+      expect(page.errors()).toEqual({})
+    })
+
+    it('returns an error if the answer has not been provided', () => {
+      const page = new AlternativePduReason({}, application)
+
+      expect(page.errors()).toEqual({
+        reason: 'You must provide a reason for choosing a different PDU',
+      })
+    })
+  })
+})

--- a/server/form-pages/apply/requirements-for-placement/placement-location/alternativePduReason.ts
+++ b/server/form-pages/apply/requirements-for-placement/placement-location/alternativePduReason.ts
@@ -1,0 +1,44 @@
+import { PageResponse, TaskListErrors } from '@approved-premises/ui'
+import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
+import { Page } from '../../../utils/decorators'
+import TasklistPage from '../../../tasklistPage'
+
+export type AlternativePduReasonBody = {
+  reason: string
+}
+
+@Page({ name: 'alternative-pdu-reason', bodyProperties: ['reason'] })
+export default class AlternativePduReason implements TasklistPage {
+  title = 'Provide a reason for choosing a different PDU (probation delivery unit)'
+
+  htmlDocumentTitle = this.title
+
+  constructor(
+    readonly body: Partial<AlternativePduReasonBody>,
+    readonly application: Application,
+  ) {}
+
+  previous(): string {
+    return 'alternative-pdu'
+  }
+
+  next(): string {
+    return ''
+  }
+
+  response(): PageResponse {
+    return {
+      'Reason for choosing an alternative PDU': this.body.reason,
+    }
+  }
+
+  errors(): Partial<Record<keyof this['body'], unknown>> {
+    const errors: TaskListErrors<this> = {}
+
+    if (!this.body.reason) {
+      errors.reason = 'You must provide a reason for choosing a different PDU'
+    }
+
+    return errors
+  }
+}

--- a/server/form-pages/apply/requirements-for-placement/placement-location/index.ts
+++ b/server/form-pages/apply/requirements-for-placement/placement-location/index.ts
@@ -2,11 +2,12 @@
 
 import { Task } from '../../../utils/decorators'
 import AlternativePdu from './alternativePdu'
+import AlternativePduReason from './alternativePduReason'
 
 @Task({
   name: 'Placement location',
   actionText: 'Confirm placement location',
   slug: 'placement-location',
-  pages: [AlternativePdu],
+  pages: [AlternativePdu, AlternativePduReason],
 })
 export default class PlacementLocation {}

--- a/server/services/referenceDataService.test.ts
+++ b/server/services/referenceDataService.test.ts
@@ -33,22 +33,31 @@ describe('ReferenceDataService', () => {
     })
   })
 
-  describe('getRegionPdus', () => {
-    it('returns a list of PDUs from the current region sorted by name', async () => {
-      const pdu1 = referenceDataFactory.pdu().build({ name: 'XYZ' })
-      const pdu2 = referenceDataFactory.pdu().build({ name: 'ABC' })
-      const pdu3 = referenceDataFactory.pdu().build({ name: 'FOO' })
+  describe('getPdus', () => {
+    const pduXYZ = referenceDataFactory.pdu().build({ name: 'XYZ' })
+    const pduABC = referenceDataFactory.pdu().build({ name: 'ABC' })
+    const pduFOO = referenceDataFactory.pdu().build({ name: 'FOO' })
 
+    beforeEach(() => {
       referenceDataClient.getReferenceData.mockImplementation(async () => {
-        return [pdu1, pdu2, pdu3]
+        return [pduXYZ, pduABC, pduFOO]
       })
+    })
 
-      const result = await referenceDataService.getRegionPdus(callConfig)
+    it('returns a list of all PDUs sorted by name', async () => {
+      const result = await referenceDataService.getPdus(callConfig)
+
+      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('probation-delivery-units', {})
+      expect(result).toEqual([pduABC, pduFOO, pduXYZ])
+    })
+
+    it("returns a list of PDUs from the current user's region sorted by name", async () => {
+      const result = await referenceDataService.getPdus(callConfig, { regional: true })
 
       expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('probation-delivery-units', {
         probationRegionId: probationRegion.id,
       })
-      expect(result).toEqual([pdu2, pdu3, pdu1])
+      expect(result).toEqual([pduABC, pduFOO, pduXYZ])
     })
   })
 })

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -1,4 +1,5 @@
 import { LocalAuthorityArea, ProbationDeliveryUnit } from '@approved-premises/api'
+import { GetPdusOptions } from '@approved-premises/ui'
 import { ReferenceDataClient, RestClientBuilder } from '../data'
 import { CallConfig } from '../data/restClient'
 
@@ -13,12 +14,12 @@ export default class ReferenceDataService {
     )
   }
 
-  async getRegionPdus(callConfig: CallConfig) {
+  async getPdus(callConfig: CallConfig, options: GetPdusOptions = {}) {
     const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
     return (
       await referenceDataClient.getReferenceData<ProbationDeliveryUnit>('probation-delivery-units', {
-        probationRegionId: callConfig.probationRegion.id,
+        probationRegionId: options.regional ? callConfig.probationRegion.id : undefined,
       })
     ).sort((a, b) => a.name.localeCompare(b.name))
   }

--- a/server/utils/checkYourAnswersUtils/index.ts
+++ b/server/utils/checkYourAnswersUtils/index.ts
@@ -8,6 +8,7 @@ import { formatLines } from '../viewUtils'
 import { embeddedSummaryListItem } from './embeddedSummaryListItem'
 import { forPagesInTask } from '../applicationUtils'
 import { offenceIdKey } from '../../form-pages/apply/accommodation-need/sentence-information/offendingSummary'
+import logger from '../../../logger'
 
 const checkYourAnswersSections = (application: TemporaryAccommodationApplication) =>
   reviewSections(application, getTaskResponsesAsSummaryListItems)
@@ -21,14 +22,19 @@ export const getTaskResponsesAsSummaryListItems = (
   forPagesInTask(application, task, (page, pageName) => {
     const response = page.response()
 
-    Object.keys(response).forEach(key => {
-      const value =
-        typeof response[key] === 'string' || response[key] instanceof String
-          ? ({ html: formatLines(response[key] as string) } as HtmlItem)
-          : ({ html: embeddedSummaryListItem(response[key] as Array<Record<string, unknown>>) } as HtmlItem)
+    try {
+      Object.keys(response).forEach(key => {
+        const value =
+          typeof response[key] === 'string' || response[key] instanceof String
+            ? ({ html: formatLines(response[key] as string) } as HtmlItem)
+            : ({ html: embeddedSummaryListItem(response[key] as Array<Record<string, unknown>>) } as HtmlItem)
 
-      items.push(summaryListItemForResponse(key, value, task, pageName, application))
-    })
+        items.push(summaryListItemForResponse(key, value, task, pageName, application))
+      })
+    } catch (e) {
+      logger.error(e)
+      logger.debug('response:', response)
+    }
   })
 
   return items

--- a/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu-reason.njk
+++ b/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu-reason.njk
@@ -1,0 +1,19 @@
+{% extends "../../layout.njk" %}
+
+{% block questions %}
+
+    {% set pageTitleHTML %}
+        <span class="govuk-caption-l">{{ section.title }}</span>
+        {{ page.title }}
+    {% endset %}
+
+    {{ formPageTextarea({
+        fieldName: "reason",
+        label: {
+            html: pageTitleHTML,
+            isPageHeading: true,
+            classes: "govuk-label--l"
+        }
+    },fetchContext()) }}
+
+{% endblock %}

--- a/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
+++ b/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
@@ -1,47 +1,48 @@
-{% from "govuk/components/details/macro.njk" import govukDetails %}
+{% from "../../../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
 {% extends "../../layout.njk" %}
 
 {% block questions %}
 
-  {% set pageTitleHTML %}
-    <span class="govuk-caption-l">{{ section.title }}</span>
-    {{ page.title }}
-  {% endset %}
+    {% set pageTitleHTML %}
+        <span class="govuk-caption-l">{{ section.title }}</span>
+        {{ page.title }}
+    {% endset %}
 
-  {% set alternativePduDetailHtml %}
-    {{ formPageTextarea({
-      fieldName: "alternativePduDetail",
-      label: {
-        text: "Provide the alternative PDU and the reason it is preferred",
-        classes: "govuk-label--s"
-      }
+    {% set alternativePduDetailHtml %}
+        {{ formPageSelect({
+            fieldName: 'pduId',
+            label: {
+                text: "Select a PDU",
+                classes: "govuk-label--s"
+            },
+            items: page.getAllPdus()
+        }, fetchContext()) }}
+    {% endset %}
+
+    {{ formPageRadios({
+        fieldName: "alternativePdu",
+        fieldset: {
+            legend: {
+                html: pageTitleHTML,
+                isPageHeading: true,
+                classes: "govuk-fieldset__legend--l"
+            }
+        },
+        hint: {
+            text: "If placement is required in a PDU that's different to the person's current PDU, select 'yes'"
+        },
+        items: [
+            {
+                value: "yes",
+                text: "Yes",
+                conditional: {
+                html: alternativePduDetailHtml
+            }
+            },
+            {
+                value: "no",
+                text: "No"
+            }
+        ]
     },fetchContext()) }}
-  {% endset %}
-
-  {{ formPageRadios({
-    fieldName: "alternativePdu",
-    fieldset: {
-      legend: {
-        html: pageTitleHTML,
-        isPageHeading: true,
-        classes: "govuk-fieldset__legend--l"
-      }
-    },
-    hint: {
-      text: "If placement is required in a PDU that's different to the person's current PDU, select 'yes'"
-    },
-    items: [
-      {
-        value: "yes",
-        text: "Yes",
-        conditional: {
-          html: alternativePduDetailHtml
-        }
-      },
-      {
-        value: "no",
-        text: "No"
-      }
-    ]
-  },fetchContext()) }}
 {% endblock %}

--- a/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
+++ b/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
@@ -1,6 +1,11 @@
 {% from "../../../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
 {% extends "../../layout.njk" %}
 
+{% block head %}
+    {{ super() }}
+    <link href="/assets/css/accessible-autocomplete.min.css?{{ version }}" rel="stylesheet" />
+{% endblock %}
+
 {% block questions %}
 
     {% set pageTitleHTML %}
@@ -45,4 +50,21 @@
             }
         ]
     },fetchContext()) }}
+{% endblock %}
+
+{% block extraScripts %}
+
+    <script type="text/javascript" nonce="{{ cspNonce }}" src="/assets/js/accessible-autocomplete.min.js"></script>
+    <script type="text/javascript" nonce="{{ cspNonce }}">
+      accessibleAutocomplete.enhanceSelectElement({
+        selectElement: document.querySelector('select#pduId'),
+        defaultValue: '',
+      })
+
+      const hint = document.createElement('p')
+      hint.className = 'govuk-hint'
+      hint.textContent = 'Start typing and then select an option'
+      document.querySelector('label[for="pduId"]').insertAdjacentElement('afterend', hint)
+    </script>
+
 {% endblock %}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-489

# Changes in this PR

This changes the user flow slightly for the question about placement in another PDU (probation delivery unit): if the user selects 'Yes', [an auto-complete field](https://github.com/alphagov/accessible-autocomplete) pre-populated with all the available PDUs is shown, instead of a free text box, then the next page is a standalone free text field to add the reason for requesting a separate PDU. This ensures the Probation Practitioner enters a PDU that exists, and will help in displaying referrals by PDU.

## Screenshots of UI changes

### Before

#### Yes/No question (showing free text field)

<img width="798" alt="Screenshot 2024-08-13 at 10 11 00" src="https://github.com/user-attachments/assets/aefa6c2e-ef9b-4aa1-9ac5-49f2f68d0720">

---

#### Review your answers

<img width="1199" alt="Screenshot 2024-08-13 at 10 12 03" src="https://github.com/user-attachments/assets/7b098cb0-85dd-40c3-9053-27d2d7a84e66">

---

#### Full referral

<img width="1199" alt="Screenshot 2024-08-13 at 10 12 30" src="https://github.com/user-attachments/assets/a437c6d6-cd82-4c27-9b55-817f3dec5753">

---

### After

#### Yes/No question (showing auto-complete)

<img width="796" alt="Screenshot 2024-08-13 at 09 57 52" src="https://github.com/user-attachments/assets/125944da-376d-47c3-9845-156be8461e1d">

---

#### Details

<img width="796" alt="Screenshot 2024-08-13 at 10 00 36" src="https://github.com/user-attachments/assets/8b952e2d-1ca0-47f3-b1c2-6196cfc9b563">

---

#### Review your answers

<img width="1195" alt="Screenshot 2024-08-13 at 10 02 06" src="https://github.com/user-attachments/assets/0c7edaa2-e1d4-4786-9b02-27fd7cd4f043">

---

#### Full referral

<img width="1195" alt="Screenshot 2024-08-13 at 10 02 46" src="https://github.com/user-attachments/assets/45e1d8c5-1cd5-433d-b834-135f9e91ef9f">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
