### PR TITLE
run e2e tests in parallel on Circle CI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -19,6 +19,7 @@ parameters:
 
 jobs:
   e2e_environment_test:
+    parallelism: 5
     circleci_ip_ranges: true # opt-in to jobs running on a restricted set of IPs
     docker:
       - image: cypress/browsers:node16.14.2-slim-chrome100-ff99-edge


### PR DESCRIPTION
# Context
Currently it can take over 25mins for e2e tests to pass on circle ci. this is an attempt to speed it up by running the cypress tests in parallel.