### PR TITLE
Add notification banner with link to external guidance to "Alternative PDU" page

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -665,6 +665,7 @@ export default class ApplyHelper {
 
     // When I complete the form
     const alternativePduPage = new AlternativePduPage(this.application)
+    alternativePduPage.checkNotificationBannerHasLinkToExternalGuidance()
     alternativePduPage.completeForm()
     alternativePduPage.clickSubmit()
 

--- a/cypress_shared/pages/apply/requirements-for-placement/placement-location/alternativePdu.ts
+++ b/cypress_shared/pages/apply/requirements-for-placement/placement-location/alternativePdu.ts
@@ -24,4 +24,12 @@ export default class AlternativePduPage extends ApplyPage {
       cy.get('li[role="option"]').contains(pduName).click()
     }
   }
+
+  checkNotificationBannerHasLinkToExternalGuidance() {
+    cy.get('.moj-banner a').should(
+      'have.attr',
+      'href',
+      'https://equip-portal.equip.service.justice.gov.uk/CtrlWebIsapi.dll/app/diagram/0:FF2D8D3F16B44268B814F7F8177A16F7.303E3A0E23194CF082C1598E11FA3314',
+    )
+  }
 }

--- a/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
+++ b/server/views/applications/pages/requirements-for-placement/placement-location/alternative-pdu.njk
@@ -1,4 +1,5 @@
 {% from "../../../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
+{%- from "moj/components/banner/macro.njk" import mojBanner -%}
 {% extends "../../layout.njk" %}
 
 {% block head %}
@@ -7,6 +8,22 @@
 {% endblock %}
 
 {% block questions %}
+
+    {% set notificationBannerHTML %}
+        <h2 class="govuk-notification-banner__heading">
+            Before you begin
+        </h2>
+        <p class="govuk-body">
+            Selecting an out of region PDU will not guarantee accommodation. You must contact the relevant Homelessness Prevention Team about the 
+            referral and <a class="govuk-link" href="https://equip-portal.equip.service.justice.gov.uk/CtrlWebIsapi.dll/app/diagram/0:FF2D8D3F16B44268B814F7F8177A16F7.303E3A0E23194CF082C1598E11FA3314" rel="noreferrer noopener" target="_blank">follow this guidance (opens in a new window)</a>
+        </p>
+    {% endset %}
+
+    {{ mojBanner({
+        type: 'information',
+        html: notificationBannerHTML,
+        iconFallbackText: 'information'
+    }) }}
 
     {% set pageTitleHTML %}
         <span class="govuk-caption-l">{{ section.title }}</span>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-580

Background: The central HPT team and HPT Leads want to flag that accommodation is not guaranteed when PPs request accommodation in a PDU outside of their probation region. Due to policy change and increase in number of referrals the central HPT team wants point PPs to relevant guidance on Equip if PP want to make an out of region referral.

Acceptance Criteria

A warning message displayed on ‘Is accommodation required in alternate PDU section’ on the referral form

The warning message should inform PP to check guidance and speak to relevant HPT team if accommodation is required in an alternate PDU outside of the PP’s region.



<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/75821c09-2bc8-4e56-af8a-65841e67f9e2)

### After
![image](https://github.com/user-attachments/assets/88589906-b95d-492d-aafe-847559136836)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
