### PR TITLE
Fix failing e2e test not finding pdu in bedspace search page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -57,10 +57,9 @@ export default class BedspaceSearchPage extends Page {
   }
 
   completeForm(searchParameters: BedSearchParameters) {
-    cy.debug()
     this.completeDateInputsByLegend('Available from', searchParameters.startDate)
     this.completeTextInputByLabel('Number of days required', `${searchParameters.durationDays}`)
-    cy.debug()
+
     searchParameters.probationDeliveryUnits.forEach(pdu => {
       this.checkCheckboxByNameAndValue('probationDeliveryUnits[]', pdu)
     })

--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -21,7 +21,7 @@ Given('I search for a bedspace', () => {
     const page = Page.verifyOnPage(BedspaceSearchPage)
 
     const searchParameters = bedSearchParametersFactory.build({
-      probationDeliveryUnit: this.premises.probationDeliveryUnit.name,
+      probationDeliveryUnits: [this.premises.probationDeliveryUnit.id],
       attributes: characteristicsToSearchAttributes(this.premises),
     })
 


### PR DESCRIPTION
Caused by https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1099

