### PR TITLE
Skip testing empty PDU field creates error

### DIFF
--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -63,7 +63,14 @@ Then('I should see a list of the problems encountered searching for a bedspace',
   cy.then(function _() {
     const page = Page.verifyOnPage(BedspaceSearchPage)
     page.shouldShowErrorMessagesForFields(
-      ['startDate', 'durationDays', 'probationDeliveryUnit'],
+      // FIXME: Until the work to search for multiple PDUs is complete in both API and UI, the API is unable to
+      //  natively validate that all fields are required at the same time, and instead validates startDate and
+      //  durationDays first, and only validates probationDeliveryUnit if those are valid. Because of this, for now we
+      //  remove the test that checks for the probationDeliveryUnit error. We will reinstate this when the
+      //  probationDeliveryUnits property is available and can be validated natively and at the same time as the other
+      //  fields.
+      // ['startDate', 'durationDays', 'probationDeliveryUnit'],
+      ['startDate', 'durationDays'],
       'empty',
       'bedspaceSearch',
     )


### PR DESCRIPTION
This should be temporary: until the mvoe to searching for multiple PDUs is complete, the API is unable to create errors for all fields at once, and instead returns errors for startDate and durationDays being required first, and an error for probationDeliveryUnit being required only if those two other fields are valid.

We can skip testing for the PDU error for now, but will reinstate it when the API only accepts a `probationDeliveryUnits` parameter as a list of PDUs.

