### PR TITLE
CAS-475 FE implement the results page for bed space with improved and increased details

### DIFF
--- a/cypress_shared/components/bedspaceSearchResult.ts
+++ b/cypress_shared/components/bedspaceSearchResult.ts
@@ -22,7 +22,10 @@ export default class BedspaceSearchResult extends Component {
         this.shouldShowKeyAndValue('Address', fullAddress)
 
         if (checkCount) {
-          this.shouldShowKeyAndValue('Bedspaces', `${this.result.premises.bedCount} total`)
+          this.shouldShowKeyAndValue(
+            'Bedspaces',
+            `${this.result.premises.bedCount} total: ${this.result.premises.bookedBedCount} booked, ${this.result.premises.bedCount - this.result.premises.bookedBedCount} available`,
+          )
         }
 
         this.result.premises.characteristics.forEach(characteristic => {

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -15,7 +15,7 @@ export default class BedspaceSearchPage extends Page {
   private readonly bedspaceSearchResults: Map<string, BedspaceSearchResult>
 
   constructor(results?: BedSearchResults) {
-    super(results ? 'Bedspace search results' : 'Search for available bedspaces')
+    super('Search for available bedspaces')
 
     this.bedspaceSearchResults = new Map<string, BedspaceSearchResult>()
 
@@ -34,7 +34,7 @@ export default class BedspaceSearchPage extends Page {
 
   shouldShowSearchResults(checkCount = true) {
     if (checkCount) {
-      cy.get('h1').should('contain', `(${this.bedspaceSearchResults.size})`)
+      cy.get('h2').should('contain', `${this.bedspaceSearchResults.size} results for your bedspace search`)
     }
 
     this.bedspaceSearchResults.forEach(result => result.shouldShowResult(checkCount))

--- a/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
@@ -299,7 +299,7 @@ context('Bedspace Search', () => {
     const page = BedspaceSearchPage.visit()
 
     // And I click the previous bread crumb
-    page.clickBreadCrumbUp()
+    page.clickBack()
 
     // Then I navigate to the dashboard page
     Page.verifyOnPage(DashboardPage)

--- a/server/views/temporary-accommodation/bedspace-search/index.njk
+++ b/server/views/temporary-accommodation/bedspace-search/index.njk
@@ -1,6 +1,6 @@
 {% from "govuk/components/button/macro.njk" import govukButton %}
 {% from "../../partials/showErrorSummary.njk" import showErrorSummary %}
-{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../components/place-context-value/macro.njk" import placeContextValue %}
 
 {% extends "../../partials/layout.njk" %}
@@ -9,7 +9,11 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-    {{ breadCrumb('Search for available bedspaces', []) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: '/',
+    classes: 'govuk-!-display-none-print'
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/temporary-accommodation/bedspace-search/results.njk
+++ b/server/views/temporary-accommodation/bedspace-search/results.njk
@@ -78,7 +78,7 @@
                                     },
                                     {
                                         key: { text: 'Bedspaces' },
-                                        value: { text: result.premises.bedCount + ' total' }
+                                        value: { text: result.premises.bedCount + ' total: ' + result.premises.bookedBedCount + ' booked, ' +  (result.premises.bedCount - result.premises.bookedBedCount) + ' available' }
                                     }
                                 ]
                             }) }}

--- a/server/views/temporary-accommodation/bedspace-search/results.njk
+++ b/server/views/temporary-accommodation/bedspace-search/results.njk
@@ -3,7 +3,7 @@
 {% from "govuk/components/details/macro.njk" import govukDetails %}
 
 {% from "moj/components/filter/macro.njk" import mojFilter %}
-{% from "../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 
 {% extends "../../partials/layout.njk" %}
 
@@ -13,7 +13,11 @@
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
-    {{ breadCrumb('Search for available bedspaces', []) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: '/',
+    classes: 'govuk-!-display-none-print'
+  }) }}
 {% endblock %}
 
 {% block content %}

--- a/server/views/temporary-accommodation/bedspace-search/results.njk
+++ b/server/views/temporary-accommodation/bedspace-search/results.njk
@@ -7,7 +7,9 @@
 
 {% extends "../../partials/layout.njk" %}
 
-{% set pageTitle = "Bedspace search results (" + results.length + ") - " + applicationName %}
+{% set numberOfResults =  results.length + (' result' if results.length === 1 else ' results' ) %}
+
+{% set pageTitle = "Search for available bedspaces - " + numberOfResults + " - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -17,7 +19,9 @@
 {% block content %}
     {% include "../../_messages.njk" %}
 
-    <h1 class="govuk-heading-l">Bedspace search results ({{ results.length }})</h1>
+    <h1 class="govuk-heading-l">Search for available bedspaces</h1>
+
+    <h2 class="govuk-heading-m">{{ numberOfResults }} for your bedspace search</h2>
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-one-third govuk-!-margin-bottom-8">


### PR DESCRIPTION
# Context
https://dsdmoj.atlassian.net/browse/CAS-475
<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR

- Updated the copy of the page heading
- Added new h2 as described in the tickets description
- Update “Bedspaces” in the summary cards to show how many beds in the property are booked and available.

## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/6f1e9d60-2931-4b8e-8f36-e9580c286999)

### After
![image](https://github.com/user-attachments/assets/82cbd58f-0169-40dc-ab8d-a9d6302c225e)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
