### PR TITLE
Rename Wiremock test docker container name

### DIFF
--- a/docker-compose-test.yml
+++ b/docker-compose-test.yml
@@ -13,7 +13,7 @@ services:
     image: wiremock/wiremock
     networks:
       - hmpps_int
-    container_name: wiremock_test
+    container_name: wiremock_test_cas3
     restart: always
     command: --local-response-templating
     ports:


### PR DESCRIPTION
CAS2 uses the same wiremock test container name and so it makes it difficult to switch from cas3 to cas2 without remembering tear to tear it down before there are name conflicts. This image is only used when running the integration test i.e `npm run test:integration` and should not impact anything else within the service.
