### PR TITLE
Fix for flaky e2e

### DIFF
--- a/e2e_playwright/pages/manage/addPropertyPage.ts
+++ b/e2e_playwright/pages/manage/addPropertyPage.ts
@@ -22,7 +22,7 @@ export class AddPropertyPage extends BasePage {
       'Select a probation region',
     )
     property.pdu = await this.selectOptionAtRandom('What is the PDU?', 'Select a PDU')
-    property.propertyAttributesValues = await this.check3CharacteristicsAtRandom()
+    property.propertyAttributesValues = [await this.checkCheckboxAtRandom()]
     property.status = await this.clickRandomStatusRadioButton()
 
     await this.page.getByLabel('Please provide any further property details').fill(property.notes)
@@ -31,10 +31,6 @@ export class AddPropertyPage extends BasePage {
         'Enter the number of working days required to turnaround the property. The standard turnaround time should be 2 days',
       )
       .fill(String(property.turnaroundWorkingDayCount))
-  }
-
-  private async check3CharacteristicsAtRandom(): Promise<Array<string>> {
-    return [await this.checkCheckboxAtRandom(), await this.checkCheckboxAtRandom(), await this.checkCheckboxAtRandom()]
   }
 
   private async clickRandomStatusRadioButton(): Promise<string> {


### PR DESCRIPTION
**Context**
* We were getting some strange behaviour in the `Add and Edit property` playwright e2e test
* This happens when it clicks 3 characteristics when adding the property and we save the ids of the charcteristics nd assert on them in the edit screen
* The problem occurs when instead of clicking unique checkboxes, there is cross over so we check and then uncheck the same one
* Temporary work around is to only check one checkbox so there is no cross-over (will come back to this soon!)