### PR TITLE
CAS-513: Get user details from profile v2 endpoint

### DIFF
--- a/cypress_shared/utils/setupTestUser.ts
+++ b/cypress_shared/utils/setupTestUser.ts
@@ -1,5 +1,5 @@
 import { TemporaryAccommodationUserRole as UserRole } from '../../server/@types/shared'
-import { referenceDataFactory, userFactory } from '../../server/testutils/factories'
+import { referenceDataFactory, userFactory, userProfileFactory } from '../../server/testutils/factories'
 
 export function setupTestUser(role: UserRole) {
   setupTestWithRoles([role])
@@ -19,10 +19,10 @@ function setupTestWithRoles(roles: Array<UserRole>) {
     roles,
     telephoneNumber: undefined,
   })
+  const userProfile = userProfileFactory.build({ user: actingUser })
 
   cy.wrap(actingUser).as('actingUser')
   cy.wrap(probationRegion).as('actingUserProbationRegion')
 
-  cy.task('stubActingUser', actingUser)
-  cy.task('stubGetUserById', actingUser)
+  cy.task('stubUserProfile', userProfile)
 }

--- a/integration_tests/mockApis/user.ts
+++ b/integration_tests/mockApis/user.ts
@@ -1,8 +1,8 @@
-import { User } from '../../server/@types/shared'
+import { ProfileResponse } from '@approved-premises/api'
 import { stubFor } from '../../wiremock'
 import path from '../../server/paths/api'
 
-const stubGetActingUser = (user: User) =>
+const stubGetUserProfile = (userProfile: ProfileResponse) =>
   stubFor({
     request: {
       method: 'GET',
@@ -13,26 +13,10 @@ const stubGetActingUser = (user: User) =>
       headers: {
         'Content-Type': 'application/json;charset=UTF-8',
       },
-      jsonBody: user,
-    },
-  })
-
-const stubGetUserById = (user: User) =>
-  stubFor({
-    request: {
-      method: 'GET',
-      urlPath: path.users.actingUser.show({ id: user.id }),
-    },
-    response: {
-      status: 200,
-      headers: {
-        'Content-Type': 'application/json;charset=UTF-8',
-      },
-      jsonBody: user,
+      jsonBody: userProfile,
     },
   })
 
 export default {
-  stubActingUser: (user: User) => stubGetActingUser(user),
-  stubGetUserById: (user: User) => stubGetUserById(user),
+  stubUserProfile: (userProfile: ProfileResponse) => stubGetUserProfile(userProfile),
 }

--- a/integration_tests/tests/login.cy.ts
+++ b/integration_tests/tests/login.cy.ts
@@ -3,7 +3,7 @@ import AuthSignInPage from '../../cypress_shared/pages/authSignIn'
 import Page from '../../cypress_shared/pages/page'
 import DashboardPage from '../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import { setupTestUser } from '../../cypress_shared/utils/setupTestUser'
