### PR TITLE
Add premises sorting functionality

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesList.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesList.ts
@@ -1,4 +1,4 @@
-import type { Cas3Premises, Cas3PremisesSearchResult } from '@approved-premises/api'
+import type { Cas3Premises, Cas3PremisesSearchResult, Cas3PremisesSortBy } from '@approved-premises/api'
 
 import paths from '../../../../../server/paths/temporary-accommodation/manage'
 import Page from '../../../page'
@@ -23,7 +23,7 @@ export default class PremisesListPage extends Page {
     return new PremisesListPage('Archived properties')
   }
 
-  shouldShowPremises(premises: Array<Cas3PremisesSearchResult>): void {
+  shouldShowPremises(premises: Array<Cas3PremisesSearchResult>, sortBy: Cas3PremisesSortBy = 'pdu'): void {
     premises.forEach((item: Cas3PremisesSearchResult) => {
       cy.contains(item.addressLine1)
         .contains(item.addressLine2)
@@ -46,7 +46,9 @@ export default class PremisesListPage extends Page {
             item.bedspaces.forEach(bedspace => cy.get('td').eq(1).contains(bedspace.reference))
           }
 
-          cy.get('td').eq(2).contains(item.pdu)
+          cy.get('td')
+            .eq(2)
+            .contains(sortBy === 'pdu' ? item.pdu : item.localAuthorityAreaName)
           cy.get('td').eq(3).contains('Manage').should('have.attr', 'href', `/v2/properties/${item.id}`)
         })
     })
@@ -75,6 +77,14 @@ export default class PremisesListPage extends Page {
 
   clickBedspaceReference(reference: string): void {
     cy.get('main table tbody a').contains(reference).click()
+  }
+
+  toggleSortBy() {
+    cy.get('[data-cy="toggle-sort"]').click()
+  }
+
+  shouldShowSortByHeader(text: string) {
+    cy.get('[data-cy="sort-by-header"]').should('contain', text)
   }
 
   clickPremisesManageLink(premises: Cas3Premises): void {

--- a/integration_tests/mockApis/v2/premises.ts
+++ b/integration_tests/mockApis/v2/premises.ts
@@ -1,4 +1,9 @@
-import type { Cas3Premises, Cas3PremisesSearchResults, Cas3PremisesStatus } from '@approved-premises/api'
+import type {
+  Cas3Premises,
+  Cas3PremisesSearchResults,
+  Cas3PremisesSortBy,
+  Cas3PremisesStatus,
+} from '@approved-premises/api'
 import type { Response } from 'superagent'
 import { stubFor } from '..'
 import paths from '../../../server/paths/api'
@@ -13,6 +18,7 @@ type SearchArguments = {
   searchResults: Cas3PremisesSearchResults
   postcodeOrAddress: string
   premisesStatus: Cas3PremisesStatus
+  sortBy?: Cas3PremisesSortBy
 }
 
 const stubPremisesSearchV2 = (args: SearchArguments) =>
@@ -23,6 +29,7 @@ const stubPremisesSearchV2 = (args: SearchArguments) =>
       queryParameters: {
         postcodeOrAddress: { equalTo: args.postcodeOrAddress },
         premisesStatus: { equalTo: args.premisesStatus },
+        sortBy: { equalTo: args.sortBy ?? 'pdu' },
       },
     },
     response: {

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,8 @@
-import type { TemporaryAccommodationApplication as Application, ProbationRegion } from '@approved-premises/api'
+import type {
+  TemporaryAccommodationApplication as Application,
+  Cas3PremisesSortBy,
+  ProbationRegion,
+} from '@approved-premises/api'
 import type { ErrorMessages, PlaceContext } from '@approved-premises/ui'
 import { UserDetails } from '../../services/userService'
 
@@ -13,6 +17,7 @@ declare module 'express-session' {
     previousPage: string
     probationRegion: ProbationRegion
     userDetails: UserDetails
+    premisesSortBy: Cas3PremisesSortBy
   }
 }
 

--- a/server/controllers/temporary-accommodation/manage/v2/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/premisesController.test.ts
@@ -94,6 +94,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: undefined },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived', active: false },
@@ -105,6 +106,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -136,6 +138,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: undefined },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived', active: false },
@@ -147,6 +150,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -176,6 +180,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: 'NE1' },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online?postcodeOrAddress=NE1', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived?postcodeOrAddress=NE1', active: false },
@@ -187,6 +192,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -218,6 +224,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: undefined },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived', active: false },
@@ -229,6 +236,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -260,6 +268,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: undefined },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived', active: false },
@@ -275,6 +284,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -304,6 +314,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: 'NE1' },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online?postcodeOrAddress=NE1', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived?postcodeOrAddress=NE1', active: false },
@@ -319,6 +330,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -348,6 +360,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: 'NONEXISTENT' },
         status: 'online',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online?postcodeOrAddress=NONEXISTENT', active: true },
           { text: 'Archived properties', href: '/v2/properties/archived?postcodeOrAddress=NONEXISTENT', active: false },
