### PR TITLE
Add bedspace actions for online and archived

### DIFF
--- a/server/controllers/temporary-accommodation/manage/v2/bedspacesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/bedspacesController.test.ts
@@ -193,7 +193,28 @@ describe('BedspacesController', () => {
         },
       ],
     }
-
+    const onlineBedspaceActions = [
+      {
+        text: 'Book bedspace',
+        href: paths.bookings.new({ premisesId, roomId: bedspaceId }),
+        classes: 'govuk-button--secondary',
+      },
+      {
+        text: 'Void bedspace',
+        href: paths.lostBeds.new({ premisesId, roomId: bedspaceId }),
+        classes: 'govuk-button--secondary',
+      },
+      {
+        text: 'Archive bedspace',
+        href: '#',
+        classes: 'govuk-button--secondary',
+      },
+      {
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId, bedspaceId }),
+        classes: 'govuk-button--secondary',
+      },
+    ]
     const archivedBedspace = cas3BedspaceFactory.build({
       id: bedspaceId,
       status: 'archived',
@@ -220,7 +241,18 @@ describe('BedspacesController', () => {
         },
       ],
     }
-
+    const archivedBedspaceActions = [
+      {
+        text: 'Make bedspace online',
+        href: '#',
+        classes: 'govuk-button--secondary',
+      },
+      {
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId, bedspaceId }),
+        classes: 'govuk-button--secondary',
+      },
+    ]
     const upcomingBedspace = cas3BedspaceFactory.build({
       id: bedspaceId,
       status: 'upcoming',
@@ -247,12 +279,23 @@ describe('BedspacesController', () => {
         },
       ],
     }
-
+    const upcomingBedspaceActions = [
+      {
+        text: 'Cancel scheduled bedspace online date',
+        href: paths.premises.v2.bedspaces.cancelArchive({ premisesId, bedspaceId }),
+        classes: 'govuk-button--secondary',
+      },
+      {
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId, bedspaceId }),
+        classes: 'govuk-button--secondary',
+      },
+    ]
     it.each([
-      [onlineBedspace, onlineBedspaceSummary],
-      [archivedBedspace, archivedBedspaceSummary],
-      [upcomingBedspace, upcomingBedspaceSummary],
-    ])('should return a bedspace', async (bedspace: Cas3Bedspace, summary: SummaryList) => {
+      [onlineBedspace, onlineBedspaceSummary, onlineBedspaceActions],
+      [archivedBedspace, archivedBedspaceSummary, archivedBedspaceActions],
+      [upcomingBedspace, upcomingBedspaceSummary, upcomingBedspaceActions],
+    ])('should return a bedspace', async (bedspace: Cas3Bedspace, summary: SummaryList, actions: []) => {
       const params = { premisesId, bedspaceId }
 
       premisesService.getSinglePremisesDetails.mockResolvedValue(premisesWithFullAddress)
@@ -273,13 +316,7 @@ describe('BedspacesController', () => {
         premises: premisesWithFullAddress,
         summary,
         bedspace,
-        actions: [
-          {
-            text: 'Edit bedspace details',
-            classes: 'govuk-button--secondary',
-            href: paths.premises.v2.bedspaces.edit({ premisesId, bedspaceId }),
-          },
-        ],
+        actions,
       })
 
       expect(premisesService.getSinglePremisesDetails).toHaveBeenCalledWith(callConfig, premisesId)

--- a/server/utils/v2/bedspaceUtils.test.ts
+++ b/server/utils/v2/bedspaceUtils.test.ts
@@ -4,12 +4,95 @@ import paths from '../../paths/temporary-accommodation/manage'
 
 describe('bedspaceV2Utils', () => {
   describe('bedspaceActions', () => {
-    it('returns "Edit bedspace details" for a bedspace', () => {
+    it('returns correct actions for an online bedspace', () => {
       const premises = cas3PremisesFactory.build()
-      const bedspace = cas3BedspaceFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ status: 'online', endDate: undefined })
 
       const actions = bedspaceActions(premises, bedspace)
 
+      expect(actions).toHaveLength(4)
+      expect(actions).toContainEqual({
+        text: 'Book bedspace',
+        href: paths.bookings.new({ premisesId: premises.id, roomId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Void bedspace',
+        href: paths.lostBeds.new({ premisesId: premises.id, roomId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Archive bedspace',
+        href: '#',
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+    })
+
+    it('returns correct actions for an online bedspace with scheduled archive', () => {
+      const premises = cas3PremisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ status: 'online', endDate: '2125-08-20' })
+
+      const actions = bedspaceActions(premises, bedspace)
+
+      expect(actions).toHaveLength(4)
+      expect(actions).toContainEqual({
+        text: 'Book bedspace',
+        href: paths.bookings.new({ premisesId: premises.id, roomId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Void bedspace',
+        href: paths.lostBeds.new({ premisesId: premises.id, roomId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Cancel scheduled bedspace archive',
+        href: paths.premises.v2.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+    })
+
+    it('returns correct actions for an archived bedspace', () => {
+      const premises = cas3PremisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ status: 'archived' })
+
+      const actions = bedspaceActions(premises, bedspace)
+
+      expect(actions).toHaveLength(2)
+      expect(actions).toContainEqual({
+        text: 'Make bedspace online',
+        href: '#',
+        classes: 'govuk-button--secondary',
+      })
+      expect(actions).toContainEqual({
+        text: 'Edit bedspace details',
+        href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
+    })
+
+    it('returns correct actions for an archived bedspace with scheduled online', () => {
+      const premises = cas3PremisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ status: 'archived', startDate: '2125-08-20' })
+
+      const actions = bedspaceActions(premises, bedspace)
+
+      expect(actions).toHaveLength(2)
+      expect(actions).toContainEqual({
+        text: 'Cancel scheduled bedspace online date',
+        href: paths.premises.v2.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
       expect(actions).toContainEqual({
         text: 'Edit bedspace details',
         href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),

--- a/server/utils/v2/bedspaceUtils.ts
+++ b/server/utils/v2/bedspaceUtils.ts
@@ -3,20 +3,68 @@ import { PageHeadingBarItem } from '@approved-premises/ui'
 import paths from '../../paths/temporary-accommodation/manage'
 
 export function bedspaceActions(premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> {
+  const actions =
+    bedspace.status === 'online'
+      ? onlineBedspaceActions(premises, bedspace)
+      : archivedBedspaceActions(premises, bedspace)
+  return actions
+}
+
+const archivedBedspaceActions = (premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> => {
+  const actions: Array<PageHeadingBarItem> = []
+
+  if (bedspace.startDate && new Date(bedspace.startDate) > new Date()) {
+    actions.push({
+      text: 'Cancel scheduled bedspace online date',
+      href: paths.premises.v2.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      classes: 'govuk-button--secondary',
+    })
+  } else {
+    actions.push({
+      text: 'Make bedspace online',
+      href: '#',
+      classes: 'govuk-button--secondary',
+    })
+  }
+
+  actions.push({
+    text: 'Edit bedspace details',
+    href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+    classes: 'govuk-button--secondary',
+  })
+  return actions
+}
+
+const onlineBedspaceActions = (premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> => {
   const actions: Array<PageHeadingBarItem> = [
     {
-      text: 'Edit bedspace details',
-      href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      text: 'Book bedspace',
+      href: paths.bookings.new({ premisesId: premises.id, roomId: bedspace.id }),
+      classes: 'govuk-button--secondary',
+    },
+    {
+      text: 'Void bedspace',
+      href: paths.lostBeds.new({ premisesId: premises.id, roomId: bedspace.id }),
       classes: 'govuk-button--secondary',
     },
   ]
-
-  if (bedspace.endDate && bedspace.status !== 'archived') {
+  if (bedspace.endDate) {
     actions.push({
       text: 'Cancel scheduled bedspace archive',
       href: paths.premises.v2.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
       classes: 'govuk-button--secondary',
     })
+  } else {
+    actions.push({
+      text: 'Archive bedspace',
+      href: '#',
+      classes: 'govuk-button--secondary',
+    })
   }
+  actions.push({
+    text: 'Edit bedspace details',
+    href: paths.premises.v2.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),
+    classes: 'govuk-button--secondary',
+  })
   return actions
 }


### PR DESCRIPTION
# Context

This adds further options to the bedspace actions dropdown

Archive bedspace and make bedspace online are currently non functioning, they just need to be hooked up when ready.

# Changes in this PR

## Screenshots of UI changes

<img width="819" height="442" alt="image" src="https://github.com/user-attachments/assets/3bbae0a0-7593-4067-a0a5-79682c37044a" />

<img width="805" height="455" alt="image" src="https://github.com/user-attachments/assets/d5c20584-2077-4c6e-a491-fd51259a206a" />

<img width="802" height="481" alt="image" src="https://github.com/user-attachments/assets/ed3a6f91-4a7c-4464-bc54-3ee0ba431568" />

<img width="806" height="488" alt="image" src="https://github.com/user-attachments/assets/d602e1ae-29f3-4f11-a4d1-e9d45c1f7f0b" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
