### PR TITLE
CAS-1803 Edit bedspace page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceEdit.ts
@@ -1,0 +1,85 @@
+import Page from '../../../page'
+import { Cas3Bedspace, Cas3Premises } from '../../../../../server/@types/shared'
+import paths from '../../../../../server/paths/temporary-accommodation/manage'
+import { convertToTitleCase } from '../../../../../server/utils/utils'
+
+export default class BedspaceEditPage extends Page {
+  constructor() {
+    super('Edit bedspace')
+  }
+
+  static visit(premises: Cas3Premises, bedspace: Cas3Bedspace) {
+    cy.visit(paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }))
+    return new BedspaceEditPage()
+  }
+
+  shouldShowPropertySummary(premises: Cas3Premises) {
+    cy.get('dl').contains('Status').siblings('dd').contains(convertToTitleCase(premises.status))
+    cy.get('dl')
+      .contains('Address')
+      .siblings('dd')
+      .contains(premises.addressLine1)
+      .contains(premises.addressLine2)
+      .contains(premises.town)
+      .contains(premises.postcode)
+  }
+
+  validateEnteredInformation(bedspace: Cas3Bedspace) {
+    this.validateEnteredReference(bedspace.reference)
+    this.validateEnteredCharacteristics(bedspace.characteristics.map(ch => ch.name))
+    this.validateEnteredAdditionalDetails(bedspace.notes)
+  }
+
+  clearForm() {
+    this.getTextInputByIdAndClear('reference')
+    this.getTextInputByIdAndClear('notes')
+
+    cy.get('legend')
+      .contains('Select bedspace details')
+      .parent()
+      .within(() => {
+        cy.get('label').siblings('input').uncheck()
+      })
+  }
+
+  enterReference(reference: string) {
+    this.clearTextInputByLabel('Bedspace reference')
+    if (reference) {
+      this.completeTextInputByLabel('Bedspace reference', reference)
+    }
+  }
+
+  enterCharacteristics(characteristics: Array<string>) {
+    cy.get('legend')
+      .contains('Select bedspace details')
+      .parent()
+      .within(() => {
+        characteristics.forEach(characteristic => {
+          cy.get('label').contains(characteristic).siblings('input').click()
+        })
+      })
+  }
+
+  enterAdditionalDetails(notes: string) {
+    this.completeTextArea('notes', notes)
+  }
+
+  validateEnteredReference(reference: string) {
+    this.shouldShowTextInputByLabel('Bedspace reference', reference)
+  }
+
+  validateEnteredCharacteristics(characteristics: Array<string>) {
+    cy.get('legend')
+      .contains('Select bedspace details')
+      .parent()
+      .within(() => {
+        characteristics.forEach(characteristic => {
+          cy.get('label').contains(characteristic).siblings('input').should('be.checked')
+        })
+      })
+  }
+
+  validateEnteredAdditionalDetails(notes: string) {
+    this.shouldShowTextareaInput('notes', notes)
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
@@ -75,4 +75,16 @@ export default class BedspaceShowPage extends Page {
     const lostBedListingComponent = new LostBedListingComponent(lostBed)
     lostBedListingComponent.shouldShowLostBedDetails()
   }
+
+  clickEditPropertyDetailsAction(): void {
+    // TODO: uncomment when additional actions are added
+    // cy.get('button').contains('Actions').parent().click()
+    // cy.get('button').contains('Actions').parent().siblings('ul').contains('Edit bedspace details').click()
+
+    cy.get('[role="button"]').contains('Edit bedspace details').click()
+  }
+
+  shouldShowBedspaceUpdatedBanner(): void {
+    cy.get('main .govuk-notification-banner--success').contains('Bedspace edited')
+  }
 }

--- a/e2e_playwright/pages/basePage.ts
+++ b/e2e_playwright/pages/basePage.ts
@@ -57,6 +57,24 @@ export class BasePage {
     return randomCheckbox.getAttribute('value')
   }
 
+  async checkRandomCheckboxes(checkBoxes: Array<Locator>): Promise<Array<string>> {
+    const labels = []
+
+    // using a for loop with awaits here as playwright was unreliable checking checkboxes with Promise.all and map/forEach
+    // eslint-disable-next-line no-restricted-syntax
+    for (const checkbox of checkBoxes.filter(_ => Math.random() > 0.5)) {
+      const parent = checkbox.locator('..')
+      const label = parent.locator('label').first()
+      // eslint-disable-next-line no-await-in-loop
+      await label.click()
+      // eslint-disable-next-line no-await-in-loop
+      const labelText = await label.innerText()
+      labels.push(labelText)
+    }
+
+    return labels
+  }
+
   async getTableRow(expectedStringInRow: string) {
     const tableRows = await this.page.locator('.govuk-table__row').all()
     const promises: Array<Promise<string>> = []
@@ -74,5 +92,13 @@ export class BasePage {
       tableRowIndex: foundRowIndex,
       tableRow: foundRowIndex !== -1 ? this.page.locator('.govuk-table__row').nth(foundRowIndex) : undefined,
     }
+  }
+
+  getRowTextByLabel(label: string, exact: boolean = false): Locator {
+    return this.page.getByText(label, { exact }).locator('..').locator('dd')
+  }
+
+  findCheckboxByLabel(label: string, exact: boolean = false) {
+    return this.page.getByLabel(label, { exact }).locator('..').locator('input')
   }
 }

--- a/e2e_playwright/pages/manage/v2/addBedspacePage.ts
+++ b/e2e_playwright/pages/manage/v2/addBedspacePage.ts
@@ -1,0 +1,31 @@
+import { Page, expect } from '@playwright/test'
+import { Bedspace } from '@temporary-accommodation-ui/e2e'
+import { BasePage } from '../../basePage'
+
+export class AddBedspacePage extends BasePage {
+  static async initialise(page: Page) {
+    await expect(page.locator('h1')).toContainText('Add a bedspace')
+    return new AddBedspacePage(page)
+  }
+
+  async enterFormDetails(bedspace: Bedspace) {
+    await this.page.getByLabel('Enter a bedspace reference').fill(bedspace.reference)
+    await this.enterStartDate(bedspace.startDate)
+    await this.enterCharacteristics(bedspace)
+    await this.page.getByLabel('Additional bedspace details').fill(bedspace.additionalDetails)
+  }
+
+  async enterStartDate(startDate: Date) {
+    await this.page.getByLabel('Day').clear()
+    await this.page.getByLabel('Day').fill(startDate.getDate().toString())
+    await this.page.getByLabel('Month').clear()
+    await this.page.getByLabel('Month').fill((startDate.getMonth() + 1).toString())
+    await this.page.getByLabel('Year').clear()
+    await this.page.getByLabel('Year').fill(startDate.getFullYear().toString())
+  }
+
+  async enterCharacteristics(bedspace: Bedspace) {
+    const checkboxes = await this.page.getByRole('checkbox').all()
+    bedspace.details = await this.checkRandomCheckboxes(checkboxes)
+  }
+}

