### PR TITLE
fix/failing e2e test

### DIFF
--- a/cypress_shared/utils/bedspaceSearch.ts
+++ b/cypress_shared/utils/bedspaceSearch.ts
@@ -19,9 +19,13 @@ export const characteristicsToSearchAttributes = (premises: TemporaryAccommodati
     .map((characteristic: Characteristic) => occupancyAttributesMap[characteristic.name])
     .find(attribute => attribute !== undefined)
 
-  const sexualRiskAttributes = premises.characteristics
+  const matchedSexualRiskAttributes = premises.characteristics
     .map((characteristic: Characteristic) => sexualRiskMap[characteristic.name])
-    .filter(attribute => attribute !== undefined) as BedspaceSearchFormParameters['sexualRiskAttributes']
+    .filter(attribute => attribute !== undefined)
+
+  const sexualRiskAttributes = Object.values(sexualRiskMap).filter(
+    attr => !matchedSexualRiskAttributes.includes(attr),
+  ) as BedspaceSearchFormParameters['sexualRiskAttributes']
 
   const wheelchairAccessibility = room.characteristics
     .map((characteristic: Characteristic) => wheelchairAccessibilityMap[characteristic.name])


### PR DESCRIPTION
# Context

This fixes a failing [e2e](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/15850257621/job/44684742785) test. Test was failing when a premise was created with a not suitable sexual risk, then when searching because the way sexual risk works, it was applying the filter for "is suitable", so no suitable bedspaces would be returned, resulting in the test failing.

Logic is it now works in reverse, so removes the sexual risk from the characteristics to check.

For testing you can add the below lines to `/e2e/tests/stepDefinitions/manage/premises.ts` around line 74 to force a premise characteristic.
```
const risk = {id: "cb7447cd-d629-4c89-be93-cd48c1060af8", name: "Not suitable for those who pose a sexual risk to adults"} as Premises['characteristics'][number]
premises.characteristics = [...premises.characteristics, risk]
```


# Changes in this PR

## Screenshots of UI changes

"Not suitable for those who pose a sexual risk to adults" is checked when creating premise
<img width="587" alt="image" src="https://github.com/user-attachments/assets/f1ebeebb-09bf-437b-85cc-878052d84a4b" />

Suitable "Risk to adults" unchecked on search
<img width="285" alt="image" src="https://github.com/user-attachments/assets/daf2e6dc-b71e-4452-ba8e-3eb8a984476c" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
