### PR TITLE
CAS-594: Show actual task status on referral form

### DIFF
--- a/server/form-pages/utils/getTaskStatus.ts
+++ b/server/form-pages/utils/getTaskStatus.ts
@@ -9,31 +9,42 @@ const getPageData = (applicationOrAssessment: Application | Assessment, taskName
 }
 
 const getTaskStatus = (task: Task, applicationOrAssessment: Application | Assessment): TaskStatus => {
+  const pageStatuses: Array<TaskStatus> = []
   const pageIds = Object.keys(task.pages)
   let pageId = pageIds?.[0]
 
   while (pageId) {
     const pageData = getPageData(applicationOrAssessment, task.id, pageId)
+    let pageStatus: TaskStatus = 'not_started'
 
-    // If there's no page data for this page, then we know the task is incomplete
-    if (!pageData) {
-      return pageIds.some(progessTestPageId => !!getPageData(applicationOrAssessment, task.id, progessTestPageId))
+    if (pageData) {
+      const Page = task.pages[pageId]
+      const page = new Page(pageData, applicationOrAssessment)
+
+      pageStatus = Object.keys(page.errors()).length ? 'in_progress' : 'complete'
+
+      pageId = pageStatus === 'complete' ? page.next() : null
+    } else {
+      // Check subsequent pages for any data
+      pageStatus = pageIds.some(progessTestPageId => !!getPageData(applicationOrAssessment, task.id, progessTestPageId))
         ? 'in_progress'
         : 'not_started'
+
+      pageId = null
     }
 
-    const Page = task.pages[pageId]
-    const page = new Page(pageData, applicationOrAssessment)
-
-    // If there's errors for this page, then we know the task incomplete
-    if (Object.keys(page.errors()).length) {
-      return 'in_progress'
-    }
-
-    pageId = page.next()
+    pageStatuses.push(pageStatus)
   }
 
-  return 'complete'
+  if (pageStatuses.every(status => status === 'not_started')) {
+    return 'not_started'
+  }
+
+  if (pageStatuses.every(status => status === 'complete')) {
+    return 'complete'
+  }
+
+  return 'in_progress'
 }
 
 export default getTaskStatus

--- a/server/services/tasklistService.test.ts
+++ b/server/services/tasklistService.test.ts
@@ -50,6 +50,18 @@ const sections = [
       },
     ],
   },