@@ -363,6 +376,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'online',
+        'pdu',
       )
     })
 
@@ -394,6 +408,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: undefined },
         status: 'archived',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online', active: false },
           { text: 'Archived properties', href: '/v2/properties/archived', active: true },
@@ -409,6 +424,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'archived',
+        'pdu',
       )
     })
 
@@ -438,6 +454,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: 'SW1' },
         status: 'archived',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online?postcodeOrAddress=SW1', active: false },
           { text: 'Archived properties', href: '/v2/properties/archived?postcodeOrAddress=SW1', active: true },
@@ -453,6 +470,7 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'archived',
+        'pdu',
       )
     })
 
@@ -482,6 +500,7 @@ describe('PremisesController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
         params: { postcodeOrAddress: 'NOTFOUND' },
         status: 'archived',
+        premisesSortBy: 'pdu',
         subNavArr: [
           { text: 'Online properties', href: '/v2/properties/online?postcodeOrAddress=NOTFOUND', active: false },
           { text: 'Archived properties', href: '/v2/properties/archived?postcodeOrAddress=NOTFOUND', active: true },
@@ -497,7 +516,98 @@ describe('PremisesController', () => {
         callConfig,
         params.postcodeOrAddress,
         'archived',
+        'pdu',
       )
+    })
+  })
+
+  it('searches premises data and returns as table rows when premisesSortBy is "la"', async () => {
+    const params: PremisesSearchParameters = { postcodeOrAddress: undefined }
+    const searchData = {
+      results: [] as Array<Cas3PremisesSearchResult>,
+      totalPremises: 1,
+      totalOnlineBedspaces: 2,
+      totalUpcomingBedspaces: 0,
+      tableRows: [] as Array<never>,
+    }
+
+    request = createMock<Request>({
+      session: {
+        probationRegion: probationRegionFactory.build(),
+        premisesSortBy: 'la',
+      },
+      query: params,
+      path: '/v2/properties/online',
+    })
+
+    premisesService.searchDataAndGenerateTableRows.mockResolvedValue(searchData)
+
+    const requestHandler = premisesController.index('online')
+    await requestHandler(request, response, next)
+
+    expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/premises/index', {
+      params: { postcodeOrAddress: undefined },
+      status: 'online',
+      premisesSortBy: 'la',
+      subNavArr: [
+        { text: 'Online properties', href: '/v2/properties/online', active: true },
+        { text: 'Archived properties', href: '/v2/properties/archived', active: false },
+      ],
+      ...searchData,
+    })
+
+    expect(premisesService.searchDataAndGenerateTableRows).toHaveBeenCalledWith(
+      callConfig,
+      params.postcodeOrAddress,
+      'online',
+      'la',
+    )
+  })
+
+  describe('toggleSort', () => {
+    it('toggles from pdu to la and redirects with query params', async () => {
+      const req = createMock<Request>({
+        session: { premisesSortBy: 'pdu' },
+        query: { postcodeOrAddress: 'SW1A' },
+      })
+      const res = createMock<Response>({})
+      res.redirect = jest.fn()
+
+      const requestHandler = premisesController.toggleSort()
+      await requestHandler(req, res, next)
+
+      expect(req.session.premisesSortBy).toBe('la')
+      expect(res.redirect).toHaveBeenCalledWith('/v2/properties/online?postcodeOrAddress=SW1A')
+    })
+
+    it('toggles from la to pdu and redirects without query params', async () => {
+      const req = createMock<Request>({
+        session: { premisesSortBy: 'la' },
+        query: {},
+      })
+      const res = createMock<Response>({})
+      res.redirect = jest.fn()
+
+      const requestHandler = premisesController.toggleSort()
+      await requestHandler(req, res, next)
+
+      expect(req.session.premisesSortBy).toBe('pdu')
+      expect(res.redirect).toHaveBeenCalledWith('/v2/properties/online')
+    })
+
+    it('defaults to pdu if session value is missing, then toggles to la', async () => {
+      const req = createMock<Request>({
+        session: {},
+        query: {},
+      })
+      const res = createMock<Response>({})
+      res.redirect = jest.fn()
+
+      const requestHandler = premisesController.toggleSort()
+      await requestHandler(req, res, next)
+
+      expect(req.session.premisesSortBy).toBe('la')
+      expect(res.redirect).toHaveBeenCalledWith('/v2/properties/online')
     })
   })
 

