### PR TITLE
PDU id being incorrectly set to PDU name in e2e tests

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -165,7 +165,7 @@ export default class PremisesShowPage extends Page {
 
     const pduName = pduElement.text().trim()
     const pdu = pduFactory.build({
-      id: pduName,
+      id,
       name: pduName,
     })
 


### PR DESCRIPTION
# Context

In Circle CI, we were seeing e2e tests failing for the full apply-and-place feature. The tests were failing because they were looking for a PDU checkbox on the search bedspace page with a value relating to the PDU name. This was recently changes in #1099 instead of a single PDU name, we were passing a collection of PDU ids. We partially fixed the failing e2e for Bedspace search feature in #1101.  

It was odd that Bedspace search feature was passing yet apply-and-place feature was failing. There are two difference in the way the tests are setup.

Bedspace search feature generates pdus from factories where apply-and-place generate PDU's through the UI and scrap the screen to find the details needs for the models.
