### PR TITLE
Booking area with Bedspace v2

### DIFF
--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -95,10 +95,10 @@ export default class PlaceHelper {
     this.assessmentToBedspaceSearch()
     this.bedspaceSearchToSearchResults()
     this.searchResultsToBedspace()
-    // this.bedspaceToNewBooking()
-    // this.newBookingToSelectAssessment()
-    // this.selectAssessmentToConfirm()
-    // this.confirmToShowBooking()
+    this.bedspaceToNewBooking()
+    this.newBookingToSelectAssessment()
+    this.selectAssessmentToConfirm()
+    this.confirmToShowBooking()
   }
 
   private assessmentToBedspaceSearch() {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingHistory.ts
@@ -1,4 +1,4 @@
-import type { Booking, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, Premises, Room } from '@approved-premises/api'
 
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
@@ -13,17 +13,27 @@ export default class BookingHistoryPage extends Page {
 
   private readonly bookingInfoComponents: BookingInfoComponent[]
 
-  constructor(premises: Premises, room: Room, booking: Booking, historicBookings: Booking[]) {
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking, historicBookings: Booking[]) {
     super('Booking history')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
     this.bookingInfoComponents = historicBookings.map(historicBooking => new BookingInfoComponent(historicBooking))
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking, bookings: Booking[]): BookingHistoryPage {
-    cy.visit(paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingHistoryPage(premises, room, booking, bookings)
+  static visit(
+    premises: Premises,
+    room: Room,
+    bedspace: Cas3Bedspace,
+    booking: Booking,
+    bookings: Booking[],
+  ): BookingHistoryPage {
+    if (room) {
+      cy.visit(paths.bookings.history({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(paths.bookings.history({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }))
+    }
+    return new BookingHistoryPage(premises, room, bedspace, booking, bookings)
   }
 
   shouldShowBookingHistory(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingNew.ts
@@ -25,7 +25,7 @@ export default class BookingNewPage extends BookingEditablePage {
 
   static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace): BookingNewPage {
     if (room) {
-      cy.visit(paths.bookings.new({ premisesId: premises.id, roomId: room.id }))
+      cy.visit(paths.bookings.new({ premisesId: premises.id, bedspaceId: room.id }))
     } else {
       cy.visit(paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id }))
     }

--- a/cypress_shared/utils/booking.ts
+++ b/cypress_shared/utils/booking.ts
@@ -1,16 +1,16 @@
-import { Booking, BookingStatus, Premises, Room } from '../../server/@types/shared'
-import { premisesFactory, roomFactory } from '../../server/testutils/factories'
+import { Booking, BookingStatus, Cas3Bedspace, Premises } from '../../server/@types/shared'
+import { cas3BedspaceFactory, premisesFactory } from '../../server/testutils/factories'
 import { statusName } from '../../server/utils/bookingUtils'
 
-export const setupBookingStateStubs = (booking: Booking): { premises: Premises; room: Room } => {
+export const setupBookingStateStubs = (booking: Booking): { premises: Premises; bedspace: Cas3Bedspace } => {
   const premises = premisesFactory.build()
-  const room = roomFactory.build()
+  const bedspace = cas3BedspaceFactory.build({ status: 'online' })
 
   cy.task('stubSinglePremises', premises)
-  cy.task('stubSingleRoom', { premisesId: premises.id, room })
+  cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
   cy.task('stubBooking', { premisesId: premises.id, booking })
 
-  return { premises, room }
+  return { premises, bedspace }
 }
 
 export const assignModifiedBookingForTurnarounds = (

--- a/e2e/tests/booking-errors.feature
+++ b/e2e/tests/booking-errors.feature
@@ -3,21 +3,21 @@ Feature: Manage Temporary Accommodation - Booking Errors
     Given I am logged in as an assessor
     And I view an existing active premises
     And I'm creating a bedspace
+    And I create a bedspace with all necessary details
 
   Scenario: Showing booking creation errors
-    Given I create a bedspace with all necessary details
-#    Given I'm creating a booking
-#    And I attempt to create a booking with required details missing
-#    Then I should see a list of the problems encountered creating the booking
-#
-#  Scenario: Showing booking creation conflict errors
-#    Given I'm creating a booking
-#    And I create a booking with all necessary details
-#    And I go up a breadcrumb level
-#    And I'm creating a booking
-#    And I attempt to create a conflicting booking
-#    Then I should see errors for the conflicting booking
-#
+    Given I'm creating a booking
+    And I attempt to create a booking with required details missing
+    Then I should see a list of the problems encountered creating the booking
+
+  Scenario: Showing booking creation conflict errors
+    Given I'm creating a booking
+    And I create a booking with all necessary details
+    And I go up a breadcrumb level
+    And I'm creating a booking
+    And I attempt to create a conflicting booking
+    Then I should see errors for the conflicting booking
+
 #  Scenario: Showing booking cancellation errors
 #    Given I'm creating a booking
 #    And I create a booking with all necessary details

--- a/e2e/tests/bookingSearch.feature
+++ b/e2e/tests/bookingSearch.feature
@@ -4,14 +4,13 @@ Feature: Manage Temporary Accommodation - Booking search
     Given I am logged in as an assessor
     And I view an existing active premises
     And I'm creating a bedspace
-#    And I create a bedspace with all necessary details
-#    And I'm creating a booking
-#    And I create a booking with all necessary details
+    And I create a bedspace with all necessary details
+    And I'm creating a booking
+    And I create a booking with all necessary details
 
   Scenario: Showing bookings of all statuses
-    When I create a bedspace with all necessary details
-#    When I'm searching bookings
-#    Then I should see a summary of the booking on the provisional bookings page
+    When I'm searching bookings
+    Then I should see a summary of the booking on the provisional bookings page
 #    And I confirm the booking
 #    And I'm searching bookings
 #    Then I should see a summary of the booking on the confirmed bookings page
@@ -22,10 +21,10 @@ Feature: Manage Temporary Accommodation - Booking search
 #    And I'm searching bookings
 #    Then I should see a summary of the booking on the departed bookings page
 #
-#  Scenario: Searching for a booking by CRN
-#    Given I'm searching bookings
-#    When I search for a CRN that does not exist in provisional bookings
-#    Then I should see a message that the provisional booking is not found
+  Scenario: Searching for a booking by CRN
+    Given I'm searching bookings
+    When I search for a CRN that does not exist in provisional bookings
+    Then I should see a message that the provisional booking is not found
 #    When I click on the Departed bookings tab
 #    Then I should see a message that the departed booking is not found
 #    When I click on the Provisional bookings tab

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -11,10 +11,10 @@ import { person } from '../utils'
 
 Given("I'm creating a booking", () => {
   cy.then(function _() {
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.name)
     bedspaceShowPage.clickBookBedspaceLink()
 
-    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room, null)
     bookingNewPage.shouldShowBookingDetails()
 
     cy.wrap([]).as('historicBookings')
@@ -23,7 +23,7 @@ Given("I'm creating a booking", () => {
 
 Given('I create a booking with all necessary details', () => {
   cy.then(function _() {
-    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room, null)
     bookingNewPage.assignTurnaroundDays('turnaroundDays')
 
     cy.then(function __() {
@@ -53,7 +53,7 @@ Given('I create a booking with all necessary details', () => {
         }
         bookingSelectAssessmentPage.clickSubmit()
 
-        const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
+        const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, null, person)
         bookingConfirmPage.shouldShowBookingDetails()
 
         bookingConfirmPage.clickSubmit()
@@ -67,7 +67,7 @@ Given('I create a booking with all necessary details', () => {
 
 Given('I attempt to create a booking with required details missing', () => {
   cy.then(function _() {
-    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room, null)
     bookingNewPage.enterCrn(person.crn)
     bookingNewPage.clickSubmit()
   })
@@ -75,7 +75,7 @@ Given('I attempt to create a booking with required details missing', () => {
 
 Given('I attempt to create a conflicting booking', () => {
   cy.then(function _() {
-    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    const bookingNewPage = Page.verifyOnPage(BookingNewPage, this.premises, this.room, null)
 
     const newBooking = newBookingFactory.build({
       ...this.booking,
@@ -92,7 +92,7 @@ Given('I attempt to create a conflicting booking', () => {
       }
       bookingSelectAssessmentPage.clickSubmit()
 
-      const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, person)
+      const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, this.premises, this.room, null, person)
       bookingConfirmPage.shouldShowBookingDetails()
 
       bookingConfirmPage.clickSubmit()
@@ -102,13 +102,13 @@ Given('I attempt to create a conflicting booking', () => {
 
 Then('I should see a confirmation for my new booking', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Booking created')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.name)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -116,7 +116,7 @@ Then('I should see a confirmation for my new booking', () => {
 
 Then('I should see previous booking states in the booking history', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickHistoryLink()
 
     const bookingHistoryPage = Page.verifyOnPage(
@@ -134,14 +134,14 @@ Then('I should see previous booking states in the booking history', () => {
 
 Then('I should see a list of the problems encountered creating the booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room, null)
     page.shouldShowErrorMessagesForFields(['arrivalDate', 'departureDate'])
   })
 })
 
 Then('I should see errors for the conflicting booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room)
+    const page = Page.verifyOnPage(BookingNewPage, this.premises, this.room, null)
     page.shouldShowDateConflictErrorMessages(this.booking, 'booking')
   })
 })

--- a/e2e/tests/stepDefinitions/manage/confirmation.ts
+++ b/e2e/tests/stepDefinitions/manage/confirmation.ts
@@ -7,7 +7,7 @@ import { bookingFactory, confirmationFactory, newConfirmationFactory } from '../
 
 Given('I confirm the booking', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickConfirmBookingButton()
 
     const newConfirmation = newConfirmationFactory.build()
@@ -37,13 +37,13 @@ Given('I confirm the booking', () => {
 
 Then('I should see the booking with the confirmed status', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Booking confirmed')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.name)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })

--- a/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/booking.cy.ts
@@ -1,19 +1,20 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
-// import BookingConfirmPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirm'
-// import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
-// import BookingSelectAssessmentPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import Page from '../../../../cypress_shared/pages/page'
+import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import BookingConfirmPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirm'
+import BookingNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingNew'
+import BookingSelectAssessmentPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSelectAssessment'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import {
-//   assessmentSummaryFactory,
-//   bookingFactory,
-//   lostBedFactory,
-//   newBookingFactory,
-//   personFactory,
-//   premisesFactory,
-//   roomFactory,
-// } from '../../../../server/testutils/factories'
+import {
+  assessmentSummaryFactory,
+  bedFactory,
+  bookingFactory,
+  cas3BedspaceFactory,
+  cas3PremisesFactory,
+  newBookingFactory,
+  personFactory,
+  premisesFactory,
+} from '../../../../server/testutils/factories'
 
 context('Booking', () => {
   beforeEach(() => {
@@ -24,259 +25,265 @@ context('Booking', () => {
   it('navigates to the create booking page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there is an active premises and a room the database
-    //     const premises = premisesFactory.active().build()
-    //     const room = roomFactory.build()
-    //
-    //     cy.task('stubSinglePremises', premises)
-    //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //
-    //     // When I visit the show bedspace page
-    //     const bedspaceShow = BedspaceShowPage.visit(premises, room)
-    //
-    //     // Add I click the book bedspace link
-    //     bedspaceShow.clickBookBedspaceLink()
-    //
-    //     // Then I navigate to the new booking page
-    //     Page.verifyOnPage(BookingNewPage, premises, room)
+
+    // And there is an active premises and a bedspace the database
+    const premises = premisesFactory.active().build()
+
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online', startDate: '2023-10-18' })
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace: cas3Bedspace })
+
+    // When I visit the show bedspace page
+    const bedspaceShow = BedspaceShowPage.visit(premises, null, cas3Bedspace)
+
+    // Add I click the book bedspace link
+    bedspaceShow.clickBookBedspaceLink()
+
+    // Then I navigate to the new booking page
+    Page.verifyOnPage(BookingNewPage, premises, null, cas3Bedspace)
   })
-  //
-  //   it('navigates to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and bookings in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const bookings = bookingFactory
-  //       .params({
-  //         bed: room.beds[0],
-  //       })
-  //       .buildList(5)
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
-  //     cy.task('stubBooking', { premisesId: premises.id, booking: bookings[0] })
-  //
-  //     // When I visit the show bedspace page
-  //     const bedspaceShowPage = BedspaceShowPage.visit(premises, room)
-  //
-  //     // Add I click the booking link
-  //     bedspaceShowPage.clickBookingLink(bookings[0])
-  //
-  //     // Then I navigate to the booking page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, bookings[0])
-  //   })
-  //
-  //   it('allows me to create a booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and a person in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const person = personFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubFindPerson', { person })
-  //
-  //     // And there are assessments in the database
-  //     const assessmentSummaries = assessmentSummaryFactory.buildList(5)
-  //     cy.task('stubAssessments', { data: assessmentSummaries })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // Then I should see the booking details
-  //     bookingNewPage.shouldShowBookingDetails()
-  //
-  //     // And when I fill out the form
-  //     const booking = bookingFactory.build({ person, assessmentId: assessmentSummaries[0].id })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // And I select an assessment
-  //     const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, assessmentSummaries)
-  //     bookingSelectAssessmentPage.shouldDisplayAssessments()
-  //     bookingSelectAssessmentPage.selectAssessment(assessmentSummaries[0])
-  //
-  //     bookingSelectAssessmentPage.clickSubmit()
-  //
-  //     // And I confirm the booking
-  //     const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, room, person)
-  //     bookingConfirmPage.shouldShowBookingDetails()
-  //
-  //     cy.task('stubBookingCreate', { premisesId: premises.id, booking })
-  //     cy.task('stubBooking', { premisesId: premises.id, booking })
-  //
-  //     bookingConfirmPage.clickSubmit()
-  //
-  //     // Then a booking should have been created in the API
-  //     cy.task('verifyBookingCreate', premises.id).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //
-  //       expect(requestBody.service).equal('temporary-accommodation')
-  //       expect(requestBody.bedId).equal(room.beds[0].id)
-  //       expect(requestBody.crn).equal(newBooking.crn)
-  //       expect(requestBody.arrivalDate).equal(newBooking.arrivalDate)
-  //       expect(requestBody.departureDate).equal(newBooking.departureDate)
-  //       expect(requestBody.assessmentId).equal(newBooking.assessmentId)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Booking created')
-  //   })
-  //
-  //   it('allows me to create a booking without linking an assessment', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and a person in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const person = personFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubFindPerson', { person })
-  //
-  //     // And there are assessments in the database
-  //     cy.task('stubAssessments', { data: [] })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // Then I should see the booking details
-  //     bookingNewPage.shouldShowBookingDetails()
-  //
-  //     // And when I fill out the form
-  //     const booking = bookingFactory.build({ person })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // And I do not select an assessment
-  //     const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
-  //     bookingSelectAssessmentPage.clickSubmit()
-  //
-  //     // And I confirm the booking
-  //     const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, room, person)
-  //     bookingConfirmPage.shouldShowBookingDetails()
-  //
-  //     cy.task('stubBookingCreate', { premisesId: premises.id, booking })
-  //     cy.task('stubBooking', { premisesId: premises.id, booking })
-  //
-  //     bookingConfirmPage.clickSubmit()
-  //
-  //     // Then a booking should have been created in the API
-  //     cy.task('verifyBookingCreate', premises.id).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //
-  //       expect(requestBody.service).equal('temporary-accommodation')
-  //       expect(requestBody.bedId).equal(room.beds[0].id)
-  //       expect(requestBody.crn).equal(newBooking.crn)
-  //       expect(requestBody.arrivalDate).equal(newBooking.arrivalDate)
-  //       expect(requestBody.departureDate).equal(newBooking.departureDate)
-  //       expect(requestBody.assessmentId).equal(undefined)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Booking created')
-  //   })
-  //
-  //   it('shows a suggested end date for the booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // When I visit the new booking page
-  //     const page = BookingNewPage.visit(premises, room)
-  //
-  //     // And I enter a start date
-  //     page.completeDateInputs('arrivalDate', '2022-07-08')
-  //
-  //     // Then I should see a suggested end date
-  //     page.shouldShowEndDateHint('30/9/2022')
-  //   })
-  //
-  //   it('shows error when the API returns a person not found 404', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     // And there is no person in the database
-  //     const person = personFactory.build()
-  //     cy.task('stubPersonNotFound', { person })
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // And when I fill out the form with a CRN that is not found in the API
-  //     const booking = bookingFactory.build({ person })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // Then I should see the relevant error message
-  //     const page = Page.verifyOnPage(BookingNewPage, premises, room)
-  //     page.shouldShowCrnDoesNotExistErrorMessage()
-  //   })
-  //
-  //   it('shows errors when the API returns missing field errors', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and a person in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const person = personFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubFindPerson', { person })
-  //
-  //     // And there are no assessments in the database
-  //     cy.task('stubAssessments', { data: [] })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // And I miss required fields
-  //     bookingNewPage.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
-  //     returnedBookingNewPage.shouldShowErrorMessagesForFields(['crn', 'arrivalDate', 'departureDate'])
-  //   })
-  //
+
+  it('navigates to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and bookings in the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({ id: cas3Bedspace.id }),
+      })
+      .buildList(5)
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace: cas3Bedspace })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubBooking', { premisesId: premises.id, booking: bookings[0] })
+
+    // When I visit the show bedspace page
+    BedspaceShowPage.visit(premises, null, cas3Bedspace)
+
+    // todo: add everything below back in once CAS-1924 delivered
+    // Add I click the booking link
+    // bedspaceShowPage.clickBookingLink(bookings[0])
+
+    // Then I navigate to the booking page
+    // Page.verifyOnPage(BookingShowPage, premises, null, cas3Bedspace, bookings[0])
+  })
+
+  it('allows me to create a booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room and a person in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const person = personFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubFindPerson', { person })
+
+    // And there are assessments in the database
+    const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+    cy.task('stubAssessments', { data: assessmentSummaries })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // Then I should see the booking details
+    bookingNewPage.shouldShowBookingDetails()
+
+    // And when I fill out the form
+    const booking = bookingFactory.build({ person, assessmentId: assessmentSummaries[0].id })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // And I select an assessment
+    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, assessmentSummaries)
+    bookingSelectAssessmentPage.shouldDisplayAssessments()
+    bookingSelectAssessmentPage.selectAssessment(assessmentSummaries[0])
+
+    bookingSelectAssessmentPage.clickSubmit()
+
+    // And I confirm the booking
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, null, cas3Bedspace, person)
+    bookingConfirmPage.shouldShowBookingDetails()
+
+    cy.task('stubBookingCreate', { premisesId: premises.id, booking })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    bookingConfirmPage.clickSubmit()
+
+    // Then a booking should have been created in the API
+    cy.task('verifyBookingCreate', premises.id).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.service).equal('temporary-accommodation')
+      expect(requestBody.bedId).equal(cas3Bedspace.id)
+      expect(requestBody.crn).equal(newBooking.crn)
+      expect(requestBody.arrivalDate).equal(newBooking.arrivalDate)
+      expect(requestBody.departureDate).equal(newBooking.departureDate)
+      expect(requestBody.assessmentId).equal(newBooking.assessmentId)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, cas3Bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking created')
+  })
+
+  it('allows me to create a booking without linking an assessment', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room and a person in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    const person = personFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubFindPerson', { person })
+
+    // And there are assessments in the database
+    cy.task('stubAssessments', { data: [] })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // Then I should see the booking details
+    bookingNewPage.shouldShowBookingDetails()
+
+    // And when I fill out the form
+    const booking = bookingFactory.build({ person })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // And I do not select an assessment
+    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
+    bookingSelectAssessmentPage.clickSubmit()
+
+    // And I confirm the booking
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, null, cas3Bedspace, person)
+    bookingConfirmPage.shouldShowBookingDetails()
+
+    cy.task('stubBookingCreate', { premisesId: premises.id, booking })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    bookingConfirmPage.clickSubmit()
+
+    // Then a booking should have been created in the API
+    cy.task('verifyBookingCreate', premises.id).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.service).equal('temporary-accommodation')
+      expect(requestBody.bedId).equal(cas3Bedspace.id)
+      expect(requestBody.crn).equal(newBooking.crn)
+      expect(requestBody.arrivalDate).equal(newBooking.arrivalDate)
+      expect(requestBody.departureDate).equal(newBooking.departureDate)
+      expect(requestBody.assessmentId).equal(undefined)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, cas3Bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking created')
+  })
+
+  it('shows a suggested end date for the booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a room the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+
+    // When I visit the new booking page
+    const page = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And I enter a start date
+    page.completeDateInputs('arrivalDate', '2022-07-08')
+
+    // Then I should see a suggested end date
+    page.shouldShowEndDateHint('30/9/2022')
+  })
+
+  it('shows error when the API returns a person not found 404', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a room the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+
+    // And there is no person in the database
+    const person = personFactory.build()
+    cy.task('stubPersonNotFound', { person })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And when I fill out the form with a CRN that is not found in the API
+    const booking = bookingFactory.build({ person })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+    bookingNewPage.completeForm(newBooking)
+
+    // Then I should see the relevant error message
+    const page = Page.verifyOnPage(BookingNewPage, premises, null, cas3Bedspace)
+    page.shouldShowCrnDoesNotExistErrorMessage()
+  })
+
+  it('shows errors when the API returns missing field errors', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room and a person in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const person = personFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubFindPerson', { person })
+
+    // And there are no assessments in the database
+    cy.task('stubAssessments', { data: [] })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And I miss required fields
+    bookingNewPage.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, null, cas3Bedspace)
+    returnedBookingNewPage.shouldShowErrorMessagesForFields(['crn', 'arrivalDate', 'departureDate'])
+  })
+
   //   it('shows errors when the API returns a 409 Conflict with a void', () => {
   //     // Given I am signed in
   //     cy.signIn()
@@ -330,240 +337,245 @@ context('Booking', () => {
   //     returnedBookingNewPage.shouldShowDateConflictErrorMessages(conflictingLostBed, 'lost-bed')
   //   })
   //
-  //   it('shows errors when the API returns a 409 Conflict with the bedspace end date', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, and a room in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const person = personFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubFindPerson', { person })
-  //
-  //     // And there are no assessments in the database
-  //     cy.task('stubAssessments', { data: [] })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // And I fill out the form with dates that conflict with the bedspace end date
-  //     const booking = bookingFactory.build({
-  //       person,
-  //     })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // And I select no assessment
-  //     const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
-  //     bookingSelectAssessmentPage.clickSubmit()
-  //
-  //     // And I confirm the booking
-  //     const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, room, person)
-  //
-  //     cy.task('stubBookingCreateConflictError', {
-  //       premisesId: premises.id,
-  //       conflictingEntityId: '',
-  //       conflictingEntityType: 'bedspace-end-date',
-  //     })
-  //     bookingConfirmPage.clickSubmit()
-  //
-  //     // Then I should see error messages for the conflict
-  //     const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
-  //
-  //     returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
-  //     returnedBookingNewPage.shouldShowDateConflictErrorMessages(null, 'bedspace-end-date')
-  //   })
-  //
-  //   it('shows errors when the API returns a 403 Forbidden error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // And there is an inaccessible person in the database
-  //     const person = personFactory.build()
-  //     cy.task('stubFindPersonForbidden', { person })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // And I fill out the form with a CRN the user does not have permission to access
-  //     const booking = bookingFactory.build({
-  //       person,
-  //     })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // Then I should see error messages for the date fields
-  //     bookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
-  //     bookingNewPage.shouldShowUserPermissionErrorMessage()
-  //   })
-  //
-  //   it('shows errors when no assessment is seleced', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and a person in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const person = personFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubFindPerson', { person })
-  //
-  //     // And there are assessments in the database
-  //     const assessmentSummaries = assessmentSummaryFactory.buildList(5)
-  //     cy.task('stubAssessments', { data: assessmentSummaries })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // And when I fill out the form
-  //     const booking = bookingFactory.build({ person })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // And I do not select an assessment
-  //     const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, assessmentSummaries)
-  //     bookingSelectAssessmentPage.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     const revisitedBookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, assessmentSummaries)
-  //     revisitedBookingSelectAssessmentPage.shouldShowErrorMessagesForFields(['assessmentId'])
-  //   })
-  //
-  //   it('navigates back from the new booking page to the show bedspace page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // When I visit the new booking page
-  //     const page = BookingNewPage.visit(premises, room)
-  //
-  //     // And I click the previous bread crumb
-  //     page.clickBreadCrumbUp()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BedspaceShowPage, premises, room)
-  //   })
-  //
-  //   it('navigates back from the confirm booking page to the new booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and a person in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const person = personFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubFindPerson', { person })
-  //
-  //     // And there are no assessments in the database
-  //     cy.task('stubAssessments', { data: [] })
-  //
-  //     // When I visit the new booking page
-  //     const bookingNewPage = BookingNewPage.visit(premises, room)
-  //
-  //     // And I fill out the form
-  //     const booking = bookingFactory.build({ person })
-  //     const newBooking = newBookingFactory.build({
-  //       ...booking,
-  //       crn: booking.person.crn,
-  //     })
-  //
-  //     bookingNewPage.completeForm(newBooking)
-  //
-  //     // And I select no assessment
-  //     const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
-  //     bookingSelectAssessmentPage.clickSubmit()
-  //
-  //     // And I click the back link on the confirm booking page
-  //     const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, room, person)
-  //     bookingConfirmPage.clickBack()
-  //
-  //     // Add I click the back link on the select assessment page
-  //     const revisitedBookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
-  //     revisitedBookingSelectAssessmentPage.clickBack()
-  //
-  //     // Then I navigate to the new booking page
-  //     const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, room)
-  //     returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
-  //   })
-  //
-  //   it('shows a single booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a booking in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const booking = bookingFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubBooking', { premisesId: premises.id, booking })
-  //
-  //     // When I visit the show booking page
-  //     const page = BookingShowPage.visit(premises, room, booking)
-  //
-  //     // Then I should see the booking details
-  //     page.shouldShowBookingDetails()
-  //   })
-  //
-  //   it('navigates back from the show booking page to the show bedspace page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and bookings in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const bookings = bookingFactory
-  //       .params({
-  //         bed: room.beds[0],
-  //       })
-  //       .buildList(5)
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
-  //     cy.task('stubBooking', { premisesId: premises.id, booking: bookings[0] })
-  //
-  //     // When I visit the show booking page
-  //     const page = BookingShowPage.visit(premises, room, bookings[0])
-  //
-  //     // And I click the previous bread crumb
-  //     page.clickBreadCrumbUp()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BedspaceShowPage, premises, room)
-  //  })
+
+  it('shows errors when the API returns a 409 Conflict with the bedspace end date', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, and a room in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const person = personFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubFindPerson', { person })
+
+    // And there are no assessments in the database
+    cy.task('stubAssessments', { data: [] })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And I fill out the form with dates that conflict with the bedspace end date
+    const booking = bookingFactory.build({
+      person,
+    })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // And I select no assessment
+    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
+    bookingSelectAssessmentPage.clickSubmit()
+
+    // And I confirm the booking
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, null, cas3Bedspace, person)
+
+    cy.task('stubBookingCreateConflictError', {
+      premisesId: premises.id,
+      conflictingEntityId: '',
+      conflictingEntityType: 'bedspace-end-date',
+    })
+    bookingConfirmPage.clickSubmit()
+
+    // Then I should see error messages for the conflict
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, null, cas3Bedspace)
+
+    returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
+    returnedBookingNewPage.shouldShowDateConflictErrorMessages(null, 'bedspace-end-date')
+  })
+
+  it('shows errors when the API returns a 403 Forbidden error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a room the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+
+    // And there is an inaccessible person in the database
+    const person = personFactory.build()
+    cy.task('stubFindPersonForbidden', { person })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And I fill out the form with a CRN the user does not have permission to access
+    const booking = bookingFactory.build({
+      person,
+    })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // Then I should see error messages for the date fields
+    bookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
+    bookingNewPage.shouldShowUserPermissionErrorMessage()
+  })
+
+  it('shows errors when no assessment is seleced', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room and a person in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const person = personFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubFindPerson', { person })
+
+    // And there are assessments in the database
+    const assessmentSummaries = assessmentSummaryFactory.buildList(5)
+    cy.task('stubAssessments', { data: assessmentSummaries })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And when I fill out the form
+    const booking = bookingFactory.build({ person })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // And I do not select an assessment
+    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, assessmentSummaries)
+    bookingSelectAssessmentPage.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    const revisitedBookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, assessmentSummaries)
+    revisitedBookingSelectAssessmentPage.shouldShowErrorMessagesForFields(['assessmentId'])
+  })
+
+  it('navigates back from the new booking page to the show bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a room the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubSinglePremisesV2', cas3Premises)
+
+    // When I visit the new booking page
+    const page = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BedspaceShowPage, premises, null, cas3Bedspace, cas3Bedspace.reference)
+  })
+
+  it('navigates back from the confirm booking page to the new booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room and a person in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const person = personFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubFindPerson', { person })
+
+    // And there are no assessments in the database
+    cy.task('stubAssessments', { data: [] })
+
+    // When I visit the new booking page
+    const bookingNewPage = BookingNewPage.visit(premises, null, cas3Bedspace)
+
+    // And I fill out the form
+    const booking = bookingFactory.build({ person })
+    const newBooking = newBookingFactory.build({
+      ...booking,
+      crn: booking.person.crn,
+    })
+
+    bookingNewPage.completeForm(newBooking)
+
+    // And I select no assessment
+    const bookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
+    bookingSelectAssessmentPage.clickSubmit()
+
+    // And I click the back link on the confirm booking page
+    const bookingConfirmPage = Page.verifyOnPage(BookingConfirmPage, premises, null, cas3Bedspace, person)
+    bookingConfirmPage.clickBack()
+
+    // Add I click the back link on the select assessment page
+    const revisitedBookingSelectAssessmentPage = Page.verifyOnPage(BookingSelectAssessmentPage, [])
+    revisitedBookingSelectAssessmentPage.clickBack()
+
+    // Then I navigate to the new booking page
+    const returnedBookingNewPage = Page.verifyOnPage(BookingNewPage, premises, null, cas3Bedspace)
+    returnedBookingNewPage.shouldShowPrefilledBookingDetails(newBooking)
+  })
+
+  it('shows a single booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a booking in the database
+    const premises = premisesFactory.build()
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const booking = bookingFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubBooking', { premisesId: premises.id, booking })
+
+    // When I visit the show booking page
+    const page = BookingShowPage.visit(premises, null, cas3Bedspace, booking)
+
+    // Then I should see the booking details
+    page.shouldShowBookingDetails()
+  })
+
+  it('navigates back from the show booking page to the show bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and bookings in the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const cas3Bedspace = cas3BedspaceFactory.build({ status: 'online' })
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({ id: cas3Bedspace.id }),
+      })
+      .buildList(5)
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace: cas3Bedspace })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubBooking', { premisesId: premises.id, booking: bookings[0] })
+
+    // When I visit the show booking page
+    const page = BookingShowPage.visit(premises, null, cas3Bedspace, bookings[0])
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BedspaceShowPage, premises, null, cas3Bedspace, cas3Bedspace.reference)
+  })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/bookingSearch.cy.ts
@@ -1,11 +1,11 @@
-// import type { BookingSearchApiStatus } from '@approved-premises/ui'
-// import { BookingSearchResult } from '@approved-premises/api'
-// import Page from '../../../../cypress_shared/pages/page'
-// import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
-// import BookingSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSearch'
+import type { BookingSearchApiStatus } from '@approved-premises/ui'
+import { BookingSearchResult } from '@approved-premises/api'
+import Page from '../../../../cypress_shared/pages/page'
+import DashboardPage from '../../../../cypress_shared/pages/temporary-accommodation/dashboardPage'
+import BookingSearchPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingSearch'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import { bookingSearchResultFactory, bookingSearchResultsFactory } from '../../../../server/testutils/factories/index'
-// import { MockPagination } from '../../../mockApis/bookingSearch'
+import { bookingSearchResultFactory, bookingSearchResultsFactory } from '../../../../server/testutils/factories/index'
+import { MockPagination } from '../../../mockApis/bookingSearch'
 
 context('Booking search', () => {
   beforeEach(() => {
@@ -16,286 +16,286 @@ context('Booking search', () => {
   it('navigates to the find a provisional booking page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there are bookings in the database
-    //     const { data: bookings } = bookingSearchResultsFactory.build()
-    //
-    //     cy.task('stubFindBookings', { bookings, status: 'provisional' })
-    //
-    //     // When I visit the dashboard
-    //     const dashboard = DashboardPage.visit()
-    //
-    //     // And I click the View all bookings tile
-    //     dashboard.clickViewBookingsLink()
-    //
-    //     // Then I navigate to the Find a provisional booking page
-    //     const page = Page.verifyOnPage(BookingSearchPage)
-    //     page.checkBookingStatus('provisional')
+
+    // And there are bookings in the database
+    const { data: bookings } = bookingSearchResultsFactory.build()
+
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
+
+    // When I visit the dashboard
+    const dashboard = DashboardPage.visit()
+
+    // And I click the View all bookings tile
+    dashboard.clickViewBookingsLink()
+
+    // Then I navigate to the Find a provisional booking page
+    const page = Page.verifyOnPage(BookingSearchPage)
+    page.checkBookingStatus('provisional')
   })
-  //
-  //   it('navigates to the view bookings pages for each status', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there are bookings of all relevant status types in the database
-  //     const { data: bookings } = bookingSearchResultsFactory.build()
-  //
-  //     const statuses: Array<BookingSearchApiStatus> = ['provisional', 'arrived', 'departed', 'confirmed', 'closed']
-  //
-  //     statuses.forEach(status => {
-  //       cy.task('stubFindBookings', { bookings, status })
-  //     })
-  //
-  //     // And I visit the Find a provisional booking page
-  //     const page = BookingSearchPage.visit('provisional')
-  //
-  //     // And I click the Confirmed bookings link
-  //     page.clickOtherBookingStatusLink('confirmed')
-  //
-  //     // Then I navigate to the Find a confirmed booking page
-  //     page.checkBookingStatus('confirmed')
-  //
-  //     // And I click the Active bookings link
-  //     page.clickOtherBookingStatusLink('arrived')
-  //
-  //     // Then I navigate to the Find an active booking page
-  //     page.checkBookingStatus('arrived')
-  //
-  //     // And I click the Departed bookings link
-  //     page.clickOtherBookingStatusLink('departed')
-  //
-  //     // Then I navigate to the Find a departed booking page
-  //     page.checkBookingStatus('departed')
-  //   })
-  //
-  //   it('orders the results', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there are bookings in the database
-  //     const { data: bookings } = bookingSearchResultsFactory.build()
-  //     cy.task('stubFindBookings', { bookings, status: 'provisional' })
-  //     cy.task('stubFindBookings', { bookings, status: 'provisional', params: { sortBy: 'startDate' } })
-  //     cy.task('stubFindBookings', {
-  //       bookings,
-  //       status: 'provisional',
-  //       params: { sortBy: 'startDate', sortDirection: 'asc' },
-  //     })
-  //
-  //     // When I visit the Find a provisional booking page
-  //     const page = BookingSearchPage.visit('provisional')
-  //
-  //     // Then I see the results are ordered by End date descending
-  //     page.checkColumnOrder('End date', 'descending')
-  //
-  //     // When I order results by start date
-  //     page.sortColumn('Start date')
-  //
-  //     // Then I see the results are ordered by start date ascending
-  //     page.shouldHaveURLSearchParam('sortBy=startDate')
-  //     page.checkColumnOrder('Start date', 'ascending')
-  //
-  //     // When I order the results by start date again
-  //     page.sortColumn('Start date')
-  //
-  //     // Then I see the results are ordered by start date descending
-  //     page.shouldHaveURLSearchParam('sortBy=startDate&sortDirection=desc')
-  //     page.checkColumnOrder('Start date', 'descending')
-  //   })
-  //
-  //   it('shows the result of a crn or name search and clears the search', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there are bookings in the database
-  //     const { data: bookings } = bookingSearchResultsFactory.build()
-  //     const searchedForBooking = bookings[2]
-  //     const searchCrnOrName = searchedForBooking.person.crn
-  //
-  //     cy.task('stubFindBookings', { bookings, status: 'provisional' })
-  //     cy.task('stubFindBookings', {
-  //       bookings: [searchedForBooking],
-  //       status: 'provisional',
-  //       params: { crnOrName: searchCrnOrName },
-  //     })
-  //
-  //     // When I visit the Find a provisional booking page
-  //     const page = BookingSearchPage.visit('provisional')
-  //
-  //     // Then the search by CRN form is empty
-  //     page.checkCrnOrNameSearchValue('', 'provisional')
-  //
-  //     // And I see all the results
-  //     page.checkResults(bookings)
-  //
-  //     // When I submit a search by CRN or Name
-  //     page.searchByCrnOrName(searchCrnOrName, 'provisional')
-  //     Page.verifyOnPage(BookingSearchPage, 'provisional')
-  //
-  //     // Then the search by CRN or Name form is populated
-  //     page.checkCrnOrNameSearchValue(searchCrnOrName, 'provisional')
-  //
-  //     // Then I see the search result for that CRN
-  //     page.checkResults([searchedForBooking])
-  //
-  //     // When I clear the search
-  //     page.clearSearch()
-  //
-  //     Page.verifyOnPage(BookingSearchPage, 'provisional')
-  //
-  //     // Then the search by CRN or Name form is populated
-  //     page.checkCrnOrNameSearchValue('', 'provisional')
-  //
-  //     // Then I see the search result for that CRN or Name
-  //     page.checkResults(bookings)
-  //   })
-  //
-  //   it('shows a message if there are no CRN or Name search results', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there are no bookings matching a CRN or Name search in the database
-  //     const { data: bookings } = bookingSearchResultsFactory.build()
-  //     const noBookings: BookingSearchResult[] = []
-  //
-  //     cy.task('stubFindBookings', { bookings, status: 'confirmed' })
-  //     cy.task('stubFindBookings', { bookings: noBookings, status: 'confirmed', params: { crnOrName: 'N0M4TCH' } })
-  //
-  //     // When I visit the Find a provisional booking page
-  //     const page = BookingSearchPage.visit('confirmed')
-  //
-  //     // Then the search by CRN form is empty
-  //     page.checkCrnOrNameSearchValue('', 'confirmed')
-  //
-  //     // And I see all the results
-  //     page.checkResults(bookings)
-  //
-  //     // When I submit a search by CRN
-  //     page.searchByCrnOrName('N0M4TCH', 'confirmed')
-  //     Page.verifyOnPage(BookingSearchPage, 'confirmed')
-  //
-  //     // Then the search by CRN form is populated
-  //     page.checkCrnOrNameSearchValue('N0M4TCH', 'confirmed')
-  //
-  //     // Then I see no search results for that CRN
-  //     page.checkResults(noBookings)
-  //
-  //     // And I see a message
-  //     page.checkNoResultsByCRN('confirmed', 'N0M4TCH')
-  //   })
-  //
-  //   it('retains the CRN search when ordering, paginating and navigating between booking types', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there are bookings in the database
-  //     const bookings = bookingSearchResultFactory.buildList(23)
-  //     const pagination: MockPagination = {
-  //       totalResults: 76,
-  //       totalPages: 8,
-  //       pageNumber: 1,
-  //       pageSize: 10,
-  //     }
-  //
-  //     ;['confirmed', 'arrived', 'departed'].forEach(status => {
-  //       cy.task('stubFindBookings', { bookings, status })
-  //       cy.task('stubFindBookings', { bookings, status, params: { crnOrName: 'X321654' } })
-  //     })
-  //
-  //     cy.task('stubFindBookings', { bookings, status: 'provisional', pagination })
-  //     cy.task('stubFindBookings', { bookings, status: 'provisional', params: { crnOrName: 'X321654' }, pagination })
-  //     cy.task('stubFindBookings', {
-  //       bookings,
-  //       status: 'provisional',
-  //       params: { crnOrName: 'X321654', sortBy: 'endDate', sortDirection: 'asc' },
-  //       pagination,
-  //     })
-  //     cy.task('stubFindBookings', {
-  //       bookings,
-  //       status: 'provisional',
-  //       params: { crnOrName: 'X321654', sortBy: 'endDate', sortDirection: 'asc', page: 2 },
-  //       pagination: {
-  //         ...pagination,
-  //         pageNumber: 2,
-  //       },
-  //     })
-  //
-  //     // When I visit the Find a provisional booking page
-  //     const page = BookingSearchPage.visit('provisional')
-  //
-  //     // And I submit a search by CRN or Name
-  //     page.searchByCrnOrName('X321654', 'provisional')
-  //
-  //     // Then I see the provisional bookings for the given CRN or Name
-  //     Page.verifyOnPage(BookingSearchPage, 'provisional')
-  //     page.checkCrnOrNameSearchValue('X321654', 'provisional')
-  //
-  //     // When I order by end date
-  //     page.sortColumn('End date')
-  //
-  //     // Then I see the provisional bookings for the given CRN or Name
-  //     page.checkCrnOrNameSearchValue('X321654', 'provisional')
-  //
-  //     // And I see the results are ordered by end date ascending
-  //     page.shouldHaveURLSearchParam('sortBy=endDate&sortDirection=asc')
-  //     page.checkColumnOrder('End date', 'ascending')
-  //
-  //     // When I navigate to the second page of results
-  //     page.clickPaginationLink(2)
-  //
-  //     // Then I see the second page of provisional bookings for the given CRN or Name
-  //     page.shouldHaveURLSearchParam('page=2')
-  //     page.checkCrnOrNameSearchValue('X321654', 'provisional')
-  //
-  //     // And I see the results are ordered by end date ascending
-  //     page.shouldHaveURLSearchParam('sortBy=endDate&sortDirection=asc')
-  //     page.checkColumnOrder('End date', 'ascending')
-  //
-  //     // When I navigate to the confirmed bookings search
-  //     page.clickOtherBookingStatusLink('confirmed')
-  //
-  //     // Then I see the confirmed bookings for the given CRN or Name
-  //     Page.verifyOnPage(BookingSearchPage, 'confirmed')
-  //     page.checkCrnOrNameSearchValue('X321654', 'confirmed')
-  //
-  //     // When I navigate to the active bookings search
-  //     page.clickOtherBookingStatusLink('arrived')
-  //
-  //     // Then I see the active bookings for the given CRN or Name
-  //     Page.verifyOnPage(BookingSearchPage, 'arrived')
-  //     page.checkCrnOrNameSearchValue('X321654', 'active')
-  //
-  //     // When I navigate to the departed bookings search
-  //     page.clickOtherBookingStatusLink('departed')
-  //
-  //     // Then I see the departed bookings for the given CRN or Name
-  //     Page.verifyOnPage(BookingSearchPage, 'departed')
-  //     page.checkCrnOrNameSearchValue('X321654', 'departed')
-  //
-  //     // When I navigate to the provisional bookings search
-  //     page.clickOtherBookingStatusLink('provisional')
-  //
-  //     // Then I see the provisional bookings for the given CRN or Name
-  //     Page.verifyOnPage(BookingSearchPage, 'provisional')
-  //     page.checkCrnOrNameSearchValue('X321654', 'provisional')
-  //   })
-  //
-  //   it('navigates back to the dashboard from the view bookings page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there are bookings in the database
-  //     const { data: bookings } = bookingSearchResultsFactory.build()
-  //
-  //     cy.task('stubFindBookings', { bookings, status: 'provisional' })
-  //
-  //     // When I visit the View bookings page
-  //     const page = BookingSearchPage.visit('provisional')
-  //
-  //     // And I click the previous bread crumb
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the Dashboard page
-  //     Page.verifyOnPage(DashboardPage)
-  //   })
+
+  it('navigates to the view bookings pages for each status', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings of all relevant status types in the database
+    const { data: bookings } = bookingSearchResultsFactory.build()
+
+    const statuses: Array<BookingSearchApiStatus> = ['provisional', 'arrived', 'departed', 'confirmed', 'closed']
+
+    statuses.forEach(status => {
+      cy.task('stubFindBookings', { bookings, status })
+    })
+
+    // And I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // And I click the Confirmed bookings link
+    page.clickOtherBookingStatusLink('confirmed')
+
+    // Then I navigate to the Find a confirmed booking page
+    page.checkBookingStatus('confirmed')
+
+    // And I click the Active bookings link
+    page.clickOtherBookingStatusLink('arrived')
+
+    // Then I navigate to the Find an active booking page
+    page.checkBookingStatus('arrived')
+
+    // And I click the Departed bookings link
+    page.clickOtherBookingStatusLink('departed')
+
+    // Then I navigate to the Find a departed booking page
+    page.checkBookingStatus('departed')
+  })
+
+  it('orders the results', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const { data: bookings } = bookingSearchResultsFactory.build()
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
+    cy.task('stubFindBookings', { bookings, status: 'provisional', params: { sortBy: 'startDate' } })
+    cy.task('stubFindBookings', {
+      bookings,
+      status: 'provisional',
+      params: { sortBy: 'startDate', sortDirection: 'asc' },
+    })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // Then I see the results are ordered by End date descending
+    page.checkColumnOrder('End date', 'descending')
+
+    // When I order results by start date
+    page.sortColumn('Start date')
+
+    // Then I see the results are ordered by start date ascending
+    page.shouldHaveURLSearchParam('sortBy=startDate')
+    page.checkColumnOrder('Start date', 'ascending')
+
+    // When I order the results by start date again
+    page.sortColumn('Start date')
+
+    // Then I see the results are ordered by start date descending
+    page.shouldHaveURLSearchParam('sortBy=startDate&sortDirection=desc')
+    page.checkColumnOrder('Start date', 'descending')
+  })
+
+  it('shows the result of a crn or name search and clears the search', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const { data: bookings } = bookingSearchResultsFactory.build()
+    const searchedForBooking = bookings[2]
+    const searchCrnOrName = searchedForBooking.person.crn
+
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
+    cy.task('stubFindBookings', {
+      bookings: [searchedForBooking],
+      status: 'provisional',
+      params: { crnOrName: searchCrnOrName },
+    })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // Then the search by CRN form is empty
+    page.checkCrnOrNameSearchValue('', 'provisional')
+
+    // And I see all the results
+    page.checkResults(bookings)
+
+    // When I submit a search by CRN or Name
+    page.searchByCrnOrName(searchCrnOrName, 'provisional')
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+
+    // Then the search by CRN or Name form is populated
+    page.checkCrnOrNameSearchValue(searchCrnOrName, 'provisional')
+
+    // Then I see the search result for that CRN
+    page.checkResults([searchedForBooking])
+
+    // When I clear the search
+    page.clearSearch()
+
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+
+    // Then the search by CRN or Name form is populated
+    page.checkCrnOrNameSearchValue('', 'provisional')
+
+    // Then I see the search result for that CRN or Name
+    page.checkResults(bookings)
+  })
+
+  it('shows a message if there are no CRN or Name search results', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are no bookings matching a CRN or Name search in the database
+    const { data: bookings } = bookingSearchResultsFactory.build()
+    const noBookings: BookingSearchResult[] = []
+
+    cy.task('stubFindBookings', { bookings, status: 'confirmed' })
+    cy.task('stubFindBookings', { bookings: noBookings, status: 'confirmed', params: { crnOrName: 'N0M4TCH' } })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('confirmed')
+
+    // Then the search by CRN form is empty
+    page.checkCrnOrNameSearchValue('', 'confirmed')
+
+    // And I see all the results
+    page.checkResults(bookings)
+
+    // When I submit a search by CRN
+    page.searchByCrnOrName('N0M4TCH', 'confirmed')
+    Page.verifyOnPage(BookingSearchPage, 'confirmed')
+
+    // Then the search by CRN form is populated
+    page.checkCrnOrNameSearchValue('N0M4TCH', 'confirmed')
+
+    // Then I see no search results for that CRN
+    page.checkResults(noBookings)
+
+    // And I see a message
+    page.checkNoResultsByCRN('confirmed', 'N0M4TCH')
+  })
+
+  it('retains the CRN search when ordering, paginating and navigating between booking types', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const bookings = bookingSearchResultFactory.buildList(23)
+    const pagination: MockPagination = {
+      totalResults: 76,
+      totalPages: 8,
+      pageNumber: 1,
+      pageSize: 10,
+    }
+
+    ;['confirmed', 'arrived', 'departed'].forEach(status => {
+      cy.task('stubFindBookings', { bookings, status })
+      cy.task('stubFindBookings', { bookings, status, params: { crnOrName: 'X321654' } })
+    })
+
+    cy.task('stubFindBookings', { bookings, status: 'provisional', pagination })
+    cy.task('stubFindBookings', { bookings, status: 'provisional', params: { crnOrName: 'X321654' }, pagination })
+    cy.task('stubFindBookings', {
+      bookings,
+      status: 'provisional',
+      params: { crnOrName: 'X321654', sortBy: 'endDate', sortDirection: 'asc' },
+      pagination,
+    })
+    cy.task('stubFindBookings', {
+      bookings,
+      status: 'provisional',
+      params: { crnOrName: 'X321654', sortBy: 'endDate', sortDirection: 'asc', page: 2 },
+      pagination: {
+        ...pagination,
+        pageNumber: 2,
+      },
+    })
+
+    // When I visit the Find a provisional booking page
+    const page = BookingSearchPage.visit('provisional')
+
+    // And I submit a search by CRN or Name
+    page.searchByCrnOrName('X321654', 'provisional')
+
+    // Then I see the provisional bookings for the given CRN or Name
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
+
+    // When I order by end date
+    page.sortColumn('End date')
+
+    // Then I see the provisional bookings for the given CRN or Name
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
+
+    // And I see the results are ordered by end date ascending
+    page.shouldHaveURLSearchParam('sortBy=endDate&sortDirection=asc')
+    page.checkColumnOrder('End date', 'ascending')
+
+    // When I navigate to the second page of results
+    page.clickPaginationLink(2)
+
+    // Then I see the second page of provisional bookings for the given CRN or Name
+    page.shouldHaveURLSearchParam('page=2')
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
+
+    // And I see the results are ordered by end date ascending
+    page.shouldHaveURLSearchParam('sortBy=endDate&sortDirection=asc')
+    page.checkColumnOrder('End date', 'ascending')
+
+    // When I navigate to the confirmed bookings search
+    page.clickOtherBookingStatusLink('confirmed')
+
+    // Then I see the confirmed bookings for the given CRN or Name
+    Page.verifyOnPage(BookingSearchPage, 'confirmed')
+    page.checkCrnOrNameSearchValue('X321654', 'confirmed')
+
+    // When I navigate to the active bookings search
+    page.clickOtherBookingStatusLink('arrived')
+
+    // Then I see the active bookings for the given CRN or Name
+    Page.verifyOnPage(BookingSearchPage, 'arrived')
+    page.checkCrnOrNameSearchValue('X321654', 'active')
+
+    // When I navigate to the departed bookings search
+    page.clickOtherBookingStatusLink('departed')
+
+    // Then I see the departed bookings for the given CRN or Name
+    Page.verifyOnPage(BookingSearchPage, 'departed')
+    page.checkCrnOrNameSearchValue('X321654', 'departed')
+
+    // When I navigate to the provisional bookings search
+    page.clickOtherBookingStatusLink('provisional')
+
+    // Then I see the provisional bookings for the given CRN or Name
+    Page.verifyOnPage(BookingSearchPage, 'provisional')
+    page.checkCrnOrNameSearchValue('X321654', 'provisional')
+  })
+
+  it('navigates back to the dashboard from the view bookings page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there are bookings in the database
+    const { data: bookings } = bookingSearchResultsFactory.build()
+
+    cy.task('stubFindBookings', { bookings, status: 'provisional' })
+
+    // When I visit the View bookings page
+    const page = BookingSearchPage.visit('provisional')
+
+    // And I click the previous bread crumb
+    page.clickBack()
+
+    // Then I navigate to the Dashboard page
+    Page.verifyOnPage(DashboardPage)
+  })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/history.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/history.cy.ts
@@ -1,10 +1,10 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BookingHistoryPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingHistory'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-// import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingHistoryPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingHistory'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import { bookingFactory } from '../../../../server/testutils/factories'
-// import { deriveBookingHistory } from '../../../../server/utils/bookingUtils'
+import { bookingFactory } from '../../../../server/testutils/factories'
+import { deriveBookingHistory } from '../../../../server/utils/bookingUtils'
 
 context('Booking history', () => {
   beforeEach(() => {
@@ -16,66 +16,69 @@ context('Booking history', () => {
     // Given I am signed in
     cy.signIn()
 
-    //     // And there is a premises, a room, and a booking in the database
-    //     const booking = bookingFactory.build()
-    //     const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //     // When I visit the show booking page
-    //     const bookingShowPage = BookingShowPage.visit(premises, room, booking)
-    //
-    //     // Add I click the history link
-    //     bookingShowPage.clickHistoryLink()
-    //
-    //     // Then I navigate to the booking page
-    //     Page.verifyOnPage(
-    //       BookingHistoryPage,
-    //       premises,
-    //       room,
-    //       booking,
-    //       deriveBookingHistory(booking).map(({ booking: historicBooking }) => historicBooking),
-    //     )
+    // And there is a premises, a room, and a booking in the database
+    const booking = bookingFactory.build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShowPage = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the history link
+    bookingShowPage.clickHistoryLink()
+
+    // Then I navigate to the booking page
+    Page.verifyOnPage(
+      BookingHistoryPage,
+      premises,
+      null,
+      bedspace,
+      booking,
+      deriveBookingHistory(booking).map(({ booking: historicBooking }) => historicBooking),
+    )
   })
 
-  //   it('shows booking history page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a booking in the database
-  //     const booking = bookingFactory.build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking history page
-  //     const bookingHistoryPage = BookingHistoryPage.visit(
-  //       premises,
-  //       room,
-  //       booking,
-  //       deriveBookingHistory(booking).map(({ booking: historicBooking }) => historicBooking),
-  //     )
-  //
-  //     // It shows booking history
-  //     bookingHistoryPage.shouldShowBookingHistory()
-  //   })
-  //
-  //   it('navigates back from the booking history page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a booking in the database
-  //     const booking = bookingFactory.build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking history page
-  //     const bookingHistoryPage = BookingHistoryPage.visit(
-  //       premises,
-  //       room,
-  //       booking,
-  //       deriveBookingHistory(booking).map(({ booking: historicBooking }) => historicBooking),
-  //     )
-  //
-  //     // And I click the back link
-  //     bookingHistoryPage.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
+  it('shows booking history page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a booking in the database
+    const booking = bookingFactory.build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking history page
+    const bookingHistoryPage = BookingHistoryPage.visit(
+      premises,
+      null,
+      bedspace,
+      booking,
+      deriveBookingHistory(booking).map(({ booking: historicBooking }) => historicBooking),
+    )
+
+    // It shows booking history
+    bookingHistoryPage.shouldShowBookingHistory()
+  })
+
+  it('navigates back from the booking history page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a booking in the database
+    const booking = bookingFactory.build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking history page
+    const bookingHistoryPage = BookingHistoryPage.visit(
+      premises,
+      null,
+      bedspace,
+      booking,
+      deriveBookingHistory(booking).map(({ booking: historicBooking }) => historicBooking),
+    )
+
+    // And I click the back link
+    bookingHistoryPage.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
 })

--- a/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.test.ts
@@ -1,20 +1,21 @@
 import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
+import { fakerEN_GB as faker } from '@faker-js/faker'
 import { BespokeError } from '../../../@types/ui'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { AssessmentsService, BookingService, PersonService, PremisesService } from '../../../services'
-import BedspaceService from '../../../services/bedspaceService'
+import BedspaceService from '../../../services/v2/bedspaceService'
 import {
   applicationFactory,
   assessmentFactory,
   assessmentSummaryFactory,
   bookingFactory,
+  cas3BedspaceFactory,
   newBookingFactory,
   personFactory,
   placeContextFactory,
   premisesFactory,
-  roomFactory,
 } from '../../../testutils/factories'
 import {
   assessmentRadioItems,
@@ -46,7 +47,7 @@ jest.mock('../../../utils/placeUtils')
 describe('BookingsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
-  const roomId = 'roomId'
+  const bedspaceId = 'bedspaceId'
   const backLink = 'some-back-link'
   const assessmentId = 'some-assessment-id'
   const radioItems = [{ text: 'Some text', value: 'some-value' }]
@@ -82,17 +83,20 @@ describe('BookingsController', () => {
     it('renders the form', async () => {
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: 'some-crn',
       }
 
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({
+        id: bedspaceId,
+        endDate: DateFormats.dateObjToIsoDate(faker.date.future({ years: 1 })),
+      })
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
 
       const requestHandler = bookingsController.new()
       ;(fetchErrorsAndUserInput as jest.Mock).mockReturnValue({ errors: {}, errorSummary: [] })
@@ -100,12 +104,12 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premisesId)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premisesId, roomId)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premisesId, bedspaceId)
       expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/new', {
         premises,
-        room,
+        bedspace,
         bedspaceStatus: {
           rows: [
             {
@@ -117,7 +121,7 @@ describe('BookingsController', () => {
             {
               key: 'Bedspace end date',
               value: {
-                text: DateFormats.isoDateToUIDate(room.beds[0].bedEndDate),
+                text: DateFormats.isoDateToUIDate(bedspace.endDate),
               },
             },
           ],
@@ -131,12 +135,12 @@ describe('BookingsController', () => {
     it('prefills the arrival date and CRN if present in a place context', async () => {
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {}
 
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const placeContext = placeContextFactory.build({
         arrivalDate: '2024-02-01',
         assessment: assessmentFactory.build({
@@ -147,7 +151,7 @@ describe('BookingsController', () => {
       })
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       ;(preservePlaceContext as jest.MockedFunction<typeof preservePlaceContext>).mockResolvedValue(placeContext)
 
       const requestHandler = bookingsController.new()
@@ -173,7 +177,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -195,14 +199,11 @@ describe('BookingsController', () => {
       expect(personService.findByCrn).toHaveBeenCalledWith(callConfig, newBooking.crn)
       expect(assessmentRadioItems).toHaveBeenCalledWith(assessmentSummaries)
       expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
-      expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId, bedspaceId: roomId }),
-        request.query,
-      )
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.query)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/selectAssessment', {
         premisesId,
-        roomId,
+        bedspaceId,
         applyDisabled: false,
         assessmentRadioItems: radioItems,
         crn: newBooking.crn,
@@ -223,7 +224,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -243,7 +244,7 @@ describe('BookingsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/selectAssessment', {
         premisesId,
-        roomId,
+        bedspaceId,
         applyDisabled: true,
         assessmentRadioItems: radioItems,
         crn: newBooking.crn,
@@ -262,7 +263,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -282,7 +283,7 @@ describe('BookingsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/selectAssessment', {
         premisesId,
-        roomId,
+        bedspaceId,
         applyDisabled: false,
         assessmentRadioItems: radioItems,
         crn: newBooking.crn,
@@ -310,7 +311,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -395,7 +396,7 @@ describe('BookingsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
         }
         request.query = query
 
@@ -407,10 +408,7 @@ describe('BookingsController', () => {
 
         await requestHandler(request, response, next)
 
-        expect(appendQueryString).toHaveBeenCalledWith(
-          paths.bookings.new({ premisesId, bedspaceId: roomId }),
-          request.query,
-        )
+        expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.query)
         expect(insertGenericError).toHaveBeenCalledWith(new Error(), errorProperty, errorType)
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, new Error(), backLink)
       },
@@ -421,7 +419,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -440,10 +438,7 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId, bedspaceId: roomId }),
-        request.query,
-      )
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.query)
       expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'doesNotExist')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
     })
@@ -453,7 +448,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -472,10 +467,7 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId, bedspaceId: roomId }),
-        request.query,
-      )
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.query)
       expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'userPermission')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
     })
@@ -491,7 +483,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: 'some-other-crn',
@@ -518,12 +510,12 @@ describe('BookingsController', () => {
     it('renders the confirmation page', async () => {
       const newBooking = newBookingFactory.build()
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const person = personFactory.build()
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -533,7 +525,7 @@ describe('BookingsController', () => {
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       personService.findByCrn.mockResolvedValue(person)
       ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
 
@@ -542,16 +534,16 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premisesId)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premisesId, roomId)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premisesId, bedspaceId)
       expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
       expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId: room.id }),
+        paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId }),
         request.query,
       )
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/confirm', {
         premises,
-        room,
+        bedspace,
         person,
         crn: newBooking.crn,
         ...DateFormats.isoToDateAndTimeInputs(newBooking.arrivalDate, 'arrivalDate'),
@@ -570,10 +562,10 @@ describe('BookingsController', () => {
       const requestHandler = bookingsController.confirm()
 
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
 
       const err = { status: 404 }
@@ -584,7 +576,7 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId: premises.id, bedspaceId: room.id }),
+        paths.bookings.new({ premisesId: premises.id, bedspaceId }),
         request.query,
       )
       expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'doesNotExist')