--- a/e2e_playwright/pages/manage/v2/editBedspacePage.ts
+++ b/e2e_playwright/pages/manage/v2/editBedspacePage.ts
@@ -1,0 +1,45 @@
+import { Page, expect } from '@playwright/test'
+import { Bedspace, Property } from '@temporary-accommodation-ui/e2e'
+import { BasePage } from '../../basePage'
+
+export class EditBedspacePage extends BasePage {
+  static async initialise(page: Page) {
+    await expect(page.locator('h1')).toContainText('Edit bedspace')
+    return new EditBedspacePage(page)
+  }
+
+  async shouldShowPropertySummary(property: Property) {
+    await expect(this.getRowTextByLabel('Status')).toContainText('Online')
+    const addressRow = this.getRowTextByLabel('Address')
+    await expect(addressRow).toContainText(property.addressLine1)
+    await expect(addressRow).toContainText(property.addressLine2)
+    await expect(addressRow).toContainText(property.town)
+    await expect(addressRow).toContainText(property.postcode)
+  }
+
+  async shouldShowBedspaceDetails(bedspace: Bedspace) {
+    await expect(this.page.getByLabel('Bedspace reference')).toHaveValue(bedspace.reference)
+    await Promise.all(
+      bedspace.details.map(async detail => expect(this.findCheckboxByLabel(detail, true)).toBeChecked()),
+    )
+    await expect(this.page.getByLabel('Additional bedspace details')).toHaveValue(bedspace.additionalDetails)
+  }
+
+  async clearFormDetails() {
+    await this.page.getByLabel('Bedspace reference').clear()
+    // using a for loop with awaits as using Promise.all with checkboxes.map was very flaky
+    // eslint-disable-next-line no-restricted-syntax
+    for (const checkbox of await this.page.getByRole('checkbox').all()) {
+      // eslint-disable-next-line no-await-in-loop
+      await checkbox.uncheck()
+    }
+    await this.page.getByLabel('Additional bedspace details').clear()
+  }
+
+  async enterFormDetails(bedspace: Bedspace) {
+    await this.page.getByLabel('Bedspace reference').fill(bedspace.reference)
+    const detailsCheckboxes = await this.page.getByRole('checkbox').all()
+    bedspace.details = await this.checkRandomCheckboxes(detailsCheckboxes)
+    await this.page.getByLabel('Additional bedspace details').fill(bedspace.additionalDetails)
+  }
+}

--- a/e2e_playwright/pages/manage/v2/editPropertyPage.ts
+++ b/e2e_playwright/pages/manage/v2/editPropertyPage.ts
@@ -53,11 +53,11 @@ export class EditPropertyPage extends EditablePropertyPage {
 
     await expect(this.getSelectedOptionByLabel('What is the PDU?')).toHaveText(property.pdu)
 
-    // eslint-disable-next-line no-restricted-syntax
-    for (const characteristic of property.propertyAttributesValues) {
-      // eslint-disable-next-line no-await-in-loop
-      await expect(this.findCheckboxByLabel(characteristic, true)).toBeChecked()
-    }
+    await Promise.all(
+      property.propertyAttributesValues.map(async attribute =>
+        expect(this.findCheckboxByLabel(attribute, true)).toBeChecked(),
+      ),
+    )
 
     await expect(this.page.getByLabel('Additional property details')).toContainText(property.notes)
 
@@ -68,19 +68,11 @@ export class EditPropertyPage extends EditablePropertyPage {
     ).toHaveValue(`${property.turnaroundWorkingDayCount}`)
   }
 
-  private getRowTextByLabel(label: string, exact: boolean = false): Locator {
-    return this.page.getByText(label, { exact }).locator('..').locator('dd')
-  }
-
   private getInputsByLabel(label: string, exact: boolean = false): Locator {
     return this.page.getByText(label, { exact }).locator('..').locator('input')
   }
 
   private getSelectedOptionByLabel(label: string, exact: boolean = false): Locator {
     return this.page.getByLabel(label, { exact }).locator('option[selected]')
-  }
-
-  private findCheckboxByLabel(label: string, exact: boolean = false) {
-    return this.page.getByLabel(label, { exact }).locator('..').locator('input')
   }
 }

--- a/e2e_playwright/pages/manage/v2/editablePropertyPage.ts
+++ b/e2e_playwright/pages/manage/v2/editablePropertyPage.ts
@@ -20,7 +20,7 @@ export class EditablePropertyPage extends BasePage {
     property.pdu = await this.selectOptionAtRandom('What is the PDU?', 'Select a PDU')
 
     const characteristicsCheckboxes = await this.page.getByRole('checkbox').all()
-    property.propertyAttributesValues = await this.checkRandomBoxes(characteristicsCheckboxes)
+    property.propertyAttributesValues = await this.checkRandomCheckboxes(characteristicsCheckboxes)
 
     await this.page.getByLabel('Additional property details').fill(property.notes)
     await this.page
@@ -39,22 +39,5 @@ export class EditablePropertyPage extends BasePage {
 
     const index = Math.ceil(Math.random() * (options.length - 1))
     return options[index]
-  }
-
-  private async checkRandomBoxes(checkBoxes: Array<Locator>): Promise<Array<string>> {
-    const labels = []
-
-    // eslint-disable-next-line no-restricted-syntax
-    for (const checkbox of checkBoxes.filter(_ => Math.random() > 0.5)) {
-      const parent = checkbox.locator('..')
-      const label = parent.locator('label').first()
-      // eslint-disable-next-line no-await-in-loop
-      await label.click()
-      // eslint-disable-next-line no-await-in-loop
-      const labelText = await label.innerText()
-      labels.push(labelText)
-    }
-
-    return labels
   }
 }

--- a/e2e_playwright/pages/manage/v2/viewBedspacePage.ts
+++ b/e2e_playwright/pages/manage/v2/viewBedspacePage.ts
@@ -1,0 +1,57 @@
+import { Page, expect } from '@playwright/test'
+import { Bedspace, Property } from '@temporary-accommodation-ui/e2e'
+import { BasePage } from '../../basePage'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+
+export class ViewBedspacePage extends BasePage {
+  static async initialise(page: Page, reference: string) {
+    await expect(page.locator('h1')).toContainText(`Bedspace reference: ${reference}`)
+    return new ViewBedspacePage(page)
+  }
+
+  static async goto(page: Page, premisesId: string, bedspaceId: string) {
+    await page.goto(`/v2/properties/${premisesId}/bedspaces/${bedspaceId}`)
+  }
+
+  async shouldShowPropertySummary(property: Property) {
+    const addressSection = this.page.getByText('Property address').locator('..').locator('p')
+    await expect(addressSection).toContainText(property.addressLine1)
+    await expect(addressSection).toContainText(property.addressLine2)
+    await expect(addressSection).toContainText(property.town)
+    await expect(addressSection).toContainText(property.postcode)
+
+    const detailsTags = await this.page
+      .getByText('Property details')
+      .locator('..')
+      .locator('span[class="hmpps-tag-filters"]')
+      .all()
+    const allAttributes = await Promise.all(detailsTags.map(async tag => tag.innerText()))
+    property.propertyAttributesValues.forEach(attribute => {
+      expect(allAttributes).toContain(attribute)
+    })
+  }
+
+  async shouldShowBedspaceDetails(bedspace: Bedspace) {
+    await expect(this.getRowTextByLabel('Bedspace status')).toContainText('Online')
+    await expect(this.getRowTextByLabel('Start date')).toContainText(
+      DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date())),
+    )
+    const detailsRow = this.getRowTextByLabel('Bedspace details', true)
+    await Promise.all(
+      bedspace.details.map(async detail => {
+        await expect(detailsRow).toContainText(detail)
+      }),
+    )
+    await expect(this.getRowTextByLabel('Additional bedspace details')).toContainText(bedspace.additionalDetails)
+  }
+
+  async clickBackToProperty(shortAddress: string) {
+    await this.page.getByText(shortAddress).click()
+  }
+
+  async clickEditButton() {
+    // TODO: uncomment when more actions get added to bedspaces
+    // await this.page.getByRole('button').getByText('Actions').click()
+    await this.page.getByText('Edit bedspace details').click()
+  }
+}