-import { referenceDataFactory, userFactory } from '../../server/testutils/factories'
+import { referenceDataFactory, userFactory, userProfileFactory } from '../../server/testutils/factories'
 
 context('SignIn', () => {
   beforeEach(() => {
@@ -79,9 +79,9 @@ context('SignIn', () => {
       region: probationRegion,
       roles: ['assessor', 'referrer'],
     })
+    const userProfile = userProfileFactory.build({ user: actingUser })
 
-    cy.task('stubActingUser', actingUser)
-    cy.task('stubGetUserById', actingUser)
+    cy.task('stubUserProfile', userProfile)
     cy.signIn()
 
     indexPage.headerUserName().contains('B. Brown')

--- a/server/data/userClient.test.ts
+++ b/server/data/userClient.test.ts
@@ -2,7 +2,7 @@ import nock from 'nock'
 
 import config from '../config'
 import paths from '../paths/api'
-import { userFactory } from '../testutils/factories'
+import { userProfileFactory } from '../testutils/factories'
 import { CallConfig } from './restClient'
 import UserClient from './userClient'
 
@@ -27,34 +27,18 @@ describe('UserClient', () => {
     nock.cleanAll()
   })
 
-  describe('getActingUser', () => {
-    it('should return the acting user', async () => {
-      const user = userFactory.build()
+  describe('getUserProfile', () => {
+    it('should return the profile for the current user', async () => {
+      const userProfile = userProfileFactory.build()
 
       fakeApprovedPremisesApi
         .get(paths.users.actingUser.profile({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .reply(200, user)
+        .reply(200, userProfile)
 
-      const result = await userClient.getActingUser()
+      const result = await userClient.getUserProfile()
 
-      expect(result).toEqual(user)
-      expect(nock.isDone()).toBeTruthy()
-    })
-  })
-
-  describe('getUserById', () => {
-    it('should return the acting user', async () => {
-      const user = userFactory.build()
-
-      fakeApprovedPremisesApi
-        .get(paths.users.actingUser.show({ id: user.id }))
-        .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .reply(200, user)
-
-      const result = await userClient.getUserById(user.id)
-
-      expect(result).toEqual(user)
+      expect(result).toEqual(userProfile)
       expect(nock.isDone()).toBeTruthy()
     })
   })

--- a/server/data/userClient.ts
+++ b/server/data/userClient.ts
@@ -1,4 +1,4 @@
-import type { TemporaryAccommodationUser as User } from '@approved-premises/api'
+import type { ProfileResponse } from '@approved-premises/api'
 import RestClient, { CallConfig } from './restClient'
 import config, { ApiConfig } from '../config'
 import paths from '../paths/api'
@@ -10,11 +10,7 @@ export default class UserClient {
     this.restClient = new RestClient('userClient', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async getActingUser() {
-    return this.restClient.get<User>({ path: paths.users.actingUser.profile({}) })
-  }
-
-  async getUserById(id: string) {
-    return this.restClient.get<User>({ path: paths.users.actingUser.show({ id }) })
+  async getUserProfile() {
+    return this.restClient.get<ProfileResponse>({ path: paths.users.actingUser.profile({}) })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -152,8 +152,7 @@ export default {
   },
   users: {
     actingUser: {
-      show: path('/users/:id'),
-      profile: path('/profile'),
+      profile: path('/profile/v2'),
     },
   },
 }

--- a/server/services/userService.test.ts
+++ b/server/services/userService.test.ts
@@ -1,7 +1,7 @@
 import { CallConfig } from '../data/restClient'
 import UserClient from '../data/userClient'
-import { userFactory } from '../testutils/factories'
-import UserService from './userService'
+import { userFactory, userProfileFactory } from '../testutils/factories'
+import UserService, { DeliusAccountMissingStaffDetailsError } from './userService'
 import { convertToTitleCase } from '../utils/utils'
 
 jest.mock('../data/userClient')
@@ -23,9 +23,9 @@ describe('User service', () => {
   describe('getActingUser', () => {
     it('gets the acting user from the Community Accommodation API', async () => {
       const communityAccommodationUser = userFactory.build()
+      const userProfile = userProfileFactory.build({ user: communityAccommodationUser })
 
-      userClient.getActingUser.mockResolvedValue(communityAccommodationUser)
-      userClient.getUserById.mockResolvedValue(communityAccommodationUser)
+      userClient.getUserProfile.mockResolvedValue(userProfile)
 
       const result = await userService.getActingUser(callConfig)
 
@@ -43,11 +43,21 @@ describe('User service', () => {
       })
 
       expect(userClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(userClient.getActingUser).toHaveBeenCalledWith()
+      expect(userClient.getUserProfile).toHaveBeenCalledWith()
     })
 
-    it('propagates errors from the Community Accommodation API', async () => {
-      userClient.getActingUser.mockRejectedValue(new Error('some error'))
+    it('throws a DeliusAccountMissingStaffDetailsError if the user staff details are not found', async () => {
+      const userProfile = userProfileFactory.build({ loadError: 'staff_record_not_found', user: undefined })
+
+      userClient.getUserProfile.mockResolvedValue(userProfile)
+
+      await expect(userService.getActingUser(callConfig)).rejects.toEqual(
+        new DeliusAccountMissingStaffDetailsError('Delius account missing staff details'),
+      )
+    })
+
+    it('propagates errors from the API', async () => {
+      userClient.getUserProfile.mockRejectedValue(new Error('some error'))
 
       await expect(userService.getActingUser(callConfig)).rejects.toEqual(new Error('some error'))
     })

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -67,7 +67,7 @@ import turnaroundFactory from './turnaround'
 import updateLostBedFactory from './updateLostBed'
 import updatePremisesFactory from './updatePremises'
 import updateRoomFactory from './updateRoom'
-import userFactory from './user'
+import userFactory, { userProfileFactory } from './user'
 
 export {
   acctAlertFactory,
@@ -142,4 +142,5 @@ export {
   updatePremisesFactory,
   updateRoomFactory,
   userFactory,
+  userProfileFactory,
 }

--- a/server/testutils/factories/user.ts
+++ b/server/testutils/factories/user.ts
@@ -1,10 +1,10 @@
 import { faker } from '@faker-js/faker/locale/en_GB'
 import { Factory } from 'fishery'
-import type { TemporaryAccommodationUser as User } from '@approved-premises/api'
+import type { ProfileResponse, TemporaryAccommodationUser as User } from '@approved-premises/api'
 import referenceData from './referenceData'
 
-export default Factory.define<User>(opts => {
-  const name = opts.params?.name || faker.person.fullName({})
+const userFactory = Factory.define<User>(({ params }) => {
+  const name = params?.name || faker.person.fullName({})
   const deliusUsername = name.replace(/\s+/g, '.').toLowerCase()
   const pdu = referenceData.pdu().build()
   return {
@@ -22,3 +22,15 @@ export default Factory.define<User>(opts => {
     deliusUsername,
   }
 })
+
+export const userProfileFactory = Factory.define<ProfileResponse>(({ params }) => {
+  const user = userFactory.build(params?.user)
+  const { deliusUsername } = user
+  return {
+    deliusUsername,
+    user,
+    loadError: null,
+  }
+})
+
+export default userFactory

--- a/wiremock/userStub.ts
+++ b/wiremock/userStub.ts
@@ -1,5 +1,4 @@
 import paths from '../server/paths/api'
-import { guidRegex } from './index'
 import { userFactory } from '../server/testutils/factories'
 
 const userStubs: Array<Record<string, unknown>> = []
@@ -8,22 +7,6 @@ userStubs.push({
   request: {
     method: 'GET',
     urlPath: paths.users.actingUser.profile({}),
-  },
-  response: {
-    status: 200,
-    headers: {
-      'Content-Type': 'application/json;charset=UTF-8',
-    },
-    jsonBody: userFactory.build({
-      roles: ['assessor', 'referrer'],
-    }),
-  },
-})
-
-userStubs.push({
-  request: {
-    method: 'GET',
-    urlPathPattern: paths.users.actingUser.show({ id: guidRegex }),
   },
   response: {
     status: 200,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-513

# Changes in this PR

Fetching the current user's profile now uses version 2 of the API endpoint, which removes the need for a separate call to get all the user details. This also moves any error due to staff account not found to the UI instead of the API, which means it will now be possible to handle this error gracefully and instead show a message to the user with directions on how to get their account updated.

CAS1 equivalent PR, which includes the new message to users: https://github.com/ministryofjustice/hmpps-approved-premises-ui/pull/1943

## Screenshots of UI changes

n/a

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
