### PR TITLE
Ensure practitioner PDU test uses distinct ids

### DIFF
--- a/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.test.ts
+++ b/server/form-pages/apply/accommodation-need/contact-details/practitionerPdu.test.ts
@@ -111,7 +111,11 @@ describe('PractitionerPdu', () => {
 
   describe('getRegionPdus', () => {
     it('returns the PDUs formatted for use in a select element', () => {
-      const pdus = referenceDataFactory.pdu().buildList(3)
+      const pdus = [
+        referenceDataFactory.pdu().build({ id: 'pdu-1' }),
+        referenceDataFactory.pdu().build({ id: 'pdu-2' }),
+        referenceDataFactory.pdu().build({ id: 'pdu-3' }),
+      ]
 
       const page = new PractitionerPdu({ id: pdus[1].id, name: pdus[1].name }, application, mockSessionUser, pdus)
 


### PR DESCRIPTION
When buildung a list, the PDU factory may in some cases return 2 of the same PDU from the available fixtures. This means the test for getRegionsPdus would sometimes produce 2 similar entries which would both be marked as selected, which would fail the test. This ensures every PDU in the test has a different id, preventing this issue.

Example of a test run failing due to this issue: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/actions/runs/10814242216/job/30001482702?pr=1089