--- a/e2e_playwright/pages/manage/v2/viewBedspacesPage.ts
+++ b/e2e_playwright/pages/manage/v2/viewBedspacesPage.ts
@@ -1,0 +1,38 @@
+import { Locator, Page, expect } from '@playwright/test'
+import { Bedspace } from '@temporary-accommodation-ui/e2e'
+import { BasePage } from '../../basePage'
+import { DateFormats } from '../../../../server/utils/dateUtils'
+
+export class ViewBedspacesPage extends BasePage {
+  static async initialise(page: Page, shortAddress: string) {
+    await expect(page.locator('h1')).toContainText(shortAddress)
+    return new ViewBedspacesPage(page)
+  }
+
+  async shouldShowBedspace(bedspace: Bedspace) {
+    const bedspaceSection = this.page
+      .getByText(`Bedspace reference: ${bedspace.reference}`)
+      .locator('..')
+      .locator('..')
+      .locator('dl')
+    const rowTextHelper = this.getRowTextByLabelHelper(bedspaceSection)
+    await expect(rowTextHelper('Bedspace status')).toContainText('Online')
+    await expect(rowTextHelper('Start date')).toContainText(
+      DateFormats.isoDateToUIDate(DateFormats.dateObjToIsoDate(new Date())),
+    )
+    const detailsRow = rowTextHelper('Bedspace details', true)
+    await Promise.all(bedspace.details.map(async detail => expect(detailsRow).toContainText(detail)))
+    await expect(rowTextHelper('Additional bedspace details')).toContainText(bedspace.additionalDetails)
+  }
+
+  async clickManageBedspaceLink(bedspace: Bedspace) {
+    const bedspaceSection = this.page.getByText(`Bedspace reference: ${bedspace.reference}`).locator('..')
+    await bedspaceSection.getByText('View bedspace').click()
+  }
+
+  private getRowTextByLabelHelper(locator: Locator) {
+    return (label: string, exact: boolean = false): Locator => {
+      return locator.getByText(label, { exact }).locator('..').locator('dd')
+    }
+  }
+}

--- a/e2e_playwright/pages/manage/v2/viewPropertyPage.ts
+++ b/e2e_playwright/pages/manage/v2/viewPropertyPage.ts
@@ -1,4 +1,4 @@
-import { Locator, Page, expect } from '@playwright/test'
+import { Page, expect } from '@playwright/test'
 import { Property } from '@temporary-accommodation-ui/e2e'
 import { BasePage } from '../../basePage'
 import { DateFormats } from '../../../../server/utils/dateUtils'
@@ -44,7 +44,12 @@ export class ViewPropertyPage extends BasePage {
     await this.page.getByText('Edit property details').click()
   }
 
-  private getRowTextByLabel(label: string, exact: boolean = false): Locator {
-    return this.page.getByText(label, { exact }).locator('..').locator('dd')
+  async clickAddABedspace() {
+    await this.page.getByRole('button').getByText('Actions').click()
+    await this.page.getByText('Add a bedspace').click()
+  }
+
+  async clickBedspacesOverview() {
+    await this.page.getByText('Bedspaces overview').click()
   }
 }

--- a/e2e_playwright/steps/v2/manage.ts
+++ b/e2e_playwright/steps/v2/manage.ts
@@ -1,9 +1,13 @@
 import { Page, expect } from '@playwright/test'
-import { Property } from '@temporary-accommodation-ui/e2e'
+import { Bedspace, Property } from '@temporary-accommodation-ui/e2e'
 import { ListPropertiesPage } from '../../pages/manage/v2/listPropertiesPage'
 import { AddPropertyPage } from '../../pages/manage/v2/addPropertyPage'
 import { ViewPropertyPage } from '../../pages/manage/v2/viewPropertyPage'
 import { EditPropertyPage } from '../../pages/manage/v2/editPropertyPage'
