### PR TITLE
Revert "Allow user to select current date as startDate for reports"

### DIFF
--- a/server/controllers/temporary-accommodation/manage/reportsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.test.ts
@@ -82,7 +82,8 @@ describe('ReportsController', () => {
         errors: {},
         errorSummary: [],
         probationRegionId: request.session.probationRegion.id,
-        maxReportDate: '22/04/2024',
+        maxStartDate: '21/04/2024',
+        maxEndDate: '22/04/2024',
       })
     })
 
@@ -128,7 +129,8 @@ describe('ReportsController', () => {
           errors: {},
           errorSummary: [],
           probationRegionId: request.session.probationRegion.id,
-          maxReportDate: '22/04/2024',
+          maxStartDate: '21/04/2024',
+          maxEndDate: '22/04/2024',
         })
       })
     })

--- a/server/controllers/temporary-accommodation/manage/reportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.ts
@@ -1,5 +1,6 @@
 import type { Request, RequestHandler, Response } from 'express'
 
+import { addDays } from 'date-fns'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
 import ReportService from '../../../services/reportService'
@@ -26,7 +27,8 @@ export default class ReportsController {
         errors,
         errorSummary: requestErrorSummary,
         probationRegionId: req.session.probationRegion.id,
-        maxReportDate: DateFormats.isoDateToDatepickerInput(DateFormats.dateObjToIsoDate(new Date())),
+        maxStartDate: DateFormats.isoDateToDatepickerInput(DateFormats.dateObjToIsoDate(addDays(new Date(), -1))),
+        maxEndDate: DateFormats.isoDateToDatepickerInput(DateFormats.dateObjToIsoDate(new Date())),
         ...userInput,
       })
     }

--- a/server/views/temporary-accommodation/reports/index.njk
+++ b/server/views/temporary-accommodation/reports/index.njk
@@ -67,7 +67,7 @@
                             errorMessage: context.errors.startDate,
                             classes: 'hmpps-datepicker--fixed-width',
                             value: context.startDate,
-                            maxDate: maxReportDate
+                            maxDate: maxStartDate
                         }) }}
 
                     </div>
@@ -86,7 +86,7 @@
                             errorMessage: context.errors.endDate,
                             classes: 'hmpps-datepicker--fixed-width',
                             value: context.endDate,
-                            maxDate: maxReportDate
+                            maxDate: maxEndDate
                         }) }}
 
                     </div>


### PR DESCRIPTION
Reverts ministryofjustice/hmpps-temporary-accommodation-ui#1127

We need to revert these changes because it blocks the UI pipeline. We discovered once these changes were in dev that the API needs to be updated first to support these changes