### PR TITLE
Fix bug where assessments return all ready for placement

### DIFF
--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -137,7 +137,7 @@ describe('AssessmentClient', () => {
       const assessments = assessmentSummaryFactory.buildList(5)
 
       fakeApprovedPremisesApi
-        .get(`${paths.assessments.index({})}?crn=${crn}&statuses=${status}`)
+        .get(`${paths.assessments.index({})}?crnOrName=${crn}&statuses=${status}`)
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200, assessments)
 

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -47,11 +47,11 @@ export default class AssessmentClient {
     }
   }
 
-  async readyToPlaceForCrn(crn: string) {
+  async readyToPlaceForCrn(crnOrName: string) {
     const status: AssessmentSummary['status'] = 'ready_to_place'
 
     return this.restClient.get<Array<AssessmentSummary>>({
-      path: appendQueryString(paths.assessments.index.pattern, { crn: crn.trim(), statuses: status }),
+      path: appendQueryString(paths.assessments.index.pattern, { crnOrName: crnOrName.trim(), statuses: status }),
     })
   }
 


### PR DESCRIPTION
# Context
See https://dsdmoj.atlassian.net/browse/CAS-597

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
This was caused by a recent change where we started allowing users to search for an assessment by crn or name. The backend api params changed from crn to crnOrName. As a result this change it introduced this bug of returning all assessments that were ready for placement instead of all assessments for a given crn that were ready for placement.

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