+import { ViewBedspacePage } from '../../pages/manage/v2/viewBedspacePage'
+import { AddBedspacePage } from '../../pages/manage/v2/addBedspacePage'
+import { ViewBedspacesPage } from '../../pages/manage/v2/viewBedspacesPage'
+import { EditBedspacePage } from '../../pages/manage/v2/editBedspacePage'
 
 export const visitListPropertiesPage = async (page: Page) => {
   // TODO: navigate to the list properties page from the dashboard once the v2 pages are live in prod
@@ -58,4 +62,62 @@ export const editProperty = async (page: Page, property: Property, updatedProper
   const isBannerMessageDisplayed = await showUpdatedPropertyPage.isBannerMessageDisplayed('Property edited')
   expect(isBannerMessageDisplayed).toBe(true)
   await showUpdatedPropertyPage.shouldShowPropertyDetails(updatedProperty)
+}
+
+export const createBedspace = async (page: Page, property: Property, bedspace: Bedspace) => {
+  const shortAddress = `${property.addressLine1}, ${property.postcode}`
+  const showPropertyPage = await ViewPropertyPage.initialise(page, shortAddress)
+  await showPropertyPage.clickAddABedspace()
+
+  const addBedspacePage = await AddBedspacePage.initialise(page)
+  await addBedspacePage.enterFormDetails(bedspace)
+  await addBedspacePage.clickSubmit()
+
+  const showBedspacePage = await ViewBedspacePage.initialise(page, bedspace.reference)
+  const isBannerMessageDisplayed = await showBedspacePage.isBannerMessageDisplayed('Bedspace added')
+  expect(isBannerMessageDisplayed).toBe(true)
+  await showBedspacePage.shouldShowPropertySummary(property)
+  await showBedspacePage.shouldShowBedspaceDetails(bedspace)
+}
+
+export const navigateToPropertyFromBedspace = async (page: Page, property: Property, bedspace: Bedspace) => {
+  const shortAddress = `${property.addressLine1}, ${property.postcode}`
+  const showBedspacePage = await ViewBedspacePage.initialise(page, bedspace.reference)
+  await showBedspacePage.clickBackToProperty(shortAddress)
+}
+
+export const navigateToBedspace = async (page: Page, property: Property, bedspace: Bedspace) => {
+  const shortAddress = `${property.addressLine1}, ${property.postcode}`
+  const showPropertyPage = await ViewPropertyPage.initialise(page, shortAddress)
+  await showPropertyPage.clickBedspacesOverview()
+
+  const showBedspacesPage = await ViewBedspacesPage.initialise(page, shortAddress)
+  await showBedspacesPage.shouldShowBedspace(bedspace)
+  await showBedspacesPage.clickManageBedspaceLink(bedspace)
+}
+
+export const showBedspace = async (page: Page, property: Property, bedspace: Bedspace) => {
+  const showBedspacePage = await ViewBedspacePage.initialise(page, bedspace.reference)
+  await showBedspacePage.shouldShowPropertySummary(property)
+  await showBedspacePage.shouldShowBedspaceDetails(bedspace)
+}
+
+export const editBedspace = async (page: Page, property: Property, bedspace: Bedspace, updatedBedspace: Bedspace) => {
+  const showBedspacePage = await ViewBedspacePage.initialise(page, bedspace.reference)
+  await showBedspacePage.shouldShowPropertySummary(property)
+  await showBedspacePage.shouldShowBedspaceDetails(bedspace)
+  await showBedspacePage.clickEditButton()
+
+  const editBedspacePage = await EditBedspacePage.initialise(page)
+  await editBedspacePage.shouldShowPropertySummary(property)
+  await editBedspacePage.shouldShowBedspaceDetails(bedspace)
+  await editBedspacePage.clearFormDetails()
+  await editBedspacePage.enterFormDetails(updatedBedspace)
+  await editBedspacePage.clickSubmit()
+
+  const showUpdatedBedspacePage = await ViewBedspacePage.initialise(page, updatedBedspace.reference)
+  const isBannerMessageDisplayed = await showUpdatedBedspacePage.isBannerMessageDisplayed('Bedspace edited')
+  expect(isBannerMessageDisplayed).toBe(true)
+  await showBedspacePage.shouldShowPropertySummary(property)
+  await showBedspacePage.shouldShowBedspaceDetails(updatedBedspace)
 }

--- a/e2e_playwright/tests/manage/v2/manage-bedspaces.spec.ts
+++ b/e2e_playwright/tests/manage/v2/manage-bedspaces.spec.ts
@@ -1,0 +1,48 @@
+import { test } from '../../../test'
+import { getBedspace, getProperty } from '../../../utils/manage'
+import { signIn } from '../../../steps/signIn'
+import {
+  createBedspace,
+  createProperty,
+  editBedspace,
+  navigateToBedspace,
+  navigateToPropertyFromBedspace,
+  showBedspace,
+  visitListPropertiesPage,
+} from '../../../steps/v2/manage'
+
+test('Create a bedspace', async ({ page, assessor }) => {
+  const property = getProperty()
+  const bedspace = getBedspace()
+
+  await signIn(page, assessor)
+  await visitListPropertiesPage(page)
+  await createProperty(page, property)
+  await createBedspace(page, property, bedspace)
+})
+
+test('Show a bedspace', async ({ page, assessor }) => {
+  const property = getProperty()
+  const bedspace = getBedspace()
+
+  await signIn(page, assessor)
+  await visitListPropertiesPage(page)
+  await createProperty(page, property)
+  await createBedspace(page, property, bedspace)
+  await navigateToPropertyFromBedspace(page, property, bedspace)
+  await navigateToBedspace(page, property, bedspace)
+  await showBedspace(page, property, bedspace)
+})
+
+test('Edit a bedspace', async ({ page, assessor }) => {
+  const property = getProperty()
+  const bedspace = getBedspace()
+  const updatedBedspace = getBedspace()
+
+  await signIn(page, assessor)
+  await visitListPropertiesPage(page)
+  await createProperty(page, property)
+  await createBedspace(page, property, bedspace)
+  await editBedspace(page, property, bedspace, updatedBedspace)
+  await showBedspace(page, property, updatedBedspace)
+})

--- a/e2e_playwright/tests/manage/v2/manage-properties.spec.ts
+++ b/e2e_playwright/tests/manage/v2/manage-properties.spec.ts
@@ -1,7 +1,5 @@
-import { Property } from '@temporary-accommodation-ui/e2e'
-import { fakerEN_GB as faker } from '@faker-js/faker'
-import { test } from '../../test'
-import { signIn } from '../../steps/signIn'
+import { test } from '../../../test'
+import { signIn } from '../../../steps/signIn'
 import {
   createProperty,
   editProperty,
@@ -9,7 +7,8 @@ import {
   searchForProperty,
   showProperty,
   visitListPropertiesPage,
-} from '../../steps/v2/manage'
+} from '../../../steps/v2/manage'
+import { getProperty } from '../../../utils/manage'
 
 test('Create a property', async ({ page, assessor }) => {
   const property = getProperty()
@@ -40,20 +39,3 @@ test('Edit a property', async ({ page, assessor }) => {
   await editProperty(page, property, updatedProperty)
   await showProperty(page, updatedProperty)
 })
-
-function getProperty(): Property {
-  return {
-    name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
-    addressLine1: faker.location.streetAddress(),
-    addressLine2: faker.location.secondaryAddress(),
-    town: faker.location.city(),
-    postcode: faker.location.zipCode(),
-    notes: faker.lorem.lines(5),
-    turnaroundWorkingDayCount: faker.number.int({ min: 1, max: 5 }),
-    localAuthority: undefined,
-    probationRegion: undefined,
-    pdu: undefined,
-    propertyAttributesValues: [],
-    status: 'online',
-  }
-}

--- a/e2e_playwright/types/index.d.ts
+++ b/e2e_playwright/types/index.d.ts
@@ -28,6 +28,13 @@ declare module '@temporary-accommodation-ui/e2e' {
     turnaroundWorkingDayCount: number
   }
 
+  export type Bedspace = {
+    reference: string
+    startDate: Date
+    details: Array<string>
+    additionalDetails: string
+  }
+
   export type TestOptions = {
     assessor: UserFullDetails
     referrer: UserLoginDetails

--- a/e2e_playwright/utils/manage.ts
+++ b/e2e_playwright/utils/manage.ts
@@ -1,0 +1,28 @@
+import { Bedspace, Property } from '@temporary-accommodation-ui/e2e'
+import { fakerEN_GB as faker } from '@faker-js/faker'
+
+export function getProperty(): Property {
+  return {
+    name: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+    addressLine1: faker.location.streetAddress(),
+    addressLine2: faker.location.secondaryAddress(),
+    town: faker.location.city(),
+    postcode: faker.location.zipCode(),
+    notes: faker.lorem.lines(5),
+    turnaroundWorkingDayCount: faker.number.int({ min: 1, max: 5 }),
+    localAuthority: undefined,
+    probationRegion: undefined,
+    pdu: undefined,
+    propertyAttributesValues: [],
+    status: 'online',
+  }
+}
+
+export function getBedspace(): Bedspace {
+  return {
+    reference: `Room ${faker.number.int({ min: 1, max: 9999 })}`,
+    startDate: new Date(),
+    details: [],
+    additionalDetails: faker.lorem.sentences(5),
+  }
+}

--- a/integration_tests/mockApis/v2/bedspace.ts
+++ b/integration_tests/mockApis/v2/bedspace.ts
@@ -2,6 +2,7 @@ import { Cas3Bedspace, Cas3Bedspaces } from '@approved-premises/api'
 import { SuperAgentRequest } from 'superagent'
 import { getMatchingRequests, stubFor } from '../index'
 import paths from '../../../server/paths/api'
+import { errorStub } from '../utils'
 
 type BedspaceArguments = {
   premisesId: string
@@ -83,10 +84,43 @@ const stubBedspaceCreateErrors = (args: {
     },
   })
 
+const stubBedspaceUpdate = (params: { premisesId: string; bedspace: Cas3Bedspace }) =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      url: paths.cas3.premises.bedspaces.update({ premisesId: params.premisesId, bedspaceId: params.bedspace.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: params.bedspace,
+    },
+  })
+
+const verifyBedspaceUpdate = async (params: { premisesId: string; bedspaceId: string }) =>
+  (
+    await getMatchingRequests({
+      method: 'PUT',
+      url: paths.cas3.premises.bedspaces.update({ premisesId: params.premisesId, bedspaceId: params.bedspaceId }),
+    })
+  ).body.requests
+
+const stubBedspaceUpdateErrors = (params: { fields: Array<string>; premisesId: string; bedspaceId: string }) =>
+  stubFor(
+    errorStub(
+      params.fields,
+      paths.cas3.premises.bedspaces.update({ premisesId: params.premisesId, bedspaceId: params.bedspaceId }),
+      'PUT',
+    ),
+  )
+
 export default {
   stubBedspaceV2,
   stubPremisesBedspacesV2,
   stubBedspaceCreate,
   verifyBedspaceCreate,
   stubBedspaceCreateErrors,
+  stubBedspaceUpdate,
+  verifyBedspaceUpdate,
+  stubBedspaceUpdateErrors,
 }

--- a/server/controllers/temporary-accommodation/manage/v2/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/bedspacesController.test.ts
@@ -1,13 +1,14 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import { NextFunction, Request, Response } from 'express'
 import { Cas3Bedspace } from '@approved-premises/api'
-import { SummaryList } from '@approved-premises/ui'
+import { ErrorsAndUserInput, SummaryList } from '@approved-premises/ui'
 import { CallConfig } from '../../../../data/restClient'
 import BedspaceService from '../../../../services/v2/bedspaceService'
 import BedspacesController from './bedspacesController'
 import {
   cas3BedspaceFactory,
   cas3PremisesFactory,
+  cas3UpdateBedspaceFactory,
   characteristicFactory,
   probationRegionFactory,
   referenceDataFactory,
@@ -152,6 +153,7 @@ describe('BedspacesController', () => {
     const characteristic2 = characteristicFactory.build({ serviceScope: 'temporary-accommodation' })
 
     const premises = cas3PremisesFactory.build({
+      id: premisesId,
       addressLine1: '62 West Wallaby Street',
       addressLine2: undefined,
       town: 'Wigan',
@@ -163,120 +165,272 @@ describe('BedspacesController', () => {
     }
 
     const onlineBedspace = cas3BedspaceFactory.build({
+      id: bedspaceId,
       status: 'online',
       startDate: '2024-11-23',
       characteristics: [characteristic1, characteristic2],
     })
-    const onlineBedspaceWithSummary: Cas3Bedspace & { summary: SummaryList } = {
-      ...onlineBedspace,
-      summary: {
-        rows: [
-          {
-            key: { text: 'Bedspace status' },
-            value: { html: `<strong class="govuk-tag govuk-tag--green">Online</strong>` },
+    const onlineBedspaceSummary: SummaryList = {
+      rows: [
+        {
+          key: { text: 'Bedspace status' },
+          value: { html: `<strong class="govuk-tag govuk-tag--green">Online</strong>` },
+        },
+        {
+          key: { text: 'Start date' },
+          value: { text: '23 November 2024' },
+        },
+        {
+          key: { text: 'Bedspace details' },
+          value: {
+            html: `<span class="hmpps-tag-filters">Characteristic 1</span> <span class="hmpps-tag-filters">Characteristic 2</span>`,
           },
-          {
-            key: { text: 'Start date' },
-            value: { text: '23 November 2024' },
-          },
-          {
-            key: { text: 'Bedspace details' },
-            value: {
-              html: `<span class="hmpps-tag-filters">Characteristic 1</span> <span class="hmpps-tag-filters">Characteristic 2</span>`,
-            },
-          },
-          {
-            key: { text: 'Additional bedspace details' },
-            value: { text: onlineBedspace.notes },
-          },
-        ],
-      },
+        },
+        {
+          key: { text: 'Additional bedspace details' },
+          value: { text: onlineBedspace.notes },
+        },
+      ],
     }
 
     const archivedBedspace = cas3BedspaceFactory.build({
+      id: bedspaceId,
       status: 'archived',
       startDate: '2023-10-22',
       characteristics: [characteristic1],
     })
-    const archivedBedspaceWithSummary: Cas3Bedspace & { summary: SummaryList } = {
-      ...archivedBedspace,
-      summary: {
-        rows: [
-          {
-            key: { text: 'Bedspace status' },
-            value: { html: `<strong class="govuk-tag govuk-tag--grey">Archived</strong>` },
-          },
-          {
-            key: { text: 'Start date' },
-            value: { text: '22 October 2023' },
-          },
-          {
-            key: { text: 'Bedspace details' },
-            value: { html: `<span class="hmpps-tag-filters">Characteristic 1</span>` },
-          },
-          {
-            key: { text: 'Additional bedspace details' },
-            value: { text: archivedBedspace.notes },
-          },
-        ],
-      },
+    const archivedBedspaceSummary: SummaryList = {
+      rows: [
+        {
+          key: { text: 'Bedspace status' },
+          value: { html: `<strong class="govuk-tag govuk-tag--grey">Archived</strong>` },
+        },
+        {
+          key: { text: 'Start date' },
+          value: { text: '22 October 2023' },
+        },
+        {
+          key: { text: 'Bedspace details' },
+          value: { html: `<span class="hmpps-tag-filters">Characteristic 1</span>` },
+        },
+        {
+          key: { text: 'Additional bedspace details' },
+          value: { text: archivedBedspace.notes },
+        },
+      ],
     }
 
     const upcomingBedspace = cas3BedspaceFactory.build({
+      id: bedspaceId,
       status: 'upcoming',
       startDate: '2025-09-21',
       characteristics: [characteristic2],
     })
-    const upcomingBedspaceWithSummary: Cas3Bedspace & { summary: SummaryList } = {
-      ...upcomingBedspace,
-      summary: {
-        rows: [
-          {
-            key: { text: 'Bedspace status' },
-            value: { html: `<strong class="govuk-tag govuk-tag--blue">Upcoming</strong>` },
-          },
-          {
-            key: { text: 'Start date' },
-            value: { text: '21 September 2025' },
-          },
-          {
-            key: { text: 'Bedspace details' },
-            value: { html: `<span class="hmpps-tag-filters">Characteristic 2</span>` },
-          },
-          {
-            key: { text: 'Additional bedspace details' },
-            value: { text: upcomingBedspace.notes },
-          },
-        ],
-      },
+    const upcomingBedspaceSummary: SummaryList = {
+      rows: [
+        {
+          key: { text: 'Bedspace status' },
+          value: { html: `<strong class="govuk-tag govuk-tag--blue">Upcoming</strong>` },
+        },
+        {
+          key: { text: 'Start date' },
+          value: { text: '21 September 2025' },
+        },
+        {
+          key: { text: 'Bedspace details' },
+          value: { html: `<span class="hmpps-tag-filters">Characteristic 2</span>` },
+        },
+        {
+          key: { text: 'Additional bedspace details' },
+          value: { text: upcomingBedspace.notes },
+        },
+      ],
     }
 
-    it.each([[onlineBedspaceWithSummary], [archivedBedspaceWithSummary], [upcomingBedspaceWithSummary]])(
-      'should return a bedspace',
-      async bedspace => {
-        const params = { premisesId, bedspaceId }
+    it.each([
+      [onlineBedspace, onlineBedspaceSummary],
+      [archivedBedspace, archivedBedspaceSummary],
+      [upcomingBedspace, upcomingBedspaceSummary],
+    ])('should return a bedspace', async (bedspace: Cas3Bedspace, summary: SummaryList) => {
+      const params = { premisesId, bedspaceId }
 
-        premisesService.getSinglePremisesDetails.mockResolvedValue(premisesWithFullAddress)
-        bedspaceService.getSingleBedspaceDetails.mockResolvedValue(bedspace)
+      premisesService.getSinglePremisesDetails.mockResolvedValue(premisesWithFullAddress)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
+      bedspaceService.summaryList.mockReturnValue(summary)
 
-        request = createMock<Request>({
-          session: {
-            probationRegion: probationRegionFactory.build(),
+      request = createMock<Request>({
+        session: {
+          probationRegion: probationRegionFactory.build(),
+        },
+        params,
+      })
+
+      const requestHandler = bedspacesController.show()
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/bedspaces/show', {
+        premises: premisesWithFullAddress,
+        summary,
+        bedspace,
+        actions: [
+          {
+            text: 'Edit bedspace details',
+            classes: 'govuk-button--secondary',
+            href: paths.premises.v2.bedspaces.edit({ premisesId, bedspaceId }),
           },
-          params,
-        })
+        ],
+      })
 
-        const requestHandler = bedspacesController.show()
-        await requestHandler(request, response, next)
+      expect(premisesService.getSinglePremisesDetails).toHaveBeenCalledWith(callConfig, premisesId)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premisesId, bedspaceId)
+      expect(bedspaceService.summaryList).toHaveBeenCalledWith(bedspace)
+    })
+  })
 
-        expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/bedspaces/show', {
-          premises: premisesWithFullAddress,
-          bedspace,
-          actions: [],
-        })
+  describe('edit', () => {
+    const premises = cas3PremisesFactory.build({ status: 'online' })
+    const bedspace = cas3BedspaceFactory.build({ status: 'online' })
 
-        expect(bedspaceService.getSingleBedspaceDetails).toHaveBeenCalledWith(callConfig, premisesId, bedspaceId)
-      },
-    )
+    const summaryList: SummaryList = {
+      rows: [
+        {
+          key: { text: 'Status' },
+          value: { html: `<strong class="govuk-tag govuk-tag--green">Online</strong>` },
+        },
+        {
+          key: { text: 'Address' },
+          value: {
+            html: `${premises.addressLine1}<br />${premises.addressLine2}<br />${premises.town}<br />${premises.postcode}`,
+          },
+        },
+      ],
+    }
+
+    it('should render the form', async () => {
+      premisesService.getSinglePremises.mockResolvedValue(premises)
+      premisesService.shortSummaryList.mockReturnValue(summaryList)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
+      bedspaceService.getReferenceData.mockResolvedValue(referenceData)
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [], userInput: {} })
+
+      const requestHandler = bedspacesController.edit()
+
+      request.params = { premisesId: premises.id, bedspaceId: bedspace.id }
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/bedspaces/edit', {
+        premisesId: premises.id,
+        bedspaceId: bedspace.id,
+        summary: summaryList,
+        errors: {},
+        errorSummary: [],
+        characteristics: referenceData.characteristics.filter(ch => ch.propertyName !== 'other'),
+        reference: bedspace.reference,
+        notes: bedspace.notes,
+        characteristicIds: bedspace.characteristics.map(ch => ch.id),
+      })
+
+      expect(premisesService.getSinglePremises).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(premisesService.shortSummaryList).toHaveBeenCalledWith(premises)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(callConfig)
+    })
+
+    it('should render the form with errors and user input when the backend returns an error', async () => {
+      premisesService.getSinglePremises.mockResolvedValue(premises)
+      premisesService.shortSummaryList.mockReturnValue(summaryList)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
+      bedspaceService.getReferenceData.mockResolvedValue(referenceData)
+
+      const errorsAndUserInput = createMock<ErrorsAndUserInput>()
+      ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue(errorsAndUserInput)
+
+      request.params = { premisesId: premises.id, bedspaceId: bedspace.id }
+
+      const requestHandler = bedspacesController.edit()
+
+      await requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/v2/bedspaces/edit', {
+        premisesId: premises.id,
+        bedspaceId: bedspace.id,
+        summary: summaryList,
+        errors: errorsAndUserInput.errors,
+        errorSummary: errorsAndUserInput.errorSummary,
+        characteristics: referenceData.characteristics.filter(ch => ch.propertyName !== 'other'),
+        ...errorsAndUserInput.userInput,
+        reference: bedspace.reference,
+        notes: bedspace.notes,
+        characteristicIds: bedspace.characteristics.map(ch => ch.id),
+      })
+
+      expect(premisesService.getSinglePremises).toHaveBeenCalledWith(callConfig, premises.id)
+      expect(premisesService.shortSummaryList).toHaveBeenCalledWith(premises)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
+      expect(bedspaceService.getReferenceData).toHaveBeenCalledWith(callConfig)
+    })
+  })
+
+  describe('update', () => {
+    it('should successfully update a bedspace and redirect to the show bedspace page', async () => {
+      const requestHandler = bedspacesController.update()
+
+      const premises = cas3PremisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+      const updatedBedspace = cas3UpdateBedspaceFactory.build()
+
+      request.params = { premisesId: premises.id, bedspaceId: bedspace.id }
+
+      request.body = { ...updatedBedspace }
+
+      bedspaceService.updateBedspace.mockResolvedValue(bedspace)
+
+      await requestHandler(request, response, next)
+
+      expect(bedspaceService.updateBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id, {
+        ...updatedBedspace,
+      })
+      expect(request.flash).toHaveBeenCalledWith('success', 'Bedspace edited')
+      expect(response.redirect).toHaveBeenCalledWith(
+        paths.premises.v2.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      )
+    })
+
+    it('should fail to update a bedspace when the service returns an error', async () => {
+      const requestHandler = bedspacesController.update()
+
+      const bedspaceId = '8d6f6436-bda4-4d58-a2bc-72d3d2e41134'
+      const updatedBedspace = cas3UpdateBedspaceFactory.build()
+
+      request.params = { premisesId, bedspaceId }
+
+      request.body = {
+        ...updatedBedspace,
+        reference: '',
+      }
+
+      const err = {
+        data: {
+          title: 'Bad Request',
+          status: 400,
+          detail: 'There is a problem with your request',
+          'invalid-params': [{ propertyName: '$.reference', errorType: 'empty' }],
+        },
+      }
+
+      bedspaceService.updateBedspace.mockImplementation(() => {
+        throw err
+      })
+
+      await requestHandler(request, response, next)
+
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
+        request,
+        response,
+        err,
+        paths.premises.v2.bedspaces.edit({ premisesId, bedspaceId }),
+      )
+    })
   })
 })

