### PR TITLE
Use the PDU ID that is on the premises show page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -40,16 +40,20 @@ export default class PremisesShowPage extends Page {
                           .contains('Expected turnaround time')
                           .siblings('.govuk-summary-list__value')
                           .then(turnaroundTimeElement => {
-                            const premises = this.parsePremises(
-                              id,
-                              nameElement,
-                              addressElement,
-                              statusElement,
-                              pduElement,
-                              attributeElement,
-                              turnaroundTimeElement,
-                            )
-                            cy.wrap(premises).as(alias)
+                            cy.get('[data-cy-premises]').then(pduIdElement => {
+                              const premises = this.parsePremises(
+                                id,
+                                nameElement,
+                                addressElement,
+                                statusElement,
+                                pduElement,
+                                pduIdElement,
+                                attributeElement,
+                                turnaroundTimeElement,
+                              )
+
+                              cy.wrap(premises).as(alias)
+                            })
                           })
                       })
                   })
@@ -151,6 +155,7 @@ export default class PremisesShowPage extends Page {
     addressElement: JQuery<HTMLElement>,
     statusElement: JQuery<HTMLElement>,
     pduElement: JQuery<HTMLElement>,
+    pduIdElement: JQuery<HTMLElement>,
     attributeElement: JQuery<HTMLElement>,
     turnaroundTimeElement: JQuery<HTMLElement>,
   ): Premises {
@@ -165,7 +170,7 @@ export default class PremisesShowPage extends Page {
 
     const pduName = pduElement.text().trim()
     const pdu = pduFactory.build({
-      id,
+      id: pduIdElement.data('cy-pdu-id'),
       name: pduName,
     })
 

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -43,7 +43,7 @@
         items: actions
     }) }}
 
-    <div data-cy-premises="true">
+    <div data-cy-premises="true" data-cy-pdu-id="{{premises.probationDeliveryUnit.id}}">
         <div class="edit-bar">
             <div class="edit-bar__container">
                 <div class="edit-bar__title">


### PR DESCRIPTION
# Related

- #1102 
- #1101 
- #1099 

# Context

the apply-and-place feature tests were failing when the feature got to "Search for available bedspace" page because it could not find a checkbox with a pdu id from an existing premises. After debugging the tests it was discovered that we had set the premises id as the PDU id when creating the PDU from a factory. see #1102 

apply-andplace features use the ui to create the various assessments/premises etc and scrape the screen to get enough information to use with factories to store the data in memory for the tests to use dynamically. The problem with this approach is that the pdu id was not surfaced to the ui at all so could not use it when building the pdu.

I decided to surface the pdu id on the premises page where most of the information about the premises is surfaced and place it in a html data attribute called `data-cy-pdu-id`. The tests can now read that id from the page and store it for later use on the search available bedspaces page

