### PR TITLE
Move phase banner to above the page footer

### DIFF
--- a/assets/sass/local.sass
+++ b/assets/sass/local.sass
@@ -1,2 +1,7 @@
 .govuk-main-wrapper
   min-height: 600px
+
+//  Override as we are positioning the phase banner above the footer
+.govuk-phase-banner--footer
+  border-bottom: 0
+  border-top: 1px solid $govuk-border-colour

--- a/server/views/partials/layout.njk
+++ b/server/views/partials/layout.njk
@@ -13,7 +13,6 @@
 {% block header %}
     {% include "./header.njk" %}
     {% include "./probationRegionHeader.njk" %}
-    {% include "./phaseBanner.njk" %}
     {% if placeContext|length %}
         {{ placeContextHeader(placeContext) }}
     {% endif %}
@@ -29,6 +28,7 @@
 {% endblock %}
 
 {% block footer %}
+    {% include "./phaseBanner.njk" %}
     {{ govukFooter({
         meta: {
             items: [

--- a/server/views/partials/phaseBanner.njk
+++ b/server/views/partials/phaseBanner.njk
@@ -2,7 +2,7 @@
 
 {{ govukPhaseBanner({
   attributes: { "data-cy-phase-banner": "phase-banner" },
-  classes: "hmpps-header__container govuk-!-display-none-print",
+  classes: "hmpps-header__container govuk-!-display-none-print govuk-phase-banner--footer",
   tag: {
     text: "Beta"
   },


### PR DESCRIPTION


# Context
https://dsdmoj.atlassian.net/browse/CAS-596
We want to make more space at the top for primary navigation and to try stop banner blindness when we start adding more components to the top of the page
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/38fd9c29-7007-4ec9-9abf-9738c3d236c9)

### After
![image](https://github.com/user-attachments/assets/d7d8ae61-18a5-4286-b0fb-ef98f89d8342)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