--- a/server/data/v2/bedspaceClient.test.ts
+++ b/server/data/v2/bedspaceClient.test.ts
@@ -2,7 +2,12 @@ import nock from 'nock'
 import BedspaceClient from './bedspaceClient'
 import { CallConfig } from '../restClient'
 import config from '../../config'
-import { cas3BedspaceFactory, cas3BedspacesFactory, cas3NewBedspaceFactory } from '../../testutils/factories'
+import {
+  cas3BedspaceFactory,
+  cas3BedspacesFactory,
+  cas3NewBedspaceFactory,
+  cas3UpdateBedspaceFactory,
+} from '../../testutils/factories'
 import paths from '../../paths/api'
 
 describe('BedspaceClient', () => {
@@ -72,6 +77,26 @@ describe('BedspaceClient', () => {
 
       const output = await bedspaceClient.get(premisesId)
       expect(output).toEqual(bedspaces)
+    })
+  })
+
+  describe('update', () => {
+    it('should return the bedspace that has been updated', async () => {
+      const bedspace = cas3BedspaceFactory.build()
+
+      const payload = cas3UpdateBedspaceFactory.build({
+        reference: bedspace.reference,
+        notes: bedspace.notes,
+        characteristicIds: bedspace.characteristics.map(ch => ch.id),
+      })
+
+      fakeApprovedPremisesApi
+        .put(paths.cas3.premises.bedspaces.update({ premisesId, bedspaceId: bedspace.id }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, bedspace)
+
+      const result = await bedspaceClient.update(premisesId, bedspace.id, payload)
+      expect(result).toEqual(bedspace)
     })
   })
 })

