### PR TITLE
Remove arrival validation and update to cas3 endpoint

### DIFF
--- a/integration_tests/mockApis/arrival.ts
+++ b/integration_tests/mockApis/arrival.ts
@@ -10,7 +10,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`,
+        url: `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`,
       },
       response: {
         status: 201,
@@ -23,7 +23,7 @@ export default {
     bookingId: string
     params: Array<string>
   }): SuperAgentRequest =>
-    stubFor(errorStub(args.params, `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`, 'POST')),
+    stubFor(errorStub(args.params, `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`, 'POST')),
   stubArrivalCreateConflictError: (args: {
     premisesId: string
     bookingId: string
@@ -33,7 +33,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`,
+        url: `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`,
       },
       response: {
         status: 409,
@@ -47,7 +47,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: `/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`,
+        url: `/cas3/premises/${args.premisesId}/bookings/${args.bookingId}/arrivals`,
       })
     ).body.requests,
 }

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
@@ -427,42 +427,6 @@ describe('ArrivalsController', () => {
           paths.bookings.arrivals.edit({ premisesId, roomId, bookingId }),
         )
       })
-
-      it('renders with errors if arrival date is more than 7 days in the past', async () => {
-        const requestHandler = arrivalsController.update()
-
-        const currentDate = new Date()
-        const pastDate = addDays(currentDate, -8)
-
-        const arrival = arrivalFactory.build({ arrivalDate: DateFormats.dateObjToIsoDate(pastDate) })
-        const newArrival = newArrivalFactory.build({
-          ...arrival,
-        })
-
-        request.params = {
-          premisesId,
-          roomId,
-          bookingId,
-        }
-        request.body = {
-          ...newArrival,
-          ...DateFormats.isoToDateAndTimeInputs(DateFormats.dateObjToIsoDate(pastDate), 'arrivalDate'),
-        }
-
-        arrivalService.createArrival.mockResolvedValue(arrival)
-
-        const err = new Error()
-
-        await requestHandler(request, response, next)
-
-        expect(insertGenericError).toHaveBeenCalledWith(err, 'arrivalDate', 'withinLastSevenDays')
-        expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-          request,
-          response,
-          err,
-          paths.bookings.arrivals.edit({ premisesId, roomId, bookingId }),
-        )
-      })
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -4,7 +4,7 @@ import type { NewCas3Arrival as NewArrival } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { ArrivalService, BedspaceService, BookingService, PremisesService } from '../../../services'
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
-import { DateFormats, dateIsInFuture, dateIsWithinLastSevenDays } from '../../../utils/dateUtils'
+import { DateFormats, dateIsInFuture } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import {
   catchValidationErrorOrPropogate,
@@ -67,12 +67,6 @@ export default class ArrivalsController {
         }
 
         if (newArrival.arrivalDate) {
-          if (!dateIsWithinLastSevenDays(newArrival.arrivalDate)) {
-            const error = new Error()
-            insertGenericError(error, 'arrivalDate', 'withinLastSevenDays')
-            throw error
-          }
-
           const parsedDepartureDate = DateFormats.isoToDateObj(newArrival.expectedDepartureDate)
           const maxAllowedDate = new Date(newArrival.arrivalDate)
           maxAllowedDate.setDate(maxAllowedDate.getDate() + 84)
@@ -148,12 +142,6 @@ export default class ArrivalsController {
           if (dateIsInFuture(updateArrival.arrivalDate)) {
             const error = new Error()
             insertGenericError(error, 'arrivalDate', 'todayOrInThePast')
-            throw error
-          }
-
-          if (!dateIsWithinLastSevenDays(updateArrival.arrivalDate)) {
-            const error = new Error()
-            insertGenericError(error, 'arrivalDate', 'withinLastSevenDays')
             throw error
           }
         }

--- a/server/data/bookingClient.test.ts
+++ b/server/data/bookingClient.test.ts
@@ -149,7 +149,7 @@ describe('BookingClient', () => {
       })
 
       fakeApprovedPremisesApi
-        .post(`/premises/premisesId/bookings/bookingId/arrivals`, payload)
+        .post(`/cas3/premises/premisesId/bookings/bookingId/arrivals`, payload)
         .matchHeader('authorization', `Bearer ${callConfig.token}`)
         .reply(201, arrival)
 

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -66,7 +66,7 @@ export default class BookingClient {
 
   async markAsArrived(premisesId: string, bookingId: string, arrival: NewArrival) {
     return this.restClient.post<Arrival>({
-      path: `${this.bookingPath(premisesId, bookingId)}/arrivals`,
+      path: paths.cas3.premises.bookings.arrival({ premisesId, bookingId }),
       data: arrival,
     })
   }
@@ -86,7 +86,7 @@ export default class BookingClient {
 
   async markDeparture(premisesId: string, bookingId: string, departure: Cas3NewDeparture) {
     return this.restClient.post<Cas3Departure>({
-      path: this.departuresPath(premisesId, bookingId),
+      path: paths.cas3.premises.bookings.departure({ premisesId, bookingId }),
       data: departure,
     })
   }
@@ -137,9 +137,5 @@ export default class BookingClient {
 
   private bookingPath(premisesId: string, bookingId: string): string {
     return [this.bookingsPath(premisesId), bookingId].join('/')
-  }
-
-  private departuresPath(premisesId: string, bookingId: string): string {
-    return `/cas3/premises/${premisesId}/bookings/${bookingId}/departures`
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -27,7 +27,7 @@
       "invalid": "The start date is an invalid date",
       "conflict": "This bedspace is not available for these dates",
       "todayOrInThePast": "The arrival date must be today or in the past",
-      "withinLastSevenDays": "The arrival date must be within the last 7 days",
+      "arrivalAfterLatestDate": "The arrival date must be within the last 14 days",
       "bookingArrivalDateBeforeBedspaceStartDate": "Booking start date must be on or later than bedspace start date"
     },
     "date": {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -6,6 +6,7 @@ const cas3PremisesPath = cas3Path.path('premises')
 const premisesSummaryPath = cas3PremisesPath.path('summary')
 const singlePremisesPath = premisesPath.path(':premisesId')
 const singlePremisesCas3Path = cas3PremisesPath.path(':premisesId')
+const singleBookingCas3Path = singlePremisesCas3Path.path('bookings/:bookingId')
 const premisesSearchPath = cas3PremisesPath.path('search')
 
 const lostBedsPath = singlePremisesPath.path('lost-beds')
@@ -77,6 +78,10 @@ const managePathsCas3 = {
       get: bedspacesCas3Path,
       update: singleBedspacePath,
     },
+    bookings: {
+      arrival: singleBookingCas3Path.path('arrivals'),
+      departure: singleBookingCas3Path.path('departures'),
+    },
   },
 }
 
@@ -114,6 +119,10 @@ export default {
         create: managePathsCas3.premises.bedspaces.create,
         get: managePathsCas3.premises.bedspaces.get,
         update: managePathsCas3.premises.bedspaces.update,
+      },
+      bookings: {
+        arrival: managePathsCas3.premises.bookings.arrival,
+        departure: managePathsCas3.premises.bookings.departure,
       },
     },
   },

--- a/server/utils/dateUtils.test.ts
+++ b/server/utils/dateUtils.test.ts
@@ -1,4 +1,4 @@
-import { addDays, addMonths, subDays, subMonths } from 'date-fns'
+import { addMonths, subMonths } from 'date-fns'
 import type { ObjectWithDateParts } from '@approved-premises/ui'
 import {
   DateFormats,
@@ -9,7 +9,6 @@ import {
   dateIsBlank,
   dateIsInFuture,
   dateIsInThePast,
-  dateIsWithinLastSevenDays,
   dateIsWithinNextThreeMonths,
   datepickerInputsAreValidDates,
 } from './dateUtils'
@@ -490,42 +489,6 @@ describe('dateExists', () => {
 
     it('returns false if the input is an empty string', () => {
       expect(dateIsWithinNextThreeMonths('')).toBe(false)
-    })
-  })
-
-  describe('dateIsWithinLastSevenDays', () => {
-    it('returns true if the date is within the last 7 days', () => {
-      const validDate = DateFormats.dateObjToIsoDate(subDays(new Date(), 5))
-      expect(dateIsWithinLastSevenDays(validDate)).toBe(true)
-    })
-
-    it('returns true if the date is today', () => {
-      const validDate = DateFormats.dateObjToIsoDate(new Date())
-      expect(dateIsWithinLastSevenDays(validDate)).toBe(true)
-    })
-
-    it('returns true if the date is 7 days ago', () => {
-      const validDate = DateFormats.dateObjToIsoDate(subDays(new Date(), 7))
-      expect(dateIsWithinLastSevenDays(validDate)).toBe(true)
-    })
-
-    it('returns false if the date is more than 7 days in the past', () => {
-      const invalidDate = DateFormats.dateObjToIsoDate(subDays(new Date(), 8))
-      expect(dateIsWithinLastSevenDays(invalidDate)).toBe(false)
-    })
-
-    it('returns false if the date is in the future', () => {
-      const futureDate = DateFormats.dateObjToIsoDate(addDays(new Date(), 1))
-      expect(dateIsWithinLastSevenDays(futureDate)).toBe(false)
-    })
-
-    it('returns false if the input is an invalid date string', () => {
-      const invalidDateString = 'invalid'
-      expect(dateIsWithinLastSevenDays(invalidDateString)).toBe(false)
-    })
-
-    it('returns false if the input is an empty string', () => {
-      expect(dateIsWithinLastSevenDays('')).toBe(false)
     })
   })
 })

--- a/server/utils/dateUtils.ts
+++ b/server/utils/dateUtils.ts
@@ -236,10 +236,3 @@ export function dateIsBetweenInclusive(dateString: string, start: Date, end: Dat
 
   return dateString >= startString && dateString <= endString
 }
-
-export function dateIsWithinLastSevenDays(dateString: string): boolean {
-  const today = new Date()
-  const sevenDays = subDays(today, 7)
-
-  return dateIsBetweenInclusive(dateString, sevenDays, today)
-}


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1869) removes some of the FE validaiton for arrival date and switches booking arrival endpoint to /cas3

# Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="704" height="490" alt="image" src="https://github.com/user-attachments/assets/27fa74de-0d73-42b6-a0ba-bb6aa937075b" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
