### PR TITLE
Run e2e-tests locally against dev upstream services to simulate pipeline

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,31 @@ Spin up a real browser that gives you an interface to run individual E2E feature
 npm run test:e2e:ui
 ```
 
+#### End-to-End tests (via Cypress) using dev-upstream AP Tools
+This enables us to locally simulate the e2e test run in the Circle-CI pipeline
+
+First start the ap-tools using
+```
+ap-tools server stop --clear-databases
+ap-tools server start --local-ui --local-api-dev-upstream
+```
+
+* The end-to-end tests run against our local API which then integrates with the dev upstream services and the dev database due to this param `-local-api-dev-upstream`
+* Once AP is running successfully, we can run one of the two npm scripts below which both use the `e2e.dev-upstream.env` config file (instead of `e2e.local.env` config file)
+* This ensures that when we run the e2e tests we pass the same env vars that the pipeline uses. For example, this ensures we the e2e tests login as the same dev users
+
+Run E2E tests via a headless Chrome browser, with reporting matching that seen on CI:
+
+```bash
+npm run test:e2e-dev-upstream
+```
+
+Spin up a real browser that gives you an interface to run individual E2E features:
+
+```bash
+npm run test:e2e-dev-upstream:ui
+```
+
 ## Release process
 
 Our release process aligns with the other CAS teams and as such [lives in

--- a/e2e.dev-upstream.env
+++ b/e2e.dev-upstream.env
@@ -1,0 +1,7 @@
+CYPRESS_assessor_username=TEMPORARY-ACCOMMODATION-E2E-TESTER
+CYPRESS_assessor_password=doesntmatter
+CYPRESS_referrer_username=TEMPORARY-ACCOMMODATION-E2E-REFERRER
+CYPRESS_referrer_password=doesntmatter
+CYPRESS_acting_user_probation_region_id=db82d408-d440-4eb5-960b-119cb33427cd
+CYPRESS_acting_user_probation_region_name=Kent,%20Surrey%20&%20Sussex
+CYPRESS_environment=dev

--- a/package.json
+++ b/package.json
@@ -25,6 +25,8 @@
     "test:ci": "jest --runInBand",
     "test:e2e": "export $(cat e2e.local.env) && cypress run -C cypress.config.e2e.ts --config baseUrl=http://localhost:3000",
     "test:e2e:ui": "export $(cat e2e.local.env) && cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config baseUrl=http://localhost:3000",
+    "test:e2e-dev-upstream": "export $(cat e2e.dev-upstream.env) && cypress run -C cypress.config.e2e.ts --config baseUrl=http://localhost:3000",
+    "test:e2e-dev-upstream:ui": "export $(cat e2e.dev-upstream.env) && cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config baseUrl=http://localhost:3000",
     "test:e2e:ci": "cypress run -C cypress.config.e2e.ts",
     "test:integration": "npm run start-test-wiremock && start-server-and-test start-feature http://localhost:3007/ping int-test",
     "test:integration:ui": "npm run start-test-wiremock && start-server-and-test start-feature:dev http://localhost:3007/ping int-test-ui",


### PR DESCRIPTION
# Context

- @davidatkinsuk recently made changes to AP tools so that the AP tools local-api integrates with dev upstream services
- these new AP tools changes gives us the opportunity to locally run e2e tests against dev upstream services
- the advantage of this is that it allows us to locally simulate what happens in the CircleCI pipleine 
- this will make it easier to fix failures in the `cas3_e2e_tests` job 

# Changes in this PR
- new `npm scripts` to run e2e tests in this new way
- changes to the `README.md` to document this
- new `.env` config file for the new `npm scripts` to use

