### PR TITLE
Fixed manage properties e2e test, generating properties for each test

### DIFF
--- a/e2e_playwright/test.ts
+++ b/e2e_playwright/test.ts
@@ -1,4 +1,3 @@
-import { fakerEN_GB as faker } from '@faker-js/faker'
 import { test as base } from '@playwright/test'
 import { TestOptions } from '@temporary-accommodation-ui/e2e'
 
@@ -22,18 +21,4 @@ export const test = base.extend<TestOptions>({
     },
     { option: true },
   ],
-  property: {
-    name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
-    addressLine1: faker.location.streetAddress(),
-    addressLine2: faker.location.secondaryAddress(),
-    town: faker.location.city(),
-    postcode: faker.location.zipCode(),
-    notes: faker.lorem.lines(5),
-    turnaroundWorkingDayCount: faker.number.int({ min: 1, max: 5 }),
-    localAuthority: undefined,
-    probationRegion: undefined,
-    pdu: undefined,
-    propertyAttributesValues: [],
-    status: undefined,
-  },
 })

--- a/e2e_playwright/tests/manage/manage-properties.spec.ts
+++ b/e2e_playwright/tests/manage/manage-properties.spec.ts
@@ -1,3 +1,5 @@
+import { Property } from '@temporary-accommodation-ui/e2e'
+import { fakerEN_GB as faker } from '@faker-js/faker'
 import { test } from '../../test'
 import { signIn } from '../../steps/signIn'
 import {
@@ -11,7 +13,9 @@ import {
   visitManagePropertiesPage,
 } from '../../steps/manage'
 
-test('Create and edit property', async ({ page, assessor, property }) => {
+test('Create and edit property', async ({ page, assessor }) => {
+  const property = getProperty()
+
   await signIn(page, assessor)
   await visitManagePropertiesPage(page)
   await createProperty(page, property)
@@ -19,7 +23,9 @@ test('Create and edit property', async ({ page, assessor, property }) => {
   await editPropertyAndCheckSavedSuccessfully(page, property)
 })
 
-test('Create, check listed and view property', async ({ page, assessor, property }) => {
+test('Create, check listed and view property', async ({ page, assessor }) => {
+  const property = getProperty()
+
   await signIn(page, assessor)
   await visitManagePropertiesPage(page)
   await createProperty(page, property)
@@ -28,7 +34,9 @@ test('Create, check listed and view property', async ({ page, assessor, property
   await checkViewPropertyPageHasExpectedPropertyDetails(page, property)
 })
 
-test('Check created property appears in postcode/address search', async ({ page, assessor, property }) => {
+test('Check created property appears in postcode/address search', async ({ page, assessor }) => {
+  const property = getProperty()
+
   await signIn(page, assessor)
   await visitManagePropertiesPage(page)
   await createProperty(page, property)
@@ -36,3 +44,20 @@ test('Check created property appears in postcode/address search', async ({ page,
   await searchPropertiesByPostcodeOrAddress(page, property.postcode)
   await checkAllEntriesMatchPostcodeOrAddress(page, property.postcode)
 })
+
+function getProperty(): Property {
+  return {
+    name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+    addressLine1: faker.location.streetAddress(),
+    addressLine2: faker.location.secondaryAddress(),
+    town: faker.location.city(),
+    postcode: faker.location.zipCode(),
+    notes: faker.lorem.lines(5),
+    turnaroundWorkingDayCount: faker.number.int({ min: 1, max: 5 }),
+    localAuthority: undefined,
+    probationRegion: undefined,
+    pdu: undefined,
+    propertyAttributesValues: [],
+    status: undefined,
+  }
+}

--- a/e2e_playwright/types/index.d.ts
+++ b/e2e_playwright/types/index.d.ts
@@ -31,6 +31,5 @@ declare module '@temporary-accommodation-ui/e2e' {
   export type TestOptions = {
     assessor: UserFullDetails
     referrer: UserLoginDetails
-    property: Property
   }
 }


### PR DESCRIPTION
# Context

[Ticket here](https://dsdmoj.atlassian.net/browse/CAS-1635)

The issue was that the playwright tests seemed to be using the same faker-generated `Property` instance for all tests running on a thread. This caused the call to `createProperty` to fail as the names of the properties need to be unique.

I've moved the `Property` generation to the `manage-properties` test file so each test generates its own `Property` rather than using the shared instance.

# Changes in this PR

## Screenshots of UI changes

### Before

![Screenshot 2025-05-13 at 10 46 42](https://github.com/user-attachments/assets/6a7579b0-44c3-44dd-bbe0-63da7c96e3bb)

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
