### PR TITLE
Enable bookings to be searched by crn or name

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingSearch.ts
@@ -65,8 +65,8 @@ export default class BookingSearchPage extends Page {
     cy.contains(capitaliseStatus(status)).click()
   }
 
-  checkCRNSearchValue(value: string, status: string) {
-    this.shouldShowTextInputByLabel(`Search ${status} bookings by CRN (case reference number)`, value)
+  checkCrnOrNameSearchValue(value: string, status: string) {
+    this.shouldShowTextInputByLabel(`Search ${status} bookings with the person’s name or CRN`, value)
   }
 
   checkResults(bookings: BookingSearchResult[]) {
@@ -76,8 +76,8 @@ export default class BookingSearchPage extends Page {
     })
   }
 
-  searchByCRN(crn: string, status: string) {
-    this.completeTextInputByLabel(`Search ${status} bookings by CRN (case reference number)`, crn)
+  searchByCrnOrName(crnOrName: string, status: string) {
+    this.completeTextInputByLabel(`Search ${status} bookings with the person’s name or CRN`, crnOrName)
     this.clickSubmit('Search')
   }
 

--- a/e2e/tests/stepDefinitions/manage/bookingSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bookingSearch.ts
@@ -59,7 +59,7 @@ Then('I should see a summary of the booking on the departed bookings page', () =
 When('I search for a CRN that does not exist in provisional bookings', () => {
   cy.then(function _() {
     const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'provisional')
-    bookingSearchPage.searchByCRN('N000000', 'provisional')
+    bookingSearchPage.searchByCrnOrName('N000000', 'provisional')
   })
 })
 
@@ -94,7 +94,7 @@ When('I click on the Provisional bookings tab', () => {
 When('I search for a valid CRN in provisional bookings', () => {
   cy.then(function _() {
     const bookingSearchPage = Page.verifyOnPage(BookingSearchPage, 'provisional')
-    bookingSearchPage.searchByCRN(this.booking.person.crn, 'provisional')
+    bookingSearchPage.searchByCrnOrName(this.booking.person.crn, 'provisional')
   })
 })
 

--- a/integration_tests/mockApis/bookingSearch.ts
+++ b/integration_tests/mockApis/bookingSearch.ts
@@ -19,7 +19,7 @@ export default {
   }): SuperAgentRequest => {
     const url = appendQueryString(paths.bookings.search({}), {
       status: args.status,
-      crn: args.params?.crn,
+      crnOrName: args.params?.crnOrName,
       page: args.params?.page || 1,
       sortField: args.params?.sortBy || 'endDate',
       sortOrder: args.params?.sortDirection === 'asc' ? 'ascending' : 'descending',

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -103,33 +103,37 @@ context('Booking search', () => {
     page.checkColumnOrder('Start date', 'descending')
   })
 
-  it('shows the result of a crn search and clears the search', () => {
+  it('shows the result of a crn or name search and clears the search', () => {
     // Given I am signed in
     cy.signIn()
 
     // And there are bookings in the database
     const { data: bookings } = bookingSearchResultsFactory.build()
     const searchedForBooking = bookings[2]
-    const searchCRN = searchedForBooking.person.crn
+    const searchCrnOrName = searchedForBooking.person.crn
 
     cy.task('stubFindBookings', { bookings, status: 'provisional' })
-    cy.task('stubFindBookings', { bookings: [searchedForBooking], status: 'provisional', params: { crn: searchCRN } })
+    cy.task('stubFindBookings', {
+      bookings: [searchedForBooking],
+      status: 'provisional',
+      params: { crnOrName: searchCrnOrName },
+    })
 
     // When I visit the Find a provisional booking page
     const page = BookingSearchPage.visit('provisional')
 
     // Then the search by CRN form is empty
-    page.checkCRNSearchValue('', 'provisional')
+    page.checkCrnOrNameSearchValue('', 'provisional')
 
     // And I see all the results
     page.checkResults(bookings)
 
-    // When I submit a search by CRN
-    page.searchByCRN(searchCRN, 'provisional')
+    // When I submit a search by CRN or Name
+    page.searchByCrnOrName(searchCrnOrName, 'provisional')
     Page.verifyOnPage(BookingSearchPage, 'provisional')
 
-    // Then the search by CRN form is populated
-    page.checkCRNSearchValue(searchCRN, 'provisional')
+    // Then the search by CRN or Name form is populated
+    page.checkCrnOrNameSearchValue(searchCrnOrName, 'provisional')
 
     // Then I see the search result for that CRN
     page.checkResults([searchedForBooking])
@@ -139,39 +143,39 @@ context('Booking search', () => {
 
     Page.verifyOnPage(BookingSearchPage, 'provisional')
 
-    // Then the search by CRN form is populated
-    page.checkCRNSearchValue('', 'provisional')
+    // Then the search by CRN or Name form is populated
+    page.checkCrnOrNameSearchValue('', 'provisional')
 
-    // Then I see the search result for that CRN
+    // Then I see the search result for that CRN or Name
     page.checkResults(bookings)
   })
 
-  it('shows a message if there are no CRN search results', () => {
+  it('shows a message if there are no CRN or Name search results', () => {
     // Given I am signed in
     cy.signIn()
 
-    // And there are no bookings matching a CRN search in the database
+    // And there are no bookings matching a CRN or Name search in the database
     const { data: bookings } = bookingSearchResultsFactory.build()
     const noBookings: BookingSearchResult[] = []
 
     cy.task('stubFindBookings', { bookings, status: 'confirmed' })
-    cy.task('stubFindBookings', { bookings: noBookings, status: 'confirmed', params: { crn: 'N0M4TCH' } })
+    cy.task('stubFindBookings', { bookings: noBookings, status: 'confirmed', params: { crnOrName: 'N0M4TCH' } })
 
     // When I visit the Find a provisional booking page
     const page = BookingSearchPage.visit('confirmed')
 
     // Then the search by CRN form is empty
-    page.checkCRNSearchValue('', 'confirmed')
+    page.checkCrnOrNameSearchValue('', 'confirmed')
 
     // And I see all the results
     page.checkResults(bookings)
 
     // When I submit a search by CRN
-    page.searchByCRN('N0M4TCH', 'confirmed')
+    page.searchByCrnOrName('N0M4TCH', 'confirmed')
     Page.verifyOnPage(BookingSearchPage, 'confirmed')
 
     // Then the search by CRN form is populated
-    page.checkCRNSearchValue('N0M4TCH', 'confirmed')
+    page.checkCrnOrNameSearchValue('N0M4TCH', 'confirmed')
 
     // Then I see no search results for that CRN
     page.checkResults(noBookings)
@@ -195,21 +199,21 @@ context('Booking search', () => {
 
     ;['confirmed', 'arrived', 'departed'].forEach(status => {
       cy.task('stubFindBookings', { bookings, status })
-      cy.task('stubFindBookings', { bookings, status, params: { crn: 'X321654' } })
+      cy.task('stubFindBookings', { bookings, status, params: { crnOrName: 'X321654' } })
     })
 
     cy.task('stubFindBookings', { bookings, status: 'provisional', pagination })
-    cy.task('stubFindBookings', { bookings, status: 'provisional', params: { crn: 'X321654' }, pagination })
+    cy.task('stubFindBookings', { bookings, status: 'provisional', params: { crnOrName: 'X321654' }, pagination })
     cy.task('stubFindBookings', {
       bookings,
       status: 'provisional',
-      params: { crn: 'X321654', sortBy: 'endDate', sortDirection: 'asc' },
+      params: { crnOrName: 'X321654', sortBy: 'endDate', sortDirection: 'asc' },
       pagination,
     })
     cy.task('stubFindBookings', {
       bookings,
       status: 'provisional',
-      params: { crn: 'X321654', sortBy: 'endDate', sortDirection: 'asc', page: 2 },
+      params: { crnOrName: 'X321654', sortBy: 'endDate', sortDirection: 'asc', page: 2 },
       pagination: {
         ...pagination,
         pageNumber: 2,
@@ -219,18 +223,18 @@ context('Booking search', () => {
     // When I visit the Find a provisional booking page
     const page = BookingSearchPage.visit('provisional')
 
-    // And I submit a search by CRN
-    page.searchByCRN('X321654', 'provisional')
+    // And I submit a search by CRN or Name
+    page.searchByCrnOrName('X321654', 'provisional')
 
-    // Then I see the provisional bookings for the given CRN
+    // Then I see the provisional bookings for the given CRN or Name
     Page.verifyOnPage(BookingSearchPage, 'provisional')
-    page.checkCRNSearchValue('X321654', 'provisional')
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
 
     // When I order by end date
     page.sortColumn('End date')
 
-    // Then I see the provisional bookings for the given CRN
-    page.checkCRNSearchValue('X321654', 'provisional')
+    // Then I see the provisional bookings for the given CRN or Name
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
 
     // And I see the results are ordered by end date ascending
     page.shouldHaveURLSearchParam('sortBy=endDate&sortDirection=asc')
@@ -239,9 +243,9 @@ context('Booking search', () => {
     // When I navigate to the second page of results
     page.clickPaginationLink(2)
 
-    // Then I see the second page of provisional bookings for the given CRN
+    // Then I see the second page of provisional bookings for the given CRN or Name
     page.shouldHaveURLSearchParam('page=2')
-    page.checkCRNSearchValue('X321654', 'provisional')
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
 
     // And I see the results are ordered by end date ascending
     page.shouldHaveURLSearchParam('sortBy=endDate&sortDirection=asc')
@@ -250,30 +254,30 @@ context('Booking search', () => {
     // When I navigate to the confirmed bookings search
     page.clickOtherBookingStatusLink('confirmed')
 
-    // Then I see the confirmed bookings for the given CRN
+    // Then I see the confirmed bookings for the given CRN or Name
     Page.verifyOnPage(BookingSearchPage, 'confirmed')
-    page.checkCRNSearchValue('X321654', 'confirmed')
+    page.checkCrnOrNameSearchValue('X321654', 'confirmed')
 
     // When I navigate to the active bookings search
     page.clickOtherBookingStatusLink('arrived')
 
-    // Then I see the active bookings for the given CRN
+    // Then I see the active bookings for the given CRN or Name
     Page.verifyOnPage(BookingSearchPage, 'arrived')
-    page.checkCRNSearchValue('X321654', 'active')
+    page.checkCrnOrNameSearchValue('X321654', 'active')
 
     // When I navigate to the departed bookings search
     page.clickOtherBookingStatusLink('departed')
 
-    // Then I see the departed bookings for the given CRN
+    // Then I see the departed bookings for the given CRN or Name
     Page.verifyOnPage(BookingSearchPage, 'departed')
-    page.checkCRNSearchValue('X321654', 'departed')
+    page.checkCrnOrNameSearchValue('X321654', 'departed')
 
     // When I navigate to the provisional bookings search
     page.clickOtherBookingStatusLink('provisional')
 
-    // Then I see the provisional bookings for the given CRN
+    // Then I see the provisional bookings for the given CRN or Name
     Page.verifyOnPage(BookingSearchPage, 'provisional')
-    page.checkCRNSearchValue('X321654', 'provisional')
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
   })
 
   it('navigates back to the dashboard from the view bookings page', () => {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -279,7 +279,7 @@ export interface SubNavObj {
 export type BookingSearchApiStatus = 'provisional' | 'confirmed' | 'arrived' | 'departed' | 'closed'
 
 export type BookingSearchParameters = {
-  crn?: string
+  crnOrName?: string
   page?: number
   sortBy?: BookingSearchSortField
   sortDirection?: SortDirection

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.test.ts
@@ -132,7 +132,7 @@ describe('BookingSearchController', () => {
       })
     })
 
-    describe('when there is a CRN search parameter', () => {
+    describe('when there is a CRN or Name search parameter', () => {
       it.each(['provisional', 'confirmed', 'active', 'departed'])(
         'renders the filtered table view for %s bookings',
         async uiStatus => {
@@ -157,7 +157,7 @@ describe('BookingSearchController', () => {
             uiStatus,
             tableHeadings: [],
             subNavArr: [],
-            crn: searchParameters.crn,
+            crnOrName: searchParameters.crnOrName,
             response: paginatedResponse,
             pagination: {},
           })

--- a/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingSearchController.ts
@@ -27,11 +27,11 @@ export default class BookingSearchController {
 
         return res.render(`temporary-accommodation/booking-search/results`, {
           uiStatus: convertApiStatusToUiStatus(status),
-          subNavArr: createSubNavArr(status, params.crn),
+          subNavArr: createSubNavArr(status, params.crnOrName),
           tableHeadings: createTableHeadings(status, sortBy, ascending, appendQueryString('', params)), // dont send the page, will revert to 1 on sort change
           pagination: pagination(response.pageNumber, response.totalPages, appendQueryString('', params)),
           response,
-          crn: params.crn,
+          crnOrName: params.crnOrName,
         })
       } catch (err) {
         return catchValidationErrorOrPropogate(

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -295,21 +295,21 @@ describe('BookingClient', () => {
       expect(nock.isDone()).toBeTruthy()
     })
 
-    it('should return confirmed bookings for a given CRN', async () => {
+    it('should return confirmed bookings for a given CRN or Name', async () => {
       const booking = bookingSearchResultFactory.build({ person: { crn: 'C555333' } })
       const { data: bookings } = bookingSearchResultsFactory.build({ data: [booking] })
       const body = { results: bookings, resultsCount: bookings.length }
 
       fakeApprovedPremisesApi
         .get(
-          `${paths.bookings.search({})}?status=confirmed&crn=${
+          `${paths.bookings.search({})}?status=confirmed&crnOrName=${
             booking.person.crn
           }&page=1&sortField=endDate&sortOrder=descending`,
         )
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, body)
 
-      const result = await bookingClient.search('confirmed', { crn: 'C555333', page: 1, sortDirection: 'desc' })
+      const result = await bookingClient.search('confirmed', { crnOrName: 'C555333', page: 1, sortDirection: 'desc' })
 
       expect(result.data).toEqual(bookings)
       expect(nock.isDone()).toBeTruthy()

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -118,7 +118,7 @@ export default class BookingClient {
   ): Promise<PaginatedResponse<BookingSearchResult>> {
     const path = appendQueryString(paths.bookings.search({ status }), {
       status,
-      crn: params.crn,
+      crnOrName: params.crnOrName,
       page: !params.page ? 1 : params.page, // also handles NaN & <1
       sortField: params.sortBy || 'endDate',
       sortOrder: params.sortDirection === 'asc' ? 'ascending' : 'descending',

--- a/server/testutils/factories/bookingSearchParameters.ts
+++ b/server/testutils/factories/bookingSearchParameters.ts
@@ -3,5 +3,8 @@ import { faker } from '@faker-js/faker/locale/en_GB'
 import { BookingSearchParameters } from '@approved-premises/ui'
 
 export default Factory.define<BookingSearchParameters>(() => ({
-  crn: `C${faker.number.int({ min: 100000, max: 999999 })}`,
+  crnOrName: faker.helpers.arrayElement([
+    `C${faker.number.int({ min: 100000, max: 999999 })}`,
+    faker.person.firstName(),
+  ]),
 }))

--- a/server/utils/bookingSearchUtils.test.ts
+++ b/server/utils/bookingSearchUtils.test.ts
@@ -40,22 +40,22 @@ describe('bookingSearchUtils', () => {
       const sideNavArr = [
         {
           text: 'Provisional bookings',
-          href: `${paths.bookings.search.provisional.index({})}?crn=X222555`,
+          href: `${paths.bookings.search.provisional.index({})}?crnOrName=X222555`,
           active: true,
         },
         {
           text: 'Confirmed bookings',
-          href: `${paths.bookings.search.confirmed.index({})}?crn=X222555`,
+          href: `${paths.bookings.search.confirmed.index({})}?crnOrName=X222555`,
           active: false,
         },
         {
           text: 'Active bookings',
-          href: `${paths.bookings.search.active.index({})}?crn=X222555`,
+          href: `${paths.bookings.search.active.index({})}?crnOrName=X222555`,
           active: false,
         },
         {
           text: 'Departed bookings',
-          href: `${paths.bookings.search.departed.index({})}?crn=X222555`,
+          href: `${paths.bookings.search.departed.index({})}?crnOrName=X222555`,
           active: false,
         },
       ]

--- a/server/utils/bookingSearchUtils.ts
+++ b/server/utils/bookingSearchUtils.ts
@@ -5,11 +5,11 @@ import paths from '../paths/temporary-accommodation/manage'
 import { appendQueryString } from './utils'
 import { sortHeader } from './sortHeader'
 
-export function createSubNavArr(status: BookingSearchApiStatus, crn?: string): Array<SubNavObj> {
+export function createSubNavArr(status: BookingSearchApiStatus, crnOrName?: string): Array<SubNavObj> {
   const uiStatus = convertApiStatusToUiStatus(status)
   return ['provisional', 'confirmed', 'active', 'departed'].map((bookingStatus: BookingSearchApiStatus) => ({
     text: `${capitaliseStatus(bookingStatus)} bookings`,
-    href: appendQueryString(paths.bookings.search[bookingStatus].index({}), { crn }),
+    href: appendQueryString(paths.bookings.search[bookingStatus].index({}), { crnOrName }),
     active: uiStatus === bookingStatus,
   }))
 }

--- a/server/views/components/search-by-crn-or-name-form/macro.njk
+++ b/server/views/components/search-by-crn-or-name-form/macro.njk
@@ -10,40 +10,18 @@
 
 
 {% macro searchByCrnOrNameForm(params) %}
-    {% set searchLabel %}
-        {% if params.type === 'referrals' %}
-            {{ 'Search ' + params.uiStatus + ' ' +  params.type + ' with the person’s name or CRN' }}
-        {% else %}
-            {# TODO remove once bookings can be searched using crn or name #}
-            {{ 'Search ' + params.uiStatus + ' ' +  params.type + ' by CRN (case reference number)' }}
-        {% endif%}
-    {% endset %}
-
-    {% set searchHint %}
-        {% if params.type === 'referrals' %}
-            For example, James or XD7364CD
-        {% else %}
-            {# TODO remove once bookings can be searched using crn or name #}
-            For example, XD7364CD
-        {% endif%}
-    {% endset %}
-    
-
     <form action="{{ params.basePath }}" method="get">
-        {# TODO remove once bookings can be searched using crn or name #}
-        {% set fieldName = 'crnOrName' if params.type === 'referrals' else 'crn' %}
-
         {{ govukInput(
             {
                 label: {
                 classes: 'govuk-label--m',
-                text: searchLabel
+                text: 'Search ' + params.uiStatus + ' ' +  params.type + ' with the person’s name or CRN' 
             },
                 hint: {
-                text: searchHint
+                text: 'For example, James or XD7364CD'
             },
-                name: fieldName,
-                id: fieldName,
+                name: 'crnOrName',
+                id: 'crnOrName',
                 value: params.crnOrName
             }
         ) }}

--- a/server/views/temporary-accommodation/booking-search/results.njk
+++ b/server/views/temporary-accommodation/booking-search/results.njk
@@ -11,7 +11,7 @@
 
 {# TODO Move this HTML to the searchByCrnOrNameResult once HTML can be standardised between referrals and bookings #}
 {% set resultsHtml %}
-    {% if (response.data|length > 0) or (not crn) %}
+    {% if (response.data|length > 0) or (not crnOrName) %}
         {{ govukTable({
             captionClasses: "govuk-table__caption--m",
             head: tableHeadings,
@@ -41,7 +41,7 @@
             type: 'bookings',
             basePath: paths.bookings.search[uiStatus].index(), 
             uiStatus: uiStatus, 
-            crnOrName: crn
+            crnOrName: crnOrName
         })}}
     </div>
 
@@ -50,7 +50,7 @@
         errors: context.errors,
         resultsHtml: resultsHtml,
         uiStatus: uiStatus,
-        crnOrName: crn
+        crnOrName: crnOrName
     })}}
 
 {% endblock %}


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-548
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
Previously users could search for a booking by crn only, now they will be able to also search by name. This brings bookings closer inline with how referrals search works.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/f32d3be9-98e6-40a6-b2ee-348321eb9169)

### After
![image](https://github.com/user-attachments/assets/50c3f92a-99fa-4c56-9700-248b7c9fb4ae)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