+  {
+    title: 'Check your answers',
+    name: 'check-your-answers',
+    tasks: [
+      {
+        id: 'check-your-answers',
+        title: 'Check your answers',
+        actionText: 'Complete task',
+        pages: {},
+      },
+    ],
+  },
 ]
 
 describe('tasklistService', () => {
@@ -61,29 +73,17 @@ describe('tasklistService', () => {
   })
 
   describe('taskStatuses', () => {
-    it('returns cannot_start for any subsequent tasks when no tasks are complete', () => {
-      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
-
-      const tasklistService = new TasklistService(application)
-
-      expect(tasklistService.taskStatuses).toEqual({
-        'first-task': 'not_started',
-        'second-task': 'cannot_start',
-        'third-task': 'cannot_start',
-        'fourth-task': 'cannot_start',
-        'fifth-task': 'cannot_start',
-      })
-    })
-
-    it('returns a status when the previous task is complete', () => {
+    it('returns a status for each task', () => {
       ;(getTaskStatus as jest.Mock).mockImplementation(t => {
-        if (t.id === 'first-task') {
-          return 'complete'
+        switch (t.id) {
+          case 'first-task':
+          case 'fourth-task':
+            return 'complete'
+          case 'second-task':
+            return 'in_progress'
+          default:
+            return 'not_started'
         }
-        if (t.id === 'second-task') {
-          return 'in_progress'
-        }
-        return undefined
       })
 
       const tasklistService = new TasklistService(application)
@@ -91,13 +91,41 @@ describe('tasklistService', () => {
       expect(tasklistService.taskStatuses).toEqual({
         'first-task': 'complete',
         'second-task': 'in_progress',
-        'third-task': 'cannot_start',
-        'fourth-task': 'cannot_start',
-        'fifth-task': 'cannot_start',
+        'third-task': 'not_started',
+        'fourth-task': 'complete',
+        'fifth-task': 'not_started',
+        'check-your-answers': 'cannot_start',
       })
 
-      expect(getTaskStatus).toHaveBeenCalledTimes(2)
+      expect(getTaskStatus).toHaveBeenCalledTimes(5)
     })
+
+    it.each(['not_started' as const, 'complete' as const])(
+      'returns the actual task status %s for Check your answers if all other tasks are complete',
+      status => {
+        ;(getTaskStatus as jest.Mock).mockImplementation(t => {
+          switch (t.id) {
+            case 'check-your-answers':
+              return status
+            default:
+              return 'complete'
+          }
+        })
+
+        const tasklistService = new TasklistService(application)
+
+        expect(tasklistService.taskStatuses).toEqual({
+          'first-task': 'complete',
+          'second-task': 'complete',
+          'third-task': 'complete',
+          'fourth-task': 'complete',
+          'fifth-task': 'complete',
+          'check-your-answers': status,
+        })
+
+        expect(getTaskStatus).toHaveBeenCalledTimes(6)
+      },
+    )
   })
 
   describe('completeSectionCount', () => {
@@ -109,7 +137,7 @@ describe('tasklistService', () => {
       expect(tasklistService.completeSectionCount).toEqual(0)
     })
 
-    it('returns 1 when there one section is complete', () => {
+    it('returns 1 when one section is complete', () => {
       ;(getTaskStatus as jest.Mock).mockImplementation(t =>
         ['first-task', 'second-task', 'third-task'].includes(t.id) ? 'complete' : 'not_started',
       )
@@ -119,12 +147,12 @@ describe('tasklistService', () => {
       expect(tasklistService.completeSectionCount).toEqual(1)
     })
 
-    it('returns 2 when all sections are complete', () => {
+    it('returns 3 when all sections are complete', () => {
       ;(getTaskStatus as jest.Mock).mockReturnValue('complete')
 
       const tasklistService = new TasklistService(application)
 
-      expect(tasklistService.completeSectionCount).toEqual(2)
+      expect(tasklistService.completeSectionCount).toEqual(3)
     })
   })
 
@@ -148,7 +176,7 @@ describe('tasklistService', () => {
 
   describe('sections', () => {
     it('returns the section data with the status of each task and the section number', () => {
-      ;(getTaskStatus as jest.Mock).mockReturnValue('cannot_start')
+      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
 
       const tasklistService = new TasklistService(application)
 
@@ -162,14 +190,14 @@ describe('tasklistService', () => {
               title: 'First task',
               actionText: 'Complete first task',
               pages: {},
-              status: 'cannot_start',
+              status: 'not_started',
             },
             {
               id: 'second-task',
               title: 'Second task',
               actionText: 'Complete second task',
               pages: {},
-              status: 'cannot_start',
+              status: 'not_started',
             },
           ],
         },
@@ -182,19 +210,32 @@ describe('tasklistService', () => {
               title: 'Third task',
               actionText: 'Complete third task',
               pages: {},
-              status: 'cannot_start',
+              status: 'not_started',
             },
             {
               id: 'fourth-task',
               title: 'Fourth task',
               actionText: 'Complete fourth task',
               pages: {},
-              status: 'cannot_start',
+              status: 'not_started',
             },
             {
               id: 'fifth-task',
               title: 'Fifth task',
               actionText: 'Complete fifth task',
+              pages: {},
+              status: 'not_started',
+            },
+          ],
+        },
+        {
+          sectionNumber: 3,
+          title: 'Check your answers',
+          tasks: [
+            {
+              id: 'check-your-answers',
+              title: 'Check your answers',
+              actionText: 'Complete task',
               pages: {},
               status: 'cannot_start',
             },

--- a/server/services/tasklistService.test.ts
+++ b/server/services/tasklistService.test.ts
@@ -73,11 +73,51 @@ describe('tasklistService', () => {
   })
 
   describe('taskStatuses', () => {
-    it('returns a status for each task', () => {
+    it('shows the first task as not_started and subsequent tasks as cannot_start_yet', () => {
+      ;(getTaskStatus as jest.Mock).mockReturnValue('not_started')
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.taskStatuses).toEqual({
+        'first-task': 'not_started',
+        'second-task': 'cannot_start',
+        'third-task': 'cannot_start',
+        'fourth-task': 'cannot_start',
+        'fifth-task': 'cannot_start',
+        'check-your-answers': 'cannot_start',
+      })
+
+      expect(getTaskStatus).toHaveBeenCalledTimes(5)
+    })
+
+    it('shows the not started task after a complete task as not_started and subsequent tasks as cannot_start_yet', () => {
       ;(getTaskStatus as jest.Mock).mockImplementation(t => {
         switch (t.id) {
           case 'first-task':
-          case 'fourth-task':
+            return 'complete'
+          default:
+            return 'not_started'
+        }
+      })
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.taskStatuses).toEqual({
+        'first-task': 'complete',
+        'second-task': 'not_started',
+        'third-task': 'cannot_start',
+        'fourth-task': 'cannot_start',
+        'fifth-task': 'cannot_start',
+        'check-your-answers': 'cannot_start',
+      })
+
+      expect(getTaskStatus).toHaveBeenCalledTimes(5)
+    })
+
+    it('shows the first incomplete task as in_progress and subsequent tasks as cannot_start_yet', () => {
+      ;(getTaskStatus as jest.Mock).mockImplementation(t => {
+        switch (t.id) {
+          case 'first-task':
             return 'complete'
           case 'second-task':
             return 'in_progress'
@@ -91,9 +131,36 @@ describe('tasklistService', () => {
       expect(tasklistService.taskStatuses).toEqual({
         'first-task': 'complete',
         'second-task': 'in_progress',
-        'third-task': 'not_started',
-        'fourth-task': 'complete',
-        'fifth-task': 'not_started',
+        'third-task': 'cannot_start',
+        'fourth-task': 'cannot_start',
+        'fifth-task': 'cannot_start',
+        'check-your-answers': 'cannot_start',
+      })
+
+      expect(getTaskStatus).toHaveBeenCalledTimes(5)
+    })
+
+    it('can show in_progress tasks amongst complete tasks', () => {
+      ;(getTaskStatus as jest.Mock).mockImplementation(t => {
+        switch (t.id) {
+          case 'first-task':
+          case 'third-task':
+            return 'complete'
+          case 'second-task':
+            return 'in_progress'
+          default:
+            return 'not_started'
+        }
+      })
+
+      const tasklistService = new TasklistService(application)
+
+      expect(tasklistService.taskStatuses).toEqual({
+        'first-task': 'complete',
+        'second-task': 'in_progress',
+        'third-task': 'complete',
+        'fourth-task': 'not_started',
+        'fifth-task': 'cannot_start',
         'check-your-answers': 'cannot_start',
       })
 
@@ -197,7 +264,7 @@ describe('tasklistService', () => {
               title: 'Second task',
               actionText: 'Complete second task',
               pages: {},
-              status: 'not_started',
+              status: 'cannot_start',
             },
           ],
         },
@@ -210,21 +277,21 @@ describe('tasklistService', () => {
               title: 'Third task',
               actionText: 'Complete third task',
               pages: {},
-              status: 'not_started',
+              status: 'cannot_start',
             },
             {
               id: 'fourth-task',
               title: 'Fourth task',
               actionText: 'Complete fourth task',
               pages: {},
-              status: 'not_started',
+              status: 'cannot_start',
             },
             {
               id: 'fifth-task',
               title: 'Fifth task',
               actionText: 'Complete fifth task',
               pages: {},
-              status: 'not_started',
+              status: 'cannot_start',
             },
           ],
         },

--- a/server/services/tasklistService.ts
+++ b/server/services/tasklistService.ts
@@ -13,8 +13,8 @@ export default class TasklistService {
 
   constructor(applicationOrAssessment: Application | Assessment) {
     this.formSections = getSections(applicationOrAssessment)
-    this.taskStatuses = {}
 
+    this.taskStatuses = {}
     this.formSections.forEach(section => {
       section.tasks.forEach(task => {
         if (
@@ -23,7 +23,21 @@ export default class TasklistService {
         ) {
           this.taskStatuses[task.id] = 'cannot_start'
         } else {
-          this.taskStatuses[task.id] = getTaskStatus(task, applicationOrAssessment)
+          const taskStatus = getTaskStatus(task, applicationOrAssessment)
+
+          this.taskStatuses[task.id] = taskStatus
+
+          // This stops the user from starting tasks beyond the ones that have been completed,
+          // but enables showing 'in progress' tasks amongst the ones that have been completed.
+          // This is useful for showing tasks that may require more information because of a
+          // change to the questions.
+          if (taskStatus === 'not_started') {
+            const previousTaskKey = Object.keys(this.taskStatuses).at(-2)
+
+            if (previousTaskKey && this.taskStatuses[previousTaskKey] !== 'complete') {
+              this.taskStatuses[task.id] = 'cannot_start'
+            }
+          }
         }
       })
     })

--- a/server/services/tasklistService.ts
+++ b/server/services/tasklistService.ts
@@ -17,13 +17,13 @@ export default class TasklistService {
 
     this.formSections.forEach(section => {
       section.tasks.forEach(task => {
-        const previousTaskKey = Object.keys(this.taskStatuses).at(-1)
-        const previousTaskStatus = this.taskStatuses[previousTaskKey]
-
-        if (!previousTaskStatus || previousTaskStatus === 'complete') {
-          this.taskStatuses[task.id] = getTaskStatus(task, applicationOrAssessment)
-        } else {
+        if (
+          task.id === 'check-your-answers' &&
+          Object.values(this.taskStatuses).some(status => status !== 'complete')
+        ) {
           this.taskStatuses[task.id] = 'cannot_start'
+        } else {
+          this.taskStatuses[task.id] = getTaskStatus(task, applicationOrAssessment)
         }
       })
     })


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-594 

# Changes in this PR

Based on the work from #1042, this updates the logic for displaying the task statuses on the task list:

- Linear constraint is retained, so that a task can only be started if the previous task is complete
- Should a task become erroneous after a change in the application question, it will show as 'In progress', but subsequent tasks will continue to show as 'Completed' or 'In progress' of they had been started

NOTE: this closes #1042 

## Screenshots of UI changes

Given an application where the user has completed the application up to 'Outline move on plan', and where the questions have changed for the task 'Add health, disability and cultural needs', this is what the user would see:

### Before

The task list shows 'Cannot start yet' for tasks which have been completed:

<img width="803" alt="Screenshot 2024-09-04 at 17 53 29" src="https://github.com/user-attachments/assets/0d8489f7-37cc-4a3e-8762-650b0bde06af">

---

### After

The task list now shows the correct status for all tasks, but still prevents the user from progressing:

<img width="795" alt="Screenshot 2024-09-04 at 17 51 51" src="https://github.com/user-attachments/assets/1a1d7099-91ef-492f-a008-49056b60e5eb">

---

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
