### PR TITLE
CHORE/tidy up rest client types

### DIFF
--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -78,25 +78,25 @@ export default class AssessmentClient {
     })
   }
 
-  async acceptAssessment(id: string): Promise<void> {
-    await this.restClient.post({
+  async acceptAssessment(id: string) {
+    return this.restClient.post<void>({
       path: paths.assessments.acceptance({ id }),
       data: { document: {} } as AssessmentAcceptance,
     })
   }
 
-  async closeAssessment(id: string): Promise<void> {
-    await this.restClient.post({
+  async closeAssessment(id: string) {
+    return this.restClient.post<void>({
       path: paths.assessments.closure({ id }),
     })
   }
 
-  async createNote(id: string, data: NewNote): Promise<Note> {
-    return (await this.restClient.post({ path: paths.assessments.notes({ id }), data })) as Note
+  async createNote(id: string, data: NewNote) {
+    return this.restClient.post<Note>({ path: paths.assessments.notes({ id }), data })
   }
 
-  async update(id: string, data: Partial<Assessment>): Promise<void> {
+  async update(id: string, data: Partial<Assessment>) {
     const updateData = { data: {}, ...data }
-    await this.restClient.put({ path: paths.assessments.update({ id }), data: updateData })
+    return this.restClient.put<void>({ path: paths.assessments.update({ id }), data: updateData })
   }
 }

--- a/server/data/bedClient.ts
+++ b/server/data/bedClient.ts
@@ -13,10 +13,10 @@ export default class BedClient {
     this.restClient = new RestClient('bedClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async search(searchParameters: BedSearchParameters): Promise<BedSearchResults> {
-    return (await this.restClient.post({
+  async search(searchParameters: BedSearchParameters) {
+    return this.restClient.post<BedSearchResults>({
       path: paths.beds.search({}),
       data: searchParameters,
-    })) as BedSearchResults
+    })
   }
 }

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -36,11 +36,11 @@ export default class BookingClient {
     this.restClient = new RestClient('bookingClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async create(premisesId: string, data: NewBooking): Promise<Booking> {
-    return (await this.restClient.post({
+  async create(premisesId: string, data: NewBooking) {
+    return this.restClient.post<Booking>({
       path: this.bookingsPath(premisesId),
       data: { crn: data.crn.trim(), ...data },
-    })) as Booking
+    })
   }
 
   async find(premisesId: string, bookingId: string) {
@@ -58,31 +58,25 @@ export default class BookingClient {
     })
   }
 
-  async markAsConfirmed(premisesId: string, bookingId: string, confirmation: NewConfirmation): Promise<Confirmation> {
-    const response = await this.restClient.post({
+  async markAsConfirmed(premisesId: string, bookingId: string, confirmation: NewConfirmation) {
+    return this.restClient.post<Confirmation>({
       path: `${this.bookingPath(premisesId, bookingId)}/confirmations`,
       data: confirmation,
     })
-
-    return response as Confirmation
   }
 
-  async markAsArrived(premisesId: string, bookingId: string, arrival: NewArrival): Promise<Arrival> {
-    const response = await this.restClient.post({
+  async markAsArrived(premisesId: string, bookingId: string, arrival: NewArrival) {
+    return this.restClient.post<Arrival>({
       path: `${this.bookingPath(premisesId, bookingId)}/arrivals`,
       data: arrival,
     })
-
-    return response as Arrival
   }
 
-  async cancel(premisesId: string, bookingId: string, cancellation: NewCancellation): Promise<Cancellation> {
-    const response = await this.restClient.post({
+  async cancel(premisesId: string, bookingId: string, cancellation: NewCancellation) {
+    return this.restClient.post<Cancellation>({
       path: `${this.bookingPath(premisesId, bookingId)}/cancellations`,
       data: cancellation,
     })
-
-    return response as Cancellation
   }
 
   async findCancellation(premisesId: string, bookingId: string, departureId: string) {


### PR DESCRIPTION
Tidy up remaining rest client calls to remove unneeded `await`s and type casting.