### PR TITLE
Archive bedspace - Form validation handling

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceArchive.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceArchive.ts
@@ -1,0 +1,57 @@
+import type { Cas3Bedspace, Cas3Premises } from '@approved-premises/api'
+import Page from '../../../page'
+
+export default class BedspaceArchivePage extends Page {
+  constructor(
+    private readonly premises: Cas3Premises,
+    private readonly bedspace: Cas3Bedspace,
+  ) {
+    super(`When should ${bedspace.reference} be archived?`)
+  }
+
+  static visit(premises: Cas3Premises, bedspace: Cas3Bedspace): BedspaceArchivePage {
+    cy.visit(`/temporary-accommodation/manage/v2/properties/${premises.id}/bedspaces/${bedspace.id}/archive`)
+    return new BedspaceArchivePage(premises, bedspace)
+  }
+
+  shouldShowBedspaceDetails(): void {
+    cy.get('h1').should('contain', `When should ${this.bedspace.reference} be archived?`)
+  }
+
+  selectTodayOption(): void {
+    cy.get('input[value="today"]').check()
+  }
+
+  selectAnotherDateOption(): void {
+    cy.get('input[value="anotherDate"]').check()
+  }
+
+  enterArchiveDate(day: string, month: string, year: string): void {
+    cy.get('#archiveDate-day').clear().type(day)
+    cy.get('#archiveDate-month').clear().type(month)
+    cy.get('#archiveDate-year').clear().type(year)
+  }
+
+  clickSubmit(): void {
+    cy.get('button[type="submit"]').click()
+  }
+
+  shouldShowError(errorMessage: string): void {
+    cy.get('.govuk-error-summary').should('contain', errorMessage)
+  }
+
+  shouldShowValidationErrors(): void {
+    cy.get('.govuk-error-summary').should('exist')
+  }
+
+  completeArchiveWithToday(): void {
+    this.selectTodayOption()
+    this.clickSubmit()
+  }
+
+  completeArchiveWithDate(day: string, month: string, year: string): void {
+    this.selectAnotherDateOption()
+    this.enterArchiveDate(day, month, year)
+    this.clickSubmit()
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
@@ -77,14 +77,17 @@ export default class BedspaceShowPage extends Page {
   }
 
   clickArchiveLink(): void {
-    // Click the Archive link
-    cy.get('.moj-cas-page-header-actions .moj-button-menu__toggle-button').then($toggleButtons => {
-      if ($toggleButtons.length > 0) {
-        // Dropdown exists - click it first
-        cy.wrap($toggleButtons.first()).click()
+    cy.document().then((doc: Document) => {
+      const container = doc.querySelector('.moj-cas-page-header-actions')
+      if (!container) return
+
+      const hasToggleButton = container.querySelector('.moj-button-menu__toggle-button')
+      if (hasToggleButton) {
+        cy.get('.moj-cas-page-header-actions .moj-button-menu__toggle-button').click()
       }
+
+      cy.get('.moj-cas-page-header-actions a').contains('Archive').click()
     })
-    cy.get('.moj-cas-page-header-actions a').contains('Archive').click()
   }
 
   shouldShowAsArchived(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
@@ -76,7 +76,7 @@ export default class BedspaceShowPage extends Page {
     lostBedListingComponent.shouldShowLostBedDetails()
   }
 
-  clickArchiveLink(): void {
+  clickArchiveAction(): void {
     cy.document().then((doc: Document) => {
       const container = doc.querySelector('.moj-cas-page-header-actions')
       if (!container) return

--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
@@ -75,4 +75,25 @@ export default class BedspaceShowPage extends Page {
     const lostBedListingComponent = new LostBedListingComponent(lostBed)
     lostBedListingComponent.shouldShowLostBedDetails()
   }
+
+  clickArchiveLink(): void {
+    // Click the Archive link
+    cy.get('.moj-cas-page-header-actions .moj-button-menu__toggle-button').then($toggleButtons => {
+      if ($toggleButtons.length > 0) {
+        // Dropdown exists - click it first
+        cy.wrap($toggleButtons.first()).click()
+      }
+    })
+    cy.get('.moj-cas-page-header-actions a').contains('Archive').click()
+  }
+
+  shouldShowAsArchived(): void {
+    cy.get('.govuk-tag').should('contain', 'Archived')
+  }
+
+  shouldNotShowArchiveLink(): void {
+    cy.get('.moj-cas-page-header-actions').within(() => {
+      cy.root().should('not.contain', 'Archive')
+    })
+  }
 }

--- a/integration_tests/mockApis/v2/bedspace.ts
+++ b/integration_tests/mockApis/v2/bedspace.ts
@@ -83,10 +83,68 @@ const stubBedspaceCreateErrors = (args: {
     },
   })
 
+const stubBedspaceArchiveV2 = (args: { premisesId: string; bedspaceId: string }) =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPathPattern: paths.cas3.premises.bedspaces.archive({
+        premisesId: args.premisesId,
+        bedspaceId: args.bedspaceId,
+      }),
+    },
+    response: {
+      status: 200,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        id: args.bedspaceId,
+        reference: 'A1',
+        startDate: '2024-01-12',
+        status: 'archived',
+        endDate: '2025-09-25',
+        notes: null,
+        characteristics: [],
+        bedspaceCharacteristics: null,
+      },
+    },
+  })
+
+const stubBedspaceArchiveV2WithError = (args: { premisesId: string; bedspaceId: string; errorType: string }) =>
+  stubFor({
+    request: {
+      method: 'POST',
+      urlPathPattern: paths.cas3.premises.bedspaces.archive({
+        premisesId: args.premisesId,
+        bedspaceId: args.bedspaceId,
+      }),
+    },
+    response: {
+      status: 400,
+      headers: {
+        'Content-Type': 'application/json;charset=UTF-8',
+      },
+      jsonBody: {
+        'invalid-params': [
+          {
+            propertyName: '$.endDate',
+            errorType: args.errorType,
+            errorDetail: null,
+          },
+        ],
+        title: 'Bad Request',
+        status: 400,
+        detail: 'There is a problem with your request',
+      },
+    },
+  })
+
 export default {
   stubBedspaceV2,
   stubPremisesBedspacesV2,
   stubBedspaceCreate,
   verifyBedspaceCreate,
   stubBedspaceCreateErrors,
+  stubBedspaceArchiveV2,
+  stubBedspaceArchiveV2WithError,
 }

--- a/integration_tests/tests/temporary-accommodation/manage/v2/bedspaceArchive.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/bedspaceArchive.cy.ts
@@ -1,0 +1,86 @@
+import { setupTestUser } from '../../../../../cypress_shared/utils/setupTestUser'
+import Page from '../../../../../cypress_shared/pages/page'
+import BedspaceShowPage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow'
+import BedspaceArchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceArchive'
+import { cas3BedspaceFactory, cas3PremisesFactory } from '../../../../../server/testutils/factories'
+
+context('Bedspace Archive', () => {
+  beforeEach(() => {
+    cy.task('reset')
+    setupTestUser('assessor')
+
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is reference data in the database
+    cy.task('stubPremisesReferenceData')
+    cy.task('stubRoomReferenceData')
+  })
+
+  it('navigates to archive page, and archives successfully with success message based on the API response', () => {
+    // Given there is an active premises in the database
+    const premises = cas3PremisesFactory.build({ status: 'online' })
+    cy.task('stubSinglePremisesV2', premises)
+
+    // And there is an online bedspace in the database
+    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+
+    // When I visit the show bedspace page
+    const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
+
+    // Then I should see the archive button and be able to click it
+    bedspaceShowPage.clickArchiveLink()
+
+    // And I should navigate to the archive bedspace page
+    const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
+    archivePage.shouldShowBedspaceDetails()
+
+    // When I archive with today option
+    cy.task('stubBedspaceArchiveV2', { premisesId: premises.id, bedspaceId: bedspace.id })
+    const archivedBedspace = { ...bedspace, status: 'archived' }
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: archivedBedspace })
+    archivePage.completeArchiveWithToday()
+
+    // Then I should be redirected to the bedspace show page with success message based on the API response
+    const finalBedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, premises, archivedBedspace)
+    finalBedspaceShowPage.shouldShowBanner('Bedspace archived')
+    finalBedspaceShowPage.shouldShowAsArchived()
+    finalBedspaceShowPage.shouldNotShowArchiveLink()
+  })
+
+  it('navigates to archive page, and fails to archive with error based on the API response', () => {
+    // Given there is an active premises in the database
+    const premises = cas3PremisesFactory.build({ status: 'online' })
+    cy.task('stubSinglePremisesV2', premises)
+
+    // And there is an online bedspace in the database
+    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+
+    // When I visit the show bedspace page
+    const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
+
+    // Then I should see the archive button and be able to click it
+    bedspaceShowPage.clickArchiveLink()
+
+    // And I should navigate to the archive bedspace page
+    const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
+    archivePage.shouldShowBedspaceDetails()
+
+    // When I try to archive with past date
+    cy.task('stubBedspaceArchiveV2WithError', {
+      premisesId: premises.id,
+      bedspaceId: bedspace.id,
+      errorType: 'invalidEndDateInThePast',
+    })
+
+    // Select another date option and enter a past date (1/1/1900)
+    archivePage.selectAnotherDateOption()
+    archivePage.enterArchiveDate('1', '1', '1900')
+    archivePage.clickSubmit()
+
+    // Then I should see the validation error based on the API response
+    archivePage.shouldShowError('The date is not within the next 3 months')
+  })
+})

--- a/integration_tests/tests/temporary-accommodation/manage/v2/bedspaceArchive.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/bedspaceArchive.cy.ts
@@ -30,7 +30,7 @@ context('Bedspace Archive', () => {
     const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
 
     // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
+    bedspaceShowPage.clickArchiveAction()
 
     // And I should navigate to the archive bedspace page
     const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
@@ -62,7 +62,7 @@ context('Bedspace Archive', () => {
     const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
 
     // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
+    bedspaceShowPage.clickArchiveAction()
 
     // And I should navigate to the archive bedspace page
     const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
@@ -96,7 +96,7 @@ context('Bedspace Archive', () => {
     const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
 
     // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
+    bedspaceShowPage.clickArchiveAction()
 
     // And I should navigate to the archive bedspace page
     const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
@@ -116,139 +116,5 @@ context('Bedspace Archive', () => {
 
     // Then I should see the validation error based on the API response
     archivePage.shouldShowError('The date is not within the next 3 months')
-  })
-
-  it('fails to archive with invalidEndDateInTheFuture error', () => {
-    // Given there is an active premises in the database
-    const premises = cas3PremisesFactory.build({ status: 'online' })
-    cy.task('stubSinglePremisesV2', premises)
-
-    // And there is an online bedspace in the database
-    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
-    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
-
-    // When I visit the show bedspace page
-    const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
-
-    // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
-
-    // And I should navigate to the archive bedspace page
-    const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
-    archivePage.shouldShowBedspaceDetails()
-
-    // When I try to archive with future date beyond 3 months
-    cy.task('stubBedspaceArchiveV2WithError', {
-      premisesId: premises.id,
-      bedspaceId: bedspace.id,
-      errorType: 'invalidEndDateInTheFuture',
-    })
-
-    // Select another date option and enter a far future date
-    archivePage.selectAnotherDateOption()
-    archivePage.enterArchiveDate('1', '1', '2100')
-    archivePage.clickSubmit()
-
-    // Then I should see the validation error based on the API response
-    archivePage.shouldShowError('The date is not within the next 3 months')
-  })
-
-  it('fails to archive with existingBookings error', () => {
-    // Given there is an active premises in the database
-    const premises = cas3PremisesFactory.build({ status: 'online' })
-    cy.task('stubSinglePremisesV2', premises)
-
-    // And there is an online bedspace in the database
-    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
-    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
-
-    // When I visit the show bedspace page
-    const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
-
-    // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
-
-    // And I should navigate to the archive bedspace page
-    const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
-    archivePage.shouldShowBedspaceDetails()
-
-    // When I try to archive but there are existing bookings
-    cy.task('stubBedspaceArchiveV2WithError', {
-      premisesId: premises.id,
-      bedspaceId: bedspace.id,
-      errorType: 'existingBookings',
-    })
-
-    // Archive with today option
-    archivePage.completeArchiveWithToday()
-
-    // Then I should see the validation error based on the API response
-    archivePage.shouldShowError('This bedspace cannot be archived due to existing bookings after this date.')
-  })
-
-  it('fails to archive with existingVoid error', () => {
-    // Given there is an active premises in the database
-    const premises = cas3PremisesFactory.build({ status: 'online' })
-    cy.task('stubSinglePremisesV2', premises)
-
-    // And there is an online bedspace in the database
-    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
-    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
-
-    // When I visit the show bedspace page
-    const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
-
-    // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
-
-    // And I should navigate to the archive bedspace page
-    const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
-    archivePage.shouldShowBedspaceDetails()
-
-    // When I try to archive but there is an existing void period
-    cy.task('stubBedspaceArchiveV2WithError', {
-      premisesId: premises.id,
-      bedspaceId: bedspace.id,
-      errorType: 'existingVoid',
-    })
-
-    // Archive with today option
-    archivePage.completeArchiveWithToday()
-
-    // Then I should see the validation error based on the API response
-    archivePage.shouldShowError('This bedspace cannot be archived due to a void period after this date.')
-  })
-
-  it('fails to archive with existingTurnaround error', () => {
-    // Given there is an active premises in the database
-    const premises = cas3PremisesFactory.build({ status: 'online' })
-    cy.task('stubSinglePremisesV2', premises)
-
-    // And there is an online bedspace in the database
-    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
-    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
-
-    // When I visit the show bedspace page
-    const bedspaceShowPage = BedspaceShowPage.visit(premises, bedspace)
-
-    // Then I should see the archive button and be able to click it
-    bedspaceShowPage.clickArchiveLink()
-
-    // And I should navigate to the archive bedspace page
-    const archivePage = Page.verifyOnPage(BedspaceArchivePage, premises, bedspace)
-    archivePage.shouldShowBedspaceDetails()
-
-    // When I try to archive but there is an existing turnaround
-    cy.task('stubBedspaceArchiveV2WithError', {
-      premisesId: premises.id,
-      bedspaceId: bedspace.id,
-      errorType: 'existingTurnaround',
-    })
-
-    // Archive with today option
-    archivePage.completeArchiveWithToday()
-
-    // Then I should see the validation error based on the API response
-    archivePage.shouldShowError('This bedspace cannot be archived due to a turnaround scheduled after this date.')
   })
 })

--- a/server/controllers/temporary-accommodation/manage/v2/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/bedspacesController.ts
@@ -88,6 +88,7 @@ export default class BedspacesController {
       const { premisesId, bedspaceId } = req.params
 
       const bedspace = await this.bedspaceService.getSingleBedspaceDetails(callConfig, premisesId, bedspaceId)
+      const archiveOption = userInput.archiveOption || 'today'
 
       return res.render('temporary-accommodation/v2/bedspaces/archive', {
         bedspace,
@@ -95,6 +96,7 @@ export default class BedspacesController {
         errors,
         errorSummary,
         ...userInput,
+        archiveOption,
       })
     }
   }

--- a/server/controllers/temporary-accommodation/manage/v2/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/bedspacesController.ts
@@ -8,7 +8,7 @@ import paths from '../../../../paths/temporary-accommodation/manage'
 import PremisesService from '../../../../services/v2/premisesService'
 
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../../utils/validation'
-import { DateFormats, dateAndTimeInputsAreValidDates, dateIsBlank } from '../../../../utils/dateUtils'
+import { DateFormats } from '../../../../utils/dateUtils'
 
 export default class BedspacesController {
   constructor(
@@ -113,14 +113,8 @@ export default class BedspacesController {
       if (archiveOption === 'today') {
         archiveDate = DateFormats.dateObjToIsoDate(new Date())
       } else if (archiveOption === 'anotherDate') {
-        if (dateIsBlank(req.body, 'archiveDate')) {
-          errors.archiveDate = 'You must specify the archive date'
-        } else if (!dateAndTimeInputsAreValidDates(req.body, 'archiveDate')) {
-          errors.archiveDate = 'You must specify a valid archive date'
-        } else {
-          const { archiveDate: archiveDateString } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'archiveDate')
-          archiveDate = archiveDateString
-        }
+        const { archiveDate: archiveDateString } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'archiveDate')
+        archiveDate = archiveDateString || ''
       } else {
         errors.archiveOption = 'You must select when to archive the bedspace'
       }
@@ -128,10 +122,6 @@ export default class BedspacesController {
       if (Object.keys(errors).length > 0) {
         req.flash('errors', errors)
         req.flash('userInput', req.body)
-        return res.redirect(paths.premises.v2.bedspaces.archive({ premisesId, bedspaceId }))
-      }
-
-      if (!archiveDate) {
         return res.redirect(paths.premises.v2.bedspaces.archive({ premisesId, bedspaceId }))
       }
 

--- a/server/data/v2/bedspaceClient.test.ts
+++ b/server/data/v2/bedspaceClient.test.ts
@@ -74,4 +74,18 @@ describe('BedspaceClient', () => {
       expect(output).toEqual(bedspaces)
     })
   })
+
+  describe('archive', () => {
+    it('should archive a bedspace', async () => {
+      const bedspaceId = 'some-bedspace-id'
+      const archiveData = { endDate: '2024-12-31' }
+
+      fakeApprovedPremisesApi
+        .post(paths.cas3.premises.bedspaces.archive({ premisesId, bedspaceId }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200)
+
+      await bedspaceClient.archive(premisesId, bedspaceId, archiveData)
+    })
+  })
 })

--- a/server/data/v2/bedspaceClient.test.ts
+++ b/server/data/v2/bedspaceClient.test.ts
@@ -80,12 +80,15 @@ describe('BedspaceClient', () => {
       const bedspaceId = 'some-bedspace-id'
       const archiveData = { endDate: '2024-12-31' }
 
-      fakeApprovedPremisesApi
-        .post(paths.cas3.premises.bedspaces.archive({ premisesId, bedspaceId }))
+      const scope = fakeApprovedPremisesApi
+        .post(paths.cas3.premises.bedspaces.archive({ premisesId, bedspaceId }), archiveData) // Verify request body
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(200)
 
       await bedspaceClient.archive(premisesId, bedspaceId, archiveData)
+
+      expect(scope.isDone()).toBe(true)
+      expect(nock.isDone()).toBeTruthy()
     })
   })
 })

