### PR TITLE
Always display persons Sex and conditionally display Gender Identity

### DIFF
--- a/cypress_shared/components/placeContextHeader.ts
+++ b/cypress_shared/components/placeContextHeader.ts
@@ -26,11 +26,12 @@ export default class PlaceContextHeaderComponent extends Component {
           .next()
           .should('contain', DateFormats.isoDateToUIDate(person.dateOfBirth, { format: 'short' }))
 
+        cy.root().contains('Sex:').next().should('contain', person.sex)
+
         if (person.genderIdentity) {
           cy.root().contains('Gender identity:').next().should('contain', person.genderIdentity)
           cy.root().should('not.contain', 'Sex')
         } else {
-          cy.root().contains('Sex:').next().should('contain', person.sex)
           cy.root().should('not.contain', 'Gender identity')
         }
       }

--- a/server/views/components/place-context-header/macro.njk
+++ b/server/views/components/place-context-header/macro.njk
@@ -19,15 +19,14 @@
                             <dt class="place-context-header__key">Date of birth: </dt>
                             <dd class="place-context-header__value">{{ formatDate(person.dateOfBirth, {format: 'short'}) }}</dd>
                         </div>
+                        <div class="place-context-header__row">
+                            <dt class="place-context-header__key">Sex: </dt>
+                            <dd class="place-context-header__value">{{ person.sex }}</dd>
+                        </div>
                         {% if person.genderIdentity %}
                             <div class="place-context-header__row">
                                 <dt class="place-context-header__key">Gender identity: </dt>
                                 <dd class="place-context-header__value">{{ person.genderIdentity }}</dd>
-                            </div>
-                        {% else %}
-                            <div class="place-context-header__row">
-                                <dt class="place-context-header__key">Sex: </dt>
-                                <dd class="place-context-header__value">{{ person.sex }}</dd>
                             </div>
                         {% endif %}
                     {% endif %}


### PR DESCRIPTION

# Context

https://dsdmoj.atlassian.net/browse/CAS-555

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

In nDelius, gender identity is not a required field but if the user has been provided with an answer then they have to record it. Previously we were displaying either the persons sex or their gender identity which was causing issues for our users especially when trying to find a bedspace and trying to identify if the person is male/female.  So now we will also display the persons biological sex and display gender identity even it has been answered. This includes instances where gender identity and sex match or if they have answers "Prefer not to say".


## Screenshots of UI changes

### Before
<img width="1198" alt="image" src="https://github.com/user-attachments/assets/a396c347-2b9a-4b60-b9b6-5dca8c8aadd6">

<img width="1221" alt="image" src="https://github.com/user-attachments/assets/83480951-a66f-4dd6-8e13-41dba9e8bda2">

### After
![image](https://github.com/user-attachments/assets/c50c6b89-27db-4dc3-b7c8-c13fed922099)
![image](https://github.com/user-attachments/assets/e56cecf3-3031-41bf-80ff-6e55f4f43a6a)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
