### PR TITLE
CAS-373:  Show PDUs on list referral page

### DIFF
--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -50,8 +50,12 @@ export default class ListPage extends Page {
         .parent()
         .parent()
         .within(() => {
-          cy.get('th').eq(0).contains(personName(assessmentSummary.person, 'Limited access offender'))
-          cy.get('td').eq(0).contains(assessmentSummary.person.crn)
+          cy.get('th')
+            .eq(0)
+            .contains(personName(assessmentSummary.person, 'Limited access offender'))
+            .parent()
+            .contains(assessmentSummary.person.crn)
+          cy.get('td').eq(0).contains(assessmentSummary.probationDeliveryUnitName)
           cy.get('td')
             .eq(1)
             .contains(

--- a/server/@types/shared/models/AssessmentSummary.ts
+++ b/server/@types/shared/models/AssessmentSummary.ts
@@ -5,6 +5,7 @@
 import type { AssessmentDecision } from './AssessmentDecision';
 import type { Person } from './Person';
 import type { PersonRisks } from './PersonRisks';
+import { ProbationDeliveryUnit } from './ProbationDeliveryUnit';
 export type AssessmentSummary = {
     type: string;
     id: string;
@@ -15,5 +16,6 @@ export type AssessmentSummary = {
     decision?: AssessmentDecision;
     risks?: PersonRisks;
     person: Person;
+    probationDeliveryUnitName: ProbationDeliveryUnit["name"];
 };
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -62,7 +62,7 @@ describe('AssessmentsController', () => {
       },
     },
     {
-      html: '<a href="?sortBy=crn&sortDirection=asc"><button>CRN</button></a>',
+      html: '<a href="?sortBy=probationDeliveryUnitName&sortDirection=asc"><button>PDU (Probation Delivery Unit)</button></a>',
       attributes: {
         'aria-sort': 'none',
       },

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -56,7 +56,7 @@ describe('AssessmentsController', () => {
 
   const tableHeaders = [
     {
-      html: '<a href="?sortBy=name&sortDirection=asc"><button>Name</button></a>',
+      html: '<a href="?sortBy=name&sortDirection=asc"><button>Name / CRN</button></a>',
       attributes: {
         'aria-sort': 'none',
       },

--- a/server/testutils/factories/assessmentSummary.ts
+++ b/server/testutils/factories/assessmentSummary.ts
@@ -4,6 +4,7 @@ import { TemporaryAccommodationAssessmentSummary as AssessmentSummary } from '@a
 import { DateFormats } from '../../utils/dateUtils'
 import { fullPersonFactory as personFactory } from './person'
 import risksFactory from './risks'
+import referenceDataFactory from './referenceData'
 
 class AssessmentSummaryFactory extends Factory<AssessmentSummary> {
   /* istanbul ignore next */
@@ -25,4 +26,5 @@ export default AssessmentSummaryFactory.define(() => ({
   status: 'closed' as const,
   risks: risksFactory.build(),
   person: personFactory.build(),
+  probationDeliveryUnitName: referenceDataFactory.pdu().build().name,
 }))

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -59,7 +59,7 @@ describe('assessmentUtils', () => {
           html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a><div class="govuk-body govuk-!-margin-bottom-0"> ABC123</div>`,
           attributes: { 'data-sort-value': 'John Smith' },
         },
-        { text: 'ABC123' },
+        { text: assessmentSummary.probationDeliveryUnitName },
         { text: '27 Feb 23', attributes: { 'data-sort-value': '2023-02-27' } },
         { text: '13 Apr 23', attributes: { 'data-sort-value': '2023-04-13' } },
       ])
@@ -102,7 +102,39 @@ describe('assessmentUtils', () => {
           html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a><div class="govuk-body govuk-!-margin-bottom-0"> ABC123</div>`,
           attributes: { 'data-sort-value': 'John Smith' },
         },
-        { text: 'ABC123' },
+        { text: assessmentSummary.probationDeliveryUnitName },
+        { text: '27 Feb 23', attributes: { 'data-sort-value': '2023-02-27' } },
+        { text: '13 Apr 23', attributes: { 'data-sort-value': '2023-04-13' } },
+        {
+          attributes: {
+            'data-sort-value': 'Unallocated',
+          },
+          html: '<strong class="govuk-tag govuk-tag--grey">Unallocated</strong>',
+        },
+      ])
+    })
+
+    it('returns a table row for the given assessment summary for the assessments table when the referral has no PDU', () => {
+      const assessmentSummary = assessmentSummaryFactory.build({
+        id: 'some-id',
+        person: personFactory.build({
+          name: 'John Smith',
+          crn: 'ABC123',
+        }),
+        arrivalDate: '2023-04-13',
+        createdAt: '2023-02-27',
+        status: 'unallocated',
+        probationDeliveryUnitName: undefined,
+      })
+
+      const result = assessmentTableRows(assessmentSummary, true)
+
+      expect(result).toEqual([
+        {
+          html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a><div class="govuk-body govuk-!-margin-bottom-0"> ABC123</div>`,
+          attributes: { 'data-sort-value': 'John Smith' },
+        },
+        { text: undefined },
         { text: '27 Feb 23', attributes: { 'data-sort-value': '2023-02-27' } },
         { text: '13 Apr 23', attributes: { 'data-sort-value': '2023-04-13' } },
         {
@@ -447,7 +479,7 @@ describe('assessmentUtils', () => {
 
   describe('createTableHeadings', () => {
     it('returns table headings for assessment lists', () => {
-      const result = createTableHeadings('crn', true, '?foo=bar')
+      const result = createTableHeadings('probationDeliveryUnitName', true, '?foo=bar')
 
       expect(result).toEqual([
         {
@@ -455,7 +487,7 @@ describe('assessmentUtils', () => {
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=crn&sortDirection=desc"><button>CRN</button></a>',
+          html: '<a href="?foo=bar&sortBy=probationDeliveryUnitName&sortDirection=desc"><button>PDU (Probation Delivery Unit)</button></a>',
           attributes: { 'aria-sort': 'ascending' },
         },
         {
@@ -478,7 +510,7 @@ describe('assessmentUtils', () => {
           attributes: { 'aria-sort': 'none' },
         },
         {
-          html: '<a href="?foo=bar&sortBy=crn&sortDirection=asc"><button>CRN</button></a>',
+          html: '<a href="?foo=bar&sortBy=probationDeliveryUnitName&sortDirection=asc"><button>PDU (Probation Delivery Unit)</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {

--- a/server/utils/assessmentUtils.test.ts
+++ b/server/utils/assessmentUtils.test.ts
@@ -56,7 +56,7 @@ describe('assessmentUtils', () => {
 
       expect(result).toEqual([
         {
-          html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a>`,
+          html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a><div class="govuk-body govuk-!-margin-bottom-0"> ABC123</div>`,
           attributes: { 'data-sort-value': 'John Smith' },
         },
         { text: 'ABC123' },
@@ -76,7 +76,7 @@ describe('assessmentUtils', () => {
       expect(result).toEqual(
         expect.arrayContaining([
           {
-            html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">Limited access offender</a>`,
+            html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">Limited access offender</a><div class="govuk-body govuk-!-margin-bottom-0"> ${assessmentSummary.person.crn}</div>`,
             attributes: { 'data-sort-value': '' },
           },
         ]),
@@ -99,7 +99,7 @@ describe('assessmentUtils', () => {
 
       expect(result).toEqual([
         {
-          html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a>`,
+          html: `<a href="${paths.assessments.summary({ id: 'some-id' })}">John Smith</a><div class="govuk-body govuk-!-margin-bottom-0"> ABC123</div>`,
           attributes: { 'data-sort-value': 'John Smith' },
         },
         { text: 'ABC123' },
@@ -451,7 +451,7 @@ describe('assessmentUtils', () => {
 
       expect(result).toEqual([
         {
-          html: '<a href="?foo=bar&sortBy=name&sortDirection=asc"><button>Name</button></a>',
+          html: '<a href="?foo=bar&sortBy=name&sortDirection=asc"><button>Name / CRN</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {
@@ -474,7 +474,7 @@ describe('assessmentUtils', () => {
 
       expect(result).toEqual([
         {
-          html: '<a href="?foo=bar&sortBy=name&sortDirection=asc"><button>Name</button></a>',
+          html: '<a href="?foo=bar&sortBy=name&sortDirection=asc"><button>Name / CRN</button></a>',
           attributes: { 'aria-sort': 'none' },
         },
         {

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -39,7 +39,7 @@ export const assessmentTableRows = (assessmentSummary: AssessmentSummary, showSt
       )}</a><div class="govuk-body govuk-!-margin-bottom-0"> ${assessmentSummary.person.crn}</div>`,
       personName(assessmentSummary.person, ''),
     ),
-    textValue(assessmentSummary.person.crn),
+    textValue(assessmentSummary.probationDeliveryUnitName),
     dateValue(assessmentSummary.createdAt),
     dateValue(assessmentSummary.arrivalDate),
   ]
@@ -255,7 +255,7 @@ export const createTableHeadings = (
 ) => {
   const headings = [
     sortHeader('Name / CRN', 'name', currentSortBy, sortIsAscending, href),
-    sortHeader('CRN', 'crn', currentSortBy, sortIsAscending, href),
+    sortHeader('PDU (Probation Delivery Unit)', 'probationDeliveryUnitName', currentSortBy, sortIsAscending, href),
     sortHeader('Referral received', 'createdAt', currentSortBy, sortIsAscending, href),
     sortHeader('Bedspace required', 'arrivedAt', currentSortBy, sortIsAscending, href),
   ]

--- a/server/utils/assessmentUtils.ts
+++ b/server/utils/assessmentUtils.ts
@@ -36,7 +36,7 @@ export const assessmentTableRows = (assessmentSummary: AssessmentSummary, showSt
       `<a href="${paths.assessments.summary({ id: assessmentSummary.id })}">${personName(
         assessmentSummary.person,
         'Limited access offender',
-      )}</a>`,
+      )}</a><div class="govuk-body govuk-!-margin-bottom-0"> ${assessmentSummary.person.crn}</div>`,
       personName(assessmentSummary.person, ''),
     ),
     textValue(assessmentSummary.person.crn),
@@ -254,7 +254,7 @@ export const createTableHeadings = (
   includeStatusColumn: boolean = false,
 ) => {
   const headings = [
-    sortHeader('Name', 'name', currentSortBy, sortIsAscending, href),
+    sortHeader('Name / CRN', 'name', currentSortBy, sortIsAscending, href),
     sortHeader('CRN', 'crn', currentSortBy, sortIsAscending, href),
     sortHeader('Referral received', 'createdAt', currentSortBy, sortIsAscending, href),
     sortHeader('Bedspace required', 'arrivedAt', currentSortBy, sortIsAscending, href),


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-373
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

For the all referral lists
- Moves CRN to be become part of "Name" column eg Joe Bloggs ABC123456
- Replaces the CRN column with PDU (may not display PDU for all older referrals)


## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/fd260a2f-3684-4fc1-9de2-273867a7b09f)

### After
![image](https://github.com/user-attachments/assets/44e84c9d-9fd6-488c-9400-572e3bf06c6d)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
