### PR TITLE
CAS-1823 Implement unarchive premises page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
@@ -184,4 +184,13 @@ export default class PremisesShowPage extends Page {
   shouldShowPropertyAndBedspacesUpdatedBanner(): void {
     cy.get('main .govuk-notification-banner--success').contains('Property and bedspaces updated')
   }
+
+  clickMakePropertyOnlineButton(): void {
+    cy.get('button').contains('Actions').parent().click()
+    cy.get('button').contains('Actions').parent().siblings('ul').contains('Make property online').click()
+  }
+
+  shouldShowPropertyAndBedspacesOnlineBanner(): void {
+    cy.get('main .govuk-notification-banner--success').contains('Property and bedspaces online')
+  }
 }

--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesUnarchive.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesUnarchive.ts
@@ -1,0 +1,17 @@
+import Page from '../../../page'
+import { Cas3Premises } from '../../../../../server/@types/shared'
+
+export default class PremisesUnarchivePage extends Page {
+  constructor(premises: Cas3Premises) {
+    super(`When should ${premises.addressLine1} go online?`)
+  }
+
+  enterDate(date: string): void {
+    cy.get('label').contains('Another date').click()
+    this.completeDateInputsByLegend('Enter a date within the last 7 days or the next 7 days', date)
+  }
+
+  shouldShowGivenErrorMessageForField(field: string, error: string): void {
+    cy.get('.govuk-error-summary').contains(error).should('have.attr', 'href', `#${field}`)
+  }
+}

--- a/e2e_playwright/pages/manage/v2/unarchivePropertyPage.ts
+++ b/e2e_playwright/pages/manage/v2/unarchivePropertyPage.ts
@@ -1,0 +1,9 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../../basePage'
+
+export class UnarchivePropertyPage extends BasePage {
+  static async initialise(page: Page, addressLine1: string) {
+    await expect(page.locator('h1')).toContainText(`When should ${addressLine1} go online?`)
+    return new UnarchivePropertyPage(page)
+  }
+}

--- a/e2e_playwright/pages/manage/v2/viewPropertyPage.ts
+++ b/e2e_playwright/pages/manage/v2/viewPropertyPage.ts
@@ -58,6 +58,11 @@ export class ViewPropertyPage extends BasePage {
     await this.page.getByText('Archive property').click()
   }
 
+  async clickUnarchiveButton() {
+    await this.page.getByRole('button').getByText('Actions').click()
+    await this.page.getByText('Make property online').click()
+  }
+
   async shouldShowPropertyStatus(status: string) {
     await expect(this.getRowTextByLabel('Property status')).toContainText(status)
   }

--- a/e2e_playwright/steps/v2/manage.ts
+++ b/e2e_playwright/steps/v2/manage.ts
@@ -9,6 +9,7 @@ import { AddBedspacePage } from '../../pages/manage/v2/addBedspacePage'
 import { ViewBedspacesPage } from '../../pages/manage/v2/viewBedspacesPage'
 import { EditBedspacePage } from '../../pages/manage/v2/editBedspacePage'
 import { ArchivePropertyPage } from '../../pages/manage/v2/archivePropertyPage'
