### PR TITLE
Update Slack notification action

### DIFF
--- a/.github/actions/slack_failure_notification/action.yml
+++ b/.github/actions/slack_failure_notification/action.yml
@@ -3,10 +3,13 @@ description: 'Sends a Slack message to notify of a Github Action failure'
 
 inputs:
   title:
-    description: "Name of the job that failed"
+    description: "Name of the job that failed."
     required: true
+  job:
+    description: "Text for the job that failed. Optional. Defaults to the id of the job calling this action."
+    required: false
   channel_id:
-    description: "Slack channel id to send the notification to"
+    description: "Slack channel id to send the notification to."
     required: true
   slack_bot_token:
     description: "Slack bot token"
@@ -19,7 +22,8 @@ runs:
       with:
         channel-id: ${{ inputs.channel_id }}
         payload: |
-          { 
+          {
+            "text": "Failed: ${{ inputs.title }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})",
             "blocks": [
               {
                 "type": "header",
@@ -38,19 +42,21 @@ runs:
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*Job:*\n${{ github.job }}"
+                    "text": "*Job:*\n${{ inputs.job || github.job }}"
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*Project:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.event.repository_name }}>"
+                    "text": "*Repository:*\n<${{ github.server_url }}/${{ github.repository }}|${{ github.repository }}>"
                   },
                   {
                     "type": "mrkdwn",
-                    "text": "*Triggered by:*\n${{ github.actor }}"
+                    "text": "*Workflow triggered by:*\n${{ github.actor }}"
                   }
                 ]
               }
-            ]
+            ],
+            "unfurl_links": false,
+            "unfurl_media": false
           }
       env:
         SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}


### PR DESCRIPTION
- Add optional `job` input to be used when the failing job is different than the one calling the action (useful for matrix job)
- Add the `text` property to payload (used for notifications)
- Prevent link unfurling in resulting message

An example message resulting from the action can be viewed here: https://mojdt.slack.com/archives/C08NHM3MA9K/p1744885251693359