### PR TITLE
Fix flaky end-to-end tests for bedspace search

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch.ts
@@ -61,13 +61,17 @@ export default class BedspaceSearchPage extends Page {
 
     this.getLegend('Property attributes')
     this.getLegend('Occupancy')
-    this.checkRadioByNameAndValue('occupancyAttribute', searchParameters.occupancyAttribute)
+    if (typeof searchParameters.occupancyAttribute !== 'undefined') {
+      this.checkRadioByNameAndValue('occupancyAttribute', searchParameters.occupancyAttribute)
+    }
 
     this.getLegend('Bedspace attributes')
     this.getLegend('Accessibility (optional)')
-    searchParameters.attributes.forEach(attribute => {
-      this.checkCheckboxByNameAndValue('attributes[]', attribute)
-    })
+    if (typeof searchParameters.attributes[0] !== 'undefined') {
+      searchParameters.attributes.forEach(attribute => {
+        this.checkCheckboxByNameAndValue('attributes[]', attribute)
+      })
+    }
   }
 
   clickBedspaceLink(room: Room) {

--- a/cypress_shared/utils/bedspaceSearch.ts
+++ b/cypress_shared/utils/bedspaceSearch.ts
@@ -1,14 +1,23 @@
-import { BedSearchAttributes, Characteristic, TemporaryAccommodationPremises } from '../../server/@types/shared'
+import { Characteristic, Room, TemporaryAccommodationPremises } from '../../server/@types/shared'
+import { BedSearchFormParameters } from '../../server/@types/ui'
 
-export const characteristicsToSearchAttributes = (
-  premises: TemporaryAccommodationPremises,
-): Array<BedSearchAttributes> => {
-  const characteristicsToSearchAttributesMap: Record<string, BedSearchAttributes> = {
+export const characteristicsToSearchAttributes = (premises: TemporaryAccommodationPremises, room: Room) => {
+  const occupancyAttributesMap: Record<string, BedSearchFormParameters['occupancyAttribute']> = {
+    All: 'all',
     'Shared property': 'isSharedProperty',
     'Single occupancy': 'isSingleOccupancy',
   }
+  const wheelchairAccessibilityMap: Record<string, string> = {
+    'Wheelchair accessible': 'isWheelchairAccessible',
+  }
 
-  return premises.characteristics
-    .map((characteristic: Characteristic) => characteristicsToSearchAttributesMap[characteristic.name])
-    .filter(Boolean)
+  const premisesOccupancyAttribute = premises.characteristics
+    .map((characteristic: Characteristic) => occupancyAttributesMap[characteristic.name])
+    .find(attribute => attribute !== undefined)
+
+  const wheelchairAccessibility = room.characteristics
+    .map((characteristic: Characteristic) => wheelchairAccessibilityMap[characteristic.name])
+    .find(attribute => attribute !== undefined)
+
+  return { premisesOccupancyAttribute, wheelchairAccessibility }
 }

--- a/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
+++ b/e2e/tests/stepDefinitions/manage/bedspaceSearch.ts
@@ -1,4 +1,5 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
+import { BedSearchFormParameters } from '@approved-premises/ui'
 import Page from '../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import BedspaceSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceSearch'
@@ -22,7 +23,10 @@ Given('I search for a bedspace', () => {
 
     const searchParameters = bedSearchFormParametersFactory.build({
       probationDeliveryUnits: [this.premises.probationDeliveryUnit.id],
-      attributes: characteristicsToSearchAttributes(this.premises),
+      occupancyAttribute: characteristicsToSearchAttributes(this.premises, this.room).premisesOccupancyAttribute,
+      attributes: [
+        characteristicsToSearchAttributes(this.premises, this.room).wheelchairAccessibility,
+      ] as BedSearchFormParameters['attributes'],
     })
 
     page.completeForm(searchParameters)


### PR DESCRIPTION


# Context
Issue introduced  as part of  https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1153

Because we randomly select characteristics for premise and bedspace, iterating through them sometimes results in no searchable filters to return data for. Now we seperated out the wheelchair and occupancy characteristics, we now have to lookup the bedspace characteristic as well.