### PR TITLE
Flaky E2E test fixes

### DIFF
--- a/e2e/tests/stepDefinitions/manage/arrival.ts
+++ b/e2e/tests/stepDefinitions/manage/arrival.ts
@@ -11,7 +11,7 @@ Given('I mark the booking as arrived', () => {
     const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.bedspace, this.booking)
     bookingShowPage.clickMarkArrivedBookingButton()
 
-    const newArrival = newArrivalFactory.build()
+    const newArrival = newArrivalFactory.build({ expectedDepartureDate: this.booking.departureDate })
     const arrival = arrivalFactory.build({
       ...newArrival,
     })
@@ -92,7 +92,7 @@ Then('I should see a list of the problems encountered whilst changing the bookin
 
 When('I enter change booking data correctly', () => {
   cy.then(function _() {
-    const newArrival = newArrivalFactory.build()
+    const newArrival = newArrivalFactory.build({ expectedDepartureDate: this.booking.departureDate })
 
     const bookingArrivalPage = Page.verifyOnPage(BookingArrivalEditPage, this.premises, this.bedspace, this.booking)
     bookingArrivalPage.shouldShowBookingDetails()

--- a/e2e/tests/stepDefinitions/place.ts
+++ b/e2e/tests/stepDefinitions/place.ts
@@ -59,6 +59,8 @@ Given('I view the assessment', () => {
   const assessmentListPage = Page.verifyOnPage(AssessmentListPage, 'Unallocated referrals')
   const assessment = getAssessment('unallocated')
 
+  assessmentListPage.searchByCrnOrName(assessment.application.person.crn, 'unallocated')
+
   assessmentListPage.clickAssessment(assessment)
 })
 
@@ -111,6 +113,8 @@ Given('I view the list of ready to place assessments', () => {
 Given('I view the ready to place assessment', () => {
   const assessmentListPage = Page.verifyOnPage(AssessmentListPage, 'Ready to place referrals')
   const assessment = getAssessment('ready_to_place')
+
+  assessmentListPage.searchByCrnOrName(assessment.application.person.crn, 'ready to place')
 
   assessmentListPage.clickAssessment(assessment)
 })

--- a/server/testutils/factories/arrival.ts
+++ b/server/testutils/factories/arrival.ts
@@ -9,9 +9,13 @@ export default Factory.define<Arrival>(() => {
   sevenDays.setDate(sevenDays.getDate() - 7)
   const arrivalDate = faker.date.soon({ days: 7, refDate: sevenDays })
 
-  const maxDepartureDate = new Date(arrivalDate)
-  maxDepartureDate.setDate(maxDepartureDate.getDate() + 84)
-  const expectedDepartureDate = faker.date.soon({ days: 84, refDate: arrivalDate })
+  const dayAfterArrival = new Date(arrivalDate)
+  dayAfterArrival.setDate(dayAfterArrival.getDate() + 1)
+
+  const eightyFourDaysAfterArrival = new Date(arrivalDate)
+  eightyFourDaysAfterArrival.setDate(eightyFourDaysAfterArrival.getDate() + 84)
+
+  const expectedDepartureDate = faker.date.between({ from: dayAfterArrival, to: eightyFourDaysAfterArrival })
 
   return {
     arrivalDate: DateFormats.dateObjToIsoDate(arrivalDate),

--- a/server/testutils/factories/newArrival.ts
+++ b/server/testutils/factories/newArrival.ts
@@ -4,14 +4,34 @@ import { Factory } from 'fishery'
 import type { NewCas3Arrival as NewArrival } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<NewArrival>(() => {
+export default Factory.define<NewArrival>(({ params }) => {
   const sevenDays = new Date()
   sevenDays.setDate(sevenDays.getDate() - 7)
-  const arrivalDate = faker.date.soon({ days: 7, refDate: sevenDays })
 
-  const maxDepartureDate = new Date(arrivalDate)
-  maxDepartureDate.setDate(maxDepartureDate.getDate() + 84)
-  const expectedDepartureDate = faker.date.soon({ days: 84, refDate: arrivalDate })
+  let arrivalDate: Date
+  let expectedDepartureDate: Date
+
+  if (params.expectedDepartureDate) {
+    expectedDepartureDate = DateFormats.isoToDateObj(params.expectedDepartureDate)
+
+    const dayBeforeDeparture = new Date(expectedDepartureDate)
+    dayBeforeDeparture.setDate(dayBeforeDeparture.getDate() - 1)
+
+    const now = new Date()
+    const latestArrivalDate = dayBeforeDeparture < now ? dayBeforeDeparture : now
+
+    arrivalDate = faker.date.between({ from: sevenDays, to: latestArrivalDate })
+  } else {
+    arrivalDate = faker.date.soon({ days: 7, refDate: sevenDays })
+
+    const dayAfterArrival = new Date(arrivalDate)
+    dayAfterArrival.setDate(dayAfterArrival.getDate() + 1)
+
+    const eightyFourDaysAfterArrival = new Date(arrivalDate)
+    eightyFourDaysAfterArrival.setDate(eightyFourDaysAfterArrival.getDate() + 84)
+
+    expectedDepartureDate = faker.date.between({ from: dayAfterArrival, to: eightyFourDaysAfterArrival })
+  }
 
   return {
     arrivalDate: DateFormats.dateObjToIsoDate(arrivalDate),

--- a/server/testutils/factories/newBooking.ts
+++ b/server/testutils/factories/newBooking.ts
@@ -8,9 +8,14 @@ import { fullPersonFactory as personFactory } from './person'
 
 export default Factory.define<NewBooking>(() => {
   const arrivalDate = faker.date.soon()
-  const maxDepartureDate = new Date(arrivalDate)
-  maxDepartureDate.setDate(maxDepartureDate.getDate() + 84)
-  const expectedDepartureDate = faker.date.soon({ days: 84, refDate: arrivalDate })
+
+  const dayAfterArrival = new Date(arrivalDate)
+  dayAfterArrival.setDate(dayAfterArrival.getDate() + 1)
+
+  const eightyFourDaysAfterArrival = new Date(arrivalDate)
+  eightyFourDaysAfterArrival.setDate(eightyFourDaysAfterArrival.getDate() + 84)
+
+  const expectedDepartureDate = faker.date.between({ from: dayAfterArrival, to: eightyFourDaysAfterArrival })
 
   return {
     crn: personFactory.build().crn,


### PR DESCRIPTION
# Context

Apply and place:
Fixed two cases where apply and place e2e tests can fail when an assessment isn't present on the first page of results by searching for the CRN first

Booking:
Fixed an issue where adjusting the arrival or booking date can end up with dates clashing and being invalid

# Changes in this PR

## Screenshots of UI changes

### Before
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/32419156-88fe-4a9b-89ea-0fc24b6013bc" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/4f97a09c-767a-4ecd-acd4-bee6754be0c1" />
<img width="1280" height="720" alt="image" src="https://github.com/user-attachments/assets/849c1f43-7236-49d2-9c65-13551f37d534" />

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
