### PR TITLE
Enable granular log level

### DIFF
--- a/logger.ts
+++ b/logger.ts
@@ -1,11 +1,11 @@
-import bunyan from 'bunyan'
+import bunyan, { LogLevel } from 'bunyan'
 import bunyanFormat from 'bunyan-format'
 
 const formatOut = bunyanFormat({ outputMode: 'short', color: true })
 
-const logger =
-  process.env.NODE_ENV !== 'test'
-    ? bunyan.createLogger({ name: 'Temporary Accommodation UI', stream: formatOut, level: 'debug' })
-    : bunyan.createLogger({ name: 'Temporary Accommodation UI', stream: formatOut, level: 'fatal' })
+const logLevel: LogLevel =
+  (process.env.BUNYAN_LOG_LEVEL as LogLevel) || process.env.NODE_ENV !== 'test' ? 'debug' : 'fatal'
+
+const logger = bunyan.createLogger({ name: 'Temporary Accommodation UI', stream: formatOut, level: logLevel })
 
 export default logger


### PR DESCRIPTION
Allows setting a `BUNYAN_LOG_LEVEL` environment variable to control the level of logging for the Express server. If this is not set, the log level reverts to the default of `fatal` when NODE_ENV=test, or `debug` otherwise.

# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
