### PR TITLE
Tell cypress how to split up the tests between circle ci parallel runs.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,9 +39,11 @@ jobs:
       - run:
           name: E2E Check - << parameters.environment >>
           command: |
+            TESTS=$(circleci tests glob "e2e/tests/*.feature" | circleci tests split --split-by=timings | paste -sd ',')
             npm run test:e2e:ci --\
               --env "assessor_username=${CYPRESS_ASSESSOR_USERNAME_<< parameters.environment >>},assessor_password=${CYPRESS_ASSESSOR_PASSWORD_<< parameters.environment >>},referrer_username=${CYPRESS_REFERRER_USERNAME_<< parameters.environment >>},referrer_password=${CYPRESS_REFERRER_PASSWORD_<< parameters.environment >>},acting_user_probation_region_id=${CYPRESS_ACTING_USER_PROBATION_REGION_ID_<< parameters.environment >>},acting_user_probation_region_name=${CYPRESS_ACTING_USER_PROBATION_REGION_NAME_<< parameters.environment >>},environment=${CYPRESS_ENVIRONMENT_<< parameters.environment >>}"\
-              --config baseUrl=https://transitional-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk
+              --config baseUrl=https://transitional-accommodation-<< parameters.environment >>.hmpps.service.justice.gov.uk \
+              --spec $TESTS
       - store_artifacts:
           path: e2e/screenshots
           destination: screenshots


### PR DESCRIPTION
# Related to
https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1066

The previous PR configured the e2e job to run in parallel but didn't setup cypress to split up the tests for various runs