### PR TITLE
Add archive history to property page

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
@@ -1,5 +1,10 @@
 import Page from '../../../page'
-import { Cas3Bedspace, Cas3Bedspaces, Cas3Premises } from '../../../../../server/@types/shared'
+import {
+  Cas3Bedspace,
+  Cas3Bedspaces,
+  Cas3Premises,
+  Cas3PremisesArchiveAction,
+} from '../../../../../server/@types/shared'
 import { convertToTitleCase } from '../../../../../server/utils/utils'
 import { DateFormats } from '../../../../../server/utils/dateUtils'
 import paths from '../../../../../server/paths/temporary-accommodation/manage'
@@ -14,6 +19,22 @@ export default class PremisesShowPage extends Page {
     cy.get('dl').contains('Property status').siblings().contains(status)
   }
 
+  shouldShowScheduledDate(date: string): void {
+    cy.get('dl').contains('Property status').siblings().contains(date)
+  }
+
+  shouldShowPropertyArchiveHistory(archiveHistory: Array<Cas3PremisesArchiveAction>): void {
+    cy.get('dl')
+      .contains('Archive history')
+      .parent()
+      .within(() => {
+        archiveHistory.forEach(action => {
+          cy.contains(convertToTitleCase(action.status))
+          cy.contains(DateFormats.isoDateToUIDate(action.date))
+        })
+      })
+  }
+
   shouldShowPremisesOverview(premises: Cas3Premises, status: string, startDate: string): void {
     cy.get('main div .govuk-summary-card').within(() => {
       // should show property reference at the top of the summary card
@@ -24,6 +45,11 @@ export default class PremisesShowPage extends Page {
 
       // should show the property start date
       cy.get('dl').contains('Start date').siblings().contains(startDate)
+
+      // should show archive history if it exists
+      if (premises.archiveHistory && premises.archiveHistory.length > 0) {
+        this.shouldShowPropertyArchiveHistory(premises.archiveHistory)
+      }
 
       // should show the property address
       cy.get('dl')

--- a/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
@@ -781,7 +781,7 @@ context('Premises', () => {
       cy.signIn()
 
       // And there is an archived premises in the database
-      const premises = cas3PremisesFactory.build({
+      const premises = cas3PremisesFactory.withArchiveHistory(3).build({
         status: 'archived',
         startDate: '2025-02-01',
         totalOnlineBedspaces: 0,
@@ -1412,6 +1412,7 @@ context('Premises', () => {
       const expectedPremises: Cas3Premises = {
         ...premises,
         status: 'archived',
+        archiveHistory: [{ date: DateFormats.dateObjToIsoDate(new Date()), status: 'archived' }],
       }
       cy.task('stubPremisesArchiveV2', expectedPremises)
       cy.task('stubSinglePremisesV2', expectedPremises)
@@ -1435,6 +1436,7 @@ context('Premises', () => {
 
       // And the property should be archived
       showPage.shouldShowPropertyStatus('Archived')
+      showPage.shouldShowPropertyArchiveHistory(expectedPremises.archiveHistory)
     })
 
     it('should be able to archive a property tomorrow', () => {
@@ -1460,6 +1462,7 @@ context('Premises', () => {
 
       // When the backend responds with 200 ok
       const expectedPremises: Cas3Premises = premises
+      expectedPremises.endDate = tomorrow
       cy.task('stubPremisesArchiveV2', expectedPremises)
       cy.task('stubSinglePremisesV2', expectedPremises)
 
@@ -1481,6 +1484,7 @@ context('Premises', () => {
 
       // And the property should be online, with a scheduled archive
       showPage.shouldShowPropertyStatus('Online')
+      showPage.shouldShowScheduledDate(DateFormats.dateObjtoUIDate(tomorrowDate))
       // TODO: uncomment when upcoming statuses have been implemented
       // showPage.shouldShowUpcomingArchiveStatus()
     })

--- a/server/testutils/factories/cas3Premises.ts
+++ b/server/testutils/factories/cas3Premises.ts
@@ -1,13 +1,32 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
-import type { Cas3Premises } from '@approved-premises/api'
+import type { Cas3Premises, Cas3PremisesArchiveAction } from '@approved-premises/api'
 import characteristicFactory from './characteristic'
 import localAuthorityFactory from './localAuthority'
 import referenceDataFactory from './referenceData'
 import { DateFormats } from '../../utils/dateUtils'
 
-export default Factory.define<Cas3Premises>(() => ({
+class Cas3PremisesFactory extends Factory<Cas3Premises> {
+  withEndDate() {
+    return this.params({ endDate: DateFormats.dateObjToIsoDate(faker.date.future()) })
+  }
+
+  withArchiveHistory(length: number = 5) {
+    return this.params({
+      archiveHistory: Array.from(
+        { length },
+        () =>
+          ({
+            date: DateFormats.dateObjToIsoDate(faker.date.past()),
+            status: faker.helpers.arrayElement(['online', 'archived'] as const),
+          }) as Cas3PremisesArchiveAction,
+      ),
+    })
+  }
+}
+
+export default Cas3PremisesFactory.define(() => ({
   id: faker.string.uuid(),
   reference: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
   addressLine1: faker.location.streetAddress(),


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1879) adds archive history to the property page.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="700" height="561" alt="image" src="https://github.com/user-attachments/assets/5a161063-39ca-4216-80b9-8a48ce10a08e" />

<img width="698" height="321" alt="image" src="https://github.com/user-attachments/assets/525fbe7f-b4ff-4b8a-ae7b-26c89818c556" />

<img width="710" height="359" alt="image" src="https://github.com/user-attachments/assets/19421ba1-af2e-44f8-ad80-03e49c70103a" />
*this will only appear with 14+ archive actions

<img width="686" height="306" alt="image" src="https://github.com/user-attachments/assets/ad8fa50f-692f-4ab6-bedd-a80cd2cf5c9d" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
