### PR TITLE
Fix invalid Renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,36 +1,61 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-  "extends": ["github>ministryofjustice/hmpps-renovate-config:node"],
+  "extends": [
+    "github>ministryofjustice/hmpps-renovate-config:node"
+  ],
   "prBodyTemplate": "{{{table}}}{{{notes}}}{{{warnings}}}{{{controls}}}",
   "packageRules": [
     {
-      "matchManagers": ["npm"],
+      "matchManagers": [
+        "npm"
+      ],
       "rangeStrategy": "bump"
     },
     {
-      "matchManagers": ["npm"],
-      "matchUpdateTypes": ["minor", "patch"],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchUpdateTypes": [
+        "minor",
+        "patch"
+      ],
       "groupName": "all non major NPM dependencies",
       "groupSlug": "all-npm-minor-patch",
       "stabilityDays": 5
     },
     {
-      "matchPackageNames": ["typescript", "govuk-frontend"],
-      "matchUpdateTypes": ["major"],
+      "matchPackageNames": [
+        "typescript",
+        "govuk-frontend"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "enabled": true,
-      "rangeStrategy": "bump",
       "stabilityDays": 0
     },
     {
-      "matchManagers": ["npm"],
-      "matchPackageNames": ["@types/node"],
-      "matchUpdateTypes": ["major"],
+      "matchManagers": [
+        "npm"
+      ],
+      "matchPackageNames": [
+        "@types/node"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "enabled": false
     },
     {
-      "matchDatasources": ["docker"],
-      "matchPackageNames": ["node"],
-      "matchUpdateTypes": ["major"],
+      "matchDatasources": [
+        "docker"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "matchUpdateTypes": [
+        "major"
+      ],
       "enabled": false
     }
   ],


### PR DESCRIPTION
Fixes the issue: `packageRules cannot combine both matchUpdateTypes and rangeStrategy`

Resolves https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/issues/1041

