### PR TITLE
APS-1482 - e2e test data changes for new offences data from API

### DIFF
--- a/cypress_shared/fixtures/offences-local.json
+++ b/cypress_shared/fixtures/offences-local.json
@@ -1,14 +1,14 @@
 [
   {
-    "offenceId": "M2500295343",
-    "offenceDescription": "Murder - Murder of infants under 1 year of age",
-    "offenceDate": "2018-08-04",
-    "convictionId": "2500295345"
+    "offenceId": "M200002",
+    "offenceDescription": "Murder - Murder of spouse",
+    "offenceDate": "2024-10-12",
+    "convictionId": "100002"
   },
   {
-    "offenceId": "A2500108084",
+    "offenceId": "A300002",
     "offenceDescription": "Burglary in a dwelling - Burglary (dwelling) with intent to commit, or the commission of, an offence triable only on indictment",
-    "offenceDate": "2019-09-02",
-    "convictionId": "2500295345"
+    "offenceDate": "2024-10-22",
+    "convictionId": "100002"
   }
 ]


### PR DESCRIPTION
# Context
* This change relatess to this ticket: https://dsdmoj.atlassian.net/browse/APS-1482 
* We are migrting away from `Community API` to `Ap and Delius API` here
* As a result new local test data was setup in the `AP and Delius API` service to not break the UI when running the `AP tools` local infrastructure
* This also lead to breaking the local e2e tests

# Changes in this PR
* Changes to expected offence-data to fix the broken e2es

## Screenshots of UI changes
<img width="2048" alt="Screenshot 2024-11-21 at 14 26 44 (2)" src="https://github.com/user-attachments/assets/6e34276c-58c5-431a-a328-67de6d55cc08">

