### PR TITLE
Add validation messages for booking arrival and void start dates

### DIFF
--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -24,7 +24,8 @@
       "invalid": "The start date is an invalid date",
       "conflict": "This bedspace is not available for these dates",
       "todayOrInThePast": "The arrival date must be today or in the past",
-      "withinLastSevenDays": "The arrival date must be within the last 7 days"
+      "withinLastSevenDays": "The arrival date must be within the last 7 days",
+      "bookingArrivalDateBeforeBedspaceStartDate": "Booking start date must be on or later than bedspace start date"
     },
     "date": {
       "empty": "You must enter a valid departure date",
@@ -86,7 +87,8 @@
       "conflict": "This bedspace is not available for these dates",
       "afterEndDate": "The start date must be before the end date",
       "invalidStartDateInTheFuture": "Date must be within the past 7 days or the next 7 days",
-      "invalidStartDateInThePast": "Date must be within the past 7 days or the next 7 days"
+      "invalidStartDateInThePast": "Date must be within the past 7 days or the next 7 days",
+      "voidStartDateAfterBedspaceEndDate": "Void start date must be on or earlier than bedspace end date"
     },
     "endDate": {
       "empty": "You must enter an end date",


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1781) was to add  a validation message for booking start date being before bedspace start date.

[Also](https://dsdmoj.atlassian.net/browse/CAS-1784) included with this was the error message for void bedspace after bedspace end date

_Currently_ be is only passing through error token and note dates.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="810" alt="image" src="https://github.com/user-attachments/assets/6e7b529b-c68c-441c-91ba-ab8ec4185b53" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
