### PR TITLE
Specify node version file

### DIFF
--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -9,4 +9,5 @@ jobs:
     uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@v2 # WORKFLOW_VERSION
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
+      node_version_file: ".node-version"
     secrets: inherit


### PR DESCRIPTION
This ensures the NPM dependency security check uses a node version file that exists, rather than relying on the default `.nvmrc` which isn't present in this repository.
