### PR TITLE
Add cancel archive for bedspaces

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
@@ -3,6 +3,7 @@ import { Booking, Cas3Bedspace, Cas3Premises, LostBed } from '../../../../../ser
 import paths from '../../../../../server/paths/temporary-accommodation/manage'
 import BookingListingComponent from '../../../../components/bookingListing'
 import LostBedListingComponent from '../../../../components/lostBedListing'
+import { DateFormats } from '../../../../../server/utils/dateUtils'
 
 export default class BedspaceShowPage extends Page {
   constructor(
@@ -76,15 +77,32 @@ export default class BedspaceShowPage extends Page {
     lostBedListingComponent.shouldShowLostBedDetails()
   }
 
-  clickEditPropertyDetailsAction(): void {
-    // TODO: uncomment when additional actions are added
-    // cy.get('button').contains('Actions').parent().click()
-    // cy.get('button').contains('Actions').parent().siblings('ul').contains('Edit bedspace details').click()
-
-    cy.get('[role="button"]').contains('Edit bedspace details').click()
+  clickAction(action: string): void {
+    cy.get('body').then($body => {
+      if ($body.find('button:contains("Actions")').length > 0) {
+        cy.get('button').contains('Actions').parent().click()
+        cy.get('button').contains('Actions').parent().siblings('ul').contains(action).click()
+      } else {
+        cy.get('[role="button"]').contains(action).click()
+      }
+    })
   }
 
   shouldShowBedspaceUpdatedBanner(): void {
     cy.get('main .govuk-notification-banner--success').contains('Bedspace edited')
+  }
+
+  shouldShowCancelArchive(bedspace: Cas3Bedspace): void {
+    const endDate = DateFormats.isoDateToUIDate(bedspace.endDate)
+
+    cy.get('main').contains(`Are you sure you want to cancel the scheduled archive on ${endDate}?`)
+    cy.get('main').contains('Yes, I want to cancel it')
+    cy.get('main').contains('No')
+    cy.get('main').contains('Submit')
+  }
+
+  confirmCancelArchive() {
+    cy.get('main').contains('Yes').click()
+    cy.get('main').contains('Submit').click()
   }
 }

--- a/integration_tests/mockApis/v2/bedspace.ts
+++ b/integration_tests/mockApis/v2/bedspace.ts
@@ -114,6 +114,37 @@ const stubBedspaceUpdateErrors = (params: { fields: Array<string>; premisesId: s
     ),
   )
 
+const stubBedspaceCancelArchive = (args: BedspaceArguments) =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      url: paths.cas3.premises.bedspaces.cancelArchive({ premisesId: args.premisesId, bedspaceId: args.bedspace.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: args.bedspace,
+    },
+  })
+
+const stubBedspaceCancelArchiveError = (args: BedspaceArguments) =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      url: paths.cas3.premises.bedspaces.cancelArchive({ premisesId: args.premisesId, bedspaceId: args.bedspace.id }),
+    },
+    response: {
+      status: 400,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        title: 'Bad Request',
+        status: 400,
+        detail: 'This bedspace is not scheduled to be archived',
+        'invalid-params': [{ propertyName: '$.bedspaceId', errorType: 'bedspaceNotScheduledToArchive' }],
+      },
+    },
+  })
+
 export default {
   stubBedspaceV2,
   stubPremisesBedspacesV2,
@@ -121,6 +152,8 @@ export default {
   verifyBedspaceCreate,
   stubBedspaceCreateErrors,
   stubBedspaceUpdate,
+  stubBedspaceCancelArchive,
+  stubBedspaceCancelArchiveError,
   verifyBedspaceUpdate,
   stubBedspaceUpdateErrors,
 }

--- a/integration_tests/mockApis/v2/premises.ts
+++ b/integration_tests/mockApis/v2/premises.ts
@@ -1,5 +1,6 @@
 import type {
   Cas3Premises,
+  Cas3PremisesBedspaceTotals,
   Cas3PremisesSearchResults,
   Cas3PremisesSortBy,
   Cas3PremisesStatus,
@@ -151,10 +152,30 @@ const stubPremisesArchiveErrorsV2 = (params: { premisesId: string; endDate: stri
     },
   })
 
+const stubPremisesBedspaceTotalsV2 = ({
+  premisesId,
+  totals,
+}: {
+  premisesId: string
+  totals: Cas3PremisesBedspaceTotals
+}) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      urlPathPattern: paths.cas3.premises.totals({ premisesId }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: totals,
+    },
+  })
+
 export default {
   stubPremisesSearchV2,
   stubSinglePremisesV2,
   stubPremisesReferenceDataV2,
+  stubPremisesBedspaceTotalsV2,
   stubPremisesCreateV2,
   stubPremisesCreateErrorsV2,
   verifyPremisesCreateV2,

--- a/server/data/v2/bedspaceClient.test.ts
+++ b/server/data/v2/bedspaceClient.test.ts
@@ -16,6 +16,7 @@ describe('BedspaceClient', () => {
 
   const callConfig = { token: 'some-token' } as CallConfig
   const premisesId = 'some-premises-id'
+  const bedspaceId = 'some-bedspace-id'
 
   beforeEach(() => {
     config.apis.approvedPremises.url = 'http://localhost:8080'
@@ -34,7 +35,6 @@ describe('BedspaceClient', () => {
 
   describe('find', () => {
     it('should return bedspace', async () => {
-      const bedspaceId = 'some-bedspace-id'
       const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
 
       fakeApprovedPremisesApi
@@ -96,6 +96,20 @@ describe('BedspaceClient', () => {
         .reply(200, bedspace)
 
       const result = await bedspaceClient.update(premisesId, bedspace.id, payload)
+      expect(result).toEqual(bedspace)
+    })
+  })
+
+  describe('cancelArchive', () => {
+    it('should return the bedspace after cancelling the archive', async () => {
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
+
+      fakeApprovedPremisesApi
+        .put(paths.cas3.premises.bedspaces.cancelArchive({ premisesId, bedspaceId }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, bedspace)
+
+      const result = await bedspaceClient.cancelArchive(premisesId, bedspaceId)
       expect(result).toEqual(bedspace)
     })
   })

--- a/server/data/v2/bedspaceClient.ts
+++ b/server/data/v2/bedspaceClient.ts
@@ -32,4 +32,10 @@ export default class BedspaceClient {
       data,
     })
   }
+
+  async cancelArchive(premisesId: string, bedspaceId: string) {
+    return this.restClient.put<Cas3Bedspace>({
+      path: paths.cas3.premises.bedspaces.cancelArchive({ premisesId, bedspaceId }),
+    })
+  }
 }

--- a/server/data/v2/premisesClient.test.ts
+++ b/server/data/v2/premisesClient.test.ts
@@ -6,6 +6,7 @@ import config from '../../config'
 import {
   cas3ArchivePremisesFactory,
   cas3NewPremisesFactory,
+  cas3PremisesBedspaceTotalsFactory,
   cas3PremisesFactory,
   cas3PremisesSearchResultFactory,
   cas3PremisesSearchResultsFactory,
@@ -113,6 +114,21 @@ describe('PremisesClient', () => {
 
       const result = await premisesClient.archive(premisesId, payload)
       expect(result).toEqual(premises)
+    })
+  })
+
+  describe('totals', () => {
+    it('should return the bedspace totals for a premises', async () => {
+      const premisesId = 'premises-id'
+      const totals = cas3PremisesBedspaceTotalsFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.cas3.premises.totals({ premisesId }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, totals)
+
+      const result = await premisesClient.totals(premisesId)
+      expect(result).toEqual(totals)
     })
   })
 })

--- a/server/data/v2/premisesClient.ts
+++ b/server/data/v2/premisesClient.ts
@@ -1,6 +1,7 @@
 import {
   Cas3NewPremises,
   Cas3Premises,
+  Cas3PremisesBedspaceTotals,
   Cas3PremisesSearchResults,
   Cas3PremisesSortBy,
   Cas3PremisesStatus,
@@ -40,5 +41,11 @@ export default class PremisesClient {
 
   async archive(premisesId: string, data: { endDate: string }) {
     return this.restClient.post<Cas3Premises>({ path: paths.cas3.premises.archive({ premisesId }), data })
+  }
+
+  async totals(premisesId: string): Promise<Cas3PremisesBedspaceTotals> {
+    return this.restClient.get<Cas3PremisesBedspaceTotals>({
+      path: paths.cas3.premises.totals({ premisesId }),
+    })
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -176,6 +176,10 @@
         "invalidParoleSelection": "Parole cannot be combined with post sentence supervision (PSS)",
         "invalidCRDSelection": "CRD licence cannot be combined with parole, recall or RARR licences"
       }
+    },
+    "bedspaceId": {
+      "bedspaceNotScheduledToArchive": "This bedspace is not scheduled to be archived",
+      "bedspaceAlreadyArchived": "This bedspace has already been archived"
     }
   },
   "bookingCancellation": {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -74,11 +74,13 @@ const managePathsCas3 = {
     create: cas3PremisesPath,
     update: singlePremisesCas3Path,
     archive: premisesArchivePath,
+    totals: singlePremisesCas3Path.path('bedspace-totals'),
     bedspaces: {
       show: singleBedspacePath,
       create: bedspacesCas3Path,
       get: bedspacesCas3Path,
       update: singleBedspacePath,
+      cancelArchive: singleBedspacePath.path('cancel-archive'),
     },
     bookings: {
       arrival: singleBookingCas3Path.path('arrivals'),
@@ -117,11 +119,13 @@ export default {
       create: managePathsCas3.premises.create,
       update: managePathsCas3.premises.update,
       archive: managePathsCas3.premises.archive,
+      totals: managePathsCas3.premises.totals,
       bedspaces: {
         show: managePathsCas3.premises.bedspaces.show,
         create: managePathsCas3.premises.bedspaces.create,
         get: managePathsCas3.premises.bedspaces.get,
         update: managePathsCas3.premises.bedspaces.update,
+        cancelArchive: managePathsCas3.premises.bedspaces.cancelArchive,
       },
       bookings: {
         arrival: managePathsCas3.premises.bookings.arrival,

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -70,6 +70,7 @@ const paths: Record<string, any> = {
         create: bedspacesV2Path,
         list: bedspacesV2Path,
         edit: singleBedspaceV2Path.path('edit'),
+        cancelArchive: singleBedspaceV2Path.path('cancel-archive'),
         update: singleBedspaceV2Path,
       },
     },

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -142,6 +142,21 @@ export default function routes(controllers: Controllers, services: Services, rou
       ],
     })
     get(paths.premises.v2.bedspaces.edit.pattern, bedspacesControllerV2.edit(), { auditEvent: 'UPDATE_BEDSPACE_V2' })
+    get(paths.premises.v2.bedspaces.cancelArchive.pattern, bedspacesControllerV2.cancelArchive(), {
+      auditEvent: 'VIEW_BEDSPACE_CANCEL_ARCHIVE_V2',
+    })
+    put(paths.premises.v2.bedspaces.cancelArchive.pattern, bedspacesControllerV2.submitCancelArchive(), {
+      redirectAuditEventSpecs: [
+        {
+          path: paths.premises.v2.bedspaces.cancelArchive.pattern,
+          auditEvent: 'CANCEL_BEDSPACE_ARCHIVE_V2_FAILURE',
+        },
+        {
+          path: paths.premises.v2.bedspaces.show.pattern,
+          auditEvent: 'CANCEL_BEDSPACE_ARCHIVE_V2_SUCCESS',
+        },
+      ],
+    })
     post(paths.premises.v2.bedspaces.update.pattern, bedspacesControllerV2.update(), {
       redirectAuditEventSpecs: [
         {

--- a/server/services/v2/bedspaceService.test.ts
+++ b/server/services/v2/bedspaceService.test.ts
@@ -139,6 +139,19 @@ describe('BedspaceService', () => {
     })
   })
 
+  describe('cancelArchiveBedspace', () => {
+    it('calls the client to cancel the archive for the bedspace and returns the bedspace', async () => {
+      const bedspace = cas3BedspaceFactory.build()
+      bedspaceClient.cancelArchive.mockResolvedValue(bedspace)
+
+      const result = await service.cancelArchiveBedspace(callConfig, premisesId, bedspace.id)
+
+      expect(result).toEqual(bedspace)
+      expect(bedspaceClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(bedspaceClient.cancelArchive).toHaveBeenCalledWith(premisesId, bedspace.id)
+    })
+  })
+
   describe('getReferenceData', () => {
     it('returns sorted bedspace characteristics', async () => {
       const bedspaceCharacteristic1 = characteristicFactory.build({ name: 'ABC', modelScope: 'room' })

--- a/server/services/v2/bedspaceService.ts
+++ b/server/services/v2/bedspaceService.ts
@@ -120,4 +120,9 @@ export default class BedspaceService {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
     return bedspaceClient.update(premisesId, bedspaceId, updatedBedspace)
   }
+
+  async cancelArchiveBedspace(callConfig: CallConfig, premisesId: string, bedspaceId: string): Promise<Cas3Bedspace> {
+    const bedspaceClient = this.bedspaceClientFactory(callConfig)
+    return bedspaceClient.cancelArchive(premisesId, bedspaceId)
+  }
 }

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -3,6 +3,7 @@ import {
   Cas3BedspacePremisesSearchResult,
   Cas3NewPremises,
   Cas3Premises,
+  Cas3PremisesBedspaceTotals,
   Cas3PremisesSearchResult,
   Cas3PremisesSearchResults,
   Cas3PremisesSortBy,
@@ -54,6 +55,14 @@ export default class PremisesService {
   async getSinglePremises(callConfig: CallConfig, premisesId: string): Promise<Cas3Premises> {
     const premisesClient = this.premisesClientFactory(callConfig)
     return premisesClient.find(premisesId)
+  }
+
+  async getSinglePremisesBedspaceTotals(
+    callConfig: CallConfig,
+    premisesId: string,
+  ): Promise<Cas3PremisesBedspaceTotals> {
+    const premisesClient = this.premisesClientFactory(callConfig)
+    return premisesClient.totals(premisesId)
   }
 
   async getSinglePremisesDetails(

--- a/server/testutils/factories/cas3PremisesBedspaceTotals.ts
+++ b/server/testutils/factories/cas3PremisesBedspaceTotals.ts
@@ -1,0 +1,13 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import type { Cas3PremisesBedspaceTotals } from '@approved-premises/api'
+
+export default Factory.define<Cas3PremisesBedspaceTotals>(() => ({
+  id: faker.string.uuid(),
+  status: faker.helpers.arrayElement(['online', 'archived'] as const),
+  premisesEndDate: null,
+  totalOnlineBedspaces: faker.number.int({ min: 1, max: 10 }),
+  totalArchivedBedspaces: faker.number.int({ min: 1, max: 5 }),
+  totalUpcomingBedspaces: faker.number.int({ min: 1, max: 5 }),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -55,6 +55,7 @@ import premisesSummaryFactory from './premisesSummary'
 import cas3PremisesFactory from './cas3Premises'
 import cas3NewPremisesFactory from './cas3NewPremises'
 import cas3UpdatePremisesFactory from './cas3UpdatePremises'
+import cas3PremisesBedspaceTotalsFactory from './cas3PremisesBedspaceTotals'
 import cas3BedspacesFactory from './cas3Bedspaces'
 import cas3PremisesSummaryFactory from './cas3PremisesSummary'
 import cas3PremisesSearchResultFactory from './cas3PremisesSearchResult'
@@ -140,6 +141,7 @@ export {
   cas3PremisesFactory,
   cas3NewPremisesFactory,
   cas3UpdatePremisesFactory,
+  cas3PremisesBedspaceTotalsFactory,
   cas3PremisesSummaryFactory,
   cas3PremisesSearchResultFactory,
   cas3PremisesSearchResultsFactory,

--- a/server/utils/v2/bedspaceUtils.ts
+++ b/server/utils/v2/bedspaceUtils.ts
@@ -3,11 +3,20 @@ import { PageHeadingBarItem } from '@approved-premises/ui'
 import paths from '../../paths/temporary-accommodation/manage'
 
 export function bedspaceActions(premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> {
-  return [
+  const actions: Array<PageHeadingBarItem> = [
     {
       text: 'Edit bedspace details',
       href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
       classes: 'govuk-button--secondary',
     },
   ]
+
+  if (bedspace.endDate && bedspace.status !== 'archived') {
+    actions.push({
+      text: 'Cancel scheduled bedspace archive',
+      href: paths.premises.v2.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      classes: 'govuk-button--secondary',
+    })
+  }
+  return actions
 }

--- a/server/utils/v2/premisesUtils.ts
+++ b/server/utils/v2/premisesUtils.ts
@@ -1,4 +1,4 @@
-import { Cas3Premises } from '@approved-premises/api'
+import { Cas3Premises, Cas3PremisesBedspaceTotals } from '@approved-premises/api'
 import { PageHeadingBarItem } from '@approved-premises/ui'
 import paths from '../../paths/temporary-accommodation/manage'
 
@@ -26,4 +26,11 @@ export const premisesActions = (premises: Cas3Premises): Array<PageHeadingBarIte
   }
 
   return actions.sort((a, b) => a.text.localeCompare(b.text))
+}
+
+export function isPremiseScheduledToBeArchived(totals: Cas3PremisesBedspaceTotals): boolean {
+  if (!totals.premisesEndDate) return false
+  const endDate = new Date(totals.premisesEndDate)
+  const now = new Date()
+  return endDate > now && totals.status !== 'archived'
 }

--- a/server/views/temporary-accommodation/v2/bedspaces/cancel-archive.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/cancel-archive.njk
@@ -1,0 +1,64 @@
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../../components/ta-radios/macro.njk" import taRadios %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set mainClasses = "govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: 'Back',
+        href: paths.premises.v2.bedspaces.show({ premisesId: premisesId, bedspaceId: bedspaceId }),
+        classes: 'govuk-!-display-none-print'
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% include "../../../_messages.njk" %}
+
+    {{ showErrorSummary(errorSummary) }}
+
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.premises.v2.bedspaces.cancelArchive({ premisesId: premisesId, bedspaceId: bedspaceId })}}?_method=PUT" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">Are you sure you want to cancel the scheduled archive on {{ bedspaceEndDate }}?</h1>
+                    </legend>
+                    {{ taRadios(
+                        {
+                            items: [
+                            {
+                                value: "yes",
+                                text: "Yes, I want to cancel it"
+                            },
+                            {
+                                value: "no",
+                                text: "No"
+                            }
+                        ],
+                        fieldName: "bedspaceId"
+                        }, fetchContext()
+                    ) }}
+                    </fieldset>
+                </div>
+                {% if scheduledForArchive %}
+                    <p class="govuk-body">The scheduled archive of the property and any other bedspaces will also be cancelled.</p>
+                {% endif %}
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1836) adds a cancel upcoming archive for bedspaces.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="675" height="307" alt="image" src="https://github.com/user-attachments/assets/dc7c30ac-f64b-4dbc-af51-e965114961f5" />

<img width="725" height="645" alt="image" src="https://github.com/user-attachments/assets/cdc6ba0a-7bf5-463a-880c-11f6d34bcaec" />


<img width="703" height="532" alt="image" src="https://github.com/user-attachments/assets/9014c62b-7d87-49d4-9a3e-05829b877bd7" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
