### PR TITLE
Feature/cas 1457 date validation on bedspace search

### DIFF
--- a/server/controllers/temporary-accommodation/manage/reportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.ts
@@ -54,8 +54,8 @@ export default class ReportsController {
         } else if (!datepickerInputsAreValidDates(startDate, 'startDate')) {
           error = error || new Error()
           insertGenericError(error, 'startDate', 'invalid')
-        } 
-        
+        }
+
         if (!endDate) {
           error = error || new Error()
           insertGenericError(error, 'endDate', 'empty')

--- a/server/controllers/temporary-accommodation/manage/reportsController.ts
+++ b/server/controllers/temporary-accommodation/manage/reportsController.ts
@@ -6,7 +6,7 @@ import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGeneric
 import ReportService from '../../../services/reportService'
 import extractCallConfig from '../../../utils/restUtils'
 import { filterProbationRegions, userHasReporterRole } from '../../../utils/userUtils'
-import { DateFormats, dateExists } from '../../../utils/dateUtils'
+import { DateFormats, datepickerInputsAreValidDates } from '../../../utils/dateUtils'
 import { allReportProbationRegions } from '../../../utils/reportUtils'
 
 export default class ReportsController {
@@ -42,8 +42,6 @@ export default class ReportsController {
         const callConfig = extractCallConfig(req)
 
         let error: Error
-        let startDateIso: string
-        let endDateIso: string
 
         if (!probationRegionId) {
           error = new Error()
@@ -53,30 +51,24 @@ export default class ReportsController {
         if (!startDate) {
           error = error || new Error()
           insertGenericError(error, 'startDate', 'empty')
-        } else {
-          startDateIso = DateFormats.datepickerInputToIsoString(startDate)
-
-          if (!dateExists(startDateIso)) {
-            error = error || new Error()
-            insertGenericError(error, 'startDate', 'invalid')
-          }
-        }
-
+        } else if (!datepickerInputsAreValidDates(startDate, 'startDate')) {
+          error = error || new Error()
+          insertGenericError(error, 'startDate', 'invalid')
+        } 
+        
         if (!endDate) {
           error = error || new Error()
           insertGenericError(error, 'endDate', 'empty')
-        } else {
-          endDateIso = DateFormats.datepickerInputToIsoString(endDate)
-
-          if (!dateExists(endDateIso)) {
-            error = error || new Error()
-            insertGenericError(error, 'endDate', 'invalid')
-          }
+        } else if (!datepickerInputsAreValidDates(endDate, 'endDate')) {
+          error = error || new Error()
+          insertGenericError(error, 'endDate', 'invalid')
         }
 
         if (error) {
           return catchValidationErrorOrPropogate(req, res, error, paths.reports.index({}))
         }
+        const startDateIso = DateFormats.datepickerInputToIsoString(startDate)
+        const endDateIso = DateFormats.datepickerInputToIsoString(endDate)
 
         await this.reportService.pipeReportForProbationRegion(
           callConfig,

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -3,12 +3,12 @@ import {
   DateFormats,
   InvalidDateStringError,
   dateAndTimeInputsAreValidDates,
-  datepickerInputsAreValidDates,
   dateExists,
   dateInputHint,
   dateIsBlank,
   dateIsInFuture,
   dateIsInThePast,
+  datepickerInputsAreValidDates,
 } from './dateUtils'
 
 describe('DateFormats', () => {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -282,16 +282,17 @@ describe('dateAndTimeInputsAreValidDates', () => {
     expect(result).toEqual(true)
   })
 
-  it('returns false when the date is invalid', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '99',
-      'date-month': '99',
-      'date-day': '99',
-    }
-
-    const result = dateAndTimeInputsAreValidDates(obj, 'date')
-
-    expect(result).toEqual(false)
+  describe.each([
+    [{ 'date-year': '2022', 'date-month': '13', 'date-day': '11' }, 'invalid month'],
+    [{ 'date-year': '2022', 'date-month': '111', 'date-day': '11' }, 'invalid month over 2 digits'],
+    [{ 'date-year': '2022', 'date-month': '12', 'date-day': '32' }, 'invalid day'],
+    [{ 'date-year': '2022', 'date-month': '12', 'date-day': '111' }, 'invalid day over 2 digits'],
+    [{ 'date-year': '99', 'date-month': '99', 'date-day': '99' }, 'invalid date'],
+  ])('returns false when the date has %s', (obj, description) => {
+    it(`returns false for ${description}`, () => {
+      const result = dateAndTimeInputsAreValidDates(obj, 'date')
+      expect(result).toEqual(false)
+    })
   })
 
   it('returns false when the year is not 4 digits', () => {

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -3,6 +3,7 @@ import {
   DateFormats,
   InvalidDateStringError,
   dateAndTimeInputsAreValidDates,
+  datepickerInputsAreValidDates,
   dateExists,
   dateInputHint,
   dateIsBlank,
@@ -239,6 +240,18 @@ describe('DateFormats', () => {
       expect(DateFormats.isoDateToDaysFromNow('2024-04-09')).toEqual('in 1 day')
     })
   })
+
+  describe('datepickerInputToDateAndTimeInputs', () => {
+    it('converts a date string to ObjectWithDateParts', () => {
+      const dateString = '13/03/2025'
+      const result = DateFormats.datepickerInputToDateAndTimeInputs(dateString, 'startDate')
+      expect(result).toEqual({
+        'startDate-day': '13',
+        'startDate-month': '03',
+        'startDate-year': '2025',
+      })
+    })
+  })
 })
 
 describe('isoToDateAndTimeInputs', () => {
@@ -282,52 +295,46 @@ describe('dateAndTimeInputsAreValidDates', () => {
     expect(result).toEqual(true)
   })
 
+  it('returns true for a valid leap year date', () => {
+    const obj: ObjectWithDateParts<'date'> = {
+      'date-year': '2024',
+      'date-month': '02',
+      'date-day': '29',
+    }
+
+    const result = dateAndTimeInputsAreValidDates(obj, 'date')
+
+    expect(result).toEqual(true)
+  })
+
   describe.each([
     [{ 'date-year': '2022', 'date-month': '13', 'date-day': '11' }, 'invalid month'],
     [{ 'date-year': '2022', 'date-month': '111', 'date-day': '11' }, 'invalid month over 2 digits'],
     [{ 'date-year': '2022', 'date-month': '12', 'date-day': '32' }, 'invalid day'],
     [{ 'date-year': '2022', 'date-month': '12', 'date-day': '111' }, 'invalid day over 2 digits'],
     [{ 'date-year': '99', 'date-month': '99', 'date-day': '99' }, 'invalid date'],
+    [{ 'date-year': '202', 'date-month': '01', 'date-day': '01' }, 'year not 4 digits'],
+    [{ 'date-year': '2024', 'date-month': '11', 'date-day': '31' }, 'well formatted but non-existent date'],
+    [{ 'date-year': 'not', 'date-month': 'a', 'date-day': 'date' }, 'gibberish date'],
+    [{ 'date-year': '2021', 'date-month': '02', 'date-day': '29' }, 'invalid leap year date'],
   ])('returns false when the date has %s', (obj, description) => {
     it(`returns false for ${description}`, () => {
       const result = dateAndTimeInputsAreValidDates(obj, 'date')
       expect(result).toEqual(false)
     })
   })
+})
 
-  it('returns false when the year is not 4 digits', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '202',
-      'date-month': '01',
-      'date-day': '01',
-    }
-
-    const result = dateAndTimeInputsAreValidDates(obj, 'date')
-
-    expect(result).toEqual(false)
+describe('datepickerInputsAreValidDates', () => {
+  it('returns true for a valid date string', () => {
+    const dateString = '13/03/2025'
+    const result = datepickerInputsAreValidDates(dateString, 'startDate')
+    expect(result).toEqual(true)
   })
 
-  it('returns false when the date is well formatted but does not exist', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': '2024',
-      'date-month': '11',
-      'date-day': '31',
-    }
-
-    const result = dateAndTimeInputsAreValidDates(obj, 'date')
-
-    expect(result).toEqual(false)
-  })
-
-  it('returns false when the date is gibberish', () => {
-    const obj: ObjectWithDateParts<'date'> = {
-      'date-year': 'not',
-      'date-month': 'a',
-      'date-day': 'date',
-    }
-
-    const result = dateAndTimeInputsAreValidDates(obj, 'date')
-
+  it('returns false for an invalid date string', () => {
+    const dateString = '31/02/2025'
+    const result = datepickerInputsAreValidDates(dateString, 'startDate')
     expect(result).toEqual(false)
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -160,8 +160,12 @@ export const dateAndTimeInputsAreValidDates = <K extends string>(
   key: K,
 ): boolean => {
   const inputYear = dateInputObj?.[`${key}-year`] as string
+  const inputMonth = dateInputObj?.[`${key}-month`] as string
+  const inputDay = dateInputObj?.[`${key}-day`] as string
 
   if (inputYear && inputYear.length !== 4) return false
+  if (inputMonth && (Number(inputMonth) < 1 || Number(inputMonth) > 12)) return false
+  if (inputDay && (Number(inputDay) < 1 || Number(inputDay) > 31)) return false
 
   try {
     const dateString = DateFormats.dateAndTimeInputsToIsoString(dateInputObj, key)

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -136,6 +136,15 @@ export class DateFormats {
     return `${year}-${`0${month}`.slice(-2)}-${`0${day}`.slice(-2)}`
   }
 
+  static datepickerInputToDateAndTimeInputs<K extends string>(dateString: string, key: K): ObjectWithDateParts<K> {
+    const [day, month, year] = dateString.split('/')
+    return {
+      [`${key}-day`]: `${day}`,
+      [`${key}-month`]: `${month}`,
+      [`${key}-year`]: `${year}`,
+    } as ObjectWithDateParts<K>
+  }
+
   static isoDateToDatepickerInput(dateString: string) {
     return dateString.split('-').reverse().join('/')
   }
@@ -173,6 +182,14 @@ export const dateAndTimeInputsAreValidDates = <K extends string>(
   } catch (e) {
     return false
   }
+}
+
+export const datepickerInputsAreValidDates = <K extends string>(
+  dateString: string,
+  key: K,
+): boolean => {
+  const dateObj = DateFormats.datepickerInputToDateAndTimeInputs(dateString, key)
+  return dateAndTimeInputsAreValidDates(dateObj, key)
 }
 
 export const dateExists = (dateString: string) => {


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/1489?selectedIssue=CAS-1457) was to add further date validation to the bedspace search

# Changes in this PR

## Screenshots of UI changes

### Before

_Invalid day_
<img width="262" alt="image" src="https://github.com/user-attachments/assets/f3a80e43-4b5c-4d0b-8df8-c4f14218758c" />

_Invalid month_
<img width="259" alt="image" src="https://github.com/user-attachments/assets/321d1218-9fb0-447c-8313-da2dfc902789" />


### After

_Invalid day_
<img width="309" alt="image" src="https://github.com/user-attachments/assets/77d95b64-7a9a-4f7c-9143-23dbd36500cd" />

_Invalid month_
<img width="288" alt="image" src="https://github.com/user-attachments/assets/d91b0d1f-b293-44ab-8f5b-d76cd4e5d79d" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
