### PR TITLE
Feature/cas 1345 sort premises by pdu

### DIFF
--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -119,18 +119,18 @@ describe('PremisesService', () => {
   })
 
   describe('tableRows', () => {
-    const premisesSummary1 = cas3PremisesSummaryFactory.build({ addressLine1: 'ABC', postcode: '123' })
-    const premisesSummary2 = cas3PremisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '123' })
-    const premisesSummary3 = cas3PremisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '456' })
-    const premisesSummary4 = cas3PremisesSummaryFactory.build({ addressLine1: 'XYZ', postcode: '123' })
+    const premisesSummary1 = cas3PremisesSummaryFactory.build({ addressLine1: 'ABC', postcode: '123', pdu: 'Hampshire South and Isle of Wight' })
+    const premisesSummary2 = cas3PremisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '123', pdu: 'Hampshire South and Isle of Wight' })
+    const premisesSummary3 = cas3PremisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '456', pdu: 'Bedfordshire' })
+    const premisesSummary4 = cas3PremisesSummaryFactory.build({ addressLine1: 'XYZ', postcode: '123', pdu: 'Bedfordshire' })
 
     it.each([
       [
         [premisesSummary4, premisesSummary1, premisesSummary3, premisesSummary2],
         undefined,
-        [premisesSummary1, premisesSummary2, premisesSummary3, premisesSummary4],
+        [premisesSummary3, premisesSummary4, premisesSummary1, premisesSummary2],
       ],
-      [[premisesSummary3, premisesSummary2], 'GHI', [premisesSummary2, premisesSummary3]],
+      [[premisesSummary2, premisesSummary3], 'GHI', [premisesSummary3, premisesSummary2]],
       [[], 'ABC', []],
     ])(
       'returns a sorted table view of the premises for Temporary Accommodation with an option search for an address',

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -119,10 +119,26 @@ describe('PremisesService', () => {
   })
 
   describe('tableRows', () => {
-    const premisesSummary1 = cas3PremisesSummaryFactory.build({ addressLine1: 'ABC', postcode: '123', pdu: 'Hampshire South and Isle of Wight' })
-    const premisesSummary2 = cas3PremisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '123', pdu: 'Hampshire South and Isle of Wight' })
-    const premisesSummary3 = cas3PremisesSummaryFactory.build({ addressLine1: 'GHI', postcode: '456', pdu: 'Bedfordshire' })
-    const premisesSummary4 = cas3PremisesSummaryFactory.build({ addressLine1: 'XYZ', postcode: '123', pdu: 'Bedfordshire' })
+    const premisesSummary1 = cas3PremisesSummaryFactory.build({
+      addressLine1: 'ABC',
+      postcode: '123',
+      pdu: 'Hampshire South and Isle of Wight',
+    })
+    const premisesSummary2 = cas3PremisesSummaryFactory.build({
+      addressLine1: 'GHI',
+      postcode: '123',
+      pdu: 'Hampshire South and Isle of Wight',
+    })
+    const premisesSummary3 = cas3PremisesSummaryFactory.build({
+      addressLine1: 'GHI',
+      postcode: '456',
+      pdu: 'Bedfordshire',
+    })
+    const premisesSummary4 = cas3PremisesSummaryFactory.build({
+      addressLine1: 'XYZ',
+      postcode: '123',
+      pdu: 'Bedfordshire',
+    })
 
     it.each([
       [

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -75,7 +75,13 @@ export default class PremisesService {
 
     return premises
       .map(entry => ({ ...entry, shortAddress: `${entry.addressLine1}, ${entry.postcode}` }))
-      .sort((a, b) => a.shortAddress.localeCompare(b.shortAddress))
+      .sort((a, b) => {
+        const pduSort = a.pdu.localeCompare(b.pdu)
+        if (pduSort !== 0) {
+          return pduSort
+        }
+        return a.shortAddress.localeCompare(b.shortAddress)
+      })
       .map(entry => {
         return [
           this.textValue(entry.shortAddress),


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1345) changes the default sort order of premises to sort by pdu then address.

# Changes in this PR

## Screenshots of UI changes

### Before
With JS disabled
<img width="1120" alt="image" src="https://github.com/user-attachments/assets/96af46d9-4288-4678-8d61-ad51c725b1e7" />


### After
With JS disabled
<img width="1192" alt="image" src="https://github.com/user-attachments/assets/05fc282c-8119-4128-9836-4f250e5a4904" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
