### PR TITLE
Add departure date validation error message

### DIFF
--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -68,6 +68,7 @@ Given('I edit the departed booking', () => {
       ...departure,
       reasonId: departure.reason.id,
       moveOnCategoryId: departure.moveOnCategory.id,
+      dateTime: DateFormats.dateObjToIsoDate(faker.date.between({ from: this.booking.arrivalDate, to: Date.now() })),
     })
 
     const bookingDeparturePage = Page.verifyOnPage(BookingDepartureEditPage, this.premises, this.room, this.booking)

--- a/integration_tests/mockApis/departure.ts
+++ b/integration_tests/mockApis/departure.ts
@@ -23,7 +23,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`,
+        url: `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/departures`,
       },
       response: {
         status: 201,
@@ -32,14 +32,14 @@ export default {
       },
     }),
   stubDepartureCreateErrors: (args: { premisesId: string; bookingId: string; params: Array<string> }) =>
-    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`, 'POST')),
+    stubFor(errorStub(args.params, `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/departures`, 'POST')),
   stubDepartureReferenceData: (): Promise<[Response, Response]> =>
     Promise.all([stubFor(departureReasons), stubFor(moveOnCategories)]),
   verifyDepartureCreate: async (args: { premisesId: string; bookingId: string }) =>
     (
       await getMatchingRequests({
         method: 'POST',
-        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/departures`,
+        url: `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/departures`,
       })
     ).body.requests,
 }

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -1,5 +1,5 @@
 import type { Request, RequestHandler, Response } from 'express'
-import type { NewDeparture } from '@approved-premises/api'
+import type { Cas3NewDeparture } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { BedspaceService, BookingService, DepartureService, PremisesService } from '../../../services'
 import { DateFormats } from '../../../utils/dateUtils'
@@ -48,7 +48,7 @@ export default class DeparturesController {
       const { premisesId, roomId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
-      const newDeparture: NewDeparture = {
+      const newDeparture: Cas3NewDeparture = {
         ...req.body,
         ...DateFormats.dateAndTimeInputsToIsoString({ ...req.body }, 'dateTime', { representation: 'complete' }),
       }
@@ -111,7 +111,7 @@ export default class DeparturesController {
       const { premisesId, roomId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
-      const newDeparture: NewDeparture = {
+      const newDeparture: Cas3NewDeparture = {
         ...req.body,
         ...DateFormats.dateAndTimeInputsToIsoString({ ...req.body }, 'dateTime', { representation: 'complete' }),
       }

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -9,13 +9,13 @@ import {
   bookingFactory,
   bookingSearchResultFactory,
   cancellationFactory,
+  cas3NewDepartureFactory,
   confirmationFactory,
   departureFactory,
   newArrivalFactory,
   newBookingFactory,
   newCancellationFactory,
   newConfirmationFactory,
-  newDepartureFactory,
   newTurnaroundFactory,
   turnaroundFactory,
 } from '../testutils/factories'
@@ -199,10 +199,10 @@ describe('BookingClient', () => {
 
   describe('markDeparture', () => {
     it('should create a departure', async () => {
-      const departure = newDepartureFactory.build()
+      const departure = cas3NewDepartureFactory.build()
 
       fakeApprovedPremisesApi
-        .post(`/premises/premisesId/bookings/bookingId/departures`, departure)
+        .post(`/cas3/premises/premisesId/bookings/bookingId/departures`, departure)
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, departure)
 

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -2,6 +2,8 @@ import type {
   Arrival,
   Booking,
   Cancellation,
+  Cas3Departure,
+  Cas3NewDeparture,
   Confirmation,
   Departure,
   Extension,
@@ -9,7 +11,6 @@ import type {
   NewBooking,
   NewCancellation,
   NewConfirmation,
-  NewDeparture,
   NewExtension,
   NewTurnaround,
   Turnaround,
@@ -83,9 +84,9 @@ export default class BookingClient {
     })
   }
 
-  async markDeparture(premisesId: string, bookingId: string, departure: NewDeparture) {
-    return this.restClient.post<Departure>({
-      path: `${this.bookingPath(premisesId, bookingId)}/departures`,
+  async markDeparture(premisesId: string, bookingId: string, departure: Cas3NewDeparture) {
+    return this.restClient.post<Cas3Departure>({
+      path: this.departuresPath(premisesId, bookingId),
       data: departure,
     })
   }
@@ -136,5 +137,9 @@ export default class BookingClient {
 
   private bookingPath(premisesId: string, bookingId: string): string {
     return [this.bookingsPath(premisesId), bookingId].join('/')
+  }
+
+  private departuresPath(premisesId: string, bookingId: string): string {
+    return `/cas3/premises/${premisesId}/bookings/${bookingId}/departures`
   }
 }

--- a/server/services/departureService.ts
+++ b/server/services/departureService.ts
@@ -1,5 +1,5 @@
 import type { ReferenceData } from '@approved-premises/ui'
-import type { Departure, NewDeparture } from '@approved-premises/api'
+import type { Cas3Departure, Cas3NewDeparture, Departure } from '@approved-premises/api'
 import type { BookingClient, ReferenceDataClient, RestClientBuilder } from '../data'
 import { DateFormats } from '../utils/dateUtils'
 import { CallConfig } from '../data/restClient'
@@ -19,13 +19,11 @@ export default class DepartureService {
     callConfig: CallConfig,
     premisesId: string,
     bookingId: string,
-    departure: NewDeparture,
-  ): Promise<Departure> {
+    departure: Cas3NewDeparture,
+  ): Promise<Cas3Departure> {
     const bookingClient = this.bookingClientFactory(callConfig)
 
-    const confirmedDeparture = await bookingClient.markDeparture(premisesId, bookingId, departure)
-
-    return confirmedDeparture
+    return bookingClient.markDeparture(premisesId, bookingId, departure)
   }
 
   async getDeparture(

--- a/server/testutils/factories/cas3NewDeparture.ts
+++ b/server/testutils/factories/cas3NewDeparture.ts
@@ -1,0 +1,18 @@
+import { Factory } from 'fishery'
+import { fakerEN_GB as faker } from '@faker-js/faker'
+
+import type { Cas3NewDeparture } from '@approved-premises/api'
+import referenceDataFactory from './referenceData'
+import premisesFactory from './premises'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<Cas3NewDeparture>(() => {
+  const date = faker.date.soon()
+  return {
+    dateTime: DateFormats.dateObjToIsoDateTime(date),
+    reasonId: referenceDataFactory.departureReasons().build().id,
+    notes: faker.lorem.sentence(),
+    moveOnCategoryId: referenceDataFactory.moveOnCategories().build().id,
+    destinationAp: premisesFactory.build().id,
+  }
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -37,6 +37,7 @@ import newArrivalFactory from './newArrival'
 import newBookingFactory from './newBooking'
 import newCancellationFactory from './newCancellation'
 import newConfirmationFactory from './newConfirmation'
+import cas3NewDepartureFactory from './cas3NewDeparture'
 import newDepartureFactory from './newDeparture'
 import newExtensionFactory from './newExtension'
 import newLostBedFactory from './newLostBed'
@@ -113,6 +114,7 @@ export {
   newCancellationFactory,
   newConfirmationFactory,
   newDepartureFactory,
+  cas3NewDepartureFactory,
   newExtensionFactory,
   newLostBedCancellationFactory,
   newLostBedFactory,


### PR DESCRIPTION
Added error message for validation of booking departure dates where the date is in the future

# Context

[Ticket here](https://dsdmoj.atlassian.net/browse/CAS-565) to add the new error message when the entered departure date is in the future.

The BE changes are behind the feature flag `cas3-validate-booking-departure-in-future`

# Changes in this PR

## Screenshots of UI changes

### After

![Screenshot 2025-05-08 at 15-35-26 Update departure details - Transitional Accommodation (CAS3)](https://github.com/user-attachments/assets/16d3695b-88eb-4747-9644-f3365d3a0a26)
(Screenshot taken on 8th May 2025)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
