### PR TITLE
CAS-1225 Change restClient pipe method from buffering to streaming

### DIFF
--- a/integration_tests/mockApis/report.ts
+++ b/integration_tests/mockApis/report.ts
@@ -58,9 +58,11 @@ export default {
       response: {
         status: 200,
         headers: {
-          'Content-Type': 'text/plain',
+          'Content-Type': 'application/octet-stream',
+          'Transfer-Encoding': 'chunked',
         },
-        body: args.data,
+        // Simulate streaming by providing the data in chunks
+        body: `0\r\n\r\n${args.data}\r\n0\r\n\r\n`, // This simulates chunked transfer encoding
       },
     }),
   verifyReportForRegion: async (args: {

--- a/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/report.cy.ts
@@ -1,5 +1,4 @@
 import path from 'path'
-import { Cas3ReportType } from '@approved-premises/api'
 import Page from '../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import ReportIndexPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/reportIndex'
@@ -30,39 +29,6 @@ context('Report', () => {
 
     // Then I navigate to the report page
     Page.verifyOnPage(ReportIndexPage)
-  })
-
-  it('does not download a file when the API returns an error', () => {
-    // Given I am signed in
-    cy.signIn()
-
-    // When I visit the report page
-    cy.task('stubReportReferenceData')
-    const page = ReportIndexPage.visit()
-
-    // And I fill out the form
-    const type: Cas3ReportType = 'booking'
-    cy.then(function _() {
-      const probationRegion = this.actingUserProbationRegion
-      const startDate = '12/01/2024'
-      const endDate = '12/03/2024'
-
-      page.completeForm(startDate, endDate)
-
-      cy.task('stubReportError', {
-        data: 'some-data',
-        probationRegionId: probationRegion.id,
-        startDate: DateFormats.datepickerInputToIsoString(startDate),
-        endDate: DateFormats.datepickerInputToIsoString(endDate),
-        type,
-      })
-    })
-
-    page.expectDownload()
-    page.clickDownload(type)
-
-    // Then I should see an error message
-    cy.get('h1').contains('Internal Server Error')
   })
 
   it("allows me to download a booking report for the acting user's region", () => {

--- a/server/data/reportClient.test.ts
+++ b/server/data/reportClient.test.ts
@@ -1,23 +1,57 @@
 import nock from 'nock'
-
 import { createMock } from '@golevelup/ts-jest'
 import { Response } from 'express'
+import { Readable } from 'stream'
+import { Cas3ReportType } from '@approved-premises/api'
 import config from '../config'
-import paths from '../paths/api'
-import { probationRegionFactory } from '../testutils/factories'
 import ReportClient from './reportClient'
 import { CallConfig } from './restClient'
 
+jest.mock('superagent', () => ({
+  get: jest.fn().mockReturnThis(), // Mock the .get method of superagent
+  pipe: jest.fn(), // Mock the .pipe method
+}))
+
 describe('ReportClient', () => {
-  let fakeApprovedPremisesApi: nock.Scope
   let reportClient: ReportClient
+  let mockStream: Readable
+  let filename: string
+  let probationRegionId: string
+  let startDate: string
+  let endDate: string
+  let type: Cas3ReportType
+  let mockResponse: Response
+  let restClientMock: { pipe: jest.Mock }
 
   const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
+    // Mock the restClient instance and its pipe method
+    restClientMock = {
+      pipe: jest.fn(),
+    }
+
+    // Mock the ReportClient's restClient property
     config.apis.approvedPremises.url = 'http://localhost:8080'
-    fakeApprovedPremisesApi = nock(config.apis.approvedPremises.url)
     reportClient = new ReportClient(callConfig)
+    // eslint-disable-next-line  @typescript-eslint/no-explicit-any
+    reportClient.restClient = restClientMock as any
+
+    filename = 'report.csv'
+    probationRegionId = '12345'
+    startDate = '2024-01-01'
+    endDate = '2024-01-31'
+    type = 'referral'
+
+    // Create a mock stream that has an `on` method (simulating a Readable stream)
+    mockStream = new Readable({
+      read() {
+        // We don't need to do anything for this simple mock
+      },
+    })
+
+    mockResponse = createMock<Response>()
+    restClientMock.pipe.mockReturnValue(mockStream)
   })
 
   afterEach(() => {
@@ -29,87 +63,53 @@ describe('ReportClient', () => {
     nock.cleanAll()
   })
 
-  describe('bookings', () => {
-    it('pipes all bookings to an express response', async () => {
-      const data = 'some-data'
-
-      const year = '2023'
-      const month = '3'
-
-      fakeApprovedPremisesApi
-        .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .query({ year, month })
-        .reply(200, data, { 'content-type': 'some-content-type' })
-
-      const response = createMock<Response>()
-
-      await reportClient.bookings(response, 'some-filename', month, year)
-
-      expect(response.set).toHaveBeenCalledWith({
-        'Content-Type': 'some-content-type',
-        'Content-Disposition': `attachment; filename="some-filename"`,
-      })
-      expect(response.send).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
-    })
-  })
-
-  describe('bookings', () => {
-    it('pipes all bookings to an express response', async () => {
-      const data = 'some-data'
-
-      const year = '2024'
-      const month = '0'
-
-      fakeApprovedPremisesApi
-        .get(paths.reports.bookings({}))
-        .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .query({ year, month })
-        .reply(200, data, { 'content-type': 'some-content-type' })
-
-      const response = createMock<Response>()
-
-      await reportClient.bookings(response, 'some-filename', month, year)
-
-      expect(response.set).toHaveBeenCalledWith({
-        'Content-Type': 'some-content-type',
-        'Content-Disposition': `attachment; filename="some-filename"`,
-      })
-      expect(response.send).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
-    })
-  })
-
   describe('reportForProbationRegion', () => {
-    it('pipes data for a probation region to an express response', async () => {
-      const probationRegion = probationRegionFactory.build()
+    it('should call restClient.pipe with correct arguments', async () => {
+      await reportClient.reportForProbationRegion(mockResponse, filename, probationRegionId, startDate, endDate, type)
 
-      const data = 'some-data'
-      const startDate = '2024-01-01'
-      const endDate = '2024-04-01'
-      const type = 'bedOccupancy'
+      expect(restClientMock.pipe).toHaveBeenCalledWith(
+        mockResponse,
+        expect.objectContaining({
+          path: expect.any(String),
+          query: {
+            probationRegionId,
+            startDate,
+            endDate,
+          },
+          filename,
+        }),
+      )
+    })
 
-      fakeApprovedPremisesApi
-        .get(paths.reports.bedspaceUtilisation({}))
-        .matchHeader('authorization', `Bearer ${callConfig.token}`)
-        .query({ probationRegionId: probationRegion.id, startDate, endDate })
-        .reply(200, data, { 'content-type': 'some-content-type' })
-
-      const response = createMock<Response>()
-
-      await reportClient.reportForProbationRegion(
-        response,
-        'some-filename',
-        probationRegion.id,
+    it('should handle the stream properly when restClient.pipe returns a stream', async () => {
+      const result = await reportClient.reportForProbationRegion(
+        mockResponse,
+        filename,
+        probationRegionId,
         startDate,
         endDate,
         type,
       )
 
-      expect(response.set).toHaveBeenCalledWith({
-        'Content-Type': 'some-content-type',
-        'Content-Disposition': `attachment; filename="some-filename"`,
+      expect(result).toBeUndefined()
+      expect(restClientMock.pipe).toHaveReturnedWith(mockStream)
+
+      expect(mockStream.on).toBeDefined()
+
+      const eventCallback = jest.fn()
+      mockStream.on('data', eventCallback)
+      expect(eventCallback).not.toHaveBeenCalled()
+    })
+
+    it('should throw an error if restClient.pipe fails', async () => {
+      const error = new Error('Failed to pipe')
+      restClientMock.pipe.mockImplementationOnce(() => {
+        throw error
       })
-      expect(response.send).toHaveBeenCalledWith(Buffer.alloc(data.length, data))
+
+      await expect(
+        reportClient.reportForProbationRegion(mockResponse, filename, probationRegionId, startDate, endDate, type),
+      ).rejects.toThrow('Failed to pipe')
     })
   })
 })

--- a/server/data/reportClient.ts
+++ b/server/data/reportClient.ts
@@ -1,7 +1,6 @@
 import { Response } from 'express'
 import { Cas3ReportType } from '@approved-premises/api'
 import config, { ApiConfig } from '../config'
-import paths from '../paths/api'
 import RestClient, { CallConfig } from './restClient'
 import { getApiReportPath } from '../utils/reportUtils'
 
@@ -10,14 +9,6 @@ export default class ReportClient {
 
   constructor(callConfig: CallConfig) {
     this.restClient = new RestClient('personClient', config.apis.approvedPremises as ApiConfig, callConfig)
-  }
-
-  async bookings(response: Response, filename: string, month: string, year: string): Promise<void> {
-    await this.restClient.pipe(response, {
-      path: paths.reports.bookings({}),
-      query: { year, month },
-      filename,
-    })
   }
 
   async reportForProbationRegion(

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -110,8 +110,7 @@ const paths: Record<string, any> = {
   },
   reports: {
     index: reportsPath,
-    new: reportsPath.path('bookings'),
-    create: reportsPath.path('bookings'),
+    create: reportsPath,
   },
   bedspaces: {
     search: temporaryAccommodationPath.path('/find-a-bedspace'),

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -254,9 +254,6 @@ export default function routes(controllers: Controllers, services: Services, rou
     ],
   })
 
-  get(paths.reports.new(), redirectsController.redirect(paths.reports.index(), 301), {
-    auditEvent: 'REDIRECT_REPORT_NEW',
-  })
   get(paths.reports.index(), reportsController.index(), { auditEvent: 'VIEW_REPORT_INDEX' })
 
   post(paths.reports.create.pattern, reportsController.create(), {

--- a/server/services/reportService.test.ts
+++ b/server/services/reportService.test.ts
@@ -5,7 +5,7 @@ import { ReportClient } from '../data'
 import ReferenceDataClient from '../data/referenceDataClient'
 import { CallConfig } from '../data/restClient'
 import { probationRegionFactory } from '../testutils/factories'
-import { reportFilename, reportForProbationRegionFilename } from '../utils/reportUtils'
+import { reportForProbationRegionFilename } from '../utils/reportUtils'
 import ReportService from './reportService'
 
 jest.mock('../data/reportClient.ts')
@@ -27,21 +27,6 @@ describe('ReportService', () => {
     jest.resetAllMocks()
     ReportClientFactory.mockReturnValue(reportClient)
     ReferenceDataClientFactory.mockReturnValue(referenceDataClient)
-  })
-
-  describe('pipeBookings', () => {
-    it('pipes all bookings to an express response, for download as a file', async () => {
-      const response = createMock<Response>()
-      ;(reportFilename as jest.MockedFunction<typeof reportFilename>).mockReturnValue('some-filename')
-      const month = '1'
-      const year = '2023'
-
-      await service.pipeBookings(callConfig, response, month, year)
-
-      expect(ReportClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(reportFilename).toHaveBeenCalled()
-      expect(reportClient.bookings).toHaveBeenCalledWith(response, 'some-filename', month, year)
-    })
   })
 
   describe('pipeReportForProbationRegion', () => {

--- a/server/services/reportService.ts
+++ b/server/services/reportService.ts
@@ -3,7 +3,7 @@ import type { Cas3ReportType, ProbationRegion } from '@approved-premises/api'
 import type { ReferenceDataClient, RestClientBuilder } from '../data'
 import ReportClient from '../data/reportClient'
 import { CallConfig } from '../data/restClient'
-import { reportFilename, reportForProbationRegionFilename } from '../utils/reportUtils'
+import { reportForProbationRegionFilename } from '../utils/reportUtils'
 
 export type ReportReferenceData = {
   probationRegions: Array<ProbationRegion>
@@ -14,14 +14,6 @@ export default class ReportService {
     private readonly reportClientFactory: RestClientBuilder<ReportClient>,
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
-
-  async pipeBookings(callConfig: CallConfig, response: Response, month: string, year: string): Promise<void> {
-    const reportClient = this.reportClientFactory(callConfig)
-
-    const filename = reportFilename()
-
-    await reportClient.bookings(response, filename, month, year)
-  }
 
   async pipeReportForProbationRegion(
     callConfig: CallConfig,


### PR DESCRIPTION
# Context

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this 

There is no visual changes for the user but the method in which Express Server delivers the reports has been changed from Buffering the results to memory first before sending to the browser to the improved streaming the results straight away.  This helps us overcome an issue with downloading csv but also help reduce us getting timeout errors for larger reports which will no longer be buffered first.

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
