### PR TITLE
Add place context banner into new Manage properties V2 areas

### DIFF
--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -19,8 +19,16 @@ import BedspacesControllerV2 from './v2/bedspacesController'
 
 export const controllers = (services: Services) => {
   const dashboardController = new DashboardController()
-  const premisesControllerV2 = new PremisesControllerV2(services.v2.premisesService, services.v2.bedspaceService)
-  const bedspacesControllerV2 = new BedspacesControllerV2(services.v2.premisesService, services.v2.bedspaceService)
+  const premisesControllerV2 = new PremisesControllerV2(
+    services.v2.premisesService,
+    services.v2.bedspaceService,
+    services.assessmentsService,
+  )
+  const bedspacesControllerV2 = new BedspacesControllerV2(
+    services.v2.premisesService,
+    services.v2.bedspaceService,
+    services.assessmentsService,
+  )
   const bookingsController = new BookingsController(
     services.premisesService,
     services.bedspaceService,

--- a/server/controllers/temporary-accommodation/manage/v2/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/premisesController.ts
@@ -5,6 +5,7 @@ import type { Cas3NewPremises, Cas3PremisesStatus, Cas3UpdatePremises } from '@a
 import paths from '../../../../paths/temporary-accommodation/manage'
 import PremisesService from '../../../../services/v2/premisesService'
 import BedspaceService from '../../../../services/v2/bedspaceService'
+import AssessmentsService from '../../../../services/assessmentsService'
 import extractCallConfig from '../../../../utils/restUtils'
 import { createSubNavArr } from '../../../../utils/premisesSearchUtils'
 import { showPropertySubNavArray } from '../../../../utils/premisesUtils'
@@ -18,11 +19,13 @@ import { filterProbationRegions } from '../../../../utils/userUtils'
 import { parseNumber } from '../../../../utils/formUtils'
 import { premisesActions } from '../../../../utils/v2/premisesUtils'
 import { DateFormats } from '../../../../utils/dateUtils'
+import { preservePlaceContext } from '../../../../utils/placeUtils'
 
 export default class PremisesController {
   constructor(
     private readonly premisesService: PremisesService,
     private readonly bedspaceService: BedspaceService,
+    private readonly assessmentService: AssessmentsService,
   ) {}
 
   index(status: Cas3PremisesStatus): RequestHandler {
@@ -31,10 +34,11 @@ export default class PremisesController {
       const params = req.query as PremisesSearchParameters
 
       const premisesSortBy = req.session.premisesSortBy || 'pdu'
-
+      const placeContext = await preservePlaceContext(req, res, this.assessmentService)
       const searchData = await this.premisesService.searchDataAndGenerateTableRows(
         callConfig,
         params.postcodeOrAddress,
+        placeContext,
         status,
         premisesSortBy,
       )
@@ -43,7 +47,7 @@ export default class PremisesController {
         ...searchData,
         params,
         status,
-        subNavArr: createSubNavArr(status, params.postcodeOrAddress),
+        subNavArr: createSubNavArr(status, placeContext, params.postcodeOrAddress),
         premisesSortBy,
       })
     }
@@ -54,7 +58,10 @@ export default class PremisesController {
       const callConfig = extractCallConfig(req)
       const { premisesId } = req.params
 
-      const premises = await this.premisesService.getSinglePremises(callConfig, premisesId)
+      const [premises, placeContext] = await Promise.all([
+        await this.premisesService.getSinglePremises(callConfig, premisesId),
+        await preservePlaceContext(req, res, this.assessmentService),
+      ])
       const summary = this.premisesService.summaryList(premises)
 
       return res.render('temporary-accommodation/v2/premises/show', {
@@ -62,7 +69,7 @@ export default class PremisesController {
         summary,
         actions: premisesActions(premises),
         showPremises: true,
-        subNavArr: showPropertySubNavArray(premisesId, 'premises'),
+        subNavArr: showPropertySubNavArray(premisesId, placeContext, 'premises'),
       })
     }
   }
@@ -72,11 +79,11 @@ export default class PremisesController {
       const callConfig = extractCallConfig(req)
       const { premisesId } = req.params
 
-      const [premises, bedspaces] = await Promise.all([
+      const [premises, bedspaces, placeContext] = await Promise.all([
         this.premisesService.getSinglePremises(callConfig, premisesId),
         this.bedspaceService.getBedspacesForPremises(callConfig, premisesId),
+        await preservePlaceContext(req, res, this.assessmentService),
       ])
-
       const bedspaceSummaries = bedspaces.bedspaces.map(bedspace => {
         const bedspaceSummary = this.bedspaceService.summaryList(bedspace)
         return {
@@ -86,12 +93,13 @@ export default class PremisesController {
         }
       })
 
+      const subNavArr = showPropertySubNavArray(premisesId, placeContext, 'bedspaces')
       return res.render('temporary-accommodation/v2/premises/show', {
         premises,
         bedspaceSummaries,
         actions: premisesActions(premises),
         showPremises: false,
-        subNavArr: showPropertySubNavArray(premisesId, 'bedspaces'),
+        subNavArr,
       })
     }
   }

--- a/server/services/v2/premisesService.test.ts
+++ b/server/services/v2/premisesService.test.ts
@@ -1,8 +1,10 @@
 import { TextItem } from '@approved-premises/ui'
 import { Cas3PremisesArchiveAction } from '@approved-premises/api'
+import { createMock } from '@golevelup/ts-jest'
 import PremisesClient from '../../data/v2/premisesClient'
 import { CallConfig } from '../../data/restClient'
 import {
+  assessmentFactory,
   cas3ArchivePremisesFactory,
   cas3BedspacesReferenceFactory,
   cas3NewPremisesFactory,
@@ -14,19 +16,20 @@ import {
   characteristicFactory,
   localAuthorityFactory,
   pduFactory,
+  placeContextFactory,
   probationRegionFactory,
 } from '../../testutils/factories'
 import { statusTag } from '../../utils/premisesUtils'
 import PremisesService from './premisesService'
 import { ReferenceDataClient } from '../../data'
 import { filterCharacteristics } from '../../utils/characteristicUtils'
+import { AssessmentsService } from '../index'
 
 jest.mock('../../data/v2/premisesClient')
 jest.mock('../../data/referenceDataClient')
 jest.mock('../../utils/premisesUtils')
 jest.mock('../../utils/viewUtils')
 jest.mock('../../utils/characteristicUtils')
-jest.mock('../../utils/placeUtils')
 
 describe('PremisesService', () => {
   const premisesClient = new PremisesClient(null) as jest.Mocked<PremisesClient>
@@ -34,13 +37,18 @@ describe('PremisesService', () => {
   const premisesClientFactory = jest.fn()
   const referenceDataClientFactory = jest.fn()
   const service = new PremisesService(premisesClientFactory, referenceDataClientFactory)
+  const assessmentService = createMock<AssessmentsService>({})
+
   const callConfig = { token: 'some-token', probationRegion: probationRegionFactory.build() } as CallConfig
   const premisesId = 'premises-id'
+  const assessment = assessmentFactory.build({ status: 'ready_to_place' })
+  const placeContext = placeContextFactory.build({ assessment })
 
   beforeEach(() => {
     jest.resetAllMocks()
     premisesClientFactory.mockReturnValue(premisesClient)
     referenceDataClientFactory.mockReturnValue(referenceDataClient)
+    assessmentService.findAssessment.mockResolvedValue(assessment)
   })
 
   describe('createPremises', () => {
@@ -147,8 +155,7 @@ describe('PremisesService', () => {
     ])('returns table view of the premises for Temporary Accommodation', (searchResults, expectedResults) => {
       const premises = cas3PremisesSearchResultsFactory.build({ results: searchResults })
       ;(statusTag as jest.MockedFunction<typeof statusTag>).mockImplementation(status => `<strong>${status}</strong>`)
-
-      const rows = service.tableRows(premises)
+      const rows = service.tableRows(premises, placeContext)
 
       const expectedRows = expectedResults.map(prem => {
         const address = [prem.addressLine1, prem.addressLine2, prem.town, prem.postcode]
@@ -162,7 +169,7 @@ describe('PremisesService', () => {
                 .map(bed => {
                   const archivedTag =
                     bed.status === 'archived' ? ` <strong class="govuk-tag govuk-tag--grey">Archived</strong>` : ''
-                  return `<a href="/properties/${prem.id}/bedspaces/${bed.id}">${bed.reference}</a>${archivedTag}`
+                  return `<a href="/properties/${prem.id}/bedspaces/${bed.id}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}">${bed.reference}</a>${archivedTag}`
                 })
                 .join('<br />')
 
@@ -171,7 +178,7 @@ describe('PremisesService', () => {
           { html: bedspaces },
           { text: prem.pdu },
           {
-            html: `<a href="/properties/${prem.id}">Manage<span class="govuk-visually-hidden"> property at ${prem.addressLine1}, ${prem.postcode}</span></a>`,
+            html: `<a href="/properties/${prem.id}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}">Manage<span class="govuk-visually-hidden"> property at ${prem.addressLine1}, ${prem.postcode}</span></a>`,
           },
         ]
       })
@@ -192,7 +199,7 @@ describe('PremisesService', () => {
       const premises = cas3PremisesSearchResultsFactory.build({ results: [searchResult] })
       ;(statusTag as jest.MockedFunction<typeof statusTag>).mockImplementation(status => `<strong>${status}</strong>`)
 
-      const rows = service.tableRows(premises, 'la')
+      const rows = service.tableRows(premises, placeContext, 'la')
 
       const address = [searchResult.addressLine1, searchResult.addressLine2, searchResult.town, searchResult.postcode]
         .filter(s => s !== undefined && s !== '')
@@ -206,7 +213,7 @@ describe('PremisesService', () => {
           { html: bedspaces },
           { text: searchResult.localAuthorityAreaName },
           {
-            html: `<a href="/properties/${searchResult.id}">Manage<span class="govuk-visually-hidden"> property at ${searchResult.addressLine1}, ${searchResult.postcode}</span></a>`,
+            html: `<a href="/properties/${searchResult.id}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}">Manage<span class="govuk-visually-hidden"> property at ${searchResult.addressLine1}, ${searchResult.postcode}</span></a>`,
           },
         ],
       ])
@@ -239,7 +246,7 @@ describe('PremisesService', () => {
 
       premisesClient.search.mockResolvedValue(searchResults)
 
-      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress)
+      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress, placeContext)
 
       expect(result).toEqual({
         ...searchResults,
@@ -261,7 +268,12 @@ describe('PremisesService', () => {
 
       premisesClient.search.mockResolvedValue(searchResults)
 
-      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress, 'archived')
+      const result = await service.searchDataAndGenerateTableRows(
+        callConfig,
+        postcodeOrAddress,
+        placeContext,
+        'archived',
+      )
 
       expect(result).toEqual({
         ...searchResults,
@@ -283,7 +295,7 @@ describe('PremisesService', () => {
 
       premisesClient.search.mockResolvedValue(searchResults)
 
-      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress)
+      const result = await service.searchDataAndGenerateTableRows(callConfig, postcodeOrAddress, placeContext)
 
       expect(result).toEqual({
         ...searchResults,

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -16,7 +16,7 @@ import {
   ProbationDeliveryUnit,
   ProbationRegion,
 } from '@approved-premises/api'
-import { SummaryList, TableRow } from '@approved-premises/ui'
+import { PlaceContext, SummaryList, TableRow } from '@approved-premises/ui'
 import { PremisesClientV2 as PremisesClient, ReferenceDataClient, RestClientBuilder } from '../../data'
 
 import { CallConfig } from '../../data/restClient'
@@ -24,6 +24,7 @@ import paths from '../../paths/temporary-accommodation/manage'
 import { DateFormats } from '../../utils/dateUtils'
 import { convertToTitleCase } from '../../utils/utils'
 import { filterCharacteristics } from '../../utils/characteristicUtils'
+import { addPlaceContext } from '../../utils/placeUtils'
 
 const ARCHIVE_HISTORY_THRESHOLD = 14
 
@@ -43,6 +44,7 @@ export default class PremisesService {
   async searchDataAndGenerateTableRows(
     callConfig: CallConfig,
     postcodeOrAddress: string | undefined,
+    placeContext: PlaceContext,
     status: Cas3PremisesStatus = 'online',
     premisesSortBy: Cas3PremisesSortBy = 'pdu',
   ): Promise<Cas3PremisesSearchResults & { tableRows: Array<TableRow> }> {
@@ -52,7 +54,7 @@ export default class PremisesService {
 
     return {
       ...premises,
-      tableRows: this.tableRows(premises, premisesSortBy),
+      tableRows: this.tableRows(premises, placeContext, premisesSortBy),
     }
   }
 
@@ -132,15 +134,19 @@ export default class PremisesService {
     return premisesClient.unarchive(premisesId, unarchivePayload)
   }
 
-  tableRows(premises: Cas3PremisesSearchResults, premisesSortBy: Cas3PremisesSortBy = 'pdu'): Array<TableRow> {
+  tableRows(
+    premises: Cas3PremisesSearchResults,
+    placeContext: PlaceContext,
+    premisesSortBy: Cas3PremisesSortBy = 'pdu',
+  ): Array<TableRow> {
     return premises.results === undefined
       ? []
       : premises.results.map(entry => {
           return [
             this.htmlValue(this.formatAddress(entry)),
-            this.htmlValue(this.formatBedspaces(entry)),
+            this.htmlValue(this.formatBedspaces(entry, placeContext)),
             this.textValue(premisesSortBy === 'pdu' ? entry.pdu : entry.localAuthorityAreaName),
-            this.htmlValue(this.formatPremisesManageLink(entry)),
+            this.htmlValue(this.formatPremisesManageLink(entry, placeContext)),
           ]
         })
   }
@@ -244,24 +250,30 @@ export default class PremisesService {
     return paths.premises.show({ premisesId })
   }
 
-  private formatPremisesManageLink(premises: Cas3PremisesSearchResult): string {
+  private formatPremisesManageLink(premises: Cas3PremisesSearchResult, placeContext: PlaceContext): string {
     const hidden = `<span class="govuk-visually-hidden"> property at ${premises.addressLine1}, ${premises.postcode}</span>`
-    return `<a href="${this.premisesUrl(premises.id)}">Manage${hidden}</a>`
+    const premisesUrl = this.premisesUrl(premises.id)
+    const showPremisesLinkWithPlaceContext = addPlaceContext(premisesUrl, placeContext)
+    return `<a href="${showPremisesLinkWithPlaceContext}">Manage${hidden}</a>`
   }
 
-  private formatBedspace(premisesId: string, bedspace: Cas3BedspacePremisesSearchResult): string {
+  private formatBedspace(
+    premisesId: string,
+    bedspace: Cas3BedspacePremisesSearchResult,
+    placeContext: PlaceContext,
+  ): string {
     const archived =
       bedspace.status === 'archived' ? ` <strong class="govuk-tag govuk-tag--grey">Archived</strong>` : ''
-
-    return `<a href="${this.bedspaceUrl(premisesId, bedspace.id)}">${bedspace.reference}</a>${archived}`
+    const showBedspaceLinkWithPlaceContext = addPlaceContext(this.bedspaceUrl(premisesId, bedspace.id), placeContext)
+    return `<a href="${showBedspaceLinkWithPlaceContext}">${bedspace.reference}</a>${archived}`
   }
 
-  private formatBedspaces(premises: Cas3PremisesSearchResult): string {
+  private formatBedspaces(premises: Cas3PremisesSearchResult, placeContext: PlaceContext): string {
     if (premises.bedspaces === undefined || premises.bedspaces.length === 0) {
       return `No bedspaces<br /><a href="${paths.premises.bedspaces.new({ premisesId: premises.id })}">Add a bedspace</a>`
     }
 
-    return premises.bedspaces.map(bedspace => this.formatBedspace(premises.id, bedspace)).join('<br />')
+    return premises.bedspaces.map(bedspace => this.formatBedspace(premises.id, bedspace, placeContext)).join('<br />')
   }
 
   private formatDate(dateString: string | undefined | null): string {

--- a/server/utils/premisesSearchUtils.test.ts
+++ b/server/utils/premisesSearchUtils.test.ts
@@ -1,57 +1,61 @@
 import { createSubNavArr } from './premisesSearchUtils'
 import paths from '../paths/temporary-accommodation/manage'
+import { assessmentFactory, placeContextFactory } from '../testutils/factories'
 
 describe('premisesSearchUtils', () => {
   describe('createSubNavArr', () => {
+    const placeContext = placeContextFactory.build({
+      assessment: assessmentFactory.build(),
+    })
     it('returns sub nav with given status selected', () => {
       const subNavArr = [
         {
           text: 'Online properties',
-          href: paths.premises.online({}),
+          href: `${paths.premises.online({})}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: true,
         },
         {
           text: 'Archived properties',
-          href: paths.premises.archived({}),
+          href: `${paths.premises.archived({})}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: false,
         },
       ]
 
-      expect(createSubNavArr('online')).toEqual(subNavArr)
+      expect(createSubNavArr('online', placeContext)).toEqual(subNavArr)
     })
 
     it('returns sub nav with archived status selected', () => {
       const subNavArr = [
         {
           text: 'Online properties',
-          href: paths.premises.online({}),
+          href: `${paths.premises.online({})}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: false,
         },
         {
           text: 'Archived properties',
-          href: paths.premises.archived({}),
+          href: `${paths.premises.archived({})}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: true,
         },
       ]
 
-      expect(createSubNavArr('archived')).toEqual(subNavArr)
+      expect(createSubNavArr('archived', placeContext)).toEqual(subNavArr)
     })
 
     it('appends the postcode or address parameter if given', () => {
       const subNavArr = [
         {
           text: 'Online properties',
-          href: `${paths.premises.online({})}?postcodeOrAddress=NE1`,
+          href: `${paths.premises.online({})}?postcodeOrAddress=NE1&placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: true,
         },
         {
           text: 'Archived properties',
-          href: `${paths.premises.archived({})}?postcodeOrAddress=NE1`,
+          href: `${paths.premises.archived({})}?postcodeOrAddress=NE1&placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: false,
         },
       ]
 
-      expect(createSubNavArr('online', 'NE1')).toEqual(subNavArr)
+      expect(createSubNavArr('online', placeContext, 'NE1')).toEqual(subNavArr)
     })
   })
 })

--- a/server/utils/premisesSearchUtils.ts
+++ b/server/utils/premisesSearchUtils.ts
@@ -1,12 +1,17 @@
 import type { Cas3PremisesStatus } from '@approved-premises/api'
-import type { SubNavObj } from '@approved-premises/ui'
+import { PlaceContext, SubNavObj } from '@approved-premises/ui'
 import paths from '../paths/temporary-accommodation/manage'
 import { appendQueryString } from './utils'
+import { addPlaceContext } from './placeUtils'
 
-export function createSubNavArr(status: Cas3PremisesStatus, postcodeOrAddress?: string): Array<SubNavObj> {
+export function createSubNavArr(
+  status: Cas3PremisesStatus,
+  placeContext: PlaceContext,
+  postcodeOrAddress?: string,
+): Array<SubNavObj> {
   return ['online', 'archived'].map((premisesStatus: Cas3PremisesStatus) => ({
     text: `${capitaliseStatus(premisesStatus)} properties`,
-    href: appendQueryString(paths.premises[premisesStatus]({}), { postcodeOrAddress }),
+    href: addPlaceContext(appendQueryString(paths.premises[premisesStatus]({}), { postcodeOrAddress }), placeContext),
     active: status === premisesStatus,
   }))
 }

--- a/server/utils/premisesUtils.test.ts
+++ b/server/utils/premisesUtils.test.ts
@@ -1,5 +1,5 @@
 import paths from '../paths/temporary-accommodation/manage'
-import { premisesFactory } from '../testutils/factories'
+import { assessmentFactory, placeContextFactory, premisesFactory } from '../testutils/factories'
 import {
   getActiveStatuses,
   premisesActions,
@@ -10,6 +10,11 @@ import {
 } from './premisesUtils'
 
 describe('premisesUtils', () => {
+  const placeContext = placeContextFactory.build({
+    assessment: assessmentFactory.build({
+      accommodationRequiredFromDate: '2025-08-27',
+    }),
+  })
   describe('premisesActions', () => {
     it('returns add a bedspace for an active premises', () => {
       const premises = premisesFactory.active().build()
@@ -93,17 +98,17 @@ describe('premisesUtils', () => {
       const expectedResult = [
         {
           text: 'Property overview',
-          href: '/properties/83b4062f-963e-450d-b912-589eab7ca91c',
+          href: `/properties/83b4062f-963e-450d-b912-589eab7ca91c?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: true,
         },
         {
           text: 'Bedspaces overview',
-          href: '/properties/83b4062f-963e-450d-b912-589eab7ca91c/bedspaces',
+          href: `/properties/83b4062f-963e-450d-b912-589eab7ca91c/bedspaces?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: false,
         },
       ]
 
-      const result = showPropertySubNavArray('83b4062f-963e-450d-b912-589eab7ca91c', 'premises')
+      const result = showPropertySubNavArray('83b4062f-963e-450d-b912-589eab7ca91c', placeContext, 'premises')
 
       expect(result).toEqual(expectedResult)
     })
@@ -112,17 +117,17 @@ describe('premisesUtils', () => {
       const expectedResult = [
         {
           text: 'Property overview',
-          href: '/properties/6a2fc984-8cdd-4eef-8736-cc74f845ee47',
+          href: `/properties/6a2fc984-8cdd-4eef-8736-cc74f845ee47?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: false,
         },
         {
           text: 'Bedspaces overview',
-          href: '/properties/6a2fc984-8cdd-4eef-8736-cc74f845ee47/bedspaces',
+          href: `/properties/6a2fc984-8cdd-4eef-8736-cc74f845ee47/bedspaces?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
           active: true,
         },
       ]
 
-      const result = showPropertySubNavArray('6a2fc984-8cdd-4eef-8736-cc74f845ee47', 'bedspaces')
+      const result = showPropertySubNavArray('6a2fc984-8cdd-4eef-8736-cc74f845ee47', placeContext, 'bedspaces')
 
       expect(result).toEqual(expectedResult)
     })

--- a/server/utils/premisesUtils.ts
+++ b/server/utils/premisesUtils.ts
@@ -1,6 +1,7 @@
 import type { Premises, PropertyStatus } from '@approved-premises/api'
-import { PageHeadingBarItem, PremisesShowTabs, type SubNavObj } from '../@types/ui'
+import { PageHeadingBarItem, PlaceContext, PremisesShowTabs, type SubNavObj } from '../@types/ui'
 import paths from '../paths/temporary-accommodation/manage'
+import { addPlaceContext } from './placeUtils'
 
 type StatusInfo = { name: string; id: PropertyStatus; colour: string; isActive: boolean }
 
@@ -57,16 +58,20 @@ export const shortAddress = (premises: Premises): string => {
   return elements.join(', ')
 }
 
-export const showPropertySubNavArray = (premisesId: string, activeTab: PremisesShowTabs): Array<SubNavObj> => {
+export const showPropertySubNavArray = (
+  premisesId: string,
+  placeContext: PlaceContext,
+  activeTab: PremisesShowTabs,
+): Array<SubNavObj> => {
   return [
     {
       text: 'Property overview',
-      href: paths.premises.show({ premisesId }),
+      href: addPlaceContext(paths.premises.show({ premisesId }), placeContext),
       active: activeTab === 'premises',
     },
     {
       text: 'Bedspaces overview',
-      href: paths.premises.bedspaces.list({ premisesId }),
+      href: addPlaceContext(paths.premises.bedspaces.list({ premisesId }), placeContext),
       active: activeTab === 'bedspaces',
     },
   ]

--- a/server/utils/v2/bedspaceUtils.test.ts
+++ b/server/utils/v2/bedspaceUtils.test.ts
@@ -1,19 +1,29 @@
-import { cas3BedspaceFactory, cas3PremisesFactory } from '../../testutils/factories'
+import {
+  assessmentFactory,
+  cas3BedspaceFactory,
+  cas3PremisesFactory,
+  placeContextFactory,
+} from '../../testutils/factories'
 import { bedspaceActions } from './bedspaceUtils'
 import paths from '../../paths/temporary-accommodation/manage'
 
 describe('bedspaceV2Utils', () => {
   describe('bedspaceActions', () => {
+    const placeContext = placeContextFactory.build({
+      assessment: assessmentFactory.build({
+        accommodationRequiredFromDate: '2025-08-27',
+      }),
+    })
     it('returns correct actions for an online bedspace', () => {
       const premises = cas3PremisesFactory.build()
       const bedspace = cas3BedspaceFactory.build({ status: 'online', endDate: undefined })
 
-      const actions = bedspaceActions(premises, bedspace)
+      const actions = bedspaceActions(premises, bedspace, placeContext)
 
       expect(actions).toHaveLength(4)
       expect(actions).toContainEqual({
         text: 'Book bedspace',
-        href: paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        href: `${paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id })}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
         classes: 'govuk-button--secondary',
       })
       expect(actions).toContainEqual({
@@ -37,12 +47,12 @@ describe('bedspaceV2Utils', () => {
       const premises = cas3PremisesFactory.build()
       const bedspace = cas3BedspaceFactory.build({ status: 'online', endDate: '2125-08-20' })
 
-      const actions = bedspaceActions(premises, bedspace)
+      const actions = bedspaceActions(premises, bedspace, placeContext)
 
       expect(actions).toHaveLength(4)
       expect(actions).toContainEqual({
         text: 'Book bedspace',
-        href: paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        href: `${paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id })}?placeContextAssessmentId=${placeContext.assessment.id}&placeContextArrivalDate=${placeContext.arrivalDate}`,
         classes: 'govuk-button--secondary',
       })
       expect(actions).toContainEqual({
@@ -66,7 +76,7 @@ describe('bedspaceV2Utils', () => {
       const premises = cas3PremisesFactory.build()
       const bedspace = cas3BedspaceFactory.build({ status: 'archived' })
 
-      const actions = bedspaceActions(premises, bedspace)
+      const actions = bedspaceActions(premises, bedspace, placeContext)
 
       expect(actions).toHaveLength(2)
       expect(actions).toContainEqual({
@@ -85,7 +95,7 @@ describe('bedspaceV2Utils', () => {
       const premises = cas3PremisesFactory.build()
       const bedspace = cas3BedspaceFactory.build({ status: 'archived', startDate: '2125-08-20' })
 
-      const actions = bedspaceActions(premises, bedspace)
+      const actions = bedspaceActions(premises, bedspace, placeContext)
 
       expect(actions).toHaveLength(2)
       expect(actions).toContainEqual({

--- a/server/utils/v2/bedspaceUtils.ts
+++ b/server/utils/v2/bedspaceUtils.ts
@@ -1,10 +1,15 @@
 import { Cas3Bedspace, Cas3Premises } from '@approved-premises/api'
-import { PageHeadingBarItem } from '@approved-premises/ui'
+import { PageHeadingBarItem, PlaceContext } from '@approved-premises/ui'
 import paths from '../../paths/temporary-accommodation/manage'
+import { addPlaceContext } from '../placeUtils'
 
-export function bedspaceActions(premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> {
+export function bedspaceActions(
+  premises: Cas3Premises,
+  bedspace: Cas3Bedspace,
+  placeContext: PlaceContext,
+): Array<PageHeadingBarItem> {
   return bedspace.status === 'online'
-    ? onlineBedspaceActions(premises, bedspace)
+    ? onlineBedspaceActions(premises, bedspace, placeContext)
     : archivedBedspaceActions(premises, bedspace)
 }
 
@@ -33,11 +38,15 @@ const archivedBedspaceActions = (premises: Cas3Premises, bedspace: Cas3Bedspace)
   return actions
 }
 
-const onlineBedspaceActions = (premises: Cas3Premises, bedspace: Cas3Bedspace): Array<PageHeadingBarItem> => {
+const onlineBedspaceActions = (
+  premises: Cas3Premises,
+  bedspace: Cas3Bedspace,
+  placeContext: PlaceContext,
+): Array<PageHeadingBarItem> => {
   const actions: Array<PageHeadingBarItem> = [
     {
       text: 'Book bedspace',
-      href: paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      href: addPlaceContext(paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id }), placeContext),
       classes: 'govuk-button--secondary',
     },
     {

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -9,7 +9,7 @@
 
 {% block beforeContent %}
   {{ breadCrumb('Book bedspace', [
-    {title: 'List of properties', href: paths.premises.index()},
+    {title: 'List of properties', href: paths.premises.online()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
     {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
   ]) }}

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -14,7 +14,7 @@
 
 {% block beforeContent %}
     {{ breadCrumb('View a booking', [
-        {title: 'List of properties', href: addPlaceContext(paths.premises.index())},
+        {title: 'List of properties', href: addPlaceContext(paths.premises.online())},
         {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))},
         {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
     ]) }}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -25,7 +25,7 @@
     <div class="card">
       <div class="card-body">
         <h2 class="govuk-heading-s">
-            <a class="govuk-link" href="{{ paths.premises.index({}) }}">Manage properties, bedspaces, and bookings</a>
+            <a class="govuk-link" href="{{ paths.premises.online({}) }}">Manage properties, bedspaces, and bookings</a>
         </h2>
         <p class="govuk-body">Add new properties, bedspaces, and bookings, and update attributes</p>
       </div>

--- a/server/views/temporary-accommodation/lost-beds/edit.njk
+++ b/server/views/temporary-accommodation/lost-beds/edit.njk
@@ -8,7 +8,7 @@
 
 {% block beforeContent %}
   {{ breadCrumb('Record void bedspace', [
-    {title: 'List of properties', href: paths.premises.index()},
+    {title: 'List of properties', href: paths.premises.online()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
     {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
   ]) }}

--- a/server/views/temporary-accommodation/lost-beds/new.njk
+++ b/server/views/temporary-accommodation/lost-beds/new.njk
@@ -8,7 +8,7 @@
 
 {% block beforeContent %}
   {{ breadCrumb('Record void bedspace', [
-    {title: 'List of properties', href: paths.premises.index()},
+    {title: 'List of properties', href: paths.premises.online()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
     {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
   ]) }}

--- a/server/views/temporary-accommodation/v2/bedspaces/show.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/show.njk
@@ -12,7 +12,7 @@
     {{ govukBreadcrumbs({
         items: [
             { text: "Home", href: "/" },
-            { text: "List of properties", href: addPlaceContext(paths.premises.index()) },
+            { text: "List of properties", href: addPlaceContext(paths.premises.online()) },
             {
                 text: premises.addressLine1 + ", " + premises.postcode,
                 href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))

--- a/server/views/temporary-accommodation/v2/premises/new.njk
+++ b/server/views/temporary-accommodation/v2/premises/new.njk
@@ -13,7 +13,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: 'Back',
-        href: paths.premises.index({}),
+        href: paths.premises.online({}),
         classes: 'govuk-!-display-none-print'
     }) }}
 {% endblock %}

--- a/server/views/temporary-accommodation/v2/premises/show.njk
+++ b/server/views/temporary-accommodation/v2/premises/show.njk
@@ -13,7 +13,7 @@
     {{ govukBreadcrumbs({
         items: [
             { text: "Home", href: "/" },
-            { text: "List of properties", href: addPlaceContext(paths.premises.index()) }
+            { text: "List of properties", href: addPlaceContext(paths.premises.online()) }
         ]
     }) }}
 {% endblock %}


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1936

The e2e tests were failing due to not finding the “Place context” banner in a few places around the application.

After a bit of digging, I have found that in the v1 version (what is in production) we show this banner in the following areas:
* View bedspace
* List Premises
* View Premises
* Bedspace search
* Create booking
* Confirm booking

# Changes in this PR

Add the banner in the missing V2 areas and pass around the `placeContextAssessmentId` as a request param to all areas when come from an assessment. This includes:
* View bedspace V2
* List Premises V2
* View Premises V2

## Screenshots of UI changes
<img width="2048" height="1152" alt="01__placecontext_banner_for_list_properties" src="https://github.com/user-attachments/assets/ceee063f-aac5-4343-8b1a-3a9691c546e4" />
<img width="2048" height="1152" alt="03__placecontext_banner_for_view_bedspace" src="https://github.com/user-attachments/assets/348dfefe-27a9-4136-9a11-280bbc8d9640" />
