### PR TITLE
Remove UUID dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -51,8 +51,7 @@
         "static-path": "^0.0.4",
         "superagent": "^8.0.2",
         "typescript-json-schema": "^0.64.0",
-        "url-value-parser": "^2.2.0",
-        "uuid": "^9.0.0"
+        "url-value-parser": "^2.2.0"
       },
       "devDependencies": {
         "@badeball/cypress-cucumber-preprocessor": "^19.0.0",
@@ -78,7 +77,6 @@
         "@types/passport-oauth2": "^1.4.17",
         "@types/superagent": "^4.1.15",
         "@types/supertest": "^2.0.12",
-        "@types/uuid": "^9.0.8",
         "@typescript-eslint/eslint-plugin": "^8.3.0",
         "@typescript-eslint/parser": "^8.3.0",
         "audit-ci": "^6.3.0",
@@ -4386,12 +4384,6 @@
       "dependencies": {
         "@types/superagent": "*"
       }
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
-      "dev": true
     },
     "node_modules/@types/yargs": {
       "version": "17.0.31",

--- a/package.json
+++ b/package.json
@@ -174,8 +174,7 @@
     "static-path": "^0.0.4",
     "superagent": "^8.0.2",
     "typescript-json-schema": "^0.64.0",
-    "url-value-parser": "^2.2.0",
-    "uuid": "^9.0.0"
+    "url-value-parser": "^2.2.0"
   },
   "devDependencies": {
     "@badeball/cypress-cucumber-preprocessor": "^19.0.0",
@@ -201,7 +200,6 @@
     "@types/passport-oauth2": "^1.4.17",
     "@types/superagent": "^4.1.15",
     "@types/supertest": "^2.0.12",
-    "@types/uuid": "^9.0.8",
     "@typescript-eslint/eslint-plugin": "^8.3.0",
     "@typescript-eslint/parser": "^8.3.0",
     "audit-ci": "^6.3.0",

--- a/server/middleware/setUpWebSession.ts
+++ b/server/middleware/setUpWebSession.ts
@@ -1,7 +1,6 @@
 import RedisStore from 'connect-redis'
 import express, { Router } from 'express'
 import session from 'express-session'
-import { v4 as uuidv4 } from 'uuid'
 import logger from '../../logger'
 import config from '../config'
 import { createRedisClient } from '../data/redisClient'
@@ -32,7 +31,7 @@ export default function setUpWebSession(): Router {
   router.use((req, res, next) => {
     const headerName = 'X-Request-Id'
     const oldValue = req.get(headerName)
-    const id = oldValue === undefined ? uuidv4() : oldValue
+    const id = oldValue === undefined ? crypto.randomUUID() : oldValue
 
     res.set(headerName, id)
     req.id = id


### PR DESCRIPTION


# Context
This dependency was removed from HMPPS Typescript template back in September so this commit brings this codebase inline with the template.

See https://github.com/ministryofjustice/hmpps-template-typescript/pull/439

