### PR TITLE
Pin Ubuntu version in github action to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ env:
 jobs:
   type_checking:
     name: "Type check 🔎"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps: 
       - name: Check out code
         uses: actions/checkout@v4.2.2
@@ -33,7 +33,7 @@ jobs:
 
   linting: 
     name: "Linting 🔎"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps: 
       - name: Check out code
         uses: actions/checkout@v4.2.2
@@ -55,7 +55,7 @@ jobs:
   
   unit_test:
     name: "Unit testing 🧪"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4.2.2
@@ -74,7 +74,7 @@ jobs:
 
   integration_test:
     name: "Integration testing 🧪"
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Check out code
         uses: actions/checkout@v4.2.2


### PR DESCRIPTION
This week, Github changed the `ubuntu-latest` to Ubuntu 24. This broken our linting action where shellcheck keep on following with the following error:

```
Run npm run shellcheck

> temporary-accommodation-ui@0.0.1 shellcheck
> npx shellcheck ./script/**/*[^utils] ./script/utils/**

[INFO ] ShellCheck binary not found or invalid, downloading to '/home/runner/work/hmpps-temporary-accommodation-ui/hmpps-temporary-accommodation-ui/node_modules/shellcheck/bin/shellcheck'
[INFO ] Downloading 'https://github.com/vscode-shellcheck/shellcheck-binaries/releases/download/v0.10.0/shellcheck-v0.10.0.linux.x86_64.tar.gz' to '/tmp/uNDjpK/shellcheck.download'
[INFO ] Extracting '/tmp/uNDjpK/shellcheck.download' to '/tmp/uNDjpK'
[INFO ] Copying '/tmp/uNDjpK/shellcheck' to '/home/runner/work/hmpps-temporary-accommodation-ui/hmpps-temporary-accommodation-ui/node_modules/shellcheck/bin/shellcheck'
[INFO ] ShellCheck binary successfully downloaded to '/home/runner/work/hmpps-temporary-accommodation-ui/hmpps-temporary-accommodation-ui/node_modules/shellcheck/bin/shellcheck'
./script/**/*[^utils]: ./script/**/*[^utils]: openBinaryFile: does not exist (No such file or directory)
Error: Process completed with exit code 2.

```
See: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/actions/runs/12350577855/job/34517811023

We have seen this error before and it was an issue with github action runners. I noticed that the ubuntu version has been bumped and its most likely why shellcheck has broken again.

All the jobs also had the following warning from Github: ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636