--- a/server/data/v2/bedspaceClient.ts
+++ b/server/data/v2/bedspaceClient.ts
@@ -1,4 +1,4 @@
-import { Cas3Bedspace, Cas3Bedspaces, Cas3NewBedspace } from '@approved-premises/api'
+import { Cas3Bedspace, Cas3Bedspaces, Cas3NewBedspace, Cas3UpdateBedspace } from '@approved-premises/api'
 import RestClient, { CallConfig } from '../restClient'
 import config, { ApiConfig } from '../../config'
 import paths from '../../paths/api'
@@ -23,6 +23,13 @@ export default class BedspaceClient {
   async get(premisesId: string) {
     return this.restClient.get<Cas3Bedspaces>({
       path: paths.cas3.premises.bedspaces.get({ premisesId }),
+    })
+  }
+
+  async update(premisesId: string, bedspaceId: string, data: Cas3UpdateBedspace) {
+    return this.restClient.put<Cas3Bedspace>({
+      path: paths.cas3.premises.bedspaces.update({ premisesId, bedspaceId }),
+      data,
     })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -75,6 +75,7 @@ const managePathsCas3 = {
       show: singleBedspacePath,
       create: bedspacesCas3Path,
       get: bedspacesCas3Path,
+      update: singleBedspacePath,
     },
   },
 }
