### PR TITLE
Feature/cas 1711 display online properties tab summary counts

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesList.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesList.ts
@@ -4,13 +4,23 @@ import paths from '../../../../../server/paths/temporary-accommodation/manage'
 import Page from '../../../page'
 
 export default class PremisesListPage extends Page {
-  constructor() {
-    super('Online properties')
+  constructor(pageTitle = 'Online properties') {
+    super(pageTitle)
   }
 
   static visit(): PremisesListPage {
     cy.visit(paths.premises.v2.index({}))
     return new PremisesListPage()
+  }
+
+  static visitOnline(): PremisesListPage {
+    cy.visit(paths.premises.v2.online({}))
+    return new PremisesListPage()
+  }
+
+  static visitArchived(): PremisesListPage {
+    cy.visit(paths.premises.v2.archived({}))
+    return new PremisesListPage('Archived properties')
   }
 
   shouldShowPremises(premises: Array<Cas3PremisesSearchResult>): void {

--- a/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
@@ -24,7 +24,7 @@ context('Premises', () => {
     cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
 
     // When I visit the premises page
-    const page = PremisesListPage.visit()
+    const page = PremisesListPage.visitOnline()
 
     // Then I should see all the premises listed
     page.shouldShowPremises(searchResults.results)
@@ -67,7 +67,7 @@ context('Premises', () => {
     })
 
     // When I visit the premises page
-    const page = PremisesListPage.visit()
+    const page = PremisesListPage.visitOnline()
 
     // Then I should see all the premises listed
     page.shouldShowPremises(searchResults.results)
@@ -109,7 +109,7 @@ context('Premises', () => {
     })
 
     // When I visit the premises page
-    const page = PremisesListPage.visit()
+    const page = PremisesListPage.visitOnline()
 
     // Then I should see all the premises listed
     page.shouldShowPremises(searchResults.results)
@@ -139,12 +139,512 @@ context('Premises', () => {
     cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
 
     // When I visit the premises list page
-    const page = PremisesListPage.visit()
+    const page = PremisesListPage.visitOnline()
 
     // And I click the previous bread crumb
     page.clickHome()
 
     // Then I navigate to the dashboard page
     Page.verifyOnPage(DashboardPage)
+  })
+
+  it('should display property and bedspace counts', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database with specific counts
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(3),
+      totalPremises: 3,
+      totalOnlineBedspaces: 8,
+      totalUpcomingBedspaces: 2,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
+
+    // When I visit the premises page
+    PremisesListPage.visitOnline()
+
+    // Then I should see the correct property count
+    cy.contains('3 online properties').should('exist')
+
+    // And I should see the correct bedspace counts
+    cy.contains('Online bedspaces: 8').should('exist')
+    cy.contains('Upcoming bedspaces: 2').should('exist')
+  })
+
+  it('should display property count with search term when searching', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const allResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(5),
+      totalPremises: 5,
+      totalOnlineBedspaces: 12,
+      totalUpcomingBedspaces: 0,
+    })
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+      totalPremises: 2,
+      totalOnlineBedspaces: 4,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults: allResults, postcodeOrAddress: '', premisesStatus: 'online' })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: 'NE1', premisesStatus: 'online' })
+
+    // When I visit the premises page
+    const page = PremisesListPage.visitOnline()
+
+    // Then I should see the total count without search term
+    cy.contains('5 online properties').should('exist')
+
+    // When I search for a postcode
+    page.search('NE1')
+
+    // Then I should see the count with search term
+    cy.contains("2 online properties matching 'NE1'").should('exist')
+    cy.contains('Online bedspaces: 4').should('exist')
+  })
+
+  it('should display zero properties message when database is empty', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are no premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: [],
+      totalPremises: 0,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
+
+    // When I visit the premises page
+    PremisesListPage.visitOnline()
+
+    // Then I should see the zero properties message
+    cy.contains('0 online properties').should('exist')
+
+    // And the search form should not be visible
+    cy.get('main form').should('not.exist')
+
+    // And bedspace counts should not be shown when there are no properties
+    cy.contains('Online bedspaces:').should('not.exist')
+    cy.contains('Upcoming bedspaces:').should('not.exist')
+  })
+
+  it('should not display upcoming bedspaces when there are 0 upcoming bedspaces', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises with 0 upcoming bedspaces
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(3),
+      totalPremises: 3,
+      totalOnlineBedspaces: 8,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
+
+    // When I visit the premises page
+    PremisesListPage.visitOnline()
+
+    // Then I should see the property count and online bedspaces
+    cy.contains('3 online properties').should('exist')
+    cy.contains('Online bedspaces: 8').should('exist')
+
+    // But upcoming bedspaces should not be displayed when count is 0
+    cy.contains('Upcoming bedspaces:').should('not.exist')
+  })
+
+  it('should redirect from base v2 properties route to online tab', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(3),
+      totalPremises: 3,
+      totalOnlineBedspaces: 8,
+      totalUpcomingBedspaces: 2,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
+
+    // When I visit the base v2 properties route
+    cy.visit('/v2/properties')
+
+    // Then I should be redirected to the online tab
+    cy.url().should('include', '/v2/properties/online')
+
+    // And I should see the online properties page
+    cy.contains('Online properties').should('exist')
+    cy.contains('3 online properties').should('exist')
+  })
+
+  it('should display archived properties in archived tab', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are archived premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(4),
+      totalPremises: 4,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'archived' })
+
+    // When I visit the archived premises page
+    const page = PremisesListPage.visitArchived()
+
+    // Then I should see all the archived premises listed
+    page.shouldShowPremises(searchResults.results)
+
+    // And I should see the correct archived property count
+    cy.contains('4 archived properties').should('exist')
+
+    // And the page title should be correct
+    cy.title().should('include', 'Archived properties')
+  })
+
+  it('should search archived properties by postcode', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are archived premises in the database
+    const postcode = 'SW1 1AA'
+    const matchingSearchResults = cas3PremisesSearchResultsFactory.build({
+      results: [
+        cas3PremisesSearchResultFactory.build({ postcode }),
+        cas3PremisesSearchResultFactory.build({ postcode }),
+      ],
+      totalPremises: 2,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    const allSearchResults = cas3PremisesSearchResultsFactory.build({
+      results: [
+        ...matchingSearchResults.results,
+        cas3PremisesSearchResultFactory.build({ postcode: 'SW2 2BB' }),
+        cas3PremisesSearchResultFactory.build({ postcode: 'SW3 3CC' }),
+      ],
+      totalPremises: 4,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: allSearchResults,
+      postcodeOrAddress: '',
+      premisesStatus: 'archived',
+    })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: matchingSearchResults,
+      postcodeOrAddress: postcode,
+      premisesStatus: 'archived',
+    })
+
+    // When I visit the archived premises page
+    const page = PremisesListPage.visitArchived()
+
+    // Then I should see all the archived premises listed
+    page.shouldShowPremises(allSearchResults.results)
+
+    // When I search for the postcode
+    page.search(postcode)
+
+    // Then only archived premises matching that postcode should be listed
+    page.shouldShowOnlyPremises(matchingSearchResults.results)
+
+    // And I should see the count with search term
+    cy.contains(`2 archived properties matching '${postcode}'`).should('exist')
+
+    // When I clear the search field and search again
+    page.clearSearch()
+
+    // Then all the archived premises should be listed again
+    page.shouldShowPremises(allSearchResults.results)
+  })
+
+  it('should show no results when searching archived properties with no matches', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are archived premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: [
+        cas3PremisesSearchResultFactory.build({ postcode: 'SW1 1AA' }),
+        cas3PremisesSearchResultFactory.build({ postcode: 'SW2 2BB' }),
+      ],
+      totalPremises: 2,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    const matchingSearchResults = cas3PremisesSearchResultsFactory.build({
+      results: [],
+      totalPremises: 0,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'archived' })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: matchingSearchResults,
+      postcodeOrAddress: 'NOTFOUND',
+      premisesStatus: 'archived',
+    })
+
+    // When I visit the archived premises page
+    const page = PremisesListPage.visitArchived()
+
+    // Then I should see all the archived premises listed
+    page.shouldShowPremises(searchResults.results)
+
+    // When I search for a postcode with no results
+    page.search('NOTFOUND')
+
+    // Then a 'no results' message should be shown
+    page.shouldShowOnlyPremises([])
+    page.shouldShowMessages(["0 archived properties matching 'NOTFOUND'"])
+
+    // When I clear the search field and search again
+    page.clearSearch()
+
+    // Then all the archived premises should be listed again
+    page.shouldShowPremises(searchResults.results)
+  })
+
+  it('should display archived property counts', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are archived premises in the database with specific counts
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(5),
+      totalPremises: 5,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'archived' })
+
+    // When I visit the archived premises page
+    PremisesListPage.visitArchived()
+
+    // Then I should see the correct archived property count
+    cy.contains('5 archived properties').should('exist')
+
+    // And bedspace counts should not be shown for archived properties
+    cy.contains('Online bedspaces:').should('not.exist')
+    cy.contains('Upcoming bedspaces:').should('not.exist')
+  })
+
+  it('should display zero archived properties message when database is empty', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are no archived premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: [],
+      totalPremises: 0,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'archived' })
+
+    // When I visit the archived premises page
+    PremisesListPage.visitArchived()
+
+    // Then I should see the zero archived properties message
+    cy.contains('0 archived properties').should('exist')
+
+    // And the search form should not be visible
+    cy.get('main form').should('not.exist')
+  })
+
+  it('should navigate between online and archived tabs', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are both online and archived premises in the database
+    const onlineResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(3),
+      totalPremises: 3,
+      totalOnlineBedspaces: 8,
+      totalUpcomingBedspaces: 2,
+    })
+    const archivedResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+      totalPremises: 2,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults: onlineResults, postcodeOrAddress: '', premisesStatus: 'online' })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: archivedResults,
+      postcodeOrAddress: '',
+      premisesStatus: 'archived',
+    })
+
+    // When I visit the online premises page
+    PremisesListPage.visitOnline()
+
+    // Then I should see the online tab is active
+    cy.get('.moj-sub-navigation a[aria-current="page"]').should('contain', 'Online properties')
+    cy.contains('3 online properties').should('exist')
+
+    // When I click on the archived tab
+    cy.get('.moj-sub-navigation a').contains('Archived properties').click()
+
+    // Then I should be on the archived tab
+    cy.url().should('include', '/v2/properties/archived')
+    cy.get('.moj-sub-navigation a[aria-current="page"]').should('contain', 'Archived properties')
+    cy.contains('2 archived properties').should('exist')
+
+    // When I click on the online tab
+    cy.get('.moj-sub-navigation a').contains('Online properties').click()
+
+    // Then I should be back on the online tab
+    cy.url().should('include', '/v2/properties/online')
+    cy.get('.moj-sub-navigation a[aria-current="page"]').should('contain', 'Online properties')
+    cy.contains('3 online properties').should('exist')
+  })
+
+  it('should preserve search terms when switching between tabs', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in both tabs that match a search term
+    const searchTerm = 'NE1'
+    const onlineResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(3),
+      totalPremises: 3,
+      totalOnlineBedspaces: 8,
+      totalUpcomingBedspaces: 2,
+    })
+    const onlineSearchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+      totalPremises: 2,
+      totalOnlineBedspaces: 4,
+      totalUpcomingBedspaces: 1,
+    })
+    const archivedResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+      totalPremises: 2,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+    const archivedSearchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(1),
+      totalPremises: 1,
+      totalOnlineBedspaces: 0,
+      totalUpcomingBedspaces: 0,
+    })
+
+    cy.task('stubPremisesSearchV2', { searchResults: onlineResults, postcodeOrAddress: '', premisesStatus: 'online' })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: onlineSearchResults,
+      postcodeOrAddress: searchTerm,
+      premisesStatus: 'online',
+    })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: archivedResults,
+      postcodeOrAddress: '',
+      premisesStatus: 'archived',
+    })
+    cy.task('stubPremisesSearchV2', {
+      searchResults: archivedSearchResults,
+      postcodeOrAddress: searchTerm,
+      premisesStatus: 'archived',
+    })
+
+    // When I visit the online premises page and search
+    const page = PremisesListPage.visitOnline()
+    page.search(searchTerm)
+
+    // Then I should see the search results
+    cy.contains(`2 online properties matching '${searchTerm}'`).should('exist')
+
+    // When I switch to the archived tab
+    cy.get('.moj-sub-navigation a').contains('Archived properties').click()
+
+    // Then the search term should be preserved in the URL
+    cy.url().should('include', `/v2/properties/archived?postcodeOrAddress=${searchTerm}`)
+
+    // And I should see the archived search results
+    cy.contains(`1 archived properties matching '${searchTerm}'`).should('exist')
+
+    // And the search input should still contain the search term
+    cy.get('main form input').should('have.value', searchTerm)
+
+    // When I switch back to the online tab
+    cy.get('.moj-sub-navigation a').contains('Online properties').click()
+
+    // Then the search term should still be preserved
+    cy.url().should('include', `/v2/properties/online?postcodeOrAddress=${searchTerm}`)
+    cy.contains(`2 online properties matching '${searchTerm}'`).should('exist')
+    cy.get('main form input').should('have.value', searchTerm)
+  })
+
+  it('should show correct active tab state', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+      totalPremises: 2,
+      totalOnlineBedspaces: 4,
+      totalUpcomingBedspaces: 1,
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'archived' })
+
+    // When I visit the online premises page
+    PremisesListPage.visitOnline()
+
+    // Then the online tab should be active and archived tab should not be
+    cy.get('.moj-sub-navigation a[aria-current="page"]').should('contain', 'Online properties')
+    cy.get('.moj-sub-navigation a').contains('Archived properties').should('not.have.attr', 'aria-current')
+
+    // When I visit the archived premises page
+    PremisesListPage.visitArchived()
+
+    // Then the archived tab should be active and online tab should not be
+    cy.get('.moj-sub-navigation a[aria-current="page"]').should('contain', 'Archived properties')
+    cy.get('.moj-sub-navigation a').contains('Online properties').should('not.have.attr', 'aria-current')
+  })
+
+  it('should display correct page title for online properties', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are online premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'online' })
+
+    // When I visit the online premises page
+    PremisesListPage.visitOnline()
+
+    // Then the page title should be correct
+    cy.title().should('include', 'Online properties')
+    cy.get('h1').should('contain', 'Online properties')
+  })
+
+  it('should display correct page title for archived properties', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are archived premises in the database
+    const searchResults = cas3PremisesSearchResultsFactory.build({
+      results: cas3PremisesSearchResultFactory.buildList(2),
+    })
+    cy.task('stubPremisesSearchV2', { searchResults, postcodeOrAddress: '', premisesStatus: 'archived' })
+
+    // When I visit the archived premises page
+    PremisesListPage.visitArchived()
+
+    // Then the page title should be correct
+    cy.title().should('include', 'Archived properties')
+    cy.get('h1').should('contain', 'Archived properties')
   })
 })

