### PR TITLE
CAS-504: Add occupancy search attributes to bedspace search

### DIFF
--- a/assets/sass/application.sass
+++ b/assets/sass/application.sass
@@ -30,3 +30,4 @@ $path: "/assets/images/"
 @import './pages/temporary-accommodation/dashboard/index'
 @import './pages/temporary-accommodation/bookings/show'
 @import './pages/temporary-accommodation/applications/pages/accommodation-need/sentence-information/sentence-length'
+@import './pages/temporary-accommodation/bedspace-search'

--- a/assets/sass/components/_filter.scss
+++ b/assets/sass/components/_filter.scss
@@ -8,6 +8,10 @@
   background: govuk-colour("light-grey");
 }
 
+.moj-filter__options > * {
+  margin-bottom: govuk-spacing(6);
+}
+
 .moj-filter .govuk-select {
   min-width: 0;
 }

--- a/assets/sass/pages/temporary-accommodation/_bedspace-search.scss
+++ b/assets/sass/pages/temporary-accommodation/_bedspace-search.scss
@@ -1,0 +1,15 @@
+.bedspace-search-form {
+  @include govuk-media-query($from: desktop) {
+    column-count: 3;
+    column-gap: govuk-spacing(8);
+    column-rule: solid 1px govuk-colour('mid-grey');
+
+    & > * {
+      break-after: column;
+    }
+  }
+
+  .govuk-select {
+    min-width: 0;
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -58,6 +58,12 @@ export default class BedspaceSearchPage extends Page {
     this.completeDateInputsByLegend('Available from', searchParameters.startDate)
     this.completeTextInputByLabel('Number of days required', `${searchParameters.durationDays}`)
     this.completeSelectInputByLabel('Probation Delivery Unit (PDU)', searchParameters.probationDeliveryUnit)
+
+    this.getLegend('Bedspace attributes')
+    this.getLegend('Occupancy (optional)')
+    searchParameters.attributes.forEach(attribute => {
+      this.checkCheckboxByNameAndValue('attributes[]', attribute)
+    })
   }
 
   clickBedspaceLink(room: Room) {

--- a/cypress_shared/utils/bedspaceSearch.ts
+++ b/cypress_shared/utils/bedspaceSearch.ts
@@ -1,0 +1,14 @@
+import { BedSearchAttributes, Characteristic, TemporaryAccommodationPremises } from '../../server/@types/shared'
+
+export const characteristicsToSearchAttributes = (
+  premises: TemporaryAccommodationPremises,
+): Array<BedSearchAttributes> => {
+  const characteristicsToSearchAttributesMap: Record<string, BedSearchAttributes> = {
+    'Shared property': 'sharedProperty',
+    'Single occupancy': 'singleOccupancy',
+  }
+
+  return premises.characteristics
+    .map((characteristic: Characteristic) => characteristicsToSearchAttributesMap[characteristic.name])
+    .filter(Boolean)
+}

--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -7,6 +7,7 @@ import {
   bedSearchResultFactory,
   bedSearchResultsFactory,
 } from '../../../../server/testutils/factories'
+import { characteristicsToSearchAttributes } from '../../../../cypress_shared/utils/bedspaceSearch'
 
 Given("I'm searching for a bedspace", () => {
   const dashboardPage = Page.verifyOnPage(DashboardPage)
@@ -21,6 +22,7 @@ Given('I search for a bedspace', () => {
 
     const searchParameters = bedSearchParametersFactory.build({
       probationDeliveryUnit: this.premises.probationDeliveryUnit.name,
+      attributes: characteristicsToSearchAttributes(this.premises),
     })
 
     page.completeForm(searchParameters)

--- a/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
@@ -59,7 +59,7 @@ context('Bedspace Search', () => {
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 
-    // Then a search should have been recieved by the API
+    // Then a search should have been received by the API
     cy.task('verifyBedSearch').then(requests => {
       expect(requests).to.have.length(1)
       const requestBody = JSON.parse(requests[0].body)
@@ -67,6 +67,7 @@ context('Bedspace Search', () => {
       expect(requestBody.startDate).equal(searchParameters.startDate)
       expect(requestBody.durationDays).equal(searchParameters.durationDays)
       expect(requestBody.probationDeliveryUnit).equal(searchParameters.probationDeliveryUnit)
+      expect(requestBody.attributes).to.have.members(searchParameters.attributes)
     })
 
     // And I should see the search results
@@ -106,6 +107,7 @@ context('Bedspace Search', () => {
       expect(requestBody.startDate).equal(searchParameters.startDate)
       expect(requestBody.durationDays).equal(searchParameters.durationDays)
       expect(requestBody.probationDeliveryUnit).equal(searchParameters.probationDeliveryUnit)
+      expect(requestBody.attributes).to.have.members(searchParameters.attributes)
     })
 
     // And I should see empty search results

--- a/server/testutils/factories/bedSearchParameters.ts
+++ b/server/testutils/factories/bedSearchParameters.ts
@@ -1,19 +1,19 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
 
-import { TemporaryAccommodationBedSearchParameters as BedSearchAPIParameters } from '@approved-premises/api'
+import {
+  TemporaryAccommodationBedSearchParameters as BedSearchAPIParameters,
+  BedSearchAttributes,
+} from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 import referenceData from './referenceData'
 
-// NOTE: this fixes mismatched GET/POST types for bedspace searches.
-type BedSearchUIParameters = BedSearchAPIParameters & {
-  sharedProperty?: string
-  singleOccupancy?: string
-}
+const bedSearchAttributes: Array<BedSearchAttributes> = ['singleOccupancy', 'sharedProperty']
 
-export default Factory.define<BedSearchUIParameters>(() => ({
+export default Factory.define<BedSearchAPIParameters>(() => ({
   startDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
   durationDays: faker.number.int({ min: 1, max: 10 }),
   probationDeliveryUnit: referenceData.pdu().build().name,
   serviceName: 'temporary-accommodation',
+  attributes: faker.helpers.arrayElements(bedSearchAttributes),
 }))

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -10,7 +10,6 @@
 
 {% block beforeContent %}
     {{ breadCrumb('Search for available bedspaces', []) }}
-
 {% endblock %}
 
 {% block content %}
@@ -21,9 +20,11 @@
     <h1 class="govuk-heading-l">Search for available bedspaces</h1>
 
     <form action="{{ paths.bedspaces.search({}) }}" method="get">
-        {% include './partials/search-fields.njk' %}
+        <div class="bedspace-search-form">
+            {% include './partials/search-fields.njk' %}
+        </div>
 
-        <div class="govuk-button-group">
+        <div class="govuk-button-group govuk-!-margin-top-6">
             {{ govukButton({
                 text: "Apply filters YO" if results else "Search",
                 preventDoubleClick: true

--- a/server/views/temporary-accommodation/bedspace-search/partials/search-fields.njk
+++ b/server/views/temporary-accommodation/bedspace-search/partials/search-fields.njk
@@ -1,4 +1,5 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
+{% from "../../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
 {% from "../../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
 {% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "../../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
@@ -49,3 +50,28 @@
     items: convertObjectsToSelectOptions(allPdus, 'Select a PDU', 'name', 'id', 'probationDeliveryUnit'),
     fieldName: "probationDeliveryUnit"
 }, fetchContext()) }}
+
+{% call govukFieldset({
+    legend: {
+        text: "Bedspace attributes",
+        classes: "govuk-fieldset__legend--m"
+    },
+    classes: "govuk-!-margin-bottom-4"
+}) %}
+    {{ formPageCheckboxes({
+        fieldName: "attributes",
+        fieldset: {
+            legend: {
+                text: "Occupancy (optional)",
+                classes: "govuk-fieldset__legend--s"
+            }
+        },
+        hint: {
+            text: "Select all that apply"
+        },
+        items: [
+            { text: "Single", value: "singleOccupancy" },
+            { text: "Shared", value: "sharedProperty" }
+        ]
+    }, fetchContext()) }}
+{% endcall %}

--- a/server/views/temporary-accommodation/bedspace-search/partials/search-fields.njk
+++ b/server/views/temporary-accommodation/bedspace-search/partials/search-fields.njk
@@ -11,8 +11,7 @@
     legend: {
         text: "Dates",
         classes: "govuk-fieldset__legend--m"
-    },
-    classes: "govuk-!-margin-bottom-4"
+    }
 }) %}
 
     {{ formPageDateInput({
@@ -55,8 +54,7 @@
     legend: {
         text: "Bedspace attributes",
         classes: "govuk-fieldset__legend--m"
-    },
-    classes: "govuk-!-margin-bottom-4"
+    }
 }) %}
     {{ formPageCheckboxes({
         fieldName: "attributes",


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-504

# Changes in this PR

Introduces occupancy search attributes to the bedspace search. For larger screens, the search page form is split into 3 columns.

## Screenshots of UI changes

### Search page form

<img width="1146" alt="Screenshot 2024-09-10 at 11 51 49" src="https://github.com/user-attachments/assets/30f01898-1cb6-4f17-8491-a4e9382e6c56">

---

### Results page form

<img width="381" alt="Screenshot 2024-09-10 at 11 52 14" src="https://github.com/user-attachments/assets/57dd9338-9290-4976-ba56-a43b27a499e6">

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
