### PR TITLE
Convert occupancy attributes to radio button and add "All" option

### DIFF
--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -9,7 +9,7 @@ import {
 import { PlaceContext } from '../../server/@types/ui'
 import {
   assessmentSummaryFactory,
-  bedSearchApiParametersFactory,
+  bedSearchFormParametersFactory,
   bedSearchResultFactory,
   bedSearchResultsFactory,
   bookingFactory,
@@ -25,7 +25,6 @@ import BookingConfirmPage from '../pages/temporary-accommodation/manage/bookingC
 import BookingNewPage from '../pages/temporary-accommodation/manage/bookingNew'
 import BookingSelectAssessmentPage from '../pages/temporary-accommodation/manage/bookingSelectAssessment'
 import BookingShowPage from '../pages/temporary-accommodation/manage/bookingShow'
-import { characteristicsToSearchAttributes } from '../utils/bedspaceSearch'
 
 export default class PlaceHelper {
   private readonly bedSearchResults: BedSearchResults
@@ -111,12 +110,11 @@ export default class PlaceHelper {
   private bedspaceSearchToSearchResults() {
     // Given I am viewing the bedspace search page
     const bedspaceSearchPage = Page.verifyOnPage(BedspaceSearchPage)
-
     // When I fill out the form
-    const searchParameters = bedSearchApiParametersFactory.build({
+
+    const searchParameters = bedSearchFormParametersFactory.build({
       startDate: this.placeContext.arrivalDate,
       probationDeliveryUnits: [this.premises.probationDeliveryUnit.id],
-      attributes: characteristicsToSearchAttributes(this.premises),
     })
 
     bedspaceSearchPage.completeForm(searchParameters)

--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -1,10 +1,5 @@
-import {
-  TemporaryAccommodationBedSearchParameters as BedSearchParameters,
-  BedSearchResults,
-  Room,
-  TemporaryAccommodationBedSearchResult,
-} from '../../../../server/@types/shared'
-import { PlaceContext } from '../../../../server/@types/ui'
+import { BedSearchResults, Room, TemporaryAccommodationBedSearchResult } from '../../../../server/@types/shared'
+import { BedSearchFormParameters, PlaceContext } from '../../../../server/@types/ui'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BedspaceSearchResult from '../../../components/bedspaceSearchResult'
@@ -44,7 +39,7 @@ export default class BedspaceSearchPage extends Page {
     cy.get('h2').should('contain', 'There are no available bedspaces')
   }
 
-  shouldShowPrefilledSearchParameters(searchParameters: BedSearchParameters) {
+  shouldShowPrefilledSearchParameters(searchParameters: BedSearchFormParameters) {
     this.shouldShowDateInputsByLegend('Available from', searchParameters.startDate)
     this.shouldShowTextInputByLabel('Number of days required', `${searchParameters.durationDays}`)
     searchParameters.probationDeliveryUnits.forEach(pduId => {
@@ -56,7 +51,7 @@ export default class BedspaceSearchPage extends Page {
     this.shouldShowDateInputsByLegend('Available from', placeContext.assessment.accommodationRequiredFromDate)
   }
 
-  completeForm(searchParameters: BedSearchParameters) {
+  completeForm(searchParameters: BedSearchFormParameters) {
     this.completeDateInputsByLegend('Available from', searchParameters.startDate)
     this.completeTextInputByLabel('Number of days required', `${searchParameters.durationDays}`)
 
@@ -65,20 +60,14 @@ export default class BedspaceSearchPage extends Page {
     })
 
     this.getLegend('Property attributes')
-    this.getLegend('Occupancy (optional)')
-    searchParameters.attributes
-      .filter(attribute => attribute !== 'isWheelchairAccessible')
-      .forEach(attribute => {
-        this.checkCheckboxByNameAndValue('occupancyAttributes[]', attribute)
-      })
+    this.getLegend('Occupancy')
+    this.checkRadioByNameAndValue('occupancyAttribute', searchParameters.occupancyAttribute)
 
     this.getLegend('Bedspace attributes')
     this.getLegend('Accessibility (optional)')
-    searchParameters.attributes
-      .filter(attribute => attribute === 'isWheelchairAccessible')
-      .forEach(attribute => {
-        this.checkCheckboxByNameAndValue('attributes[]', attribute)
-      })
+    searchParameters.attributes.forEach(attribute => {
+      this.checkCheckboxByNameAndValue('attributes[]', attribute)
+    })
   }
 
   clickBedspaceLink(room: Room) {

--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -3,7 +3,7 @@ import Page from '../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import BedspaceSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch'
 import {
-  bedSearchApiParametersFactory,
+  bedSearchFormParametersFactory,
   bedSearchResultFactory,
   bedSearchResultsFactory,
 } from '../../../../server/testutils/factories'
@@ -20,7 +20,7 @@ Given('I search for a bedspace', () => {
   cy.then(function _() {
     const page = Page.verifyOnPage(BedspaceSearchPage)
 
-    const searchParameters = bedSearchApiParametersFactory.build({
+    const searchParameters = bedSearchFormParametersFactory.build({
       probationDeliveryUnits: [this.premises.probationDeliveryUnit.id],
       attributes: characteristicsToSearchAttributes(this.premises),
     })

--- a/integration_tests/tests/place/place.cy.ts
+++ b/integration_tests/tests/place/place.cy.ts
@@ -8,7 +8,7 @@ context('Place', () => {
     setupTestUser('assessor')
   })
 
-  it('allows the user progress along the "place" joureny', () => {
+  it('allows the user progress along the "place" journey', () => {
     // Given I am signed in
     cy.signIn()
 

--- a/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
@@ -6,7 +6,7 @@ import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommo
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import {
   assessmentFactory,
-  bedSearchApiParametersFactory,
+  bedSearchFormParametersFactory,
   bedSearchResultFactory,
   bedSearchResultsFactory,
   overlapFactory,
@@ -56,7 +56,7 @@ context('Bedspace Search', () => {
     const results = bedSearchResultsFactory.build()
     cy.task('stubBedSearch', results)
 
-    const searchParameters = bedSearchApiParametersFactory.build()
+    const searchParameters = bedSearchFormParametersFactory.build()
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 
@@ -68,7 +68,7 @@ context('Bedspace Search', () => {
       expect(requestBody.startDate).equal(searchParameters.startDate)
       expect(requestBody.durationDays).equal(searchParameters.durationDays)
       expect(requestBody.probationDeliveryUnits).to.have.members(searchParameters.probationDeliveryUnits)
-      expect(requestBody.attributes).to.have.members(searchParameters.attributes)
+      expect(requestBody.attributes).to.include.members(searchParameters.attributes)
     })
 
     // And I should see the search results
@@ -96,7 +96,7 @@ context('Bedspace Search', () => {
     })
     cy.task('stubBedSearch', results)
 
-    const searchParameters = bedSearchApiParametersFactory.build()
+    const searchParameters = bedSearchFormParametersFactory.build()
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 
@@ -108,7 +108,7 @@ context('Bedspace Search', () => {
       expect(requestBody.startDate).equal(searchParameters.startDate)
       expect(requestBody.durationDays).equal(searchParameters.durationDays)
       expect(requestBody.probationDeliveryUnits).to.include.members(searchParameters.probationDeliveryUnits)
-      expect(requestBody.attributes).to.have.members(searchParameters.attributes)
+      expect(requestBody.attributes).to.include.members(searchParameters.attributes)
     })
 
     // And I should see empty search results
@@ -138,7 +138,7 @@ context('Bedspace Search', () => {
     cy.task('stubSinglePremises', premises)
     cy.task('stubSingleRoom', { premisesId: premises.id, room })
 
-    const searchParameters = bedSearchApiParametersFactory.build()
+    const searchParameters = bedSearchFormParametersFactory.build()
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 
@@ -195,7 +195,7 @@ context('Bedspace Search', () => {
     })
 
     // And when I fill out the form
-    const searchParameters = bedSearchApiParametersFactory.build()
+    const searchParameters = bedSearchFormParametersFactory.build()
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 
@@ -243,7 +243,7 @@ context('Bedspace Search', () => {
     const results = bedSearchResultsFactory.build()
     cy.task('stubBedSearch', results)
 
-    const searchParameters = bedSearchApiParametersFactory.build()
+    const searchParameters = bedSearchFormParametersFactory.build()
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 
@@ -276,7 +276,7 @@ context('Bedspace Search', () => {
     const results = bedSearchResultsFactory.build()
     cy.task('stubBedSearch', results)
 
-    const searchParameters = bedSearchApiParametersFactory.build()
+    const searchParameters = bedSearchFormParametersFactory.build()
     preSearchPage.completeForm(searchParameters)
     preSearchPage.clickSubmit()
 

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -336,3 +336,11 @@ export type PrimaryNavigationItem = {
 export type BedspaceOccupancyAttributes = 'isSharedProperty' | 'isSingleOccupancy'
 
 export type BedspaceAccessiblityAttributes = 'isWheelchairAccessible'
+
+export type BedSearchFormParameters = {
+  startDate: string
+  durationDays: number
+  probationDeliveryUnits: Array<string>
+  occupancyAttribute: 'all' | BedspaceOccupancyAttributes
+  attributes?: Array<BedspaceAccessiblityAttributes>
+}

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.test.ts
@@ -6,7 +6,7 @@ import { AssessmentsService } from '../../../services'
 import BedspaceSearchService from '../../../services/bedspaceSearchService'
 import {
   assessmentFactory,
-  bedSearchApiParametersFactory,
+  bedSearchFormParametersFactory,
   bedSearchResultsFactory,
   placeContextFactory,
   referenceDataFactory,
@@ -59,6 +59,7 @@ describe('BedspaceSearchController', () => {
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspace-search/index', {
           allPdus: referenceData.pdus,
+          occupancyAttribute: 'all',
           errors: {},
           errorSummary: [],
           durationDays: DEFAULT_DURATION_DAYS,
@@ -85,7 +86,7 @@ describe('BedspaceSearchController', () => {
       })
 
       it('renders with errors if the API returns an error', async () => {
-        const searchParameters = bedSearchApiParametersFactory.build()
+        const searchParameters = bedSearchFormParametersFactory.build()
         const placeContext = placeContextFactory.build()
 
         request.query = {
@@ -122,7 +123,7 @@ describe('BedspaceSearchController', () => {
 
     describe('when showing results', () => {
       it('renders the search results page with search results when given a search query', async () => {
-        const searchParameters = bedSearchApiParametersFactory.build()
+        const searchParameters = bedSearchFormParametersFactory.build()
 
         request.query = {
           ...searchParameters,
@@ -140,6 +141,7 @@ describe('BedspaceSearchController', () => {
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bedspace-search/results', {
           allPdus: referenceData.pdus,
+          occupancyAttribute: 'all',
           results: searchResults.results,
           errors: {},
           errorSummary: [],
@@ -148,7 +150,7 @@ describe('BedspaceSearchController', () => {
       })
 
       it('updates the place context when given a search query', async () => {
-        const searchParameters = bedSearchApiParametersFactory.build()
+        const searchParameters = bedSearchFormParametersFactory.build()
         const placeContext = placeContextFactory.build()
 
         request.query = {

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -54,15 +54,21 @@ export default class BedspaceSearchController {
 
           const durationDays = parseNumber(query.durationDays)
 
-          const selectedAttributes: BedSearchAttributes[] = [
-            ...((req.query.occupancyAttributes as BedspaceOccupancyAttributes[]) ?? []),
+          const selectedAttributes = [
+            ...(
+              [
+                req.query.occupancyAttribute && req.query.occupancyAttribute !== 'all'
+                  ? req.query.occupancyAttribute
+                  : null,
+              ] as BedspaceOccupancyAttributes[]
+            ).filter(Boolean),
             ...((req.query.attributes as BedspaceAccessiblityAttributes[]) ?? []),
           ]
 
           results = (
             await this.searchService.search(callConfig, {
               ...query,
-              attributes: selectedAttributes,
+              attributes: selectedAttributes as BedSearchAttributes[],
               startDate,
               durationDays,
             })
@@ -82,6 +88,7 @@ export default class BedspaceSearchController {
           errors,
           errorSummary,
           durationDays: req.query.durationDays || DEFAULT_DURATION_DAYS,
+          occupancyAttribute: req.query.occupancyAttribute || 'all',
           ...startDatePrefill,
           ...query,
           ...userInput,

--- a/server/testutils/factories/bedSearchFormParameters.ts
+++ b/server/testutils/factories/bedSearchFormParameters.ts
@@ -1,0 +1,13 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+import { BedSearchFormParameters } from '@approved-premises/ui'
+import { DateFormats } from '../../utils/dateUtils'
+import referenceData from './referenceData'
+
+export default Factory.define<BedSearchFormParameters>(() => ({
+  startDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
+  durationDays: faker.number.int({ min: 1, max: 10 }),
+  probationDeliveryUnits: [referenceData.pdu().build().id, referenceData.pdu().build().id],
+  occupancyAttribute: 'all',
+  attributes: ['isWheelchairAccessible'],
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -9,6 +9,7 @@ import assessmentSearchParametersFactory from './assessmentSearchParameters'
 import assessmentSummaryFactory from './assessmentSummary'
 import bedFactory from './bed'
 import bedSearchApiParametersFactory from './bedSearchApiParameters'
+import bedSearchFormParametersFactory from './bedSearchFormParameters'
 import bedSearchResultFactory from './bedSearchResult'
 import bedSearchResultsFactory from './bedSearchResults'
 import bookingFactory from './booking'
@@ -82,6 +83,7 @@ export {
   assessmentSummaryFactory,
   bedFactory,
   bedSearchApiParametersFactory,
+  bedSearchFormParametersFactory,
   bedSearchResultFactory,
   bedSearchResultsFactory,
   bookingFactory,

--- a/server/views/temporary-accommodation/bedspace-search/partials/search-fields.njk
+++ b/server/views/temporary-accommodation/bedspace-search/partials/search-fields.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/fieldset/macro.njk" import govukFieldset %}
 {% from "../../../components/formFields/form-page-checkboxes/macro.njk" import formPageCheckboxes %}
+{% from "../../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 {% from "../../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
 {% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
 {% from "../../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
@@ -65,23 +66,21 @@
 		        classes: "govuk-fieldset__legend--m"
 		    }
 		}) %}
-		    {{ formPageCheckboxes({
-		        classes: "govuk-checkboxes--small",
-		        fieldName: "occupancyAttributes",
-		        fieldset: {
-		            legend: {
-		                text: "Occupancy (optional)",
-		                classes: "govuk-fieldset__legend--s"
-		            }
-		        },
-		        hint: {
-		            text: "Select all that apply"
-		        },
-		        items: [
-		            { text: "Single", value: "isSingleOccupancy" },
-		            { text: "Shared", value: "isSharedProperty" }
-		        ]
-		    }, fetchContext()) }}
+      {{ formPageRadios({
+        classes: "govuk-radios--small",
+        fieldName: "occupancyAttribute",
+        fieldset: {
+          legend: {
+            text: "Occupancy",
+            classes: "govuk-fieldset__legend--s"
+          }
+        },
+        items: [
+          { text: "All", value: "all" },
+          { text: "Single", value: "isSingleOccupancy" },
+          { text: "Shared", value: "isSharedProperty" }
+        ]
+      }, fetchContext()) }}
 		{% endcall %}
 	</div>
 	<div class="govuk-form-group">


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-1187

<!-- Is there a Trello ticket you can link to? -->
<!-- Do you need to add any environment variables? -->
<!-- Is an ADR required? An ADR should be added if this PR introduces a change to the architecture. -->

# Changes in this PR
We now know that premises can only every be marked as a single occupancy or a shared property. However when it comes to searching, users might not be concerned what type of occupancy the premises is and would like to return all premises regardless of whether its single or shared
## Screenshots of UI changes

### Before
![image](https://github.com/user-attachments/assets/87902331-6ef2-4843-a964-95510497f670)

### After

https://github.com/user-attachments/assets/cb00a4f3-6cba-4778-961e-e1932f8f5bad


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
