### PR TITLE
Ensure existing PDU is valid or flag section as 'In progress'

### DIFF
--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.ts
@@ -3,7 +3,7 @@ import {
   ProbationDeliveryUnit,
   TemporaryAccommodationApplication,
 } from '@approved-premises/api'
-import type { DataServices, TaskListErrors } from '@approved-premises/ui'
+import { DataServices, SelectOption, TaskListErrors } from '@approved-premises/ui'
 import { SessionData } from 'express-session'
 import { Page } from '../../../utils/decorators'
 import TasklistPage from '../../../tasklistPage'
@@ -77,7 +77,7 @@ export default class PractitionerPdu implements TasklistPage {
     return errors
   }
 
-  getRegionPdus() {
+  getRegionPdus(): Array<SelectOption> {
     return [
       {
         value: '',

--- a/server/form-pages/apply/accommodation-need/contact-details/probationPractitioner.test.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/probationPractitioner.test.ts
@@ -75,6 +75,22 @@ describe('ProbationPractitioner', () => {
         },
       })
     })
+
+    describe('backwards compatibility', () => {
+      it('sets the value to undefined if the PDU had been entered in a free text field', () => {
+        const updatedApplication = applicationFactory.build()
+        updatedApplication.data = {
+          'contact-details': {
+            'practitioner-pdu': {
+              pdu: 'Some PDU',
+            },
+          },
+        }
+        const page = new ProbationPractitioner({}, updatedApplication)
+
+        expect(page.body.pdu).toBeUndefined()
+      })
+    })
   })
 
   itShouldHavePreviousValue(new ProbationPractitioner({}, application), 'dashboard')
@@ -110,6 +126,16 @@ describe('ProbationPractitioner', () => {
 
       expect(page.errors()).toEqual({ [key]: errorMessages[key] })
     })
+
+    it.each([{}, { id: 'pdu-id' }, { name: 'PDU name' }, { pdu: 'Some PDU' }])(
+      'returns a PDU error if the PDU data is invalid',
+      pduData => {
+        const bodyInvalidPDU = { ...body, pdu: pduData } as Partial<ProbationPractitionerBody>
+        const page = new ProbationPractitioner(bodyInvalidPDU, application)
+
+        expect(page.errors()).toEqual({ pdu: errorMessages.pdu })
+      },
+    )
   })
 
   describe('summaryListItems', () => {

--- a/server/form-pages/apply/accommodation-need/contact-details/probationPractitioner.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/probationPractitioner.ts
@@ -48,9 +48,8 @@ export default class ProbationPractitioner implements TasklistPage {
       let updatedValue: string | ProbationDeliveryUnit
 
       if (key === 'pdu' && applicationData) {
-        updatedValue = {
-          id: applicationData.id,
-          name: applicationData.name,
+        if (applicationData.id && applicationData.name) {
+          updatedValue = applicationData
         }
       } else {
         updatedValue = applicationData?.[key]
@@ -92,7 +91,7 @@ export default class ProbationPractitioner implements TasklistPage {
       errors.phone = errorMessages.phone
     }
 
-    if (!this.body.pdu) {
+    if (!this.body.pdu?.name || !this.body.pdu?.id) {
       errors.pdu = errorMessages.pdu
     }
 

--- a/wiremock/stubs/pdus.json
+++ b/wiremock/stubs/pdus.json
@@ -150,7 +150,7 @@
     "serviceScope": "temporary-accommodation"
   },
   {
-    "id": "f6fd8e4d-50a4-438d-83b8-335c538b8b66",
+    "id": "f6fd8e4d-50a4-438d-83b8-335c538b8b67",
     "name": "Essex South",
     "isActive": true,
     "serviceScope": "temporary-accommodation"


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-589

When an application was started before the change to the Practitioner details screen, old data would still pass validation and mark the step as 'Completed', when it should have been marked as 'In progress' instead, with subsequent steps showing as 'Cannot start yet'. This data would however trigger a validation error in the API, preventing the user from submitting the application.

This ensures that, when loading the task list, any old PDU data is considered invalid, and prevents the user from attempting to submit the application without updating the Contact details section.
