### PR TITLE
fix/failing e2e playwright test

### DIFF
--- a/e2e_playwright/pages/manage/editPropertyPage.ts
+++ b/e2e_playwright/pages/manage/editPropertyPage.ts
@@ -15,10 +15,10 @@ export class EditPropertyPage extends BasePage {
     await expect(this.page.getByLabel('Town or city (optional)')).toHaveValue(property.town)
     await expect(this.page.getByLabel('Postcode')).toHaveValue(property.postcode)
 
-    const selectedOptions = await this.page.locator('select > option[selected]').all()
-    await expect(selectedOptions[0]).toHaveText(property.localAuthority)
-    await expect(selectedOptions[1]).toHaveText(property.probationRegion)
-    await expect(selectedOptions[2]).toHaveText(property.pdu)
+    const selectedOptions = this.page.locator('select > option[selected]')
+    await expect(selectedOptions.nth(0)).toHaveText(property.localAuthority)
+    await expect(selectedOptions.nth(1)).toHaveText(property.probationRegion)
+    await expect(selectedOptions.nth(2)).toHaveText(property.pdu)
 
     await this.isCorrectPropertyAttributesChecked(property)
 


### PR DESCRIPTION
# Context

This is to two a failing e2e playwright test, [here](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/15873118566/job/44755481690) and [here](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/15848200520/job/44676155455).

I wasn't able to replicate early but I have a feeling the page isn't fully loading before `.all()` was being called, switching to `nth()`  will auto wait.

**NOTE** [locator.all()](https://playwright.dev/docs/api/class-locator) does not wait for elements to match the locator, and instead immediately returns whatever is present in the page.

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
