### PR TITLE
Ensure test search matches premises attributes

### DIFF
--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -23,6 +23,7 @@ import BookingConfirmPage from '../pages/temporary-accommodation/manage/bookingC
 import BookingNewPage from '../pages/temporary-accommodation/manage/bookingNew'
 import BookingSelectAssessmentPage from '../pages/temporary-accommodation/manage/bookingSelectAssessment'
 import BookingShowPage from '../pages/temporary-accommodation/manage/bookingShow'
+import { characteristicsToSearchAttributes } from '../utils/bedspaceSearch'
 
 export default class PlaceHelper {
   private readonly bedSearchResults: BedSearchResults
@@ -105,6 +106,7 @@ export default class PlaceHelper {
     const searchParameters = bedSearchParametersFactory.build({
       startDate: this.placeContext.arrivalDate,
       probationDeliveryUnit: this.premises.probationDeliveryUnit.name,
+      attributes: characteristicsToSearchAttributes(this.premises),
     })
     bedspaceSearchPage.completeForm(searchParameters)
     bedspaceSearchPage.clickSubmit()


### PR DESCRIPTION
Fix failing CAS3 E2E tests.

The bedspace search test was producing flaky results, as the attributes checked for said search were selected at random. In some cases, this matched the attributes of the premises created earlier in the test and used for context, but more often than not, there was no match, meaning no results were returned and a failing test.

This fix ensures the search attributes are selected based on the ones applied to the premises created earlier, which means the bedspace result should always be returned.