+import { UnarchivePropertyPage } from '../../pages/manage/v2/unarchivePropertyPage'
 import { ArchiveBedspacePage } from '../../pages/manage/v2/archiveBedspacePage'
 
 export const visitListPropertiesPage = async (page: Page) => {
@@ -80,6 +81,22 @@ export const archiveProperty = async (page: Page, property: Property) => {
   )
   expect(isBannerMessageDisplayed).toBe(true)
   await showArchivedPropertyPage.shouldShowPropertyStatus('Archived')
+}
+
+export const unarchiveProperty = async (page: Page, property: Property) => {
+  const shortAddress = `${property.addressLine1}, ${property.postcode}`
+  const showPropertyPage = await ViewPropertyPage.initialise(page, shortAddress)
+  await showPropertyPage.clickUnarchiveButton()
+
+  const unarchivePropertyPage = await UnarchivePropertyPage.initialise(page, property.addressLine1)
+  await unarchivePropertyPage.clickSubmit()
+
+  const showUnarchivedPropertyPage = await ViewPropertyPage.initialise(page, shortAddress)
+  const isBannerMessageDisplayed = await showUnarchivedPropertyPage.isBannerMessageDisplayed(
+    'Property and bedspaces online',
+  )
+  expect(isBannerMessageDisplayed).toBe(true)
+  await showUnarchivedPropertyPage.shouldShowPropertyStatus('Online')
 }
 
 export const createBedspace = async (page: Page, property: Property, bedspace: Bedspace) => {

--- a/e2e_playwright/tests/manage/v2/manage-properties.spec.ts
+++ b/e2e_playwright/tests/manage/v2/manage-properties.spec.ts
@@ -7,6 +7,7 @@ import {
   navigateToProperty,
   searchForProperty,
   showProperty,
+  unarchiveProperty,
   visitListPropertiesPage,
 } from '../../../steps/v2/manage'
 import { getProperty } from '../../../utils/manage'
@@ -49,4 +50,15 @@ test('Archive a property', async ({ page, assessor }) => {
   await createProperty(page, property)
   await showProperty(page, property)
   await archiveProperty(page, property)
+})
+
+test('Unarchive a property', async ({ page, assessor }) => {
+  const property = getProperty()
+
+  await signIn(page, assessor)
+  await visitListPropertiesPage(page)
+  await createProperty(page, property)
+  await showProperty(page, property)
+  await archiveProperty(page, property)
+  await unarchiveProperty(page, property)
 })

--- a/integration_tests/mockApis/v2/premises.ts
+++ b/integration_tests/mockApis/v2/premises.ts
@@ -152,6 +152,50 @@ const stubPremisesArchiveErrorsV2 = (params: { premisesId: string; endDate: stri
     },
   })
 