@@ -112,6 +113,7 @@ export default {
         show: managePathsCas3.premises.bedspaces.show,
         create: managePathsCas3.premises.bedspaces.create,
         get: managePathsCas3.premises.bedspaces.get,
+        update: managePathsCas3.premises.bedspaces.update,
       },
     },
   },

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -68,6 +68,8 @@ const paths: Record<string, any> = {
         show: singleBedspaceV2Path,
         create: bedspacesV2Path,
         list: bedspacesV2Path,
+        edit: singleBedspaceV2Path.path('edit'),
+        update: singleBedspaceV2Path,
       },
     },
   },

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -128,6 +128,19 @@ export default function routes(controllers: Controllers, services: Services, rou
         },
       ],
     })
+    get(paths.premises.v2.bedspaces.edit.pattern, bedspacesControllerV2.edit(), { auditEvent: 'UPDATE_BEDSPACE_V2' })
+    post(paths.premises.v2.bedspaces.update.pattern, bedspacesControllerV2.update(), {
+      redirectAuditEventSpecs: [
+        {
+          path: paths.premises.v2.bedspaces.edit.pattern,
+          auditEvent: 'UPDATE_BEDSPACE_V2_FAILURE',
+        },
+        {
+          path: paths.premises.v2.bedspaces.show.pattern,
+          auditEvent: 'UPDATE_BEDSPACE_V2_SUCCESS',
+        },
+      ],
+    })
   }
 
   get(paths.premises.bedspaces.new.pattern, bedspacesController.new(), { auditEvent: 'VIEW_BEDSPACE_CREATE' })

--- a/server/services/v2/bedspaceService.ts
+++ b/server/services/v2/bedspaceService.ts
@@ -3,6 +3,7 @@ import {
   type Cas3BedspaceStatus,
   Cas3Bedspaces,
   Cas3NewBedspace,
+  Cas3UpdateBedspace,
   Characteristic,
 } from '@approved-premises/api'
 import { SummaryList } from '@approved-premises/ui'
@@ -24,19 +25,9 @@ export default class BedspaceService {
     private readonly referenceDataClientFactory: RestClientBuilder<ReferenceDataClient>,
   ) {}
 