--- a/server/data/v2/premisesClient.test.ts
+++ b/server/data/v2/premisesClient.test.ts
@@ -42,10 +42,11 @@ describe('PremisesClient', () => {
         .query({
           postcodeOrAddress: 'NE1 1AB',
           premisesStatus: 'online',
+          sortBy: 'pdu',
         })
         .reply(200, searchResults)
 
-      const output = await premisesClient.search('NE1 1AB', 'online')
+      const output = await premisesClient.search('NE1 1AB', 'online', 'pdu')
       expect(output).toEqual(searchResults)
     })
   })

--- a/server/data/v2/premisesClient.ts
+++ b/server/data/v2/premisesClient.ts
@@ -1,4 +1,4 @@
-import { Cas3Premises, Cas3PremisesSearchResults, Cas3PremisesStatus } from '@approved-premises/api'
+import { Cas3Premises, Cas3PremisesSearchResults, Cas3PremisesSortBy, Cas3PremisesStatus } from '@approved-premises/api'
 import RestClient, { CallConfig } from '../restClient'
 import config, { ApiConfig } from '../../config'
 import paths from '../../paths/api'
@@ -10,10 +10,10 @@ export default class PremisesClient {
     this.restClient = new RestClient('premisesClientV2', config.apis.approvedPremises as ApiConfig, callConfig)
   }
 
