### PR TITLE
CAS 1870 Archive premises access rules

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesCannotArchive.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesCannotArchive.ts
@@ -1,0 +1,22 @@
+import Page from '../../../page'
+import { Cas3BedspaceReference, Cas3Premises } from '../../../../../server/@types/shared'
+
+export default class PremisesCannotArchivePage extends Page {
+  constructor(premises: Cas3Premises) {
+    super(`You cannot archive ${premises.addressLine1}`)
+  }
+
+  shouldShowAffectedBedspaces(bedspaces: Array<Cas3BedspaceReference>): void {
+    bedspaces.forEach(bedspace => {
+      cy.get('ul li a').contains(bedspace.reference)
+    })
+  }
+
+  clickAffectedBedspace(reference: string): void {
+    cy.get('ul li a').contains(reference).click()
+  }
+
+  clickViewBedspacesOverview(): void {
+    cy.get('a').contains('View bedspaces overview').click()
+  }
+}

--- a/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/premisesShow.ts
@@ -1,18 +1,17 @@
 import Page from '../../../page'
-import {
-  Cas3Bedspace,
-  Cas3Bedspaces,
-  Cas3Premises,
-  Cas3PremisesArchiveAction,
-} from '../../../../../server/@types/shared'
+import { Cas3Bedspace, Cas3Premises, Cas3PremisesArchiveAction } from '../../../../../server/@types/shared'
 import { convertToTitleCase } from '../../../../../server/utils/utils'
 import { DateFormats } from '../../../../../server/utils/dateUtils'
 import paths from '../../../../../server/paths/temporary-accommodation/manage'
 
 export default class PremisesShowPage extends Page {
+  constructor(premises: Cas3Premises) {
+    super(`${premises.addressLine1}, ${premises.postcode}`)
+  }
+
   static visit(premises: Cas3Premises): PremisesShowPage {
     cy.visit(paths.premises.v2.show({ premisesId: premises.id }))
-    return new PremisesShowPage(`${premises.addressLine1}, ${premises.postcode}`)
+    return new PremisesShowPage(premises)
   }
 
   shouldShowPropertyStatus(status: string): void {
@@ -116,8 +115,8 @@ export default class PremisesShowPage extends Page {
     cy.get('main nav a').contains('Bedspaces overview').click()
   }
 
-  shouldShowBedspaceSummaries(bedspaces: Cas3Bedspaces): void {
-    bedspaces.bedspaces.forEach(bedspace => {
+  shouldShowBedspaceSummaries(bedspaces: Array<Cas3Bedspace>): void {
+    bedspaces.forEach(bedspace => {
       cy.get('main .govuk-summary-card h2')
         .contains(`Bedspace reference: ${bedspace.reference}`)
         .parents('.govuk-summary-card')

--- a/integration_tests/mockApis/v2/premises.ts
+++ b/integration_tests/mockApis/v2/premises.ts
@@ -1,4 +1,5 @@
 import type {
+  Cas3BedspacesReference,
   Cas3Premises,
   Cas3PremisesBedspaceTotals,
   Cas3PremisesSearchResults,
@@ -106,6 +107,19 @@ const verifyPremisesUpdateV2 = async (premisesId: string) =>
       url: paths.cas3.premises.update({ premisesId }),
     })
   ).body.requests
+
+const stubPremisesCanArchive = (params: { premisesId: string; bedspacesReference: Cas3BedspacesReference }) =>
+  stubFor({
+    request: {
+      method: 'GET',
+      url: paths.cas3.premises.canArchive({ premisesId: params.premisesId }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: params.bedspacesReference,
+    },
+  })
 
 const stubPremisesArchiveV2 = (premises: Cas3Premises) =>
   stubFor({
@@ -226,6 +240,7 @@ export default {
   stubPremisesUpdateV2,
   stubPremisesUpdateErrorsV2,
   verifyPremisesUpdateV2,
+  stubPremisesCanArchive,
   stubPremisesArchiveV2,
   verifyPremisesArchiveV2,
   stubPremisesArchiveErrorsV2,

--- a/integration_tests/tests/temporary-accommodation/manage/v2/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/bedspace.cy.ts
@@ -97,7 +97,7 @@ context('Bedspace', () => {
     premisesPage.clickBedspacesOverviewTab()
 
     // Then I should see the bedspace summaries
-    premisesPage.shouldShowBedspaceSummaries(bedspaces)
+    premisesPage.shouldShowBedspaceSummaries(bedspaces.bedspaces)
 
     // When I click on the "View bedspace" link
     premisesPage.clickViewBedspaceLink(bedspace)

--- a/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/premises.cy.ts
@@ -1,4 +1,10 @@
-import { Cas3Premises, Characteristic, LocalAuthorityArea, ProbationDeliveryUnit } from '@approved-premises/api'
+import {
+  Cas3BedspacesReference,
+  Cas3Premises,
+  Characteristic,
+  LocalAuthorityArea,
+  ProbationDeliveryUnit,
+} from '@approved-premises/api'
 import Page from '../../../../../cypress_shared/pages/page'
 import DashboardPage from '../../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import PremisesListPage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/premisesList'
@@ -18,6 +24,8 @@ import PremisesEditPage from '../../../../../cypress_shared/pages/temporary-acco
 import PremisesArchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/premisesArchive'
 import PremisesUnarchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/premisesUnarchive'
 import { DateFormats } from '../../../../../server/utils/dateUtils'
+import PremisesCannotArchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/premisesCannotArchive'
+import BedspaceShowPage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow'
 
 context('Premises', () => {
   beforeEach(() => {
@@ -704,7 +712,7 @@ context('Premises', () => {
       page.clickPremisesManageLink(premises)
 
       // Then I navigate to the show premises page
-      const showPage = Page.verifyOnPage(PremisesShowPage, `${premises.addressLine1}, ${premises.postcode}`)
+      const showPage = Page.verifyOnPage(PremisesShowPage, premises)
 
       // Then I should see the premises overview
       showPage.shouldShowPremisesOverview(premises, 'Online', '1 February 2025')
@@ -716,7 +724,7 @@ context('Premises', () => {
       showPage.clickBedspacesOverviewTab()
 
       // Then I should see the bedspace summaries
-      showPage.shouldShowBedspaceSummaries(bedspaces)
+      showPage.shouldShowBedspaceSummaries(bedspaces.bedspaces)
     })
 
     it('should show an online property with upcoming bedspaces', () => {
@@ -762,7 +770,7 @@ context('Premises', () => {
       page.clickPremisesManageLink(premises)
 
       // Then I navigate to the show premises page
-      const showPage = Page.verifyOnPage(PremisesShowPage, `${premises.addressLine1}, ${premises.postcode}`)
+      const showPage = Page.verifyOnPage(PremisesShowPage, premises)
 
       // Then I should see the premises overview
       showPage.shouldShowPremisesOverview(premises, 'Online', '1 February 2025')
@@ -774,7 +782,7 @@ context('Premises', () => {
       showPage.clickBedspacesOverviewTab()
 
       // Then I should see the bedspace summaries
-      showPage.shouldShowBedspaceSummaries(bedspaces)
+      showPage.shouldShowBedspaceSummaries(bedspaces.bedspaces)
     })
 
     it('should show an archived property', () => {
@@ -819,7 +827,7 @@ context('Premises', () => {
       page.clickPremisesManageLink(premises)
 
       // Then I navigate to the show premises page
-      const showPage = Page.verifyOnPage(PremisesShowPage, `${premises.addressLine1}, ${premises.postcode}`)
+      const showPage = Page.verifyOnPage(PremisesShowPage, premises)
 
       // Then I should see a notification that this is an archived property
       showPage.shouldShowArchivedBanner()
@@ -831,7 +839,7 @@ context('Premises', () => {
       showPage.clickBedspacesOverviewTab()
 
       // Then I should see the bedspace summaries
-      showPage.shouldShowBedspaceSummaries(bedspaces)
+      showPage.shouldShowBedspaceSummaries(bedspaces.bedspaces)
     })
 
     it('should show an online property with no bedspaces', () => {
@@ -1062,7 +1070,7 @@ context('Premises', () => {
       })
 
       // And I should be taken to the new property
-      const showPage = Page.verifyOnPage(PremisesShowPage, `${premises.addressLine1}, ${premises.postcode}`)
+      const showPage = Page.verifyOnPage(PremisesShowPage, premises)
 
       // And I should see the 'Property added' banner
       showPage.shouldShowPropertyAddedBanner()
@@ -1307,10 +1315,7 @@ context('Premises', () => {
       })
 
       // And I should be taken to the existing updated property
-      const showPage = Page.verifyOnPage(
-        PremisesShowPage,
-        `${expectedPremises.addressLine1}, ${expectedPremises.postcode}`,
-      )
+      const showPage = Page.verifyOnPage(PremisesShowPage, expectedPremises)
 
       // And I should see the 'Property updated' banner
       showPage.shouldShowPropertyUpdatedBanner()
@@ -1399,6 +1404,7 @@ context('Premises', () => {
       const premises = cas3PremisesFactory.build({ status: 'online' })
       cy.task('stubSinglePremisesV2', premises)
       cy.task('stubPremisesBedspacesV2', { premisesId: premises.id, bedspaces: cas3BedspacesFactory.build() })
+      cy.task('stubPremisesCanArchive', { premisesId: premises.id, undefined })
 
       // When I visit the show premises page
       let showPage = PremisesShowPage.visit(premises)
@@ -1430,7 +1436,7 @@ context('Premises', () => {
       })
 
       // And I should be taken to the existing archived premises
-      showPage = Page.verifyOnPage(PremisesShowPage, `${expectedPremises.addressLine1}, ${expectedPremises.postcode}`)
+      showPage = Page.verifyOnPage(PremisesShowPage, expectedPremises)
 
       // And I should see the 'Property and bedspaces archived' banner
       showPage.shouldShowPropertyAndBedspacesArchivedBanner()
@@ -1445,6 +1451,7 @@ context('Premises', () => {
       const premises = cas3PremisesFactory.build({ status: 'online' })
       cy.task('stubSinglePremisesV2', premises)
       cy.task('stubPremisesBedspacesV2', { premisesId: premises.id, bedspaces: cas3BedspacesFactory.build() })
+      cy.task('stubPremisesCanArchive', { premisesId: premises.id, undefined })
 
       // When I visit the show premises page
       let showPage = PremisesShowPage.visit(premises)
@@ -1478,7 +1485,7 @@ context('Premises', () => {
       })
 
       // And I should be taken to the existing archived premises
-      showPage = Page.verifyOnPage(PremisesShowPage, `${expectedPremises.addressLine1}, ${expectedPremises.postcode}`)
+      showPage = Page.verifyOnPage(PremisesShowPage, expectedPremises)
 
       // And I should see the 'Property and bedspaces archived' banner
       showPage.shouldShowPropertyAndBedspacesUpdatedBanner()
@@ -1501,6 +1508,7 @@ context('Premises', () => {
       })
       cy.task('stubSinglePremisesV2', premises)
       cy.task('stubPremisesBedspacesV2', { premisesId: premises.id, bedspaces })
+      cy.task('stubPremisesCanArchive', { premisesId: premises.id, undefined })
 
       // When I visit the show premises page
       const showPage = PremisesShowPage.visit(premises)
@@ -1531,6 +1539,110 @@ context('Premises', () => {
         'endDate',
         `Earliest archive date is ${DateFormats.dateObjtoUIDate(oneWeek)} because of an upcoming bedspace`,
       )
+    })
+
+    it('should show a "Cannot archive" page when the property has bedspaces with bookings beyond when the property can be archived', () => {
+      // And there is an online premises in the database with some upcoming bedspace bookings
+      const premises = cas3PremisesFactory.build({ status: 'online' })
+      const bedspaces = cas3BedspaceFactory.buildList(4)
+      const bedspacesReference: Cas3BedspacesReference = {
+        affectedBedspaces: [
+          { id: bedspaces[0].id, reference: bedspaces[0].reference },
+          { id: bedspaces[1].id, reference: bedspaces[1].reference },
+        ],
+      }
+      cy.task('stubSinglePremisesV2', premises)
+      cy.task('stubPremisesBedspacesV2', {
+        premisesId: premises.id,
+        bedspaces: cas3BedspacesFactory.build({ bedspaces }),
+      })
+      cy.task('stubPremisesCanArchive', { premisesId: premises.id, bedspacesReference })
+
+      // When I visit the show premises page
+      const showPage = PremisesShowPage.visit(premises)
+
+      // And click on the "Archive property" action
+      showPage.clickArchivePropertyButton()
+
+      // Then I should see the cannot archive premises page
+      const cannotArchivePage = Page.verifyOnPage(PremisesCannotArchivePage, premises)
+
+      // And I should see the affected bedspaces
+      cannotArchivePage.shouldShowAffectedBedspaces(bedspacesReference.affectedBedspaces)
+    })
+
+    it('should navigate to a bedspace from the "Cannot archive" page', () => {
+      // And there is an online premises in the database with some upcoming bedspace bookings
+      const premises = cas3PremisesFactory.build({ status: 'online' })
+      const bedspaces = cas3BedspaceFactory.buildList(4)
+      const bedspacesReference: Cas3BedspacesReference = {
+        affectedBedspaces: [
+          { id: bedspaces[0].id, reference: bedspaces[0].reference },
+          { id: bedspaces[1].id, reference: bedspaces[1].reference },
+        ],
+      }
+      cy.task('stubSinglePremisesV2', premises)
+      cy.task('stubPremisesBedspacesV2', {
+        premisesId: premises.id,
+        bedspaces: cas3BedspacesFactory.build({ bedspaces }),
+      })
+      cy.task('stubPremisesCanArchive', { premisesId: premises.id, bedspacesReference })
+
+      // When I visit the show premises page
+      const showPage = PremisesShowPage.visit(premises)
+
+      // And click on the "Archive property" action
+      showPage.clickArchivePropertyButton()
+
+      // Then I should see the cannot archive premises page
+      const cannotArchivePage = Page.verifyOnPage(PremisesCannotArchivePage, premises)
+
+      // And I should see the affected bedspaces
+      cannotArchivePage.shouldShowAffectedBedspaces(bedspacesReference.affectedBedspaces)
+
+      // When I click on one of the affected bedspaces
+      cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: bedspaces[1] })
+      cannotArchivePage.clickAffectedBedspace(bedspaces[1].reference)
+
+      // Then I should see the show bedspace page
+      Page.verifyOnPage(BedspaceShowPage, premises, bedspaces[1])
+    })
+
+    it('should navigate back to the bedspaces overview page from the "Cannot archive" page', () => {
+      // And there is an online premises in the database with some upcoming bedspace bookings
+      const premises = cas3PremisesFactory.build({ status: 'online' })
+      const bedspaces = cas3BedspaceFactory.buildList(4)
+      const bedspacesReference: Cas3BedspacesReference = {
+        affectedBedspaces: [
+          { id: bedspaces[0].id, reference: bedspaces[0].reference },
+          { id: bedspaces[1].id, reference: bedspaces[1].reference },
+        ],
+      }
+      cy.task('stubSinglePremisesV2', premises)
+      cy.task('stubPremisesBedspacesV2', {
+        premisesId: premises.id,
+        bedspaces: cas3BedspacesFactory.build({ bedspaces }),
+      })
+      cy.task('stubPremisesCanArchive', { premisesId: premises.id, bedspacesReference })
+
+      // When I visit the show premises page
+      let showPage = PremisesShowPage.visit(premises)
+
+      // And click on the "Archive property" action
+      showPage.clickArchivePropertyButton()
+
+      // Then I should see the cannot archive premises page
+      const cannotArchivePage = Page.verifyOnPage(PremisesCannotArchivePage, premises)
+
+      // And I should see the affected bedspaces
+      cannotArchivePage.shouldShowAffectedBedspaces(bedspacesReference.affectedBedspaces)
+
+      // When I click on the "View bedspaces overview" button
+      cannotArchivePage.clickViewBedspacesOverview()
+
+      // Then I should see the bedspace overview page
+      showPage = Page.verifyOnPage(PremisesShowPage, premises)
+      showPage.shouldShowBedspaceSummaries(bedspaces)
     })
   })
 
@@ -1575,7 +1687,7 @@ context('Premises', () => {
       })
 
       // And I should be taken to the existing unarchived premises
-      showPage = Page.verifyOnPage(PremisesShowPage, `${expectedPremises.addressLine1}, ${expectedPremises.postcode}`)
+      showPage = Page.verifyOnPage(PremisesShowPage, expectedPremises)
 
       // And I should see the 'Property and bedspaces online' banner
       showPage.shouldShowPropertyAndBedspacesOnlineBanner()
@@ -1621,7 +1733,7 @@ context('Premises', () => {
       })
 
       // And I should be taken to the existing unarchived premises
-      showPage = Page.verifyOnPage(PremisesShowPage, `${expectedPremises.addressLine1}, ${expectedPremises.postcode}`)
+      showPage = Page.verifyOnPage(PremisesShowPage, expectedPremises)
 
       // And I should see the 'Property and bedspaces updated' banner
       showPage.shouldShowPropertyAndBedspacesUpdatedBanner()

--- a/server/data/v2/premisesClient.test.ts
+++ b/server/data/v2/premisesClient.test.ts
@@ -5,6 +5,7 @@ import { CallConfig } from '../restClient'
 import config from '../../config'
 import {
   cas3ArchivePremisesFactory,
+  cas3BedspacesReferenceFactory,
   cas3NewPremisesFactory,
   cas3PremisesBedspaceTotalsFactory,
   cas3PremisesFactory,
@@ -99,6 +100,21 @@ describe('PremisesClient', () => {
 
       const result = await premisesClient.update(premisesId, payload)
       expect(result).toEqual(premises)
+    })
+  })
+
+  describe('canArchive', () => {
+    it('should return the bedspace references that are preventing a premises from being archived', async () => {
+      const premisesId = '6b0ef164-1078-4186-9b31-5fb1de20c9ac'
+      const bedspacesReference = cas3BedspacesReferenceFactory.build()
+
+      fakeApprovedPremisesApi
+        .get(paths.cas3.premises.canArchive({ premisesId }))
+        .matchHeader('authorization', `Bearer ${callConfig.token}`)
+        .reply(200, bedspacesReference)
+
+      const result = await premisesClient.canArchive(premisesId)
+      expect(result).toEqual(bedspacesReference)
     })
   })
 

--- a/server/data/v2/premisesClient.ts
+++ b/server/data/v2/premisesClient.ts
@@ -1,4 +1,5 @@
 import {
+  Cas3BedspacesReference,
   Cas3NewPremises,
   Cas3Premises,
   Cas3PremisesBedspaceTotals,
@@ -37,6 +38,10 @@ export default class PremisesClient {
 
   async update(premisesId: string, data: Cas3UpdatePremises) {
     return this.restClient.put<Cas3Premises>({ path: paths.cas3.premises.update({ premisesId }), data })
+  }
+
+  async canArchive(premisesId: string) {
+    return this.restClient.get<Cas3BedspacesReference>({ path: paths.cas3.premises.canArchive({ premisesId }) })
   }
 
   async archive(premisesId: string, data: { endDate: string }) {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -8,6 +8,7 @@ const singlePremisesPath = premisesPath.path(':premisesId')
 const singlePremisesCas3Path = cas3PremisesPath.path(':premisesId')
 const singleBookingCas3Path = singlePremisesCas3Path.path('bookings/:bookingId')
 const premisesSearchPath = cas3PremisesPath.path('search')
+const premisesCanArchivePath = singlePremisesCas3Path.path('can-archive')
 const premisesArchivePath = singlePremisesCas3Path.path('archive')
 const premisesUnarchivePath = singlePremisesCas3Path.path('unarchive')
 
@@ -74,6 +75,7 @@ const managePathsCas3 = {
     show: singlePremisesCas3Path,
     create: cas3PremisesPath,
     update: singlePremisesCas3Path,
+    canArchive: premisesCanArchivePath,
     archive: premisesArchivePath,
     unarchive: premisesUnarchivePath,
     totals: singlePremisesCas3Path.path('bedspace-totals'),
@@ -120,6 +122,7 @@ export default {
       show: managePathsCas3.premises.show,
       create: managePathsCas3.premises.create,
       update: managePathsCas3.premises.update,
+      canArchive: managePathsCas3.premises.canArchive,
       archive: managePathsCas3.premises.archive,
       unarchive: managePathsCas3.premises.unarchive,
       totals: managePathsCas3.premises.totals,

--- a/server/services/v2/premisesService.test.ts
+++ b/server/services/v2/premisesService.test.ts
@@ -4,6 +4,7 @@ import PremisesClient from '../../data/v2/premisesClient'
 import { CallConfig } from '../../data/restClient'
 import {
   cas3ArchivePremisesFactory,
+  cas3BedspacesReferenceFactory,
   cas3NewPremisesFactory,
   cas3PremisesFactory,
   cas3PremisesSearchResultFactory,
@@ -67,6 +68,19 @@ describe('PremisesService', () => {
 
       expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
       expect(premisesClient.update).toHaveBeenCalledWith(premises.id, updatedPremises)
+    })
+  })
+
+  describe('canArchivePremises', () => {
+    it('returns the bedspaces that are preventing a premises from being archived', async () => {
+      const bedspacesReference = cas3BedspacesReferenceFactory.build()
+      premisesClient.canArchive.mockResolvedValue(bedspacesReference)
+
+      const result = await service.canArchivePremises(callConfig, premisesId)
+      expect(result).toEqual(bedspacesReference)
+
+      expect(premisesClientFactory).toHaveBeenCalledWith(callConfig)
+      expect(premisesClient.canArchive).toHaveBeenCalledWith(premisesId)
     })
   })
 

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -117,6 +117,11 @@ export default class PremisesService {
     return premisesClient.update(premisesId, updatedPremises)
   }
 
+  async canArchivePremises(callConfig: CallConfig, premisesId: string) {
+    const premisesClient = this.premisesClientFactory(callConfig)
+    return premisesClient.canArchive(premisesId)
+  }
+
   async archivePremises(callConfig: CallConfig, premisesId: string, archivePayload: Cas3ArchivePremises) {
     const premisesClient = this.premisesClientFactory(callConfig)
     return premisesClient.archive(premisesId, archivePayload)

--- a/server/testutils/factories/cas3BedspaceReference.ts
+++ b/server/testutils/factories/cas3BedspaceReference.ts
@@ -1,0 +1,8 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+import { Cas3BedspaceReference } from '@approved-premises/api'
+
+export default Factory.define<Cas3BedspaceReference>(() => ({
+  id: faker.string.uuid(),
+  reference: `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`,
+}))

--- a/server/testutils/factories/cas3BedspacesReference.ts
+++ b/server/testutils/factories/cas3BedspacesReference.ts
@@ -1,0 +1,7 @@
+import { Factory } from 'fishery'
+import { Cas3BedspacesReference } from '@approved-premises/api'
+import cas3BedspaceReferenceFactory from './cas3BedspaceReference'
+
+export default Factory.define<Cas3BedspacesReference>(() => ({
+  affectedBedspaces: cas3BedspaceReferenceFactory.buildList(5),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -67,6 +67,8 @@ import cas3BedspaceArchiveActionFactory from './cas3BedspaceArchiveAction'
 import cas3NewBedspaceFactory from './cas3NewBedspace'
 import cas3UpdateBedspaceFactory from './cas3UpdateBedspace'
 import cas3BedspaceSummaryFactory from './cas3BedspaceSummary'
+import cas3BedspaceReferenceFactory from './cas3BedspaceReference'
+import cas3BedspacesReferenceFactory from './cas3BedspacesReference'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import probationRegionFactory from './probationRegion'
 import referenceDataFactory from './referenceData'
@@ -155,6 +157,8 @@ export {
   cas3NewBedspaceFactory,
   cas3UpdateBedspaceFactory,
   cas3BedspaceSummaryFactory,
+  cas3BedspaceReferenceFactory,
+  cas3BedspacesReferenceFactory,
   prisonCaseNotesFactory,
   probationRegionFactory,
   referenceDataFactory,

--- a/server/views/temporary-accommodation/v2/premises/cannot-archive.njk
+++ b/server/views/temporary-accommodation/v2/premises/cannot-archive.njk
@@ -1,0 +1,43 @@
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: "Back",
+        href: paths.premises.v2.show({ premisesId: premises.id }),
+        classes: "govuk-!-display-none-print"
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% include "../../../_messages.njk" %}
+
+    <h1 class="govuk-heading-l">You cannot archive {{ premises.addressLine1 }}</h1>
+
+    <div class="govuk-row">
+        <div class="govuk-grid-column-two-thirds">
+            <p>This property has a booking or void that prevents it from being archived</p>
+
+            <p>The affected bedspaces are:</p>
+
+            <ul class="govuk-list govuk-!-margin-bottom-6">
+                {% for bedspace in bedspaces %}
+                    <li class="govuk-list-item">
+                        <span class="govuk-visually-hidden">View bedspace</span>
+                        <a class="govuk-link govuk-link--no-visited-state" href="{{ paths.premises.v2.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id }) }}">
+                            {{ bedspace.reference }}
+                        </a>
+                    </li>
+                {% endfor %}
+            </ul>
+
+            {{ govukButton({
+                text: "View bedspaces overview",
+                href: paths.premises.v2.bedspaces.list({ premisesId: premises.id })
+            }) }}
+        </div>
+    </div>
+
+{%  endblock %}


### PR DESCRIPTION
# Context

Ticket [C3 FE: Handle Archive Premises Access Rules](https://dsdmoj.atlassian.net/browse/CAS-1870)
Requires `MANAGE_PROPERTIES_V2_ENABLED` feature flag

BE isn't currently removing duplicates in the response from `/cas3/premises/{premisesId}/can-archive`
BE is using the beds table for references rather than cas3 bedspaces table

# Changes in this PR

## Screenshots of UI changes

### After
<img width="1706" height="1329" alt="image" src="https://github.com/user-attachments/assets/01838abb-2067-4c3d-bb20-d58ddf760f2a" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
