### PR TITLE
Cas 1386 UI bedspace search fail when entering the year as two digits

### DIFF
--- a/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bedspaceSearch.cy.ts
@@ -206,7 +206,7 @@ context('Bedspace Search', () => {
     Page.verifyOnPage(AssessmentSummaryPage, assessment, timeline)
   })
 
-  it('shows errors when the API returns an error', () => {
+  it('shows validation errors when required fields are missing or incorrect', () => {
     // Given I am signed in
     cy.signIn()
 

--- a/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
+++ b/server/controllers/temporary-accommodation/manage/bedspaceSearchController.ts
@@ -5,11 +5,16 @@ import { BedspaceAccessiblityAttributes, BedspaceOccupancyAttributes, ObjectWith
 import paths from '../../../paths/temporary-accommodation/manage'
 import { AssessmentsService } from '../../../services'
 import BedspaceSearchService from '../../../services/bedspaceSearchService'
-import { DateFormats } from '../../../utils/dateUtils'
+import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../utils/dateUtils'
 import { parseNumber } from '../../../utils/formUtils'
 import { addPlaceContext, preservePlaceContext, updatePlaceContextWithArrivalDate } from '../../../utils/placeUtils'
 import extractCallConfig from '../../../utils/restUtils'
-import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, setUserInput } from '../../../utils/validation'
+import {
+  catchValidationErrorOrPropogate,
+  fetchErrorsAndUserInput,
+  insertGenericError,
+  setUserInput,
+} from '../../../utils/validation'
 
 export const DEFAULT_DURATION_DAYS = 84
 
@@ -29,9 +34,7 @@ export default class BedspaceSearchController {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
       const placeContext = await preservePlaceContext(req, res, this.assessmentService)
-
       const callConfig = extractCallConfig(req)
-
       const { pdus: allPdus } = await this.searchService.getReferenceData(callConfig)
 
       const query =
@@ -47,6 +50,19 @@ export default class BedspaceSearchController {
 
       try {
         if (query) {
+          const validationError = this.validateSearchQuery(query)
+
+          if (validationError) {
+            setUserInput(req, 'get')
+            return catchValidationErrorOrPropogate(
+              req,
+              res,
+              validationError,
+              addPlaceContext(paths.bedspaces.search({}), placeContext),
+              'bedspaceSearch',
+            )
+          }
+
           startDate = DateFormats.dateAndTimeInputsToIsoString(
             query as ObjectWithDateParts<'startDate'>,
             'startDate',
@@ -81,7 +97,7 @@ export default class BedspaceSearchController {
           ? 'temporary-accommodation/bedspace-search/results'
           : 'temporary-accommodation/bedspace-search/index'
 
-        res.render(template, {
+        return res.render(template, {
           allPdus,
           results,
           startDate,
@@ -95,7 +111,7 @@ export default class BedspaceSearchController {
         })
       } catch (err) {
         setUserInput(req, 'get')
-        catchValidationErrorOrPropogate(
+        return catchValidationErrorOrPropogate(
           req,
           res,
           err,
@@ -104,5 +120,28 @@ export default class BedspaceSearchController {
         )
       }
     }
+  }
+
+  private validateSearchQuery(query: BedspaceSearchQuery): Error | null {
+    const error = new Error() as Error & {
+      data?: { 'invalid-params'?: Array<{ propertyName: string; errorType: string }> }
+    }
+    error.data = { 'invalid-params': [] }
+
+    if (dateIsBlank(query, 'startDate')) {
+      insertGenericError(error, 'startDate', 'empty')
+    } else if (!dateAndTimeInputsAreValidDates(query, 'startDate')) {
+      insertGenericError(error, 'startDate', 'invalid')
+    }
+
+    if (!query.probationDeliveryUnits || query.probationDeliveryUnits.length === 0) {
+      insertGenericError(error, 'probationDeliveryUnits', 'empty')
+    }
+
+    if (!query.durationDays || Number.isNaN(parseNumber(query.durationDays)) || parseNumber(query.durationDays) < 1) {
+      insertGenericError(error, 'durationDays', 'mustBeAtLeast1')
+    }
+
+    return error.data?.['invalid-params']?.length ? error : null
   }
 }

--- a/server/utils/bedspaceSearchUtils.test.ts
+++ b/server/utils/bedspaceSearchUtils.test.ts
@@ -1,0 +1,102 @@
+import { validateSearchQuery } from './bedspaceSearchUtils'
+import { ObjectWithDateParts } from '../@types/ui'
+import referenceData from '../testutils/factories/referenceData'
+
+type BedspaceSearchQuery = ObjectWithDateParts<'startDate'> & {
+  probationDeliveryUnits: Array<string>
+  durationDays: string
+}
+
+interface ValidationError extends Error {
+  data?: {
+    'invalid-params'?: Array<{ propertyName: string; errorType: string }>
+  }
+}
+
+describe('validateSearchQuery', () => {
+  let query: BedspaceSearchQuery
+
+  beforeEach(() => {
+    query = {
+      'startDate-day': '10',
+      'startDate-month': '05',
+      'startDate-year': '2024',
+      probationDeliveryUnits: [referenceData.pdu().build().id, referenceData.pdu().build().id],
+      durationDays: '10',
+    } as unknown as BedspaceSearchQuery
+  })
+
+  const expectValidationError = (
+    result: ValidationError | null,
+    expectedErrors: Array<{ propertyName: string; errorType: string }>,
+  ) => {
+    expect(result).not.toBeNull()
+    expect(result).toHaveProperty('data.invalid-params')
+    expect(result!.data?.['invalid-params']).toEqual(expect.arrayContaining(expectedErrors))
+  }
+
+  it('returns an error when startDate is empty', () => {
+    query['startDate-day'] = ''
+    query['startDate-month'] = ''
+    query['startDate-year'] = ''
+
+    const result = validateSearchQuery(query)
+
+    expectValidationError(result, [{ propertyName: '$.startDate', errorType: 'empty' }])
+  })
+
+  it('returns an error when startDate is invalid', () => {
+    query['startDate-day'] = '31'
+    query['startDate-month'] = '02'
+    query['startDate-year'] = '20'
+
+    const result = validateSearchQuery(query)
+
+    expectValidationError(result, [{ propertyName: '$.startDate', errorType: 'invalid' }])
+  })
+
+  it('returns an error when durationDays is empty', () => {
+    query.durationDays = ''
+
+    const result = validateSearchQuery(query)
+
+    expectValidationError(result, [{ propertyName: '$.durationDays', errorType: 'empty' }])
+  })
+
+  it('returns an error when durationDays is invalid (less than 1)', () => {
+    query.durationDays = '0'
+
+    const result = validateSearchQuery(query)
+
+    expectValidationError(result, [{ propertyName: '$.durationDays', errorType: 'mustBeAtLeast1' }])
+  })
+
+  it('returns an error when probationDeliveryUnits is missing', () => {
+    query.probationDeliveryUnits = []
+
+    const result = validateSearchQuery(query)
+
+    expectValidationError(result, [{ propertyName: '$.probationDeliveryUnits', errorType: 'empty' }])
+  })
+
+  it('returns multiple errors when multiple fields are invalid', () => {
+    query['startDate-day'] = ''
+    query['startDate-month'] = ''
+    query['startDate-year'] = ''
+    query.probationDeliveryUnits = []
+    query.durationDays = ''
+
+    const result = validateSearchQuery(query)
+
+    expectValidationError(result, [
+      { propertyName: '$.startDate', errorType: 'empty' },
+      { propertyName: '$.probationDeliveryUnits', errorType: 'empty' },
+      { propertyName: '$.durationDays', errorType: 'empty' },
+    ])
+  })
+
+  it('returns null when there are no validation errors', () => {
+    const result = validateSearchQuery(query)
+    expect(result).toBeNull()
+  })
+})

--- a/server/utils/bedspaceSearchUtils.ts
+++ b/server/utils/bedspaceSearchUtils.ts
@@ -1,0 +1,34 @@
+import { dateAndTimeInputsAreValidDates, dateIsBlank } from './dateUtils'
+import { ObjectWithDateParts } from '../@types/ui'
+import { insertGenericError } from './validation'
+import { parseNumber } from './formUtils'
+
+type BedspaceSearchQuery = ObjectWithDateParts<'startDate'> & {
+  probationDeliveryUnits: Array<string>
+  durationDays: string
+}
+
+export function validateSearchQuery(query: BedspaceSearchQuery): Error | null {
+  const error = new Error() as Error & {
+    data?: { 'invalid-params'?: Array<{ propertyName: string; errorType: string }> }
+  }
+  error.data = { 'invalid-params': [] }
+
+  if (dateIsBlank(query, 'startDate')) {
+    insertGenericError(error, 'startDate', 'empty')
+  } else if (!dateAndTimeInputsAreValidDates(query, 'startDate')) {
+    insertGenericError(error, 'startDate', 'invalid')
+  }
+
+  if (!query.probationDeliveryUnits?.length) {
+    insertGenericError(error, 'probationDeliveryUnits', 'empty')
+  }
+
+  if (!query.durationDays) {
+    insertGenericError(error, 'durationDays', 'empty')
+  } else if (Number.isNaN(parseNumber(query.durationDays)) || parseNumber(query.durationDays) < 1) {
+    insertGenericError(error, 'durationDays', 'mustBeAtLeast1')
+  }
+
+  return error.data?.['invalid-params']?.length ? error : null
+}


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-1386

# Changes in this PR

## Screenshots of UI changes

### Before

![Bedspace search fail when entering the year as two digits](https://github.com/user-attachments/assets/d330603b-2b50-4b70-82a5-fb09c0371225)

### After

<img width="1223" alt="Screenshot 2025-02-13 at 09 54 47" src="https://github.com/user-attachments/assets/80cb684a-b0cc-4cfe-8604-24e88098dfcb" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