-  async search(postcodeOrAddress: string, premisesStatus: Cas3PremisesStatus) {
+  async search(postcodeOrAddress: string, premisesStatus: Cas3PremisesStatus, sortBy: Cas3PremisesSortBy) {
     return this.restClient.get<Cas3PremisesSearchResults>({
       path: paths.cas3.premises.search({}),
-      query: { postcodeOrAddress, premisesStatus },
+      query: { postcodeOrAddress, premisesStatus, sortBy },
     })
   }
 

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -57,6 +57,7 @@ const paths: Record<string, any> = {
       index: premisesV2Path,
       online: premisesV2OnlinePath,
       archived: premisesV2ArchivedPath,
+      toggleSort: premisesV2Path.path('toggle-sort'),
       show: singlePremisesV2Path,
       bedspaces: {
         new: bedspacesV2Path.path('new'),

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -80,6 +80,9 @@ export default function routes(controllers: Controllers, services: Services, rou
     get(paths.premises.v2.archived.pattern, premisesControllerV2.index('archived'), {
       auditEvent: 'VIEW_PREMISES_LIST_V2_ARCHIVED',
     })
+    get(paths.premises.v2.toggleSort.pattern, premisesControllerV2.toggleSort(), {
+      auditEvent: 'TOGGLE_PREMISES_SORT_V2',
+    })
     get(paths.premises.v2.show.pattern, premisesControllerV2.show(), { auditEvent: 'SHOW_PREMISES_V2' })
 
     get(paths.premises.v2.bedspaces.new.pattern, bedspacesControllerV2.new(), { auditEvent: 'VIEW_BEDSPACE_V2_CREATE' })

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -3,6 +3,7 @@ import {
   Cas3Premises,
   Cas3PremisesSearchResult,
   Cas3PremisesSearchResults,
+  Cas3PremisesSortBy,
   Cas3PremisesStatus,
   Characteristic,
 } from '@approved-premises/api'
@@ -21,14 +22,15 @@ export default class PremisesService {
     callConfig: CallConfig,
     postcodeOrAddress: string | undefined,
     status: Cas3PremisesStatus = 'online',
+    premisesSortBy: Cas3PremisesSortBy = 'pdu',
   ): Promise<Cas3PremisesSearchResults & { tableRows: Array<TableRow> }> {
     const premisesClient = this.premisesClientFactory(callConfig)
 
-    const premises = await premisesClient.search(postcodeOrAddress ?? '', status)
+    const premises = await premisesClient.search(postcodeOrAddress ?? '', status, premisesSortBy)
 
     return {
       ...premises,
-      tableRows: this.tableRows(premises),
+      tableRows: this.tableRows(premises, premisesSortBy),
     }
   }
 
@@ -49,14 +51,14 @@ export default class PremisesService {
     }
   }
 
-  tableRows(premises: Cas3PremisesSearchResults): Array<TableRow> {
+  tableRows(premises: Cas3PremisesSearchResults, premisesSortBy: Cas3PremisesSortBy = 'pdu'): Array<TableRow> {
     return premises.results === undefined
       ? []
       : premises.results.map(entry => {
           return [
             this.htmlValue(this.formatAddress(entry)),
             this.htmlValue(this.formatBedspaces(entry)),
-            this.textValue(entry.pdu),
+            this.textValue(premisesSortBy === 'pdu' ? entry.pdu : entry.localAuthorityAreaName),
             this.htmlValue(this.formatPremisesManageLink(entry)),
           ]
         })

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -196,4 +196,11 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   njkEnv.addGlobal('AttachDocumentsUtils', AttachDocumentsUtils)
   njkEnv.addGlobal('PhaseBannerUtils', PhaseBannerUtils)
   njkEnv.addGlobal('formatNotes', formatNotes)
+  njkEnv.addGlobal('toQueryString', function toQueryString(params: Record<string, unknown>): string {
+    if (!params) return ''
+    return Object.entries(params)
+      .filter(([_, v]) => v !== undefined && v !== '')
+      .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
+      .join('&')
+  })
 }

--- a/server/views/temporary-accommodation/v2/premises/index.njk
+++ b/server/views/temporary-accommodation/v2/premises/index.njk
@@ -9,6 +9,7 @@
 
 {% set pageTitle = (status | title) + " properties - " + applicationName %}
 {% set mainClasses = "app-container govuk-body" %}
+{% set sortByHeader = premisesSortBy == 'pdu' and 'PDU' or 'LA' %}
 
 {% block beforeContent %}
     {{ govukBreadcrumbs({
@@ -70,7 +71,7 @@
         {% endif %}
         {% if totalPremises is defined %}
         <div class="govuk-grid-column-full">
-            <div class="govuk-!-margin-bottom-6">
+            <div class="govuk-!-margin-bottom-1">
                 <div class="govuk-!-padding-bottom-4">
                     {% if params.postcodeOrAddress %}
                     <h2 class="govuk-heading-l govuk-!-margin-bottom-6">{{ totalPremises }} {{ status }} properties matching ‘{{ params.postcodeOrAddress }}’</h2>
@@ -89,6 +90,28 @@
             </div>
         </div>
         {% endif %}
+        <div class="govuk-grid-column-full">
+            {% if premisesSortBy is defined and premisesSortBy == 'pdu' %}
+                <span class="govuk-heading-m" data-cy="sort-by-header">
+                    Properties by probation delivery unit
+                </span>
+                <div class="govuk-!-margin-bottom-6">
+                    <a href="{{ paths.premises.v2.toggleSort() }}{% if params %}?{{ toQueryString(params) }}{% endif %}" data-cy="toggle-sort" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-normal govuk-!-margin-bottom-4">
+                        View by local authority
+                    </a>
+                </div>
+            {% else %}
+                <span class="govuk-heading-m" data-cy="sort-by-header">
+                    Properties by local authority
+                </span>
+                <div class="govuk-!-margin-bottom-6">
+                    <a href="{{ paths.premises.v2.toggleSort() }}{% if params %}?{{ toQueryString(params) }}{% endif %}" data-cy="toggle-sort" class="govuk-link govuk-link--no-visited-state govuk-!-font-weight-normal govuk-!-margin-bottom-4">
+                        View by probation delivery unit
+                    </a>
+                </div>
+            {% endif %}
+            <span class="govuk-visually-hidden">(column headers with buttons are sortable).</span>
+        </div>
     </div>
     <div>
         {% if (tableRows | length > 0) %}
@@ -107,7 +130,7 @@
                         classes: "govuk-!-width-one-quarter"
                     },
                     {
-                        text: "PDU",
+                        text: sortByHeader | trim,
                         attributes: { "aria-sort": "ascending" }
                     },
                     {


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1713) is to add a new feature to the v2 premises page, which allows the user to toggle between pdu and la sort.

# Changes in this PR

## Screenshots of UI changes

### Before

<img width="1213" alt="image" src="https://github.com/user-attachments/assets/e13dcb33-6716-4707-b858-5a6240a8cecc" />

### After

<img width="1204" alt="image" src="https://github.com/user-attachments/assets/df6ea9fb-f7a9-4c53-84da-54ec038c6223" />

<img width="1199" alt="image" src="https://github.com/user-attachments/assets/4077def2-25e7-4eda-ad74-6a1711a71521" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