+const stubPremisesUnarchiveV2 = (premises: Cas3Premises) =>
+  stubFor({
+    request: {
+      method: 'POST',
+      url: paths.cas3.premises.unarchive({ premisesId: premises.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: premises,
+    },
+  })
+
+const verifyPremisesUnarchiveV2 = async (premisesId: string) =>
+  (
+    await getMatchingRequests({
+      method: 'POST',
+      url: paths.cas3.premises.unarchive({ premisesId }),
+    })
+  ).body.requests
+
+const stubPremisesUnarchiveErrorsV2 = (premisesId: string) =>
+  stubFor({
+    request: {
+      method: 'POST',
+      url: paths.cas3.premises.unarchive({ premisesId }),
+    },
+    response: {
+      status: 400,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        type: 'https://example.net/validation-error',
+        title: 'Invalid request parameters',
+        code: 400,
+        'invalid-params': [
+          {
+            propertyName: '$.restartDate',
+            errorType: 'invalidRestartDateInTheFuture',
+          },
+        ],
+      },
+    },
+  })
+
 const stubPremisesBedspaceTotalsV2 = ({
   premisesId,
   totals,
@@ -185,4 +229,7 @@ export default {
   stubPremisesArchiveV2,
   verifyPremisesArchiveV2,
   stubPremisesArchiveErrorsV2,
+  stubPremisesUnarchiveV2,
+  verifyPremisesUnarchiveV2,
+  stubPremisesUnarchiveErrorsV2,
 }

--- a/server/data/v2/premisesClient.test.ts
+++ b/server/data/v2/premisesClient.test.ts
@@ -10,6 +10,7 @@ import {
   cas3PremisesFactory,
   cas3PremisesSearchResultFactory,
   cas3PremisesSearchResultsFactory,
+  cas3UnarchivePremisesFactory,
   cas3UpdatePremisesFactory,
 } from '../../testutils/factories'
 import paths from '../../paths/api'
@@ -113,6 +114,22 @@ describe('PremisesClient', () => {
         .reply(200, premises)
 
       const result = await premisesClient.archive(premisesId, payload)
+      expect(result).toEqual(premises)
+    })
+  })
+
+  describe('unarchive', () => {
+    it('should return the premises that has been unarchived', async () => {
+      const premisesId = 'fc321526-7d54-4e1b-94b4-8df4225d0763'
+      const premises = cas3PremisesFactory.build({ id: premisesId })
+      const payload = cas3UnarchivePremisesFactory.build()
+
+      fakeApprovedPremisesApi
+        .post(paths.cas3.premises.unarchive({ premisesId }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, premises)
+
+      const result = await premisesClient.unarchive(premisesId, payload)
       expect(result).toEqual(premises)
     })
   })

--- a/server/data/v2/premisesClient.ts
+++ b/server/data/v2/premisesClient.ts
@@ -43,6 +43,10 @@ export default class PremisesClient {
     return this.restClient.post<Cas3Premises>({ path: paths.cas3.premises.archive({ premisesId }), data })
   }
 
+  async unarchive(premisesId: string, data: { restartDate: string }) {
+    return this.restClient.post<Cas3Premises>({ path: paths.cas3.premises.unarchive({ premisesId }), data })
+  }
+
   async totals(premisesId: string): Promise<Cas3PremisesBedspaceTotals> {
     return this.restClient.get<Cas3PremisesBedspaceTotals>({
       path: paths.cas3.premises.totals({ premisesId }),

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -335,5 +335,14 @@
       "existingTurnaround": "Earliest archive date is :earliestDate because of a turnaround",
       "endDateOverlapPreviousPremisesArchiveEndDate": "Archive conflicts with an earlier archive ending on :endDate"
     }
+  },
+  "premisesUnarchive": {
+    "restartDate": {
+      "empty": "You must enter a date",
+      "invalid": "You must enter a real date",
+      "invalidRestartDateInThePast": "The date cannot be more than 7 days in the past",
+      "invalidRestartDateInTheFuture": "The date cannot be more than 7 days in the future",
+      "beforeLastPremisesArchivedDate": "The restart date must be after the last archive end date"
+    }
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -9,6 +9,7 @@ const singlePremisesCas3Path = cas3PremisesPath.path(':premisesId')
 const singleBookingCas3Path = singlePremisesCas3Path.path('bookings/:bookingId')
 const premisesSearchPath = cas3PremisesPath.path('search')
 const premisesArchivePath = singlePremisesCas3Path.path('archive')
+const premisesUnarchivePath = singlePremisesCas3Path.path('unarchive')
 
 const lostBedsPath = singlePremisesPath.path('lost-beds')
 const singleLostBedPath = lostBedsPath.path(':lostBedId')
@@ -74,6 +75,7 @@ const managePathsCas3 = {
     create: cas3PremisesPath,
     update: singlePremisesCas3Path,
     archive: premisesArchivePath,
+    unarchive: premisesUnarchivePath,
     totals: singlePremisesCas3Path.path('bedspace-totals'),
     bedspaces: {
       show: singleBedspacePath,
@@ -119,6 +121,7 @@ export default {
       create: managePathsCas3.premises.create,
       update: managePathsCas3.premises.update,
       archive: managePathsCas3.premises.archive,
+      unarchive: managePathsCas3.premises.unarchive,
       totals: managePathsCas3.premises.totals,
       bedspaces: {
         show: managePathsCas3.premises.bedspaces.show,

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -64,6 +64,7 @@ const paths: Record<string, any> = {
       edit: singlePremisesV2Path.path('edit'),
       update: singlePremisesV2Path,
       archive: singlePremisesV2Path.path('archive'),
+      unarchive: singlePremisesV2Path.path('unarchive'),
       bedspaces: {
         new: bedspacesV2Path.path('new'),
         show: singleBedspaceV2Path,

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -126,6 +126,19 @@ export default function routes(controllers: Controllers, services: Services, rou
         },
       ],
     })
+    get(paths.premises.v2.unarchive.pattern, premisesControllerV2.unarchive(), { auditEvent: 'UNARCHIVE_PREMISES_V2' })
+    post(paths.premises.v2.unarchive.pattern, premisesControllerV2.unarchiveSubmit(), {
+      redirectAuditEventSpecs: [
+        {
+          path: paths.premises.v2.unarchive.pattern,
+          auditEvent: 'UNARCHIVE_PREMISES_V2_FAILURE',
+        },
+        {
+          path: paths.premises.v2.show.pattern,
+          auditEvent: 'UNARCHIVE_PREMISES_V2_SUCCESS',
+        },
+      ],
+    })
 
     get(paths.premises.v2.bedspaces.new.pattern, bedspacesControllerV2.new(), { auditEvent: 'VIEW_BEDSPACE_V2_CREATE' })
     get(paths.premises.v2.bedspaces.show.pattern, bedspacesControllerV2.show(), { auditEvent: 'VIEW_BEDSPACE_V2' })

--- a/server/services/v2/premisesService.test.ts
+++ b/server/services/v2/premisesService.test.ts
@@ -8,6 +8,7 @@ import {
   cas3PremisesFactory,
   cas3PremisesSearchResultFactory,
   cas3PremisesSearchResultsFactory,
+  cas3UnarchivePremisesFactory,
   cas3UpdatePremisesFactory,
   characteristicFactory,
   localAuthorityFactory,
@@ -80,6 +81,20 @@ describe('PremisesService', () => {
 
       expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.archive).toHaveBeenCalledWith(premises.id, archivePayload)
+    })
+  })
+
+  describe('unarchivePremises', () => {
+    it('on success returns the premises that has been unarchived', async () => {
+      const premises = cas3PremisesFactory.build({ status: 'online' })
+      const unarchivePayload = cas3UnarchivePremisesFactory.build()
+      premisesClient.unarchive.mockResolvedValue(premises)
+
+      const result = await service.unarchivePremises(callConfig, premises.id, unarchivePayload)
+      expect(result).toEqual(premises)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(premisesClient.unarchive).toHaveBeenCalledWith(premises.id, unarchivePayload)
     })
   })
 

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -9,6 +9,7 @@ import {
   Cas3PremisesSearchResults,
   Cas3PremisesSortBy,
   Cas3PremisesStatus,
+  Cas3UnarchivePremises,
   Cas3UpdatePremises,
   Characteristic,
   LocalAuthorityArea,
@@ -119,6 +120,11 @@ export default class PremisesService {
   async archivePremises(callConfig: CallConfig, premisesId: string, archivePayload: Cas3ArchivePremises) {
     const premisesClient = this.premisesClientFactory(callConfig)
     return premisesClient.archive(premisesId, archivePayload)
+  }
+
+  async unarchivePremises(callConfig: CallConfig, premisesId: string, unarchivePayload: Cas3UnarchivePremises) {
+    const premisesClient = this.premisesClientFactory(callConfig)
+    return premisesClient.unarchive(premisesId, unarchivePayload)
   }
 
   tableRows(premises: Cas3PremisesSearchResults, premisesSortBy: Cas3PremisesSortBy = 'pdu'): Array<TableRow> {

--- a/server/testutils/factories/cas3UnarchivePremises.ts
+++ b/server/testutils/factories/cas3UnarchivePremises.ts
@@ -1,0 +1,9 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import type { Cas3UnarchivePremises } from '@approved-premises/api'
+import { DateFormats } from '../../utils/dateUtils'
+
+export default Factory.define<Cas3UnarchivePremises>(() => ({
+  restartDate: DateFormats.dateObjToIsoDate(faker.date.soon({ days: 2 })),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -61,6 +61,7 @@ import cas3PremisesSummaryFactory from './cas3PremisesSummary'
 import cas3PremisesSearchResultFactory from './cas3PremisesSearchResult'
 import cas3PremisesSearchResultsFactory from './cas3PremisesSearchResults'
 import cas3ArchivePremisesFactory from './cas3ArchivePremises'
+import cas3UnarchivePremisesFactory from './cas3UnarchivePremises'
 import cas3BedspaceFactory from './cas3Bedspace'
 import cas3BedspaceArchiveActionFactory from './cas3BedspaceArchiveAction'
 import cas3NewBedspaceFactory from './cas3NewBedspace'
@@ -147,6 +148,7 @@ export {
   cas3PremisesSearchResultFactory,
   cas3PremisesSearchResultsFactory,
   cas3ArchivePremisesFactory,
+  cas3UnarchivePremisesFactory,
   cas3BedspaceFactory,
   cas3BedspaceArchiveActionFactory,
   cas3BedspacesFactory,

--- a/server/utils/v2/premisesUtils.test.ts
+++ b/server/utils/v2/premisesUtils.test.ts
@@ -37,6 +37,11 @@ describe('premisesV2Utils', () => {
           classes: 'govuk-button--secondary',
           href: paths.premises.v2.edit({ premisesId: premises.id }),
         },
+        {
+          text: 'Make property online',
+          classes: 'govuk-button--secondary',
+          href: paths.premises.v2.unarchive({ premisesId: premises.id }),
+        },
       ])
     })
   })

--- a/server/utils/v2/premisesUtils.ts
+++ b/server/utils/v2/premisesUtils.ts
@@ -23,6 +23,12 @@ export const premisesActions = (premises: Cas3Premises): Array<PageHeadingBarIte
       classes: 'govuk-button--secondary',
       href: paths.premises.v2.archive({ premisesId: premises.id }),
     })
+  } else if (premises.status === 'archived') {
+    actions.push({
+      text: 'Make property online',
+      classes: 'govuk-button--secondary',
+      href: paths.premises.v2.unarchive({ premisesId: premises.id }),
+    })
   }
 
   return actions.sort((a, b) => a.text.localeCompare(b.text))

--- a/server/views/temporary-accommodation/v2/premises/unarchive.njk
+++ b/server/views/temporary-accommodation/v2/premises/unarchive.njk
@@ -1,0 +1,85 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/radios/macro.njk" import govukRadios %}
+{% from "govuk/components/date-input/macro.njk" import govukDateInput %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set mainClasses = "govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.premises.v2.show({ premisesId: premises.id }),
+        classes: "govuk-!-display-none-print"
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% include "../../../_messages.njk" %}
+
+    {{ showErrorSummary(errorSummary) }}
+
+    <h1 class="govuk-heading-l">When should {{ premises.addressLine1 }} go online?</h1>
+
+    {% set dateHtml %}
+        {{ govukDateInput({
+            id: "restartDate" if unarchiveOption == "other" else "otherDateInput",
+            namePrefix: "restartDate",
+            fieldset: {
+                legend: {
+                    text: "Enter a date within the last 7 days or the next 7 days",
+                    classes: "govuk-fieldset__legend--s"
+                }
+            },
+            hint: {
+                text: "Use numbers, for example 27 5 2025"
+            },
+            items: dateFieldValues("restartDate", errors) if unarchiveOption == "other",
+            errorMessage: errors.restartDate if unarchiveOption == "other"
+        }, mergeObjects(fetchContext())) }}
+    {% endset %}
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.premises.v2.unarchive({ premisesId: premises.id }) }}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}">
+
+                {{ govukRadios({
+                    name: "unarchiveOption",
+                    fieldset: {
+                        legend: {
+                            text: "When should " + premises.addressLine1 + " go online?",
+                            classes: "govuk-visually-hidden"
+                        }
+                    },
+                    items: [
+                        {
+                            value: "today",
+                            id: "restartDate" if unarchiveOption == "today" else "today",
+                            text: "Today",
+                            checked: unarchiveOption == "today"
+                        },
+                        {
+                            value: "other",
+                            text: "Another date",
+                            checked: unarchiveOption == "other",
+                            conditional: {
+                            html: dateHtml
+                        }
+                        }
+                    ],
+                    errorMessage: errors.restartDate if unarchiveOption == "today"
+                }) }}
+
+                <p>This propertyʼs bedspaces will also go online.</p>
+
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}


### PR DESCRIPTION
# Context
Ticket [C3 FE: Implement Unarchive Premises Page](https://dsdmoj.atlassian.net/browse/CAS-1823)
Requires `MANAGE_PROPERTIES_V2_ENABLED` feature flag

# Changes in this PR

## Screenshots of UI changes

### Before

### After
<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/49742d90-9160-4805-835d-85f5ff123e6b" />
<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/946700f3-f3ed-405c-a561-87ae7077df8d" />
<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/2ac7bb8d-40dc-40ba-b27b-91b8c3a8fbda" />
<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/a29a32ac-b2a6-4116-aef3-1d45eb301c51" />
<img width="3424" height="1988" alt="image" src="https://github.com/user-attachments/assets/9571d83b-964f-45d4-92c6-f60cddc866e6" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
