### PR TITLE
Property show v2 feedback from QA

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
@@ -114,4 +114,10 @@ export default class PremisesShowPage extends Page {
   shouldShowPropertyAddedBanner(): void {
     cy.get('main .govuk-notification-banner--success').contains('Property added')
   }
+
+  shouldShowArchivedBanner(): void {
+    cy.get('main .govuk-notification-banner h2').contains('Important')
+    cy.get('main .govuk-notification-banner p').contains('This is an archived property.')
+    cy.get('main .govuk-notification-banner p').contains('You cannot create a new bedspace, or make a new booking.')
+  }
 }

--- a/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
@@ -816,6 +816,9 @@ context('Premises', () => {
       // Then I navigate to the show premises page
       const showPage = Page.verifyOnPage(PremisesShowPage, `${premises.addressLine1}, ${premises.postcode}`)
 
+      // Then I should see a notification that this is an archived property
+      showPage.shouldShowArchivedBanner()
+
       // Then I should see the premises overview
       showPage.shouldShowPremisesOverview(premises, 'Archived', '1 February 2025')
 

--- a/server/services/v2/premisesService.test.ts
+++ b/server/services/v2/premisesService.test.ts
@@ -1,3 +1,4 @@
+import { TextItem } from '@approved-premises/ui'
 import PremisesClient from '../../data/v2/premisesClient'
 import { CallConfig } from '../../data/restClient'
 import {
@@ -379,6 +380,27 @@ describe('PremisesService', () => {
       }
 
       expect(summaryList).toEqual(expectedSummaryList)
+    })
+
+    it('should show "None" for additional property details when there are no notes', () => {
+      const premises = cas3PremisesFactory.build({ notes: '' })
+      const summaryList = service.summaryList(premises)
+
+      const additionalPropertyDetailsRow = summaryList.rows.find(
+        row => (row.key as TextItem)?.text === 'Additional property details',
+      )
+
+      expect(additionalPropertyDetailsRow.value).toEqual({ text: 'None' })
+    })
+
+    it('should show "None" and "Add property details" link for property details when there are none', () => {
+      const premises = cas3PremisesFactory.build({ characteristics: [] })
+      const summaryList = service.summaryList(premises)
+
+      const propertyDetailsRow = summaryList.rows.find(row => (row.key as TextItem)?.text === 'Property details')
+
+      const expectedHtml = `<p>None</p><p><a href="#">Add property details</a></p>`
+      expect(propertyDetailsRow.value).toEqual({ html: expectedHtml })
     })
   })
 

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -147,7 +147,7 @@ export default class PremisesService {
         },
         {
           key: { text: 'Additional property details' },
-          value: this.textValue(premises.notes),
+          value: this.textValue(premises.notes || 'None'),
         },
       ],
     }
@@ -212,7 +212,11 @@ export default class PremisesService {
   }
 
   private formatDetails(characteristics: Array<Characteristic>): string {
-    return (characteristics ?? [])
+    if (characteristics === undefined || characteristics.length === 0) {
+      return '<p>None</p><p><a href="#">Add property details</a></p>'
+    }
+
+    return characteristics
       .map(characteristic => `<span class="hmpps-tag-filters">${characteristic.name}</span>`)
       .join(' ')
   }

--- a/server/views/temporary-accommodation/v2/premises/show.njk
+++ b/server/views/temporary-accommodation/v2/premises/show.njk
@@ -2,6 +2,7 @@
 {% from "../../../components/moj-cas-page-header-actions/macro.njk" import mojCasPageHeaderActions %}
 {% from "moj/components/sub-navigation/macro.njk" import mojSubNavigation %}
 {% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
 {% extends "../../../partials/layout.njk" %}
 
@@ -19,6 +20,23 @@
 
 {% block content %}
     {% include "../../../_messages.njk" %}
+
+    {% if premises.status === 'archived' %}
+        {% if not successMessages.length %}
+            {% set archivedBannerHtml %}
+                <p class="govuk-notification-banner__heading">This is an archived property.</p>
+                <p class="govuk-body">You cannot create a new bedspace, or make a new booking.</p>
+            {% endset %}
+
+            <div class="govuk-grid-row">
+                <div class="govuk-grid-column-two-thirds">
+                    {{ govukNotificationBanner({
+                        html: archivedBannerHtml
+                    }) }}
+                </div>
+            </div>
+        {% endif %}
+    {% endif %}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">


### PR DESCRIPTION
# Context

Based on [feedback from QA session](https://dsdmoj.atlassian.net/browse/CAS-1737?focusedCommentId=631441)

Added content when there aren't any property details or additional property details

Added archived property banner

The actions button isn't visible because there currently aren't any actions. The empty list is being passed to header component so they will appear once they start getting added

# Changes in this PR

## Screenshots of UI changes

### Before

### After
<img width="3424" height="3482" alt="image" src="https://github.com/user-attachments/assets/a0ffc66b-4234-4a2d-873d-034f2a558048" />

<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/8129e983-9dc5-4725-8cc2-58bdba349b0a" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
