### PR TITLE
Namespace E2E tests artefacts

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -44,7 +44,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: E2E-playwright-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          name: CAS3-E2E-playwright-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: e2e_playwright/playwright-report
           retention-days: 30
           if-no-files-found: ignore
@@ -53,7 +53,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: E2E-playwright-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          name: CAS3-E2E-playwright-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: e2e_playwright/test-results
           retention-days: 30
           if-no-files-found: ignore
@@ -119,7 +119,7 @@ jobs:
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
-          name: E2E-cypress-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          name: CAS3-E2E-cypress-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: test_results/cypress
           retention-days: 30
           if-no-files-found: ignore
@@ -128,7 +128,7 @@ jobs:
         if: failure()
         uses: actions/upload-artifact@v4
         with:
-          name: E2E-cypress-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
+          name: CAS3-E2E-cypress-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: |
             e2e/screenshots
             e2e/videos


### PR DESCRIPTION
This will prevent artefact name collisions when the various UI E2E workflows are run as part of the same API E2E workflow run, therefore allowing the artefacts to be uploaded without error.