@@ -600,10 +592,10 @@ describe('BookingsController', () => {
       const requestHandler = bookingsController.confirm()
 
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
 
       const err = { status: 403 }
@@ -614,7 +606,7 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId: premises.id, bedspaceId: room.id }),
+        paths.bookings.new({ premisesId: premises.id, bedspaceId }),
         request.query,
       )
       expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'userPermission')
@@ -624,12 +616,12 @@ describe('BookingsController', () => {
     it('renders with an error if no assessment ID is provided', async () => {
       const newBooking = newBookingFactory.build()
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const person = personFactory.build()
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -638,7 +630,7 @@ describe('BookingsController', () => {
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       personService.findByCrn.mockResolvedValue(person)
       ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
 
@@ -647,11 +639,11 @@ describe('BookingsController', () => {
       await requestHandler(request, response, next)
 
       expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId: room.id }),
+        paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId }),
         request.query,
       )
       expect(appendQueryString).not.toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId: premises.id, bedspaceId: room.id }),
+        paths.bookings.new({ premisesId: premises.id, bedspaceId }),
         request.query,
       )
 
@@ -662,7 +654,7 @@ describe('BookingsController', () => {
     it('clears any place context if the received assessment ID differs from that in the place context', async () => {
       const newBooking = newBookingFactory.build()
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const person = personFactory.build()
       const placeContext = placeContextFactory.build({
         assessment: assessmentFactory.build({
@@ -672,7 +664,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.query = {
         crn: newBooking.crn,
@@ -682,7 +674,7 @@ describe('BookingsController', () => {
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       personService.findByCrn.mockResolvedValue(person)
       ;(preservePlaceContext as jest.MockedFunction<typeof preservePlaceContext>).mockResolvedValue(placeContext)
       ;(appendQueryString as jest.MockedFunction<typeof appendQueryString>).mockReturnValue(backLink)
@@ -698,8 +690,7 @@ describe('BookingsController', () => {
     it('creates a booking and redirects to the show room page', async () => {
       const requestHandler = bookingsController.create()
 
-      const room = roomFactory.build()
-
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const booking = bookingFactory.build()
       const newBooking = newBookingFactory.build({
         ...booking,
@@ -707,7 +698,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.body = {
         ...newBooking,
@@ -716,7 +707,7 @@ describe('BookingsController', () => {
         assessmentId,
       }
 
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.createForBedspace.mockResolvedValue(booking)
 
       await requestHandler(request, response, next)
@@ -724,20 +715,20 @@ describe('BookingsController', () => {
       expect(bookingService.createForBedspace).toHaveBeenCalledWith(
         callConfig,
         premisesId,
-        room,
+        bedspace.id,
         expect.objectContaining({ ...newBooking, assessmentId }),
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking created')
       expect(response.redirect).toHaveBeenCalledWith(
-        paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId: booking.id }),
+        paths.bookings.show({ premisesId, bedspaceId, bookingId: booking.id }),
       )
     })
 
     it('removes empty spaces from the crn before API call', async () => {
       const requestHandler = bookingsController.create()
 
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
 
       const crn = 'XJKEGDJHEJ'
       const crnWithSpaces = `  ${crn}  `
@@ -750,7 +741,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.body = {
         ...newBooking,
@@ -759,7 +750,7 @@ describe('BookingsController', () => {
         assessmentId,
       }
 
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.createForBedspace.mockResolvedValue(booking)
 
       await requestHandler(request, response, next)
@@ -767,7 +758,7 @@ describe('BookingsController', () => {
       expect(bookingService.createForBedspace).toHaveBeenCalledWith(
         callConfig,
         premisesId,
-        room,
+        bedspace.id,
         expect.objectContaining({ crn }),
       )
     })
@@ -775,7 +766,7 @@ describe('BookingsController', () => {
     it('creates a booking without an assessment ID if the given assessment ID is the known "no assessment" ID', async () => {
       const requestHandler = bookingsController.create()
 
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
 
       const booking = bookingFactory.build()
       const newBooking = newBookingFactory.build({
@@ -784,7 +775,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.body = {
         ...newBooking,
@@ -793,7 +784,7 @@ describe('BookingsController', () => {
         assessmentId: noAssessmentId,
       }
 
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.createForBedspace.mockResolvedValue(booking)
 
       await requestHandler(request, response, next)
@@ -801,21 +792,21 @@ describe('BookingsController', () => {
       expect(bookingService.createForBedspace).toHaveBeenCalledWith(
         callConfig,
         premisesId,
-        room,
+        bedspace.id,
         expect.not.objectContaining({ assessmentId: noAssessmentId }),
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking created')
       expect(response.redirect).toHaveBeenCalledWith(
-        paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId: booking.id }),
+        paths.bookings.show({ premisesId, bedspaceId, bookingId: booking.id }),
       )
     })
 
     it('renders with errors if the API returns an error', async () => {
       const requestHandler = bookingsController.create()
 
-      const room = roomFactory.build()
-      bedspaceService.getRoom.mockResolvedValue(room)
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
 
       const err = new Error()
       bookingService.createForBedspace.mockImplementation(() => {
@@ -830,7 +821,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.body = {
         ...newBooking,
@@ -840,18 +831,15 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId, bedspaceId: roomId }),
-        request.body,
-      )
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.body)
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
     })
 
     it('renders with errors if the API returns a 409 Conflict status', async () => {
       const requestHandler = bookingsController.create()
 
-      const room = roomFactory.build()
-      bedspaceService.getRoom.mockResolvedValue(room)
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
 
       const err = { status: 409 }
       bookingService.createForBedspace.mockImplementation(() => {
@@ -874,7 +862,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.body = {
         ...newBooking,
@@ -884,11 +872,8 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId, bedspaceId: roomId }),
-        request.body,
-      )
-      expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, roomId, 'plural')
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.body)
+      expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, bedspaceId, 'plural')
       expect(insertBespokeError).toHaveBeenCalledWith(err, bespokeError)
       expect(insertGenericError).toHaveBeenCalledWith(err, 'arrivalDate', 'conflict')
       expect(insertGenericError).toHaveBeenCalledWith(err, 'departureDate', 'conflict')
@@ -898,8 +883,8 @@ describe('BookingsController', () => {
     it('renders with errors if the API returns a 403 Forbidden status', async () => {
       const requestHandler = bookingsController.create()
 
-      const room = roomFactory.build()
-      bedspaceService.getRoom.mockResolvedValue(room)
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
 
       const err = { status: 403 }
       bookingService.createForBedspace.mockImplementation(() => {
@@ -914,7 +899,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
       }
       request.body = {
         ...newBooking,
@@ -924,10 +909,7 @@ describe('BookingsController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(appendQueryString).toHaveBeenCalledWith(
-        paths.bookings.new({ premisesId, bedspaceId: roomId }),
-        request.body,
-      )
+      expect(appendQueryString).toHaveBeenCalledWith(paths.bookings.new({ premisesId, bedspaceId }), request.body)
       expect(insertGenericError).toHaveBeenCalledWith(err, 'crn', 'userPermission')
       expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, backLink)
     })
@@ -935,18 +917,18 @@ describe('BookingsController', () => {
 
   describe('show', () => {
     it('renders the template for viewing a booking', async () => {
-      const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const premises = premisesFactory.build({ id: premisesId })
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const booking = bookingFactory.build()
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
       ;(bookingActions as jest.MockedFunction<typeof bookingActions>).mockReturnValue([])
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
@@ -955,13 +937,13 @@ describe('BookingsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/show', {
         premises,
-        room,
+        bedspace,
         booking,
         actions: [],
       })
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
       expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)
     })
@@ -969,12 +951,12 @@ describe('BookingsController', () => {
 
   describe('history', () => {
     it('renders the template for viewing booking history', async () => {
-      const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const premises = premisesFactory.build({ id: premisesId })
+      const bedspace = cas3BedspaceFactory.build({ id: bedspaceId })
       const booking = bookingFactory.build()
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
       ;(deriveBookingHistory as jest.MockedFunction<typeof deriveBookingHistory>).mockReturnValue([
         {
@@ -985,7 +967,7 @@ describe('BookingsController', () => {
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        roomId: bedspace.id,
         bookingId: booking.id,
       }
 
@@ -994,7 +976,7 @@ describe('BookingsController', () => {
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/bookings/history', {
         premises,
-        room,
+        bedspace,
         booking,
         history: [
           {
@@ -1005,7 +987,7 @@ describe('BookingsController', () => {
       })
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
       expect(deriveBookingHistory).toHaveBeenCalledWith(booking)
       expect(preservePlaceContext).toHaveBeenCalledWith(request, response, assessmentService)

--- a/server/controllers/temporary-accommodation/manage/bookingsController.ts
+++ b/server/controllers/temporary-accommodation/manage/bookingsController.ts
@@ -4,7 +4,7 @@ import type { NewBooking } from '@approved-premises/api'
 import { ObjectWithDateParts } from '@approved-premises/ui'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { AssessmentsService, BookingService, PersonService, PremisesService } from '../../../services'
-import BedspaceService from '../../../services/bedspaceService'
+import BedspaceService from '../../../services/v2/bedspaceService'
 import {
   assessmentRadioItems,
   bookingActions,
@@ -37,7 +37,7 @@ export default class BookingsController {
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, errorTitle } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId } = req.params
+      const { premisesId, bedspaceId } = req.params
 
       const callConfig = extractCallConfig(req)
 
@@ -48,12 +48,12 @@ export default class BookingsController {
       const crnPrefill = placeContext ? { crn: placeContext.assessment.application.person.crn } : {}
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
-      const bedspaceStatus = this.bedspacesService.summaryListForBedspaceStatus(room)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
+      const bedspaceStatus = this.bedspacesService.summaryListForBedspaceStatus(bedspace)
 
       return res.render('temporary-accommodation/bookings/new', {
         premises,
-        room,
+        bedspace,
         bedspaceStatus,
         errors,
         errorSummary,
@@ -68,7 +68,7 @@ export default class BookingsController {
   selectAssessment(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, errorTitle } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId } = req.params
+      const { premisesId, bedspaceId } = req.params
 
       const crn = req.query.crn as string
 
@@ -90,7 +90,7 @@ export default class BookingsController {
         placeContext = undefined
       }
 
-      const backLink = appendQueryString(paths.bookings.new({ premisesId, bedspaceId: roomId }), req.query)
+      const backLink = appendQueryString(paths.bookings.new({ premisesId, bedspaceId }), req.query)
       const applyDisabled = !isApplyEnabledForUser(res.locals.user)
 
       try {
@@ -118,7 +118,7 @@ export default class BookingsController {
 
         return res.render('temporary-accommodation/bookings/selectAssessment', {
           premisesId,
-          roomId,
+          bedspaceId,
           assessmentRadioItems: assessmentRadioItems(assessments),
           applyDisabled,
           forceAssessmentId: assessments.length && !applyDisabled ? undefined : noAssessmentId,
@@ -143,25 +143,23 @@ export default class BookingsController {
 
   confirm(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId } = req.params
+      const { premisesId, bedspaceId } = req.params
 
       const crn: string = req.query.crn as string
       const { assessmentId } = req.query
 
       const callConfig = extractCallConfig(req)
 
-      let placeContext = await preservePlaceContext(req, res, this.assessmentService)
-
+      const placeContext = await preservePlaceContext(req, res, this.assessmentService)
       if (placeContext && placeContext.assessment.id !== assessmentId) {
         clearPlaceContext(req, res)
-        placeContext = undefined
       }
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const backLink = appendQueryString(
-        paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId: room.id }),
+        paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId: bedspace.id }),
         req.query,
       )
 
@@ -177,7 +175,7 @@ export default class BookingsController {
 
         return res.render('temporary-accommodation/bookings/confirm', {
           premises,
-          room,
+          bedspace,
           person,
           ...req.query,
           backLink,
@@ -193,7 +191,7 @@ export default class BookingsController {
           req,
           res,
           err,
-          appendQueryString(paths.bookings.new({ premisesId: premises.id, bedspaceId: room.id }), req.query),
+          appendQueryString(paths.bookings.new({ premisesId: premises.id, bedspaceId: bedspace.id }), req.query),
         )
       }
     }
@@ -201,7 +199,7 @@ export default class BookingsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId } = req.params
+      const { premisesId, bedspaceId } = req.params
       const callConfig = extractCallConfig(req)
 
       const { assessmentId, crn } = req.body
@@ -209,7 +207,7 @@ export default class BookingsController {
       const { arrivalDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'arrivalDate')
       const { departureDate } = DateFormats.dateAndTimeInputsToIsoString(req.body, 'departureDate')
 
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const newBooking: NewBooking = {
         service: 'temporary-accommodation',
@@ -221,15 +219,15 @@ export default class BookingsController {
       }
 
       try {
-        const booking = await this.bookingsService.createForBedspace(callConfig, premisesId, room, newBooking)
+        const booking = await this.bookingsService.createForBedspace(callConfig, premisesId, bedspace.id, newBooking)
 
         req.flash('success', 'Booking created')
         clearUserInput(req)
 
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId: booking.id }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId: booking.id }))
       } catch (err) {
         if (err.status === 409) {
-          insertBespokeError(err, generateConflictBespokeError(err, premisesId, roomId, 'plural'))
+          insertBespokeError(err, generateConflictBespokeError(err, premisesId, bedspaceId, 'plural'))
           insertGenericError(err, 'arrivalDate', 'conflict')
           insertGenericError(err, 'departureDate', 'conflict')
         } else if (err.status === 403) {
@@ -240,7 +238,7 @@ export default class BookingsController {
           req,
           res,
           err,
-          appendQueryString(paths.bookings.new({ premisesId, bedspaceId: roomId }), { ...req.body, _csrf: undefined }),
+          appendQueryString(paths.bookings.new({ premisesId, bedspaceId }), { ...req.body, _csrf: undefined }),
         )
       }
     }
@@ -248,40 +246,40 @@ export default class BookingsController {
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       await preservePlaceContext(req, res, this.assessmentService)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/bookings/show', {
         premises,
-        room,
+        bedspace,
         booking,
-        actions: bookingActions(premisesId, roomId, booking),
+        actions: bookingActions(premisesId, bedspace.id, booking),
       })
     }
   }
 
   history(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       await preservePlaceContext(req, res, this.assessmentService)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/bookings/history', {
         premises,
-        room,
+        bedspace,
         booking,
         history: deriveBookingHistory(booking).map(({ booking: historicBooking, updatedAt }) => ({
           booking: historicBooking,

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -31,7 +31,7 @@ export const controllers = (services: Services) => {
   )
   const bookingsController = new BookingsController(
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.bookingService,
     services.personService,
     services.assessmentsService,

--- a/server/services/bookingSearchService.test.ts
+++ b/server/services/bookingSearchService.test.ts
@@ -63,7 +63,7 @@ describe('BookingService', () => {
           {
             html: `<a href="${paths.bookings.show({
               premisesId: booking1.premises.id,
-              bedspaceId: booking1.room.id,
+              bedspaceId: booking1.bed.id,
               bookingId: booking1.booking.id,
             })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
               booking1.person.crn
@@ -89,7 +89,7 @@ describe('BookingService', () => {
           {
             html: `<a href="${paths.bookings.show({
               premisesId: booking2.premises.id,
-              bedspaceId: booking2.room.id,
+              bedspaceId: booking2.bed.id,
               bookingId: booking2.booking.id,
             })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
               booking2.person.crn
@@ -115,7 +115,7 @@ describe('BookingService', () => {
           {
             html: `<a href="${paths.bookings.show({
               premisesId: booking3.premises.id,
-              bedspaceId: booking3.room.id,
+              bedspaceId: booking3.bed.id,
               bookingId: booking3.booking.id,
             })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${
               booking3.person.crn

--- a/server/services/bookingSearchService.ts
+++ b/server/services/bookingSearchService.ts
@@ -35,7 +35,7 @@ export default class BookingSearchService {
           this.htmlValue(
             `<a href="${paths.bookings.show({
               premisesId: summary.premises.id,
-              bedspaceId: summary.room.id,
+              bedspaceId: summary.bed.id,
               bookingId: summary.booking.id,
             })}">View<span class="govuk-visually-hidden"> booking for person with CRN ${summary.person.crn}</span></a>`,
           ),

--- a/server/services/bookingService.test.ts
+++ b/server/services/bookingService.test.ts
@@ -2,7 +2,14 @@ import BookingClient from '../data/bookingClient'
 import LostBedClient from '../data/lostBedClient'
 import BookingService from './bookingService'
 
-import { bedFactory, bookingFactory, lostBedFactory, newBookingFactory, roomFactory } from '../testutils/factories'
+import {
+  bedFactory,
+  bookingFactory,
+  cas3BedspaceFactory,
+  lostBedFactory,
+  newBookingFactory,
+  roomFactory,
+} from '../testutils/factories'
 
 import { CallConfig } from '../data/restClient'
 import paths from '../paths/temporary-accommodation/manage'
@@ -41,15 +48,11 @@ describe('BookingService', () => {
       const newBooking = newBookingFactory.build()
       bookingClient.create.mockResolvedValue(booking)
 
-      const room = roomFactory.build({
-        beds: [
-          bedFactory.build({
-            id: bedId,
-          }),
-        ],
+      const bedspace = cas3BedspaceFactory.build({
+        id: bedId,
       })
 
-      const postedBooking = await service.createForBedspace(callConfig, premisesId, room, newBooking)
+      const postedBooking = await service.createForBedspace(callConfig, premisesId, bedspace.id, newBooking)
       expect(postedBooking).toEqual(booking)
 
       expect(bookingClientFactory).toHaveBeenCalledWith(callConfig)

--- a/server/services/bookingService.ts
+++ b/server/services/bookingService.ts
@@ -31,14 +31,14 @@ export default class BookingService {
   async createForBedspace(
     callConfig: CallConfig,
     premisesId: string,
-    room: Room,
+    bedspaceId: string,
     booking: NewBooking,
   ): Promise<Booking> {
     const bookingClient = this.bookingClientFactory(callConfig)
 
     const confirmedBooking = await bookingClient.create(premisesId, {
       serviceName: 'temporary-accommodation',
-      bedId: room.beds[0].id,
+      bedId: bedspaceId,
       enableTurnarounds: true,
       ...booking,
     })

--- a/server/services/v2/bedspaceService.ts
+++ b/server/services/v2/bedspaceService.ts
@@ -15,6 +15,7 @@ import ReferenceDataClient from '../../data/referenceDataClient'
 import { DateFormats } from '../../utils/dateUtils'
 import { convertToTitleCase } from '../../utils/utils'
 import { filterCharacteristics } from '../../utils/characteristicUtils'
+import { bedspaceStatus } from '../../utils/v2/bedspaceUtils'
 
 export type BedspaceReferenceData = {
   characteristics: Array<Characteristic>
@@ -162,6 +163,43 @@ export default class BedspaceService {
   ): Promise<void> {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
     return bedspaceClient.archive(premisesId, bedspaceId, { endDate })
+  }
+
+  summaryListForBedspaceStatus(bedspace: Cas3Bedspace): SummaryList {
+    let endDate = 'No end date added'
+
+    if (bedspace.endDate) {
+      endDate = DateFormats.isoDateToUIDate(bedspace.endDate)
+
+      if (bedspaceStatus(bedspace) === 'online') {
+        endDate += ` (${DateFormats.isoDateToDaysFromNow(bedspace.endDate)})`
+      }
+    }
+
+    return {
+      rows: [
+        {
+          key: this.textValue('Bedspace status'),
+          value: this.htmlValue(
+            bedspaceStatus(bedspace) === 'online'
+              ? `<span class="govuk-tag govuk-tag--green">Online</span>`
+              : `<span class="govuk-tag govuk-tag--grey">Archived</span>`,
+          ),
+        },
+        {
+          key: this.textValue('Bedspace end date'),
+          value: this.textValue(endDate),
+        },
+      ],
+    }
+  }
+
+  private textValue(value: string) {
+    return { text: value }
+  }
+
+  private htmlValue(value: string) {
+    return { html: value }
   }
 
   async unarchiveBedspace(

--- a/server/testutils/factories/cas3Bedspace.ts
+++ b/server/testutils/factories/cas3Bedspace.ts
@@ -15,4 +15,5 @@ export default Factory.define<Cas3Bedspace>(() => ({
     .multiple(() => `${faker.word.adjective()} ${faker.word.adverb()} ${faker.word.noun()}`)
     .join(', '),
   archiveHistory: [],
+  endDate: undefined,
 }))

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -12,14 +12,14 @@ type ParsedConflictError = {
 
 export const noAssessmentId = 'no-assessment'
 
-export function bookingActions(premisesId: string, roomId: string, booking: Booking): Array<PageHeadingBarItem> {
+export function bookingActions(premisesId: string, bedspaceId: string, booking: Booking): Array<PageHeadingBarItem> {
   const items = []
   const bookingId = booking.id
 
   const cancelAction = {
     text: 'Cancel booking',
     classes: 'govuk-button--secondary',
-    href: paths.bookings.cancellations.new({ premisesId, bedspaceId: roomId, bookingId }),
+    href: paths.bookings.cancellations.new({ premisesId, bedspaceId, bookingId }),
   }
 
   switch (booking.status) {
@@ -28,7 +28,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
         {
           text: 'Mark as confirmed',
           classes: '',
-          href: paths.bookings.confirmations.new({ premisesId, bedspaceId: roomId, bookingId }),
+          href: paths.bookings.confirmations.new({ premisesId, bedspaceId, bookingId }),
         },
         cancelAction,
       )
@@ -38,7 +38,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
         {
           text: 'Mark as active',
           classes: '',
-          href: paths.bookings.arrivals.new({ premisesId, bedspaceId: roomId, bookingId }),
+          href: paths.bookings.arrivals.new({ premisesId, bedspaceId, bookingId }),
         },
         cancelAction,
       )
@@ -48,17 +48,17 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
         {
           text: 'Mark as departed',
           classes: 'govuk-button--secondary',
-          href: paths.bookings.departures.new({ premisesId, bedspaceId: roomId, bookingId }),
+          href: paths.bookings.departures.new({ premisesId, bedspaceId, bookingId }),
         },
         {
           text: 'Extend or shorten booking',
           classes: 'govuk-button--secondary',
-          href: paths.bookings.extensions.new({ premisesId, bedspaceId: roomId, bookingId }),
+          href: paths.bookings.extensions.new({ premisesId, bedspaceId, bookingId }),
         },
         {
           text: 'Change arrival date',
           classes: 'govuk-button--secondary',
-          href: paths.bookings.arrivals.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          href: paths.bookings.arrivals.edit({ premisesId, bedspaceId, bookingId }),
         },
       )
       break
@@ -67,14 +67,14 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
       items.push({
         text: 'Update departure details',
         classes: 'govuk-button--secondary',
-        href: paths.bookings.departures.edit({ premisesId, bedspaceId: roomId, bookingId }),
+        href: paths.bookings.departures.edit({ premisesId, bedspaceId, bookingId }),
       })
       break
     case 'cancelled':
       items.push({
         text: 'Update cancelled booking',
         classes: 'govuk-button--secondary',
-        href: paths.bookings.cancellations.edit({ premisesId, bedspaceId: roomId, bookingId }),
+        href: paths.bookings.cancellations.edit({ premisesId, bedspaceId, bookingId }),
       })
       break
     default:
@@ -85,7 +85,7 @@ export function bookingActions(premisesId: string, roomId: string, booking: Book
     items.push({
       text: 'Change turnaround time',
       classes: 'govuk-button--secondary',
-      href: paths.bookings.turnarounds.new({ premisesId, bedspaceId: roomId, bookingId: booking.id }),
+      href: paths.bookings.turnarounds.new({ premisesId, bedspaceId, bookingId: booking.id }),
     })
   }
 

--- a/server/utils/v2/bedspaceUtils.ts
+++ b/server/utils/v2/bedspaceUtils.ts
@@ -1,7 +1,8 @@
 import { Cas3Bedspace, Cas3Premises } from '@approved-premises/api'
-import { PageHeadingBarItem, PlaceContext } from '@approved-premises/ui'
+import { BedspaceStatus, PageHeadingBarItem, PlaceContext } from '@approved-premises/ui'
 import paths from '../../paths/temporary-accommodation/manage'
 import { addPlaceContext } from '../placeUtils'
+import { dateIsInFuture } from '../dateUtils'
 
 export function bedspaceActions(
   premises: Cas3Premises,
@@ -74,4 +75,14 @@ const onlineBedspaceActions = (
     classes: 'govuk-button--secondary',
   })
   return actions
+}
+
+export function bedspaceStatus(bedspace: Cas3Bedspace): BedspaceStatus {
+  if (bedspace.endDate) {
+    if (!dateIsInFuture(bedspace.endDate)) {
+      return 'archived'
+    }
+  }
+
+  return 'online'
 }

--- a/server/views/components/location-header/macro.njk
+++ b/server/views/components/location-header/macro.njk
@@ -10,7 +10,7 @@
     {% if not hideAddress %}
       <h2{% if headingClass %} class="{{ headingClass }}"{% endif %}>Property address</h2>
       <p>
-            {% if room.name.length %}{{ room.name }}<br/>{% endif %}
+            {% if room.reference.length %}{{ room.reference }}<br/>{% endif %}
             {{ premises.addressLine1 }}
             {% if premises.addressLine2.length %}<br/>{{ premises.addressLine2 }}{% endif %}
             {% if premises.town.length %}<br/>{{ premises.town }}{% endif %}

--- a/server/views/temporary-accommodation/bookings/confirm.njk
+++ b/server/views/temporary-accommodation/bookings/confirm.njk
@@ -23,11 +23,11 @@
   <p>Confirm that the CRN is correct. This information cannot be changed once a bedspace has been booked.</p>
 
   {{ popDetailsHeader(person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ addPlaceContext(paths.bookings.create({ premisesId: premises.id, roomId: room.id })) }}" method="post">
+      <form action="{{ addPlaceContext(paths.bookings.create({ premisesId: premises.id, bedspaceId: bedspace.id })) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ placeContextValue(placeContext) }}

--- a/server/views/temporary-accommodation/bookings/history.njk
+++ b/server/views/temporary-accommodation/bookings/history.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: addPlaceContext(paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
+    href: addPlaceContext(paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }))
   }) }}
 {% endblock %}
 
@@ -22,7 +22,7 @@
   <h1 class="govuk-heading-l">Booking history</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ room: room, premises: premises }) }}
+  {{ locationHeader({ room: bedspace, premises: premises }) }}
 
   {% for historicBookingDetail in history | reverse %}
     <div data-cy-history-index="{{ loop.revindex0 }}">

--- a/server/views/temporary-accommodation/bookings/new.njk
+++ b/server/views/temporary-accommodation/bookings/new.njk
@@ -11,7 +11,7 @@
   {{ breadCrumb('Book bedspace', [
     {title: 'List of properties', href: paths.premises.online()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
+    {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id }))}
   ]) }}
 {% endblock %}
 
@@ -22,11 +22,11 @@
   
   <h1 class="govuk-heading-l">Book bedspace</h1>
 
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.selectAssessment({ premisesId: premises.id, roomId: room.id }) }}" method="get">
+      <form action="{{ paths.bookings.selectAssessment({ premisesId: premises.id, bedspaceId: bedspace.id }) }}" method="get">
         {% include "./_editable.njk" %}  
       </form>
     </div>

--- a/server/views/temporary-accommodation/bookings/selectAssessment.njk
+++ b/server/views/temporary-accommodation/bookings/selectAssessment.njk
@@ -31,7 +31,7 @@
   
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.confirm({ premisesId: premisesId, roomId: roomId }) }}" method="get">
+      <form action="{{ paths.bookings.confirm({ premisesId: premisesId, bedspaceId: bedspaceId }) }}" method="get">
 
         {{ placeContextValue(placeContext) }}
 

--- a/server/views/temporary-accommodation/bookings/show.njk
+++ b/server/views/temporary-accommodation/bookings/show.njk
@@ -16,7 +16,7 @@
     {{ breadCrumb('View a booking', [
         {title: 'List of properties', href: addPlaceContext(paths.premises.online())},
         {title: 'View a property', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))},
-        {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
+        {title: 'View a bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id }))}
     ]) }}
 {% endblock %}
 
@@ -31,9 +31,9 @@
     }) }}
 
     {{ popDetailsHeader(booking.person, { nameLink: addPlaceContext(paths.assessments.summary({ id: booking.assessmentId })) if booking.assessmentId else "" }) }}
-    {{ locationHeader({ room: room, premises: premises }) }}
+    {{ locationHeader({ room: bedspace, premises: premises }) }}
 
-    {{ bookingInfo(booking, addPlaceContext(paths.bookings.history({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))) }}
+    {{ bookingInfo(booking, addPlaceContext(paths.bookings.history({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }))) }}
 
 {% endblock %}
 


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1928

The outcome of https://dsdmoj.atlassian.net/browse/CAS-1865 was to replace the current `Manage properties v1` routes with the new `Manage properties v2` routes. 

The above strategy helps us link into the other v1 areas of the application (e.g. `Bookings`, `Voids`, `Departures`, `Arrivals` etc) as the breadcrumbs still work (for the most part!) as they go back to v1 which is now the new v2 pages. 

However, these areas are currently driven by a `roomId` from the BE on the url path for the bedspace. With the way the new BE `cas3` endpoints have been delivered the primary key for bedspaces has become the `bedId` (not the `roomId`). This changes in the backend means that there is some refactoring to do in these `CAS3-UI` v1 areas to `retrieve the bedspace and not the room`. This has rippling effects on the v1 areas controllers, services and views and so we need to refactor these. 

# Changes in this PR
1. Get the booking areas working. Namely:
* View Booking
* Create booking
* Booking history

2. Add back in the integration test / e2e test coverage that commented out in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1382