-  async getSingleBedspaceDetails(
-    callConfig: CallConfig,
-    premisesId: string,
-    bedspaceId: string,
-  ): Promise<Cas3Bedspace & { summary: SummaryList }> {
+  async getSingleBedspace(callConfig: CallConfig, premisesId: string, bedspaceId: string): Promise<Cas3Bedspace> {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
-
-    const bedspace = await bedspaceClient.find(premisesId, bedspaceId)
-
-    return {
-      ...bedspace,
-      summary: this.summaryList(bedspace),
-    }
+    return bedspaceClient.find(premisesId, bedspaceId)
   }
 
   async getBedspacesForPremises(callConfig: CallConfig, premisesId: string): Promise<Cas3Bedspaces> {
@@ -118,5 +109,15 @@ export default class BedspaceService {
   ): Promise<Cas3Bedspace> {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
     return bedspaceClient.create(premisesId, newBedspace)
+  }
+
+  async updateBedspace(
+    callConfig: CallConfig,
+    premisesId: string,
+    bedspaceId: string,
+    updatedBedspace: Cas3UpdateBedspace,
+  ): Promise<Cas3Bedspace> {
+    const bedspaceClient = this.bedspaceClientFactory(callConfig)
+    return bedspaceClient.update(premisesId, bedspaceId, updatedBedspace)
   }
 }

--- a/server/testutils/factories/cas3UpdateBedspace.ts
+++ b/server/testutils/factories/cas3UpdateBedspace.ts
@@ -1,0 +1,22 @@
+import { Factory } from 'fishery'
+import { Cas3UpdateBedspace } from '@approved-premises/api'
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { unique } from '../../utils/utils'
+import referenceDataFactory from './referenceData'
+
+export default Factory.define<Cas3UpdateBedspace>(() => {
+  const characteristicIds = unique(
+    referenceDataFactory.characteristic('room').buildList(
+      faker.number.int({
+        min: 1,
+        max: 5,
+      }),
+    ),
+  ).map(ch => ch.id)
+
+  return {
+    reference: `Room ${faker.number.int({ min: 1, max: 9999 })}`,
+    characteristicIds,
+    notes: faker.lorem.sentences(3),
+  }
+})

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -61,6 +61,7 @@ import cas3PremisesSearchResultFactory from './cas3PremisesSearchResult'
 import cas3PremisesSearchResultsFactory from './cas3PremisesSearchResults'
 import cas3BedspaceFactory from './cas3Bedspace'
 import cas3NewBedspaceFactory from './cas3NewBedspace'
+import cas3UpdateBedspaceFactory from './cas3UpdateBedspace'
 import cas3BedspaceSummaryFactory from './cas3BedspaceSummary'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import probationRegionFactory from './probationRegion'
@@ -144,6 +145,7 @@ export {
   cas3BedspaceFactory,
   cas3BedspacesFactory,
   cas3NewBedspaceFactory,
+  cas3UpdateBedspaceFactory,
   cas3BedspaceSummaryFactory,
   prisonCaseNotesFactory,
   probationRegionFactory,

--- a/server/utils/v2/bedspaceUtils.test.ts
+++ b/server/utils/v2/bedspaceUtils.test.ts
@@ -1,0 +1,20 @@
+import { cas3BedspaceFactory, cas3PremisesFactory } from '../../testutils/factories'
+import { bedspaceActions } from './bedspaceUtils'
+import paths from '../../paths/temporary-accommodation/manage'
+
+describe('bedspaceV2Utils', () => {
+  describe('bedspaceActions', () => {
+    it('returns "Edit bedspace details" for a bedspace', () => {
+      const premises = cas3PremisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+
+      const actions = bedspaceActions(premises, bedspace)
+
+      expect(actions).toContainEqual({
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+    })
+  })
+})

--- a/server/utils/v2/bedspaceUtils.ts
+++ b/server/utils/v2/bedspaceUtils.ts
@@ -1,0 +1,13 @@
+import { Cas3Bedspace, Cas3Premises } from '@approved-premises/api'
+import { PageHeadingBarItem } from '@approved-premises/ui'
+import paths from '../../paths/temporary-accommodation/manage'
+
+export function bedspaceActions(premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> {
+  return [
+    {
+      text: 'Edit bedspace details',
+      href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      classes: 'govuk-button--secondary',
+    },
+  ]
+}

--- a/server/views/temporary-accommodation/v2/bedspaces/edit.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/edit.njk
@@ -1,0 +1,89 @@
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set mainClasses = "govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: 'Back',
+        href: paths.premises.v2.bedspaces.show({ premisesId: premisesId, bedspaceId: bedspaceId }),
+        classes: 'govuk-!-display-none-print'
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% include "../../../_messages.njk" %}
+
+    {{ showErrorSummary(errorSummary) }}
+
+    <h1 class="govuk-heading-l">Edit bedspace</h1>
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            {{ govukSummaryList({
+                rows: summary.rows
+            }) }}
+
+            <form action="{{ paths.premises.v2.bedspaces.update({ premisesId: premisesId, bedspaceId: bedspaceId })}}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+
+                {{ formPageInput(
+                    {
+                        label: {
+                            text: 'Bedspace reference',
+                            classes: "govuk-label--m"
+                        },
+                        classes: "govuk-input--width-20",
+                        hint: {
+                            text: "This will be used to identify the bedspace when making bookings and reporting on the service."
+                        },
+                        fieldName: "reference"
+                    },
+                    fetchContext()
+                ) }}
+
+                {{ govukCheckboxes({
+                    fieldset: {
+                        legend: {
+                            text: "Select bedspace details",
+                            classes: "govuk-fieldset__legend--m"
+                        }
+                    },
+                    hint: {
+                        text: "Select all that apply:"
+                    },
+                    items: convertObjectsToCheckboxItems(characteristics, 'name', 'id', 'characteristicIds'),
+                    id: "characteristicIds",
+                    name: "characteristicIds[]",
+                    errorMessage: errors.characteristicIds
+                }) }}
+
+                {{ govukTextarea({
+                    label: {
+                        text: "Additional bedspace details",
+                        classes: "govuk-label--m"
+                    },
+                    hint: {
+                        text: "This information will be used to help find a suitable bedspace for the person on probation."
+                    },
+                    id: "notes",
+                    name: "notes",
+                    value: notes,
+                    errorMessage: errors.notes
+                }) }}
+
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/temporary-accommodation/v2/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/show.njk
@@ -61,7 +61,7 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
             {{ govukSummaryList({
-                rows: bedspace.summary.rows
+                rows: summary.rows
             }) }}
         </div>
     </div>


### PR DESCRIPTION
# Context

Ticket [CAS-1803 C3 FE: Edit Bedspace Page](https://dsdmoj.atlassian.net/browse/CAS-1803)
Requires `MANAGE_PROPERTIES_V2_ENABLED` feature flag

# Changes in this PR

## Screenshots of UI changes

### Before

### After
<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/8707d0b6-47ed-47c4-b9df-276d3dc72fb8" />
<img width="3424" height="3562" alt="image" src="https://github.com/user-attachments/assets/a9370cc6-0e65-45c1-8513-3d331eab4a7d" />
<img width="3424" height="2693" alt="image" src="https://github.com/user-attachments/assets/e048d7da-3e06-45a0-b523-66e00bc48817" />
<img width="3424" height="4106" alt="image" src="https://github.com/user-attachments/assets/8e2d891d-d46b-4b5d-ae49-42313ba5608f" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