--- a/server/data/v2/bedspaceClient.ts
+++ b/server/data/v2/bedspaceClient.ts
@@ -25,4 +25,11 @@ export default class BedspaceClient {
       path: paths.cas3.premises.bedspaces.get({ premisesId }),
     })
   }
+
+  async archive(premisesId: string, bedspaceId: string, data: { endDate: string }) {
+    return this.restClient.post<void>({
+      path: paths.cas3.premises.bedspaces.archive({ premisesId, bedspaceId }),
+      data,
+    })
+  }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -209,6 +209,8 @@
   },
   "bedspaceArchive": {
     "endDate": {
+      "empty": "You must enter a valid archive date",
+      "invalid": "You must enter a valid archive date",
       "invalidEndDateInThePast": "The date is not within the next 3 months",
       "invalidEndDateInTheFuture": "The date is not within the next 3 months",
       "existingBookings": "This bedspace cannot be archived due to existing bookings after this date.",

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -207,6 +207,15 @@
       "mustBeAtLeast1": "You must enter a duration of at least 1 day"
     }
   },
+  "bedspaceArchive": {
+    "endDate": {
+      "invalidEndDateInThePast": "The date is not within the next 3 months",
+      "invalidEndDateInTheFuture": "The date is not within the next 3 months",
+      "existingBookings": "This bedspace cannot be archived due to existing bookings after this date.",
+      "existingVoid": "This bedspace cannot be archived due to a void period after this date.",
+      "existingTurnaround": "This bedspace cannot be archived due to a turnaround scheduled after this date."
+    }
+  },
   "application": {
     "releaseType": {
       "crdLicence": {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -73,7 +73,6 @@ const managePathsCas3 = {
     bedspaces: {
       show: singleBedspacePath,
       create: bedspacesCas3Path,
-      get: bedspacesCas3Path,
     },
   },
 }
@@ -109,7 +108,8 @@ export default {
       bedspaces: {
         show: managePathsCas3.premises.bedspaces.show,
         create: managePathsCas3.premises.bedspaces.create,
-        get: managePathsCas3.premises.bedspaces.get,
+        archive: singleBedspacePath.path('archive'),
+        get: bedspacesCas3Path,
       },
     },
   },

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -66,6 +66,7 @@ const paths: Record<string, any> = {
         show: singleBedspaceV2Path,
         create: bedspacesV2Path,
         list: bedspacesV2Path,
+        archive: singleBedspaceV2Path.path('archive'),
       },
     },
   },

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -103,6 +103,9 @@ export default function routes(controllers: Controllers, services: Services, rou
 
     get(paths.premises.v2.bedspaces.new.pattern, bedspacesControllerV2.new(), { auditEvent: 'VIEW_BEDSPACE_V2_CREATE' })
     get(paths.premises.v2.bedspaces.show.pattern, bedspacesControllerV2.show(), { auditEvent: 'VIEW_BEDSPACE_V2' })
+    get(paths.premises.v2.bedspaces.archive.pattern, bedspacesControllerV2.archive(), {
+      auditEvent: 'VIEW_BEDSPACE_V2_ARCHIVE',
+    })
     post(paths.premises.v2.bedspaces.create.pattern, bedspacesControllerV2.create(), {
       redirectAuditEventSpecs: [
         {
@@ -112,6 +115,18 @@ export default function routes(controllers: Controllers, services: Services, rou
         {
           path: paths.premises.v2.bedspaces.show.pattern,
           auditEvent: 'CREATE_BEDSPACE_V2_SUCCESS',
+        },
+      ],
+    })
+    post(paths.premises.v2.bedspaces.archive.pattern, bedspacesControllerV2.archiveSubmit(), {
+      redirectAuditEventSpecs: [
+        {
+          path: paths.premises.v2.bedspaces.archive.pattern,
+          auditEvent: 'ARCHIVE_BEDSPACE_V2_FAILURE',
+        },
+        {
+          path: paths.premises.v2.bedspaces.show.pattern,
+          auditEvent: 'ARCHIVE_BEDSPACE_V2_SUCCESS',
         },
       ],
     })

--- a/server/services/v2/bedspaceService.ts
+++ b/server/services/v2/bedspaceService.ts
@@ -119,4 +119,14 @@ export default class BedspaceService {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
     return bedspaceClient.create(premisesId, newBedspace)
   }
+
+  async archiveBedspace(
+    callConfig: CallConfig,
+    premisesId: string,
+    bedspaceId: string,
+    archiveDate: string,
+  ): Promise<void> {
+    const bedspaceClient = this.bedspaceClientFactory(callConfig)
+    return bedspaceClient.archive(premisesId, bedspaceId, { endDate: archiveDate })
+  }
 }

--- a/server/views/temporary-accommodation/v2/bedspaces/archive.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/archive.njk
@@ -1,0 +1,80 @@
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "../../../partials/breadCrumb.njk" import breadCrumb %}
+{% from "../../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set pageTitle = "Archive a bedspace - " + applicationName %}
+{% set mainClasses = "app-container govuk-body" %}
+
+{% block beforeContent %}
+  {{ breadCrumb('Archive a bedspace', [
+    {title: 'List of properties', href: paths.premises.v2.online()},
+    {title: 'View a bedspace', href: paths.premises.v2.bedspaces.show({ premisesId: params.premisesId, bedspaceId: bedspace.id })}
+  ]) }}
+{% endblock %}
+
+{% block content %}
+  {% include "../../../_messages.njk" %}
+  
+  {{ showErrorSummary(errorSummary) }}
+  
+  <h1 class="govuk-heading-l">When should {{ bedspace.reference }} be archived?</h1>
+
+  <div class="govuk-grid-row">
+    <div class="govuk-grid-column-two-thirds">
+      <form action="{{ paths.premises.v2.bedspaces.archive({ premisesId: params.premisesId, bedspaceId: bedspace.id })}}" method="post">
+        <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
+        
+        {% set conditionalHtml %}
+          {{ formPageDateInput({
+            fieldset: {
+              legend: {
+                text: "Enter the archive date",
+                classes: "govuk-fieldset__legend--s"
+              }
+            },
+            fieldName: "archiveDate",
+            hint: {
+              text: "Use numbers, for example 27 05 2025"
+            },
+            items: dateFieldValues('archiveDate', errors)
+          }, fetchContext()) }}
+        {% endset %}
+
+        {{ govukRadios({
+          name: "archiveOption",
+          fieldset: {
+            legend: {
+              text: "When should " + bedspace.reference + " be archived?",
+              isPageHeading: false,
+              classes: "govuk-visually-hidden"
+            }
+          },
+          items: [
+            {
+              value: "today",
+              text: "Today",
+              checked: archiveOption == "today"
+            },
+            {
+              value: "anotherDate",
+              text: "Another date",
+              checked: archiveOption == "anotherDate",
+              conditional: {
+                html: conditionalHtml
+              }
+            }
+          ],
+          errorMessage: errors.archiveOption
+        }) }}
+
+        {{ govukButton({
+          text: "Submit"
+        }) }}
+      </form>
+    </div>
+  </div>
+{% endblock %}

--- a/server/views/temporary-accommodation/v2/bedspaces/archive.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/archive.njk
@@ -1,5 +1,6 @@
 {% from "govuk/components/radios/macro.njk" import govukRadios %}
 {% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
 {% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
 {% from "../../../partials/breadCrumb.njk" import breadCrumb %}
 {% from "../../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
@@ -14,6 +15,10 @@
     {title: 'List of properties', href: paths.premises.v2.online()},
     {title: 'View a bedspace', href: paths.premises.v2.bedspaces.show({ premisesId: params.premisesId, bedspaceId: bedspace.id })}
   ]) }}
+  {{ govukBackLink({
+    text: "Back",
+    href: paths.premises.v2.bedspaces.show({ premisesId: params.premisesId, bedspaceId: bedspace.id })
+  }) }}
 {% endblock %}
 
 {% block content %}
@@ -28,7 +33,7 @@
       <form action="{{ paths.premises.v2.bedspaces.archive({ premisesId: params.premisesId, bedspaceId: bedspace.id })}}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         
-        {% set conditionalHtml %}
+        {% set archiveDateHtml %}
           {{ formPageDateInput({
             fieldset: {
               legend: {
@@ -40,8 +45,9 @@
             hint: {
               text: "Use numbers, for example 27 05 2025"
             },
-            items: dateFieldValues('archiveDate', errors)
-          }, fetchContext()) }}
+            items: dateFieldValues('archiveDate', {}),
+            errorMessage: errors
+            }, mergeObjects(fetchContext(), { errors: { archiveDate: errors.endDate } })) }}
         {% endset %}
 
         {{ govukRadios({
@@ -64,7 +70,7 @@
               text: "Another date",
               checked: archiveOption == "anotherDate",
               conditional: {
-                html: conditionalHtml
+                html: archiveDateHtml
               }
             }
           ],


### PR DESCRIPTION
# Context

Implements the UI form validation handling for the CAS3 bedspace archiving feature. Users will have the ability to archive bedspaces with proper validation and error handling fully managed by the relevant backend service.
https://dsdmoj.atlassian.net/browse/CAS-1760

# Changes in this PR

- Added archive form and archive action routes to v2 bedspaces paths configuration
- Implemented archive method in v2 bedspace client to call POST `/cas3/premises/{premisesId}/bedspaces/{bedspaceId}/archive`
- Implemented archive controller methods with backend validation error handling
- Added routes for bedspace archive functionality
- Created archive form template with radio buttons for “Today” and “Another date” options
- Added archive action button to bedspace show page (visible for non-archived bedspaces only)
- Implemented specific error message handling for backend validation errors
- Added redirect to bedspace view page with green success banner on successful archive

## Screenshots of UI changes

### Before

<img width="701" height="429" alt="Screenshot 2025-07-23 at 10 02 39" src="https://github.com/user-attachments/assets/c96f9c7f-d11e-4e89-95e2-ab4d76c01994" />


### After

<img width="645" height="417" alt="Screenshot 2025-07-23 at 10 01 09" src="https://github.com/user-attachments/assets/40fdb821-e4ff-4fa8-a42c-c6ec7cfe0dee" />

<img width="581" height="312" alt="Screenshot 2025-07-23 at 10 01 26" src="https://github.com/user-attachments/assets/c5f8944a-9b08-49eb-88b7-09344f8858f0" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
