### PR TITLE
Feature/cas 1521 date validation corrections

### DIFF
--- a/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
@@ -434,7 +434,7 @@ describe('ArrivalsController', () => {
         const currentDate = new Date()
         const pastDate = addDays(currentDate, -8)
 
-        const arrival = arrivalFactory.build({arrivalDate: DateFormats.dateObjToIsoDate(pastDate),})
+        const arrival = arrivalFactory.build({ arrivalDate: DateFormats.dateObjToIsoDate(pastDate) })
         const newArrival = newArrivalFactory.build({
           ...arrival,
         })

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -4,7 +4,7 @@ import type { NewCas3Arrival as NewArrival } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { ArrivalService, BedspaceService, BookingService, PremisesService } from '../../../services'
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
-import { DateFormats, dateIsInFuture } from '../../../utils/dateUtils'
+import { DateFormats, dateIsInFuture, dateIsWithinLastSevenDays } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import {
   catchValidationErrorOrPropogate,
@@ -67,10 +67,7 @@ export default class ArrivalsController {
         }
 
         if (newArrival.arrivalDate) {
-          const sevenDays = new Date()
-          sevenDays.setDate(sevenDays.getDate() - 7)
-
-          if (newArrival.arrivalDate < DateFormats.dateObjToIsoDate(sevenDays)) {
+          if (!dateIsWithinLastSevenDays(newArrival.arrivalDate)) {
             const error = new Error()
             insertGenericError(error, 'arrivalDate', 'withinLastSevenDays')
             throw error
@@ -147,17 +144,14 @@ export default class ArrivalsController {
           type: 'CAS3',
         }
 
-        if (updateArrival.arrivalDate && dateIsInFuture(updateArrival.arrivalDate)) {
-          const error = new Error()
-          insertGenericError(error, 'arrivalDate', 'todayOrInThePast')
-          throw error
-        }
-
         if (updateArrival.arrivalDate) {
-          const sevenDays = new Date()
-          sevenDays.setDate(sevenDays.getDate() - 7)
+          if (dateIsInFuture(updateArrival.arrivalDate)) {
+            const error = new Error()
+            insertGenericError(error, 'arrivalDate', 'todayOrInThePast')
+            throw error
+          }
 
-          if (updateArrival.arrivalDate < DateFormats.dateObjToIsoDate(sevenDays)) {
+          if (!dateIsWithinLastSevenDays(updateArrival.arrivalDate)) {
             const error = new Error()
             insertGenericError(error, 'arrivalDate', 'withinLastSevenDays')
             throw error

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -153,6 +153,17 @@ export default class ArrivalsController {
           throw error
         }
 
+        if (updateArrival.arrivalDate) {
+          const sevenDays = new Date()
+          sevenDays.setDate(sevenDays.getDate() - 7)
+
+          if (updateArrival.arrivalDate < DateFormats.dateObjToIsoDate(sevenDays)) {
+            const error = new Error()
+            insertGenericError(error, 'arrivalDate', 'withinLastSevenDays')
+            throw error
+          }
+        }
+
         // INFO: this may confuse, the API is overloading the POST with a writeback of existing and new data
         await this.arrivalService.createArrival(callConfig, premisesId, bookingId, updateArrival)
         req.flash('success', 'Arrival updated')

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.test.ts
@@ -3,7 +3,7 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
-  dateIsWithinThreeMonths,
+  dateIsWithinNextThreeMonths,
 } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import AccommodationRequiredFromDate from './accommodationRequiredFromDate'
@@ -16,7 +16,7 @@ jest.mock('../../../../utils/dateUtils', () => {
     dateIsBlank: jest.fn(),
     dateAndTimeInputsAreValidDates: jest.fn(),
     dateIsInThePast: jest.fn(),
-    dateIsWithinThreeMonths: jest.fn(),
+    dateIsWithinNextThreeMonths: jest.fn(),
   }
 })
 
@@ -48,7 +48,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({})
@@ -58,7 +58,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(true)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({
@@ -70,7 +70,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(false)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({
@@ -82,7 +82,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(true)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({
@@ -94,7 +94,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(false)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.test.ts
@@ -1,5 +1,10 @@
 import { applicationFactory } from '../../../../testutils/factories'
-import { dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
+import {
+  dateAndTimeInputsAreValidDates,
+  dateIsBlank,
+  dateIsInThePast,
+  dateIsWithinThreeMonths,
+} from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import AccommodationRequiredFromDate from './accommodationRequiredFromDate'
 
@@ -11,6 +16,7 @@ jest.mock('../../../../utils/dateUtils', () => {
     dateIsBlank: jest.fn(),
     dateAndTimeInputsAreValidDates: jest.fn(),
     dateIsInThePast: jest.fn(),
+    dateIsWithinThreeMonths: jest.fn(),
   }
 })
 
@@ -42,6 +48,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({})
@@ -51,6 +58,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(true)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({
@@ -62,6 +70,7 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(false)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({
@@ -73,10 +82,23 @@ describe('AccommodationRequiredFromDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new AccommodationRequiredFromDate(body, application)
       expect(page.errors()).toEqual({
         accommodationRequiredFromDate: 'The date accommodation is required from must not be in the past',
+      })
+    })
+
+    it('should return an error if the date is not within the next 3 months', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+      ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(false)
+
+      const page = new AccommodationRequiredFromDate(body, application)
+      expect(page.errors()).toEqual({
+        accommodationRequiredFromDate: 'Date accommodation is required from must be within 3 months',
       })
     })
   })

--- a/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/accommodationRequiredFromDate.ts
@@ -5,7 +5,7 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
-  dateIsWithinThreeMonths,
+  dateIsWithinNextThreeMonths,
 } from '../../../../utils/dateUtils'
 import TasklistPage from '../../../tasklistPage'
 import { dateBodyProperties } from '../../../utils'
@@ -61,7 +61,7 @@ export default class AccommodationRequiredFromDate implements TasklistPage {
       errors.accommodationRequiredFromDate = 'You must specify a valid date accommodation is required from'
     } else if (dateIsInThePast(this.body.accommodationRequiredFromDate)) {
       errors.accommodationRequiredFromDate = 'The date accommodation is required from must not be in the past'
-    } else if (!dateIsWithinThreeMonths(this.body.accommodationRequiredFromDate)) {
+    } else if (!dateIsWithinNextThreeMonths(this.body.accommodationRequiredFromDate)) {
       errors.accommodationRequiredFromDate = 'Date accommodation is required from must be within 3 months'
     }
 

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
@@ -1,5 +1,10 @@
 import { applicationFactory } from '../../../../testutils/factories'
-import { dateAndTimeInputsAreValidDates, dateIsBlank, dateIsInThePast } from '../../../../utils/dateUtils'
+import {
+  dateAndTimeInputsAreValidDates,
+  dateIsBlank,
+  dateIsInThePast,
+  dateIsWithinThreeMonths,
+} from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import ReleaseDate from './releaseDate'
 
@@ -11,6 +16,7 @@ jest.mock('../../../../utils/dateUtils', () => {
     dateIsBlank: jest.fn(),
     dateAndTimeInputsAreValidDates: jest.fn(),
     dateIsInThePast: jest.fn(),
+    dateIsWithinThreeMonths: jest.fn(),
   }
 })
 
@@ -38,6 +44,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({})
@@ -47,6 +54,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(true)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({ releaseDate: 'You must specify the release date' })
@@ -56,6 +64,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(false)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({ releaseDate: 'You must specify a valid release date' })
@@ -65,9 +74,22 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({ releaseDate: 'Release date cannot be in the past' })
+    })
+
+    it('should return an error if the date is not within the next 3 months', () => {
+      ;(dateIsBlank as jest.Mock).mockReturnValue(false)
+      ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
+      ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(false)
+
+      const page = new ReleaseDate(body, application)
+      expect(page.errors()).toEqual({
+        releaseDate: 'Release date must be within 3 months',
+      })
     })
   })
 

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
@@ -3,7 +3,7 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
-  dateIsWithinThreeMonths,
+  dateIsWithinNextThreeMonths,
 } from '../../../../utils/dateUtils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import ReleaseDate from './releaseDate'
@@ -16,7 +16,7 @@ jest.mock('../../../../utils/dateUtils', () => {
     dateIsBlank: jest.fn(),
     dateAndTimeInputsAreValidDates: jest.fn(),
     dateIsInThePast: jest.fn(),
-    dateIsWithinThreeMonths: jest.fn(),
+    dateIsWithinNextThreeMonths: jest.fn(),
   }
 })
 
@@ -44,7 +44,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({})
@@ -54,7 +54,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(true)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({ releaseDate: 'You must specify the release date' })
@@ -64,7 +64,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(false)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({ releaseDate: 'You must specify a valid release date' })
@@ -74,7 +74,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(true)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(true)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({ releaseDate: 'Release date cannot be in the past' })
@@ -84,7 +84,7 @@ describe('ReleaseDate', () => {
       ;(dateIsBlank as jest.Mock).mockReturnValue(false)
       ;(dateAndTimeInputsAreValidDates as jest.Mock).mockReturnValue(true)
       ;(dateIsInThePast as jest.Mock).mockReturnValue(false)
-      ;(dateIsWithinThreeMonths as jest.Mock).mockReturnValue(false)
+      ;(dateIsWithinNextThreeMonths as jest.Mock).mockReturnValue(false)
 
       const page = new ReleaseDate(body, application)
       expect(page.errors()).toEqual({

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
@@ -67,7 +67,7 @@ describe('ReleaseDate', () => {
       ;(dateIsInThePast as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
-      expect(page.errors()).toEqual({ releaseDate: 'The release date must not be in the past' })
+      expect(page.errors()).toEqual({ releaseDate: 'Release date cannot be in the past’' })
     })
   })
 

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.test.ts
@@ -67,7 +67,7 @@ describe('ReleaseDate', () => {
       ;(dateIsInThePast as jest.Mock).mockReturnValue(true)
 
       const page = new ReleaseDate(body, application)
-      expect(page.errors()).toEqual({ releaseDate: 'Release date cannot be in the past’' })
+      expect(page.errors()).toEqual({ releaseDate: 'Release date cannot be in the past' })
     })
   })
 

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -65,7 +65,7 @@ export default class ReleaseDate implements TasklistPage {
     } else if (!dateAndTimeInputsAreValidDates(this.body, 'releaseDate')) {
       errors.releaseDate = 'You must specify a valid release date'
     } else if (dateIsInThePast(this.body.releaseDate)) {
-      errors.releaseDate = 'Release date cannot be in the past’'
+      errors.releaseDate = 'Release date cannot be in the past'
     } else if (!dateIsWithinThreeMonths(this.body.releaseDate)) {
       errors.releaseDate = 'Release date must be within 3 months'
     }

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -65,7 +65,7 @@ export default class ReleaseDate implements TasklistPage {
     } else if (!dateAndTimeInputsAreValidDates(this.body, 'releaseDate')) {
       errors.releaseDate = 'You must specify a valid release date'
     } else if (dateIsInThePast(this.body.releaseDate)) {
-      errors.releaseDate = 'The release date must not be in the past'
+      errors.releaseDate = 'Release date cannot be in the past’'
     } else if (!dateIsWithinThreeMonths(this.body.releaseDate)) {
       errors.releaseDate = 'Release date must be within 3 months'
     }

--- a/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
+++ b/server/form-pages/apply/accommodation-need/eligibility/releaseDate.ts
@@ -5,7 +5,7 @@ import {
   dateAndTimeInputsAreValidDates,
   dateIsBlank,
   dateIsInThePast,
-  dateIsWithinThreeMonths,
+  dateIsWithinNextThreeMonths,
 } from '../../../../utils/dateUtils'
 import TasklistPage from '../../../tasklistPage'
 import { dateBodyProperties } from '../../../utils'
@@ -66,7 +66,7 @@ export default class ReleaseDate implements TasklistPage {
       errors.releaseDate = 'You must specify a valid release date'
     } else if (dateIsInThePast(this.body.releaseDate)) {
       errors.releaseDate = 'Release date cannot be in the past'
-    } else if (!dateIsWithinThreeMonths(this.body.releaseDate)) {
+    } else if (!dateIsWithinNextThreeMonths(this.body.releaseDate)) {
       errors.releaseDate = 'Release date must be within 3 months'
     }
 

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -53,7 +53,7 @@
       "empty": "You must enter a departure date and time",
       "invalid": "The departure date and time is an invalid date and time",
       "beforeBookingArrivalDate": "The departure date and time must be after the booking's arrival date",
-      "departureDateInFuture": "The departure date must be today or in the past"
+      "departureDateInFuture": "Departure date cannot be in the future"
     },
     "destinationProviderId": {
       "doesNotExist": "The destination provider does not exist"

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -10,7 +10,7 @@ import {
   dateIsInFuture,
   dateIsInThePast,
   dateIsWithinLastSevenDays,
-  dateIsWithinThreeMonths,
+  dateIsWithinNextThreeMonths,
   datepickerInputsAreValidDates,
 } from './dateUtils'
 
@@ -454,29 +454,29 @@ describe('dateExists', () => {
     expect(dateExists(input)).toEqual(expected)
   })
 
-  describe('dateIsWithinThreeMonths', () => {
+  describe('dateIsWithinNextThreeMonths', () => {
     it('returns true if the date is within the next 3 months', () => {
       const validDate = DateFormats.dateObjToIsoDate(addMonths(new Date(), 2))
-      expect(dateIsWithinThreeMonths(validDate)).toBe(true)
+      expect(dateIsWithinNextThreeMonths(validDate)).toBe(true)
     })
 
     it('returns false if the date is more than 3 months in the future', () => {
       const invalidDate = DateFormats.dateObjToIsoDate(addMonths(new Date(), 4))
-      expect(dateIsWithinThreeMonths(invalidDate)).toBe(false)
+      expect(dateIsWithinNextThreeMonths(invalidDate)).toBe(false)
     })
 
     it('returns false if the date is in the past', () => {
       const pastDate = DateFormats.dateObjToIsoDate(subMonths(new Date(), 1))
-      expect(dateIsWithinThreeMonths(pastDate)).toBe(false)
+      expect(dateIsWithinNextThreeMonths(pastDate)).toBe(false)
     })
 
     it('returns false if the input is an invalid date string', () => {
       const invalidDateString = 'invalid'
-      expect(dateIsWithinThreeMonths(invalidDateString)).toBe(false)
+      expect(dateIsWithinNextThreeMonths(invalidDateString)).toBe(false)
     })
 
     it('returns false if the input is an empty string', () => {
-      expect(dateIsWithinThreeMonths('')).toBe(false)
+      expect(dateIsWithinNextThreeMonths('')).toBe(false)
     })
   })
 

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,3 +1,4 @@
+import { addDays, addMonths, subDays, subMonths } from 'date-fns'
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 import {
   DateFormats,
@@ -8,6 +9,8 @@ import {
   dateIsBlank,
   dateIsInFuture,
   dateIsInThePast,
+  dateIsWithinLastSevenDays,
+  dateIsWithinThreeMonths,
   datepickerInputsAreValidDates,
 } from './dateUtils'
 
@@ -449,5 +452,57 @@ describe('dateExists', () => {
     ['not even a date', false],
   ])('for %s returns %s', (input, expected) => {
     expect(dateExists(input)).toEqual(expected)
+  })
+
+  describe('dateIsWithinThreeMonths', () => {
+    it('returns true if the date is within the next 3 months', () => {
+      const validDate = DateFormats.dateObjToIsoDate(addMonths(new Date(), 2))
+      expect(dateIsWithinThreeMonths(validDate)).toBe(true)
+    })
+
+    it('returns false if the date is more than 3 months in the future', () => {
+      const invalidDate = DateFormats.dateObjToIsoDate(addMonths(new Date(), 4))
+      expect(dateIsWithinThreeMonths(invalidDate)).toBe(false)
+    })
+
+    it('returns false if the date is in the past', () => {
+      const pastDate = DateFormats.dateObjToIsoDate(subMonths(new Date(), 1))
+      expect(dateIsWithinThreeMonths(pastDate)).toBe(false)
+    })
+
+    it('returns false if the input is an invalid date string', () => {
+      const invalidDateString = 'invalid'
+      expect(dateIsWithinThreeMonths(invalidDateString)).toBe(false)
+    })
+
+    it('returns false if the input is an empty string', () => {
+      expect(dateIsWithinThreeMonths('')).toBe(false)
+    })
+  })
+
+  describe('dateIsWithinLastSevenDays', () => {
+    it('returns true if the date is within the last 7 days', () => {
+      const validDate = DateFormats.dateObjToIsoDate(subDays(new Date(), 5))
+      expect(dateIsWithinLastSevenDays(validDate)).toBe(true)
+    })
+
+    it('returns false if the date is more than 7 days in the past', () => {
+      const invalidDate = DateFormats.dateObjToIsoDate(subDays(new Date(), 8))
+      expect(dateIsWithinLastSevenDays(invalidDate)).toBe(false)
+    })
+
+    it('returns false if the date is in the future', () => {
+      const futureDate = DateFormats.dateObjToIsoDate(addDays(new Date(), 1))
+      expect(dateIsWithinLastSevenDays(futureDate)).toBe(false)
+    })
+
+    it('returns false if the input is an invalid date string', () => {
+      const invalidDateString = 'invalid'
+      expect(dateIsWithinLastSevenDays(invalidDateString)).toBe(false)
+    })
+
+    it('returns false if the input is an empty string', () => {
+      expect(dateIsWithinLastSevenDays('')).toBe(false)
+    })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { differenceInDays, format, formatISO, isExists, subMonths, subDays, isAfter } from 'date-fns'
+import { differenceInDays, format, formatISO, isExists, subMonths, subDays, isAfter, isBefore } from 'date-fns'
 
 export class DateFormats {
   /**
@@ -223,12 +223,13 @@ export const dateInputHint = (direction: 'past' | 'future') => {
 
 export const dateIsWithinThreeMonths = (dateString: string): boolean => {
   const threeMonths = subMonths(dateString, 3)
-  return isAfter(new Date(), threeMonths)
+
+  return isAfter(new Date(), threeMonths) && dateIsInFuture(dateString)
 }
 
 export function dateIsWithinLastSevenDays(dateString: string): boolean {
   const date = new Date(dateString)
   const sevenDays = subDays(new Date(), 7)
 
-  return isAfter(date, sevenDays)
+  return isAfter(date, sevenDays) && dateIsInThePast(dateString)
 }

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -221,7 +221,7 @@ export const dateInputHint = (direction: 'past' | 'future') => {
   return `For example, 27 3 ${year}`
 }
 
-export const dateIsWithinThreeMonths = (dateString: string): boolean => {
+export const dateIsWithinNextThreeMonths = (dateString: string): boolean => {
   const threeMonths = subMonths(dateString, 3)
 
   return isAfter(new Date(), threeMonths) && dateIsInFuture(dateString)

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -1,6 +1,6 @@
 /* eslint-disable */
 import type { ObjectWithDateParts } from '@approved-premises/ui'
-import { differenceInDays, format, formatISO, isExists, subMonths, isAfter } from 'date-fns'
+import { differenceInDays, format, formatISO, isExists, subMonths, subDays, isAfter } from 'date-fns'
 
 export class DateFormats {
   /**
@@ -224,4 +224,11 @@ export const dateInputHint = (direction: 'past' | 'future') => {
 export const dateIsWithinThreeMonths = (dateString: string): boolean => {
   const threeMonths = subMonths(dateString, 3)
   return isAfter(new Date(), threeMonths)
+}
+
+export function dateIsWithinLastSevenDays(dateString: string): boolean {
+  const date = new Date(dateString)
+  const sevenDays = subDays(new Date(), 7)
+
+  return isAfter(date, sevenDays)
 }

--- a/wiremock/stubs/move-on-categories.json
+++ b/wiremock/stubs/move-on-categories.json
@@ -114,7 +114,7 @@
     "serviceScope": "temporary-accommodation"
   },
   {
-    "id": "5d622186-0ffe-4daf-9bd8-03b8bb8086e8",
+    "id": "5dfd0cc4-8be3-4788-a7ba-a84d32efe5ea",
     "name": "Pending (no category has been added to NDelius)",
     "isActive": true,
     "serviceScope": "temporary-accommodation"


### PR DESCRIPTION
# Context

This addresses some comments on [this](https://dsdmoj.atlassian.net/browse/CAS-1521) ticket.

- Update validation messages.
- Add date validation on edit date arrival.

Also updates a move on category id that was causing an e2e test to randomly fail.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="729" alt="image" src="https://github.com/user-attachments/assets/27887273-ff87-464c-92de-e281545326ea" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
