### PR TITLE
Allow user to select current date as startDate for reports

### DIFF
--- a/server/controllers/temporary-accommodation/manage/reportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.test.ts
@@ -82,8 +82,7 @@ describe('ReportsController', () => {
         errors: {},
         errorSummary: [],
         probationRegionId: request.session.probationRegion.id,
-        maxStartDate: '21/04/2024',
-        maxEndDate: '22/04/2024',
+        maxReportDate: '22/04/2024',
       })
     })
 
@@ -129,8 +128,7 @@ describe('ReportsController', () => {
           errors: {},
           errorSummary: [],
           probationRegionId: request.session.probationRegion.id,
-          maxStartDate: '21/04/2024',
-          maxEndDate: '22/04/2024',
+          maxReportDate: '22/04/2024',
         })
       })
     })

--- a/server/controllers/temporary-accommodation/manage/reportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.ts
@@ -1,6 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
 
-import { addDays } from 'date-fns'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import ReportService from '../../../services/reportService'
@@ -27,8 +26,7 @@ export default class ReportsController {
         errors,
         errorSummary: requestErrorSummary,
         probationRegionId: req.session.probationRegion.id,
-        maxStartDate: DateFormats.isoDateToDatepickerInput(DateFormats.dateObjToIsoDate(addDays(new Date(), -1))),
-        maxEndDate: DateFormats.isoDateToDatepickerInput(DateFormats.dateObjToIsoDate(new Date())),
+        maxReportDate: DateFormats.isoDateToDatepickerInput(DateFormats.dateObjToIsoDate(new Date())),
         ...userInput,
       })
     }

--- a/server/views/temporary-accommodation/reports/index.njk
+++ b/server/views/temporary-accommodation/reports/index.njk
@@ -67,7 +67,7 @@
                             errorMessage: context.errors.startDate,
                             classes: 'hmpps-datepicker--fixed-width',
                             value: context.startDate,
-                            maxDate: maxStartDate
+                            maxDate: maxReportDate
                         }) }}
 
                     </div>
@@ -86,7 +86,7 @@
                             errorMessage: context.errors.endDate,
                             classes: 'hmpps-datepicker--fixed-width',
                             value: context.endDate,
-                            maxDate: maxEndDate
+                            maxDate: maxReportDate
                         }) }}
 
                     </div>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-1190

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