--- a/server/controllers/temporary-accommodation/manage/v2/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/premisesController.ts
@@ -1,20 +1,31 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import { PremisesSearchParameters } from '@approved-premises/ui'
+import type { Cas3PremisesStatus } from '@approved-premises/api'
 import PremisesService from '../../../../services/v2/premisesService'
 import extractCallConfig from '../../../../utils/restUtils'
+import { createSubNavArr } from '../../../../utils/premisesSearchUtils'
 
 export default class PremisesController {
   constructor(private readonly premisesService: PremisesService) {}
 
-  index(): RequestHandler {
+  index(status: Cas3PremisesStatus): RequestHandler {
     return async (req: Request, res: Response) => {
       const callConfig = extractCallConfig(req)
-
       const params = req.query as PremisesSearchParameters
 
-      const tableRows = await this.premisesService.tableRows(callConfig, params)
-      return res.render('temporary-accommodation/v2/premises/index', { tableRows, params })
+      const searchData = await this.premisesService.searchDataAndGenerateTableRows(
+        callConfig,
+        params.postcodeOrAddress,
+        status,
+      )
+
+      return res.render('temporary-accommodation/v2/premises/index', {
+        ...searchData,
+        params,
+        status,
+        subNavArr: createSubNavArr(status, params.postcodeOrAddress),
+      })
     }
   }
 }

--- a/server/data/v2/premisesClient.test.ts
+++ b/server/data/v2/premisesClient.test.ts
@@ -33,7 +33,7 @@ describe('PremisesCLeint', () => {
       [cas3PremisesSearchResultsFactory.build({ results: cas3PremisesSearchResultFactory.buildList(0) })],
     ])('should get premises search results', async searchResults => {
       fakeApprovedPremisesApi
-        .get(paths.v2.premises.index({}))
+        .get(paths.v2.premises.search({}))
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .query({
           postcodeOrAddress: 'NE1 1AB',

--- a/server/data/v2/premisesClient.ts
+++ b/server/data/v2/premisesClient.ts
@@ -12,7 +12,7 @@ export default class PremisesClient {
 
   async search(postcodeOrAddress: string, premisesStatus: Cas3PremisesStatus) {
     return this.restClient.get<Cas3PremisesSearchResults>({
-      path: paths.v2.premises.index({}),
+      path: paths.v2.premises.search({}),
       query: { postcodeOrAddress, premisesStatus },
     })
   }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -91,7 +91,7 @@ const applyPaths = {
 export default {
   v2: {
     premises: {
-      index: managePathsV2.premises.search,
+      search: managePathsV2.premises.search,
     },
   },
   premises: {

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -4,6 +4,9 @@ const dashboardPath = temporaryAccommodationPath.path('dashboard')
 
 const premisesPath = temporaryAccommodationPath.path('properties')
 const premisesV2Path = temporaryAccommodationPath.path('v2/properties')
+const premisesV2OnlinePath = premisesV2Path.path('online')
+const premisesV2ArchivedPath = premisesV2Path.path('archived')
+
 const singlePremisesPath = premisesPath.path(':premisesId')
 
 const bedspacesPath = singlePremisesPath.path('bedspaces')
@@ -49,6 +52,8 @@ const paths: Record<string, any> = {
     },
     v2: {
       index: premisesV2Path,
+      online: premisesV2OnlinePath,
+      archived: premisesV2ArchivedPath,
     },
   },
   bookings: {

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -70,7 +70,15 @@ export default function routes(controllers: Controllers, services: Services, rou
 
   // premises v2
   if (config.flags.managePropertiesV2Enabled) {
-    get(paths.premises.v2.index.pattern, premisesControllerV2.index(), { auditEvent: 'VIEW_PREMISES_LIST_V2' })
+    get(paths.premises.v2.index(), redirectsController.redirect(paths.premises.v2.online(), 301), {
+      auditEvent: 'REDIRECT_PREMISES_V2',
+    })
+    get(paths.premises.v2.online.pattern, premisesControllerV2.index('online'), {
+      auditEvent: 'VIEW_PREMISES_LIST_V2_ONLINE',
+    })
+    get(paths.premises.v2.archived.pattern, premisesControllerV2.index('archived'), {
+      auditEvent: 'VIEW_PREMISES_LIST_V2_ARCHIVED',
+    })
   }
 
   get(paths.premises.bedspaces.new.pattern, bedspacesController.new(), { auditEvent: 'VIEW_BEDSPACE_CREATE' })

--- a/server/services/v2/premisesService.test.ts
+++ b/server/services/v2/premisesService.test.ts
@@ -1,4 +1,3 @@
-import { PremisesSearchParameters } from '@approved-premises/ui'
 import PremisesClient from '../../data/v2/premisesClient'
 import { CallConfig } from '../../data/restClient'
 import {
@@ -49,45 +48,127 @@ describe('PremisesService', () => {
     })
 
     it.each([
-      [[searchResult2, searchResult1, searchResult3], undefined, [searchResult2, searchResult1, searchResult3]],
-      [[searchResult2, searchResult1], 'Westminster', [searchResult2, searchResult1]],
-      [[], 'XYZ', []],
-      [undefined, 'XYZ', []],
-    ])(
-      'returns table view of the premises for Temporary Accommodation with an optional search for an address',
-      async (searchResults, postcodeOrAddress, expectedResults) => {
-        const params: PremisesSearchParameters = { postcodeOrAddress }
+      [
+        [searchResult2, searchResult1, searchResult3],
+        [searchResult2, searchResult1, searchResult3],
+      ],
+      [
+        [searchResult2, searchResult1],
+        [searchResult2, searchResult1],
+      ],
+      [[], []],
+      [undefined, []],
+    ])('returns table view of the premises for Temporary Accommodation', (searchResults, expectedResults) => {
+      const premises = cas3PremisesSearchResultsFactory.build({ results: searchResults })
+      ;(statusTag as jest.MockedFunction<typeof statusTag>).mockImplementation(status => `<strong>${status}</strong>`)
 
-        premisesClient.search.mockResolvedValue(cas3PremisesSearchResultsFactory.build({ results: searchResults }))
-        ;(statusTag as jest.MockedFunction<typeof statusTag>).mockImplementation(status => `<strong>${status}</strong>`)
+      const rows = service.tableRows(premises)
 
-        const rows = await service.tableRows(callConfig, params)
+      const expectedRows = expectedResults.map(prem => {
+        const address = [prem.addressLine1, prem.addressLine2, prem.town, prem.postcode]
+          .filter(s => s !== undefined && s !== '')
+          .join('<br />')
 
-        const expectedRows = expectedResults.map(prem => {
-          const address = [prem.addressLine1, prem.addressLine2, prem.town, prem.postcode]
-            .filter(s => s !== undefined && s !== '')
-            .join('<br />')
+        // hrefs will need updated for relevant tickets
+        const bedspaces =
+          prem.bedspaces.length === 0
+            ? `No bedspaces<br /><a href="#">Add a bedspace</a>`
+            : prem.bedspaces
+                .map(bed => {
+                  const archivedTag =
+                    bed.status === 'archived' ? ` <strong class="govuk-tag govuk-tag--grey">Archived</strong>` : ''
+                  return `<a href="#">${bed.reference}</a>${archivedTag}`
+                })
+                .join('<br />')
 
-          // hrefs will need updated for relevant tickets
-          const bedspaces =
-            prem.bedspaces.length === 0
-              ? `No bedspaces<br /><a href="#">Add a bedspace</a>`
-              : prem.bedspaces
-                  .map(bed => {
-                    const archivedTag =
-                      bed.status === 'archived' ? ` <strong class="govuk-tag govuk-tag--grey">Archived</strong>` : ''
-                    return `<a href="#">${bed.reference}</a>${archivedTag}`
-                  })
-                  .join('<br />')
+        return [{ html: address }, { html: bedspaces }, { text: prem.pdu }, { html: `<a href="#">Manage</a>` }]
+      })
 
-          return [{ html: address }, { html: bedspaces }, { text: prem.pdu }, { html: `<a href="#">Manage</a>` }]
-        })
+      expect(rows).toEqual(expectedRows)
+    })
+  })
 
-        expect(rows).toEqual(expectedRows)
+  describe('searchDataAndGenerateTableRows', () => {
+    const searchResult1 = cas3PremisesSearchResultFactory.build({
+      addressLine1: '32 Windsor Gardens',
+      town: 'London',
+      postcode: 'W9 3RQ',
+      pdu: 'Hammersmith, Fulham, Kensington, Chelsea and Westminster',
+      bedspaces: [],
+    })
+    const searchResult2 = cas3PremisesSearchResultFactory.build({
+      addressLine1: '221c Baker Street',
+      town: 'London',
+      postcode: 'NW1 6XE',
+      pdu: 'Hammersmith, Fulham, Kensington, Chelsea and Westminster',
+    })
 
-        expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
-        expect(premisesClient.search).toHaveBeenCalled()
-      },
-    )
+    it('returns search results with table rows for online status by default', async () => {
+      const postcodeOrAddress = 'London'
+      const searchResults = cas3PremisesSearchResultsFactory.build({
+        results: [searchResult1, searchResult2],
+        totalPremises: 2,
+        totalOnlineBedspaces: 5,
+        totalUpcomingBedspaces: 0,
+      })
+
+      premisesClient.search.mockResolvedValue(searchResults)
+
+      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress)
+
+      expect(result).toEqual({
+        ...searchResults,
+        tableRows: expect.any(Array),
+      })
+      expect(result.tableRows).toHaveLength(2)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(premisesClient.search).toHaveBeenCalledWith('London', 'online')
+    })
+
+    it('returns search results with table rows for specified status', async () => {
+      const postcodeOrAddress = 'London'
+      const searchResults = cas3PremisesSearchResultsFactory.build({
+        results: [searchResult1],
+        totalPremises: 1,
+        totalOnlineBedspaces: 2,
+        totalUpcomingBedspaces: 0,
+      })
+
+      premisesClient.search.mockResolvedValue(searchResults)
+
+      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress, 'archived')
+
+      expect(result).toEqual({
+        ...searchResults,
+        tableRows: expect.any(Array),
+      })
+      expect(result.tableRows).toHaveLength(1)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(premisesClient.search).toHaveBeenCalledWith('London', 'archived')
+    })
+
+    it('returns empty search results when there are no properties in the database', async () => {
+      const postcodeOrAddress = ''
+      const searchResults = cas3PremisesSearchResultsFactory.build({
+        results: [],
+        totalPremises: 0,
+        totalOnlineBedspaces: 0,
+        totalUpcomingBedspaces: 0,
+      })
+
+      premisesClient.search.mockResolvedValue(searchResults)
+
+      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress)
+
+      expect(result).toEqual({
+        ...searchResults,
+        tableRows: [],
+      })
+      expect(result.tableRows).toHaveLength(0)
+      expect(result.totalPremises).toBe(0)
+      expect(result.totalOnlineBedspaces).toBe(0)
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(premisesClient.search).toHaveBeenCalledWith('', 'online')
+    })
   })
 })

--- a/server/utils/premisesSearchUtils.test.ts
+++ b/server/utils/premisesSearchUtils.test.ts
@@ -1,0 +1,57 @@
+import { createSubNavArr } from './premisesSearchUtils'
+import paths from '../paths/temporary-accommodation/manage'
+
+describe('premisesSearchUtils', () => {
+  describe('createSubNavArr', () => {
+    it('returns sub nav with given status selected', () => {
+      const subNavArr = [
+        {
+          text: 'Online properties',
+          href: paths.premises.v2.online({}),
+          active: true,
+        },
+        {
+          text: 'Archived properties',
+          href: paths.premises.v2.archived({}),
+          active: false,
+        },
+      ]
+
+      expect(createSubNavArr('online')).toEqual(subNavArr)
+    })
+
+    it('returns sub nav with archived status selected', () => {
+      const subNavArr = [
+        {
+          text: 'Online properties',
+          href: paths.premises.v2.online({}),
+          active: false,
+        },
+        {
+          text: 'Archived properties',
+          href: paths.premises.v2.archived({}),
+          active: true,
+        },
+      ]
+
+      expect(createSubNavArr('archived')).toEqual(subNavArr)
+    })
+
+    it('appends the postcode or address parameter if given', () => {
+      const subNavArr = [
+        {
+          text: 'Online properties',
+          href: `${paths.premises.v2.online({})}?postcodeOrAddress=NE1`,
+          active: true,
+        },
+        {
+          text: 'Archived properties',
+          href: `${paths.premises.v2.archived({})}?postcodeOrAddress=NE1`,
+          active: false,
+        },
+      ]
+
+      expect(createSubNavArr('online', 'NE1')).toEqual(subNavArr)
+    })
+  })
+})

--- a/server/utils/premisesSearchUtils.ts
+++ b/server/utils/premisesSearchUtils.ts
@@ -1,0 +1,16 @@
+import type { Cas3PremisesStatus } from '@approved-premises/api'
+import type { SubNavObj } from '@approved-premises/ui'
+import paths from '../paths/temporary-accommodation/manage'
+import { appendQueryString } from './utils'
+
+export function createSubNavArr(status: Cas3PremisesStatus, postcodeOrAddress?: string): Array<SubNavObj> {
+  return ['online', 'archived'].map((premisesStatus: Cas3PremisesStatus) => ({
+    text: `${capitaliseStatus(premisesStatus)} properties`,
+    href: appendQueryString(paths.premises.v2[premisesStatus]({}), { postcodeOrAddress }),
+    active: status === premisesStatus,
+  }))
+}
+
+function capitaliseStatus(status: Cas3PremisesStatus): string {
+  return status.charAt(0).toUpperCase() + status.slice(1)
+}

--- a/server/views/temporary-accommodation/v2/premises/index.njk
+++ b/server/views/temporary-accommodation/v2/premises/index.njk
@@ -7,7 +7,7 @@
 
 {% extends "../../../partials/layout.njk" %}
 
-{% set pageTitle = "Online properties - " + applicationName %}
+{% set pageTitle = (status | title) + " properties - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
 
 {% block beforeContent %}
@@ -25,7 +25,7 @@
 
         {{ mojCasPageHeaderActions({
             heading: {
-                text: 'Online properties'
+                text: (status | title) + " properties"
             },
             actions: [{
                 text: "Add a property",
@@ -35,43 +35,62 @@
 
         {{ mojSubNavigation({
             label: "Sub navigation",
-            items: [{
-                text: "Online properties",
-                href: "#",
-                active: true
-            }]
+            items: subNavArr
         }) }}
     </div>
 
-    <div>
-        <div class="moj-search cas-search-container govuk-!-margin-bottom-6 govuk-!-padding-6 govuk-!-padding-bottom-7 govuk-grid-column-two-thirds">
-            <form action="{{ paths.premises.v2.index() }}" method="get">
-                {{ govukInput({
-                    label: {
-                        classes: 'govuk-!-font-weight-bold',
-                        text: 'Find a property'
-                    },
-                    hint: {
-                        text: 'Search by road or postcode'
-                    },
-                    name: 'postcodeOrAddress',
-                    id: 'postcodeOrAddress',
-                    value: params.postcodeOrAddress,
-                    classes: 'moj-search__input'
-                }) }}
+    <div class="govuk-grid-row">
+        {% if (totalPremises is defined and totalPremises > 0) or params.postcodeOrAddress %}
+        <div class="govuk-grid-column-full">
+            <div class="moj-search cas-search-container govuk-!-margin-bottom-6 govuk-!-padding-6 govuk-!-padding-bottom-7 govuk-grid-column-two-thirds">
+                <form action="{{ paths.premises.v2[status]({}) }}" method="get">
+                    {{ govukInput({
+                        label: {
+                            classes: 'govuk-!-font-weight-bold',
+                            text: 'Find an ' + status + ' property'
+                        },
+                        hint: {
+                            text: 'Search by road or postcode'
+                        },
+                        name: 'postcodeOrAddress',
+                        id: 'postcodeOrAddress',
+                        value: params.postcodeOrAddress,
+                        classes: 'moj-search__input'
+                    }) }}
 
-                {{ govukButton({
-                    text: 'Search',
-                    attributes: { id: 'search-button' },
-                    preventDoubleClick: true,
-                    classes: 'moj-search__button'
-                }) }}
-            </form>
+                    {{ govukButton({
+                        text: 'Search',
+                        attributes: { id: 'search-button' },
+                        preventDoubleClick: true,
+                        classes: 'moj-search__button'
+                    }) }}
+                </form>
+            </div>
         </div>
+        {% endif %}
+        {% if totalPremises is defined %}
+        <div class="govuk-grid-column-full">
+            <div class="govuk-!-margin-bottom-6">
+                <div class="govuk-!-padding-bottom-4">
+                    {% if params.postcodeOrAddress %}
+                    <h2 class="govuk-heading-l govuk-!-margin-bottom-6">{{ totalPremises }} {{ status }} properties matching '{{ params.postcodeOrAddress }}'</h2>
+                    {% else %}
+                    <h2 class="govuk-heading-l govuk-!-margin-bottom-6">{{ totalPremises }} {{ status }} properties</h2>
+                    {% endif %}
+                    {% if totalPremises is defined and totalPremises > 0 %}
+                        {% if status === 'online' and totalOnlineBedspaces is defined %}
+                        <p class="govuk-body govuk-!-margin-bottom-1">Online bedspaces: {{ totalOnlineBedspaces }}</p>
+                        {% endif %}
+                        {% if totalUpcomingBedspaces is defined and totalUpcomingBedspaces != 0 %}
+                        <p class="govuk-body govuk-!-margin-bottom-0">Upcoming bedspaces: {{ totalUpcomingBedspaces }}</p>
+                        {% endif %}
+                    {% endif %}
+                </div>
+            </div>
+        </div>
+        {% endif %}
     </div>
-
     <div>
-
         {% if (tableRows | length > 0) %}
             {{ govukTable({
                 attributes: {
@@ -98,10 +117,12 @@
                 rows: tableRows
             }) }}
         {% else %}
-            {% if params.postcodeOrAddress %}
-                <h2>{{ '0 online properties matching ‘' + params.postcodeOrAddress + '’' }}</h2>
-            {% else %}
-                <h2>0 online properties</h2>
+            {% if totalPremises is defined and totalPremises > 0 %}
+                {% if params.postcodeOrAddress %}
+                    <h2>{{ '0 online properties matching ‘' + params.postcodeOrAddress + '’' }}</h2>
+                {% else %}
+                    <h2>0 {{ (isOnlineTab and "online" or "archived") }} properties</h2>
+                {% endif %}
             {% endif %}
         {% endif %}
     </div>


### PR DESCRIPTION
# Context

Implements default v2 properties route (online) along with properties and bedspaces counts for v2 properties page. Also adds Archived Tab. 

More info here: 
https://dsdmoj.atlassian.net/browse/CAS-1711 and 
https://dsdmoj.atlassian.net/browse/CAS-1716

# Changes in this PR

- Auto-redirect to `v2/properties/online` when accessing `/v2/properties`
- Added new Archive tab in the v2 properties route
- Added counts for v2 online properties and their bedspaces above the results table

## Screenshots of UI changes

### Before
<img width="710" alt="Screenshot 2025-06-25 at 12 42 50" src="https://github.com/user-attachments/assets/b72816b4-4434-423b-90aa-befba2f2f604" />


### After
<img width="722" alt="Screenshot 2025-06-26 at 20 01 36" src="https://github.com/user-attachments/assets/7167fe01-ef06-4bdb-9327-2dee6a494ef4" />


# Release checklist

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API) 
- [ ] Have they been released to production already? 

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod