### PR TITLE
Booking Confirmation and Arrivals area with Bedspace v2

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalEdit.ts
@@ -1,4 +1,11 @@
-import type { Booking, LostBed, NewCas3Arrival as NewArrival, Premises, Room } from '@approved-premises/api'
+import type {
+  Booking,
+  Cas3Bedspace,
+  LostBed,
+  NewCas3Arrival as NewArrival,
+  Premises,
+  Room,
+} from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import BookingInfoComponent from '../../../components/bookingInfo'
@@ -15,22 +22,24 @@ export default class BookingArrivalEditPage extends Page {
 
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(
-    premises: Premises,
-    room: Room,
-    private readonly booking: Booking,
-  ) {
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking) {
     super('Change arrival')
 
-    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room, null, 'booking')
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room, bedspace, 'booking')
     this.bookingInfoComponent = new BookingInfoComponent(booking)
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingArrivalEditPage {
-    cy.visit(paths.bookings.arrivals.edit({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingArrivalEditPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingArrivalEditPage {
+    if (room) {
+      cy.visit(paths.bookings.arrivals.edit({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(
+        paths.bookings.arrivals.edit({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
+      )
+    }
+    return new BookingArrivalEditPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew.ts
@@ -1,4 +1,11 @@
-import type { Booking, LostBed, NewCas3Arrival as NewArrival, Premises, Room } from '@approved-premises/api'
+import type {
+  Booking,
+  Cas3Bedspace,
+  LostBed,
+  NewCas3Arrival as NewArrival,
+  Premises,
+  Room,
+} from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import BookingInfoComponent from '../../../components/bookingInfo'
@@ -18,6 +25,7 @@ export default class BookingArrivalNewPage extends Page {
   constructor(
     premises: Premises,
     room: Room,
+    bedspace: Cas3Bedspace,
     private readonly booking: Booking,
   ) {
     super('Mark booking as active')
@@ -25,12 +33,16 @@ export default class BookingArrivalNewPage extends Page {
     this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room, null, 'booking')
     this.bookingInfoComponent = new BookingInfoComponent(booking)
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingArrivalNewPage {
-    cy.visit(paths.bookings.arrivals.new({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingArrivalNewPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingArrivalNewPage {
+    if (room) {
+      cy.visit(paths.bookings.arrivals.new({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(paths.bookings.arrivals.new({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }))
+    }
+    return new BookingArrivalNewPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew.ts
@@ -1,4 +1,4 @@
-import type { Booking, NewConfirmation, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, NewConfirmation, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -12,17 +12,23 @@ export default class BookingConfirmationNewPage extends Page {
 
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(premises: Premises, room: Room, booking: Booking) {
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking) {
     super('Mark booking as confirmed')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingConfirmationNewPage {
-    cy.visit(paths.bookings.confirmations.new({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingConfirmationNewPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingConfirmationNewPage {
+    if (room) {
+      cy.visit(paths.bookings.confirmations.new({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(
+        paths.bookings.confirmations.new({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
+      )
+    }
+    return new BookingConfirmationNewPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/e2e/tests/booking-errors.feature
+++ b/e2e/tests/booking-errors.feature
@@ -31,22 +31,22 @@ Feature: Manage Temporary Accommodation - Booking Errors
     Given I'm creating a booking
     And I create a booking with all necessary details
     And I confirm the booking
-#    And I attempt to mark the booking as arrived with required details missing
-#    Then I should see a list of the problems encountered marking the booking as arrived
-#
+    And I attempt to mark the booking as arrived with required details missing
+    Then I should see a list of the problems encountered marking the booking as arrived
+
   Scenario: Showing booking extension errors
     Given I'm creating a booking
     And I create a booking with all necessary details
     And I confirm the booking
-#    And I mark the booking as arrived
-#    And I attempt to extend the booking with required details missing
-#    Then I should see a list of the problems encountered extending the booking
+    And I mark the booking as arrived
+ #   And I attempt to extend the booking with required details missing
+ #   Then I should see a list of the problems encountered extending the booking
 
   Scenario: Showing booking departure errors
     Given I'm creating a booking
     And I create a booking with all necessary details
     And I confirm the booking
-#    And I mark the booking as arrived
+    And I mark the booking as arrived
 #    And I attempt to mark the booking as departed with required details missing
 #    Then I should see a list of the problems encountered marking the booking as departed
 #    And I mark the booking as departed

--- a/e2e/tests/booking-errors.feature
+++ b/e2e/tests/booking-errors.feature
@@ -18,34 +18,34 @@ Feature: Manage Temporary Accommodation - Booking Errors
     And I attempt to create a conflicting booking
     Then I should see errors for the conflicting booking
 
-#  Scenario: Showing booking cancellation errors
-#    Given I'm creating a booking
-#    And I create a booking with all necessary details
+ Scenario: Showing booking cancellation errors
+    Given I'm creating a booking
+    And I create a booking with all necessary details
 #    And I attempt to cancel the booking with required details missing
 #    Then I should see a list of the problems encountered cancelling the booking
 #    And I cancel the booking
 #    And I attempt to edit the cancelled booking with required details missing
 #    Then I should see a list of the problems encountered editing the cancelling booking
 #
-#  Scenario: Showing booking arrival errors
-#    Given I'm creating a booking
-#    And I create a booking with all necessary details
-#    And I confirm the booking
+  Scenario: Showing booking arrival errors
+    Given I'm creating a booking
+    And I create a booking with all necessary details
+    And I confirm the booking
 #    And I attempt to mark the booking as arrived with required details missing
 #    Then I should see a list of the problems encountered marking the booking as arrived
 #
-#  Scenario: Showing booking extension errors
-#    Given I'm creating a booking
-#    And I create a booking with all necessary details
-#    And I confirm the booking
+  Scenario: Showing booking extension errors
+    Given I'm creating a booking
+    And I create a booking with all necessary details
+    And I confirm the booking
 #    And I mark the booking as arrived
 #    And I attempt to extend the booking with required details missing
 #    Then I should see a list of the problems encountered extending the booking
-#
-#  Scenario: Showing booking departure errors
-#    Given I'm creating a booking
-#    And I create a booking with all necessary details
-#    And I confirm the booking
+
+  Scenario: Showing booking departure errors
+    Given I'm creating a booking
+    And I create a booking with all necessary details
+    And I confirm the booking
 #    And I mark the booking as arrived
 #    And I attempt to mark the booking as departed with required details missing
 #    Then I should see a list of the problems encountered marking the booking as departed

--- a/e2e/tests/booking.feature
+++ b/e2e/tests/booking.feature
@@ -3,11 +3,11 @@ Feature: Manage Temporary Accommodation - Booking
         Given I am logged in as an assessor
         And I view an existing active premises
         And I'm creating a bedspace
+        And I create a bedspace with all necessary details
 
     Scenario: Creating a booking, and cancelling while provisional
-        Given I create a bedspace with all necessary details
-#        Given I'm creating a booking
-#        And I create a booking with all necessary details
+        Given I'm creating a booking
+        And I create a booking with all necessary details
 #        Then I should see a confirmation for my new booking
 #        And I cancel the booking
 #        Then I should see the booking with the cancelled status
@@ -15,9 +15,9 @@ Feature: Manage Temporary Accommodation - Booking
 #        Then I should see the booking with the edited cancellation details
 #        And I should see previous booking states in the booking history
 #
-#    Scenario: Creating a booking, and cancelling while confirmed
-#        Given I'm creating a booking
-#        And I create a booking with all necessary details
+    Scenario: Creating a booking, and cancelling while confirmed
+        Given I'm creating a booking
+        And I create a booking with all necessary details
 #        Then I should see a confirmation for my new booking
 #        And I confirm the booking
 #        Then I should see the booking with the confirmed status
@@ -27,9 +27,9 @@ Feature: Manage Temporary Accommodation - Booking
 #        Then I should see the booking with the edited cancellation details
 #        And I should see previous booking states in the booking history
 #
-#    Scenario: Creating a booking, confirming, marking as arrived, extending, and marking as departed
-#        Given I'm creating a booking
-#        And I create a booking with all necessary details
+   Scenario: Creating a booking, confirming, marking as arrived, extending, and marking as departed
+        Given I'm creating a booking
+        And I create a booking with all necessary details
 #        Then I should see a confirmation for my new booking
 #        And I confirm the booking
 #        Then I should see the booking with the confirmed status
@@ -43,12 +43,12 @@ Feature: Manage Temporary Accommodation - Booking
 #        Then I should see the booking with the edited departure details
 #        And I should see previous booking states in the booking history
 #
-#    Scenario: Creating a booking, confirming, marking as arrived, change arrival, change arrival error
-#        Given I'm creating a booking
-#        When I create a booking with all necessary details
-#        Then I should see a confirmation for my new booking
-#        When I confirm the booking
-#        Then I should see the booking with the confirmed status
+    Scenario: Creating a booking, confirming, marking as arrived, change arrival, change arrival error
+        Given I'm creating a booking
+        When I create a booking with all necessary details
+ #       Then I should see a confirmation for my new booking
+ #       When I confirm the booking
+ #       Then I should see the booking with the confirmed status
 #        When I mark the booking as arrived
 #        Then I should see the booking with the arrived status
 #        When I navigate to change the booking arrival
@@ -57,8 +57,8 @@ Feature: Manage Temporary Accommodation - Booking
 #        When I enter change booking data correctly
 #        Then I should see the booking with confirmation of arrival change
 #
-#    Scenario: Editing a booking's turnaround time
-#        Given I'm creating a booking
-#        And I create a booking with all necessary details
+    Scenario: Editing a booking's turnaround time
+        Given I'm creating a booking
+        And I create a booking with all necessary details
 #        And I edit the booking's turnaround time
 #        Then I should see the booking with the edited turnaround time

--- a/e2e/tests/bookingSearch.feature
+++ b/e2e/tests/bookingSearch.feature
@@ -14,7 +14,7 @@ Feature: Manage Temporary Accommodation - Booking search
     And I confirm the booking
     And I'm searching bookings
     Then I should see a summary of the booking on the confirmed bookings page
-#    And I mark the booking as arrived
+    And I mark the booking as arrived
 #    And I'm searching bookings
 #    Then I should see a summary of the booking on the active bookings page
 #    And I mark the booking as departed

--- a/e2e/tests/bookingSearch.feature
+++ b/e2e/tests/bookingSearch.feature
@@ -11,9 +11,9 @@ Feature: Manage Temporary Accommodation - Booking search
   Scenario: Showing bookings of all statuses
     When I'm searching bookings
     Then I should see a summary of the booking on the provisional bookings page
-#    And I confirm the booking
-#    And I'm searching bookings
-#    Then I should see a summary of the booking on the confirmed bookings page
+    And I confirm the booking
+    And I'm searching bookings
+    Then I should see a summary of the booking on the confirmed bookings page
 #    And I mark the booking as arrived
 #    And I'm searching bookings
 #    Then I should see a summary of the booking on the active bookings page

--- a/e2e/tests/stepDefinitions/manage/arrival.ts
+++ b/e2e/tests/stepDefinitions/manage/arrival.ts
@@ -8,7 +8,7 @@ import { arrivalFactory, bookingFactory, newArrivalFactory } from '../../../../s
 
 Given('I mark the booking as arrived', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickMarkArrivedBookingButton()
 
     const newArrival = newArrivalFactory.build()
@@ -16,7 +16,7 @@ Given('I mark the booking as arrived', () => {
       ...newArrival,
     })
 
-    const bookingArrivalPage = Page.verifyOnPage(BookingArrivalNewPage, this.premises, this.room, this.booking)
+    const bookingArrivalPage = Page.verifyOnPage(BookingArrivalNewPage, this.premises, this.room, null, this.booking)
     bookingArrivalPage.shouldShowBookingDetails()
     bookingArrivalPage.completeForm(newArrival)
 
@@ -35,10 +35,10 @@ Given('I mark the booking as arrived', () => {
 
 Given('I attempt to mark the booking as arrived with required details missing', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickMarkArrivedBookingButton()
 
-    const bookingArrivalPage = Page.verifyOnPage(BookingArrivalNewPage, this.premises, this.room, this.booking)
+    const bookingArrivalPage = Page.verifyOnPage(BookingArrivalNewPage, this.premises, this.room, null, this.booking)
     bookingArrivalPage.clearForm()
     bookingArrivalPage.clickSubmit()
   })
@@ -46,13 +46,13 @@ Given('I attempt to mark the booking as arrived with required details missing', 
 
 Then('I should see the booking with the arrived status', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Booking marked as active')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -60,7 +60,7 @@ Then('I should see the booking with the arrived status', () => {
 
 Then('I should see a list of the problems encountered marking the booking as arrived', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingArrivalNewPage, this.premises, this.room, this.booking)
+    const page = Page.verifyOnPage(BookingArrivalNewPage, this.premises, this.room, null, this.booking)
     page.shouldShowErrorMessagesForFields(['arrivalDate', 'expectedDepartureDate'])
 
     page.clickBack()
@@ -69,7 +69,7 @@ Then('I should see a list of the problems encountered marking the booking as arr
 
 When('I navigate to change the booking arrival', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickEditArrivalButton()
   })
 })
@@ -108,7 +108,7 @@ When('I enter change booking data correctly', () => {
 
 Then('I should see the booking with confirmation of arrival change', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Arrival updated')
     bookingShowPage.shouldShowBookingDetails()
     bookingShowPage.clickBreadCrumbUp()

--- a/e2e/tests/stepDefinitions/manage/booking.ts
+++ b/e2e/tests/stepDefinitions/manage/booking.ts
@@ -123,6 +123,7 @@ Then('I should see previous booking states in the booking history', () => {
       BookingHistoryPage,
       this.premises,
       this.room,
+      null,
       this.booking,
       this.historicBookings,
     )

--- a/e2e/tests/stepDefinitions/manage/confirmation.ts
+++ b/e2e/tests/stepDefinitions/manage/confirmation.ts
@@ -19,6 +19,7 @@ Given('I confirm the booking', () => {
       BookingConfirmationNewPage,
       this.premises,
       this.room,
+      null,
       this.booking,
     )
     bookingConfirmationPage.shouldShowBookingDetails()

--- a/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/arrival.cy.ts
@@ -1,18 +1,18 @@
-// import { addDays } from 'date-fns'
-// import Page from '../../../../cypress_shared/pages/page'
-// import BookingArrivalNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew'
-// import BookingArrivalEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalEdit'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-// import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
+import { addDays } from 'date-fns'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingArrivalNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalNew'
+import BookingArrivalEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingArrivalEdit'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import {
-//   arrivalFactory,
-//   bookingFactory,
-//   newArrivalFactory,
-//   premisesFactory,
-//   roomFactory,
-// } from '../../../../server/testutils/factories'
-// import { DateFormats } from '../../../../server/utils/dateUtils'
+import {
+  arrivalFactory,
+  bookingFactory,
+  cas3BedspaceFactory,
+  newArrivalFactory,
+  premisesFactory,
+} from '../../../../server/testutils/factories'
+import { DateFormats } from '../../../../server/utils/dateUtils'
 
 context('Booking arrival', () => {
   beforeEach(() => {
@@ -24,329 +24,329 @@ context('Booking arrival', () => {
     it('navigates to the booking arrival page', () => {
       // Given I am signed in
       cy.signIn()
-      //
-      //       // And there is a premises, a room, and a confirmed booking in the database
-      //       const booking = bookingFactory.confirmed().build()
-      //       const { premises, room } = setupBookingStateStubs(booking)
-      //
-      //       // When I visit the show booking page
-      //       const bookingShow = BookingShowPage.visit(premises, room, booking)
-      //
-      //       // Add I click the marked arrived booking action
-      //       bookingShow.clickMarkArrivedBookingButton()
-      //
-      //       // Then I navigate to the booking confirmation page
-      //       Page.verifyOnPage(BookingArrivalNewPage, premises, room, booking)
+
+      // And there is a premises, a room, and a confirmed booking in the database
+      const booking = bookingFactory.confirmed().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the show booking page
+      const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+      // Add I click the marked arrived booking action
+      bookingShow.clickMarkArrivedBookingButton()
+
+      // Then I navigate to the booking confirmation page
+      Page.verifyOnPage(BookingArrivalNewPage, premises, null, bedspace, booking)
     })
-    //
-    //     it('allows me to mark a booking as arrived', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a premises, a room, and a confirmed booking in the database
-    //       const booking = bookingFactory.confirmed().build()
-    //       const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalNewPage.visit(premises, room, booking)
-    //       page.shouldShowBookingDetails()
-    //
-    //       // And I fill out the form
-    //       const arrival = arrivalFactory.build()
-    //       const newArrival = newArrivalFactory.build({
-    //         ...arrival,
-    //       })
-    //
-    //       cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId: booking.id, arrival })
-    //
-    //       page.completeForm(newArrival)
-    //
-    //       // Then the confirmation should have been created in the API
-    //       cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-    //         expect(requests).to.have.length(1)
-    //         const requestBody = JSON.parse(requests[0].body)
-    //         expect(requestBody.arrivalDate).equal(newArrival.arrivalDate)
-    //         expect(requestBody.expectedDepartureDate).equal(newArrival.expectedDepartureDate)
-    //         expect(requestBody.notes).equal(newArrival.notes)
-    //       })
-    //
-    //       // And I should be redirected to the show booking page
-    //       const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    //       bookingShowPage.shouldShowBanner('Booking marked as active')
-    //     })
-    //
-    //     it('shows errors when the API returns an error', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a confirmed booking in the database
-    //       const premises = premisesFactory.build()
-    //       const room = roomFactory.build()
-    //       const booking = bookingFactory.confirmed().build()
-    //
-    //       cy.task('stubSinglePremises', premises)
-    //       cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking })
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalNewPage.visit(premises, room, booking)
-    //
-    //       // And I miss required fields
-    //       cy.task('stubArrivalCreateErrors', {
-    //         premisesId: premises.id,
-    //         bookingId: booking.id,
-    //         params: ['arrivalDate', 'expectedDepartureDate'],
-    //       })
-    //       page.clearForm()
-    //       page.clickSubmit()
-    //
-    //       // Then I should see error messages relating to those fields
-    //       page.shouldShowErrorMessagesForFields(['arrivalDate', 'expectedDepartureDate'])
-    //     })
-    //
-    //     it('shows errors when the API returns a 409 conflict error', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a confirmed booking and a conflicting booking in the database
-    //       const premises = premisesFactory.build()
-    //       const room = roomFactory.build()
-    //       const booking = bookingFactory.confirmed().build()
-    //       const conflictingBooking = bookingFactory.build()
-    //
-    //       cy.task('stubSinglePremises', premises)
-    //       cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalNewPage.visit(premises, room, booking)
-    //
-    //       // And I fill out the form with dates that conflict with an existing booking
-    //       const arrival = arrivalFactory.build()
-    //       const newArrival = newArrivalFactory.build({
-    //         ...arrival,
-    //       })
-    //       cy.task('stubArrivalCreateConflictError', {
-    //         premisesId: premises.id,
-    //         bookingId: booking.id,
-    //         conflictingEntityId: conflictingBooking.id,
-    //         conflictingEntityType: 'booking',
-    //       })
-    //
-    //       page.completeForm(newArrival)
-    //
-    //       // Then I should see error messages for the conflict
-    //       page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
-    //     })
-    //
-    //     it('shows errors if arrival date is in future', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       const currentDate = new Date()
-    //       const futureDate = addDays(currentDate, 7)
-    //
-    //       // And there is a premises, a room, and a confirmed booking in the database
-    //       const booking = bookingFactory.confirmed().build()
-    //       const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalNewPage.visit(premises, room, booking)
-    //       page.shouldShowBookingDetails()
-    //
-    //       // And I fill out the form
-    //       const arrival = arrivalFactory.build()
-    //       const newArrival = newArrivalFactory.build({
-    //         ...arrival,
-    //         arrivalDate: DateFormats.dateObjToIsoDate(futureDate),
-    //       })
-    //
-    //       page.completeForm(newArrival)
-    //
-    //       // Then I should see error messages relating to those fields
-    //       page.shouldShowErrorMessagesForFields(['arrivalDate'], 'todayOrInThePast')
-    //     })
-    //
-    //     it('navigates back from the booking arrival page to the show booking page', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a premises, a room, and a confirmed booking in the database
-    //       const booking = bookingFactory.confirmed().build()
-    //       const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //       // When I visit the booking arrival page
-    //       const page = BookingArrivalNewPage.visit(premises, room, booking)
-    //
-    //       // And I click the back link
-    //       page.clickBack()
-    //
-    //       // Then I navigate to the show bedspace page
-    //       Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    //     })
-    //   })
-    //
-    //   describe('Update Arrival', () => {
-    //     it('navigates to the booking arrival update page', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a premises, a room, and an active booking in the database
-    //       const booking = bookingFactory.arrived().build()
-    //       const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //       // When I visit the show booking page
-    //       const bookingShow = BookingShowPage.visit(premises, room, booking)
-    //
-    //       // Add I click the change arrival action
-    //       bookingShow.clickEditArrivalButton()
-    //
-    //       // Then I navigate to the change arrival page
-    //       Page.verifyOnPage(BookingArrivalEditPage, premises, room, booking)
-    //     })
-    //
-    //     it('allows me to update an arrival', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a premises, a room, and an active booking in the database
-    //       const booking = bookingFactory.arrived().build()
-    //       const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalEditPage.visit(premises, room, booking)
-    //       page.shouldShowBookingDetails()
-    //
-    //       // And I fill out the form
-    //       const newArrival = newArrivalFactory.build()
-    //       cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId: booking.id, arrival: newArrival })
-    //       page.clearForm()
-    //       page.completeForm(newArrival)
-    //
-    //       // Then the arrival should have been created in the API
-    //       cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-    //         expect(requests).to.have.length(1)
-    //         const requestBody = JSON.parse(requests[0].body)
-    //         expect(requestBody.arrivalDate).equal(newArrival.arrivalDate)
-    //         expect(requestBody.notes).equal(newArrival.notes)
-    //       })
-    //
-    //       cy.then(() => {
-    //         // And I should be redirected to the show booking page
-    //         const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    //         bookingShowPage.shouldShowBanner('Arrival updated')
-    //       })
-    //     })
-    //
-    //     it('shows errors when the API returns an error', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a confirmed booking in the database
-    //       const premises = premisesFactory.build()
-    //       const room = roomFactory.build()
-    //       const booking = bookingFactory.arrived().build()
-    //
-    //       cy.task('stubSinglePremises', premises)
-    //       cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking })
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalEditPage.visit(premises, room, booking)
-    //
-    //       // And I miss required fields
-    //       cy.task('stubArrivalCreateErrors', {
-    //         premisesId: premises.id,
-    //         bookingId: booking.id,
-    //         params: ['arrivalDate'],
-    //       })
-    //       page.clearForm()
-    //       page.clickSubmit()
-    //
-    //       // Then I should see error messages relating to those fields
-    //       page.shouldShowErrorMessagesForFields(['arrivalDate'])
-    //     })
-    //
-    //     it('shows errors when the API returns a 409 conflict error', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is an arrived booking and a conflicting booking in the database
-    //       const premises = premisesFactory.build()
-    //       const room = roomFactory.build()
-    //       const booking = bookingFactory.arrived().build()
-    //       const conflictingBooking = bookingFactory.build()
-    //
-    //       cy.task('stubSinglePremises', premises)
-    //       cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalEditPage.visit(premises, room, booking)
-    //
-    //       // And I fill out the form with dates that conflict with an existing booking
-    //       const newArrival = newArrivalFactory.build()
-    //       cy.task('stubArrivalCreateConflictError', {
-    //         premisesId: premises.id,
-    //         bookingId: booking.id,
-    //         conflictingEntityId: conflictingBooking.id,
-    //         conflictingEntityType: 'booking',
-    //       })
-    //
-    //       page.completeForm(newArrival)
-    //
-    //       // Then I should see error messages for the conflict
-    //       page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
-    //     })
-    //
-    //     it('shows errors if arrival date is in future', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       const currentDate = new Date()
-    //       const futureDate = addDays(currentDate, 7)
-    //
-    //       // And there is a confirmed booking in the database
-    //       const premises = premisesFactory.build()
-    //       const room = roomFactory.build()
-    //       const booking = bookingFactory.arrived().build()
-    //
-    //       cy.task('stubSinglePremises', premises)
-    //       cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //       cy.task('stubBooking', { premisesId: premises.id, booking })
-    //
-    //       // When I visit the booking confirmation page
-    //       const page = BookingArrivalEditPage.visit(premises, room, booking)
-    //
-    //       // And I fill out the form
-    //       const newArrival = newArrivalFactory.build()
-    //       newArrival.arrivalDate = DateFormats.dateObjToIsoDate(futureDate)
-    //       cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId: booking.id, arrival: newArrival })
-    //       page.clearForm()
-    //       page.completeForm(newArrival)
-    //
-    //       // Then I should see error messages relating to those fields
-    //       page.shouldShowErrorMessagesForFields(['arrivalDate'], 'todayOrInThePast')
-    //     })
-    //
-    //     it('navigates back from the booking arrival page to the show booking page', () => {
-    //       // Given I am signed in
-    //       cy.signIn()
-    //
-    //       // And there is a premises, a room, and a confirmed booking in the database
-    //       const booking = bookingFactory.arrived().build()
-    //       const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //       // When I visit the booking arrival page
-    //       const page = BookingArrivalEditPage.visit(premises, room, booking)
-    //
-    //       // And I click the back link
-    //       page.clickBack()
-    //
-    //       // Then I navigate to the show bedspace page
-    //       Page.verifyOnPage(BookingShowPage, premises, room, booking)
-    //     })
+
+    it('allows me to mark a booking as arrived', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a premises, a room, and a confirmed booking in the database
+      const booking = bookingFactory.confirmed().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalNewPage.visit(premises, null, bedspace, booking)
+      page.shouldShowBookingDetails()
+
+      // And I fill out the form
+      const arrival = arrivalFactory.build()
+      const newArrival = newArrivalFactory.build({
+        ...arrival,
+      })
+
+      cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId: booking.id, arrival })
+
+      page.completeForm(newArrival)
+
+      // Then the confirmation should have been created in the API
+      cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+        expect(requests).to.have.length(1)
+        const requestBody = JSON.parse(requests[0].body)
+        expect(requestBody.arrivalDate).equal(newArrival.arrivalDate)
+        expect(requestBody.expectedDepartureDate).equal(newArrival.expectedDepartureDate)
+        expect(requestBody.notes).equal(newArrival.notes)
+      })
+
+      // And I should be redirected to the show booking page
+      const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+      bookingShowPage.shouldShowBanner('Booking marked as active')
+    })
+
+    it('shows errors when the API returns an error', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a confirmed booking in the database
+      const premises = premisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+      const booking = bookingFactory.confirmed().build()
+
+      cy.task('stubSinglePremises', premises)
+      cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+      cy.task('stubBooking', { premisesId: premises.id, booking })
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalNewPage.visit(premises, null, bedspace, booking)
+
+      // And I miss required fields
+      cy.task('stubArrivalCreateErrors', {
+        premisesId: premises.id,
+        bookingId: booking.id,
+        params: ['arrivalDate', 'expectedDepartureDate'],
+      })
+      page.clearForm()
+      page.clickSubmit()
+
+      // Then I should see error messages relating to those fields
+      page.shouldShowErrorMessagesForFields(['arrivalDate', 'expectedDepartureDate'])
+    })
+
+    it('shows errors when the API returns a 409 conflict error', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a confirmed booking and a conflicting booking in the database
+      const premises = premisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+      const booking = bookingFactory.confirmed().build()
+      const conflictingBooking = bookingFactory.build()
+
+      cy.task('stubSinglePremises', premises)
+      cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+      cy.task('stubBooking', { premisesId: premises.id, booking })
+      cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalNewPage.visit(premises, null, bedspace, booking)
+
+      // And I fill out the form with dates that conflict with an existing booking
+      const arrival = arrivalFactory.build()
+      const newArrival = newArrivalFactory.build({
+        ...arrival,
+      })
+      cy.task('stubArrivalCreateConflictError', {
+        premisesId: premises.id,
+        bookingId: booking.id,
+        conflictingEntityId: conflictingBooking.id,
+        conflictingEntityType: 'booking',
+      })
+
+      page.completeForm(newArrival)
+
+      // Then I should see error messages for the conflict
+      page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
+    })
+
+    it('shows errors if arrival date is in future', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      const currentDate = new Date()
+      const futureDate = addDays(currentDate, 7)
+
+      // And there is a premises, a room, and a confirmed booking in the database
+      const booking = bookingFactory.confirmed().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalNewPage.visit(premises, null, bedspace, booking)
+      page.shouldShowBookingDetails()
+
+      // And I fill out the form
+      const arrival = arrivalFactory.build()
+      const newArrival = newArrivalFactory.build({
+        ...arrival,
+        arrivalDate: DateFormats.dateObjToIsoDate(futureDate),
+      })
+
+      page.completeForm(newArrival)
+
+      // Then I should see error messages relating to those fields
+      page.shouldShowErrorMessagesForFields(['arrivalDate'], 'todayOrInThePast')
+    })
+
+    it('navigates back from the booking arrival page to the show booking page', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a premises, a room, and a confirmed booking in the database
+      const booking = bookingFactory.confirmed().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the booking arrival page
+      const page = BookingArrivalNewPage.visit(premises, null, bedspace, booking)
+
+      // And I click the back link
+      page.clickBack()
+
+      // Then I navigate to the show bedspace page
+      Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    })
+  })
+
+  describe('Update Arrival', () => {
+    it('navigates to the booking arrival update page', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a premises, a room, and an active booking in the database
+      const booking = bookingFactory.arrived().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the show booking page
+      const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+      // Add I click the change arrival action
+      bookingShow.clickEditArrivalButton()
+
+      // Then I navigate to the change arrival page
+      Page.verifyOnPage(BookingArrivalEditPage, premises, null, bedspace, booking)
+    })
+
+    it('allows me to update an arrival', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a premises, a room, and an active booking in the database
+      const booking = bookingFactory.arrived().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalEditPage.visit(premises, null, bedspace, booking)
+      page.shouldShowBookingDetails()
+
+      // And I fill out the form
+      const newArrival = newArrivalFactory.build()
+      cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId: booking.id, arrival: newArrival })
+      page.clearForm()
+      page.completeForm(newArrival)
+
+      // Then the arrival should have been created in the API
+      cy.task('verifyArrivalCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+        expect(requests).to.have.length(1)
+        const requestBody = JSON.parse(requests[0].body)
+        expect(requestBody.arrivalDate).equal(newArrival.arrivalDate)
+        expect(requestBody.notes).equal(newArrival.notes)
+      })
+
+      cy.then(() => {
+        // And I should be redirected to the show booking page
+        const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+        bookingShowPage.shouldShowBanner('Arrival updated')
+      })
+    })
+
+    it('shows errors when the API returns an error', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a confirmed booking in the database
+      const premises = premisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+      const booking = bookingFactory.arrived().build()
+
+      cy.task('stubSinglePremises', premises)
+      cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+      cy.task('stubBooking', { premisesId: premises.id, booking })
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalEditPage.visit(premises, null, bedspace, booking)
+
+      // And I miss required fields
+      cy.task('stubArrivalCreateErrors', {
+        premisesId: premises.id,
+        bookingId: booking.id,
+        params: ['arrivalDate'],
+      })
+      page.clearForm()
+      page.clickSubmit()
+
+      // Then I should see error messages relating to those fields
+      page.shouldShowErrorMessagesForFields(['arrivalDate'])
+    })
+
+    it('shows errors when the API returns a 409 conflict error', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is an arrived booking and a conflicting booking in the database
+      const premises = premisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+      const booking = bookingFactory.arrived().build()
+      const conflictingBooking = bookingFactory.build()
+
+      cy.task('stubSinglePremises', premises)
+      cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+      cy.task('stubBooking', { premisesId: premises.id, booking })
+      cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalEditPage.visit(premises, null, bedspace, booking)
+
+      // And I fill out the form with dates that conflict with an existing booking
+      const newArrival = newArrivalFactory.build()
+      cy.task('stubArrivalCreateConflictError', {
+        premisesId: premises.id,
+        bookingId: booking.id,
+        conflictingEntityId: conflictingBooking.id,
+        conflictingEntityType: 'booking',
+      })
+
+      page.completeForm(newArrival)
+
+      // Then I should see error messages for the conflict
+      page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
+    })
+
+    it('shows errors if arrival date is in future', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      const currentDate = new Date()
+      const futureDate = addDays(currentDate, 7)
+
+      // And there is a confirmed booking in the database
+      const premises = premisesFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
+      const booking = bookingFactory.arrived().build()
+
+      cy.task('stubSinglePremises', premises)
+      cy.task('stubBedspaceV2', { premisesId: premises.id, bedspace })
+      cy.task('stubBooking', { premisesId: premises.id, booking })
+
+      // When I visit the booking confirmation page
+      const page = BookingArrivalEditPage.visit(premises, null, bedspace, booking)
+
+      // And I fill out the form
+      const newArrival = newArrivalFactory.build()
+      newArrival.arrivalDate = DateFormats.dateObjToIsoDate(futureDate)
+      cy.task('stubArrivalCreate', { premisesId: premises.id, bookingId: booking.id, arrival: newArrival })
+      page.clearForm()
+      page.completeForm(newArrival)
+
+      // Then I should see error messages relating to those fields
+      page.shouldShowErrorMessagesForFields(['arrivalDate'], 'todayOrInThePast')
+    })
+
+    it('navigates back from the booking arrival page to the show booking page', () => {
+      // Given I am signed in
+      cy.signIn()
+
+      // And there is a premises, a room, and a confirmed booking in the database
+      const booking = bookingFactory.arrived().build()
+      const { premises, bedspace } = setupBookingStateStubs(booking)
+
+      // When I visit the booking arrival page
+      const page = BookingArrivalEditPage.visit(premises, null, bedspace, booking)
+
+      // And I click the back link
+      page.clickBack()
+
+      // Then I navigate to the show bedspace page
+      Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    })
   })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/confirmation.cy.ts
@@ -1,9 +1,9 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BookingConfirmationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-// import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingConfirmationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingConfirmationNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import { bookingFactory, confirmationFactory, newConfirmationFactory } from '../../../../server/testutils/factories'
+import { bookingFactory, confirmationFactory, newConfirmationFactory } from '../../../../server/testutils/factories'
 
 context('Booking confirmation', () => {
   beforeEach(() => {
@@ -14,71 +14,71 @@ context('Booking confirmation', () => {
   it('navigates to the confirm booking page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there is a premises, a room, and a provisional booking in the database
-    //     const booking = bookingFactory.provisional().build()
-    //     const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //     // When I visit the show booking page
-    //     const bookingShow = BookingShowPage.visit(premises, room, booking)
-    //
-    //     // Add I click the confim booking action
-    //     bookingShow.clickConfirmBookingButton()
-    //
-    //     // Then I navigate to the booking confirmation page
-    //     Page.verifyOnPage(BookingConfirmationNewPage, premises, room, booking)
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the confim booking action
+    bookingShow.clickConfirmBookingButton()
+
+    // Then I navigate to the booking confirmation page
+    Page.verifyOnPage(BookingConfirmationNewPage, premises, null, bedspace, booking)
   })
-  //
-  //   it('allows me to confirm a booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a provisional booking in the database
-  //     const booking = bookingFactory.provisional().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking confirmation page
-  //     const page = BookingConfirmationNewPage.visit(premises, room, booking)
-  //     page.shouldShowBookingDetails()
-  //
-  //     // And I fill out the form
-  //     const confirmation = confirmationFactory.build()
-  //     const newConfirmation = newConfirmationFactory.build({
-  //       ...confirmation,
-  //     })
-  //
-  //     cy.task('stubConfirmationCreate', { premisesId: premises.id, bookingId: booking.id, confirmation })
-  //
-  //     page.completeForm(newConfirmation)
-  //
-  //     // Then the confirmation should have been created in the API
-  //     cy.task('verifyConfirmationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //
-  //       expect(requestBody.notes).equal(newConfirmation.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Booking confirmed')
-  //   })
-  //
-  //   it('navigates back from the booking confirmation page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a provisional booking in the database
-  //     const booking = bookingFactory.provisional().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking confirmation page
-  //     const page = BookingConfirmationNewPage.visit(premises, room, booking)
-  //
-  //     // And I click the back link
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
+
+  it('allows me to confirm a booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking confirmation page
+    const page = BookingConfirmationNewPage.visit(premises, null, bedspace, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const confirmation = confirmationFactory.build()
+    const newConfirmation = newConfirmationFactory.build({
+      ...confirmation,
+    })
+
+    cy.task('stubConfirmationCreate', { premisesId: premises.id, bookingId: booking.id, confirmation })
+
+    page.completeForm(newConfirmation)
+
+    // Then the confirmation should have been created in the API
+    cy.task('verifyConfirmationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.notes).equal(newConfirmation.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking confirmed')
+  })
+
+  it('navigates back from the booking confirmation page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking confirmation page
+    const page = BookingConfirmationNewPage.visit(premises, null, bedspace, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
 })

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.test.ts
@@ -4,14 +4,14 @@ import { addDays } from 'date-fns'
 import { BespokeError } from '../../../@types/ui'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { ArrivalService, BedspaceService, BookingService, PremisesService } from '../../../services'
+import { ArrivalService, BookingService, PremisesService } from '../../../services'
 import {
   arrivalFactory,
   bookingFactory,
+  cas3BedspaceFactory,
   confirmationFactory,
   newArrivalFactory,
   premisesFactory,
-  roomFactory,
 } from '../../../testutils/factories'
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
@@ -24,6 +24,7 @@ import {
 } from '../../../utils/validation'
 import ArrivalsController from './arrivalsController'
 import config from '../../../config'
+import BedspaceService from '../../../services/v2/bedspaceService'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
@@ -32,7 +33,7 @@ jest.mock('../../../utils/bookingUtils')
 describe('ArrivalsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
-  const roomId = 'roomId'
+  const bedspaceId = 'bedspaceId'
   const bookingId = 'bookingId'
 
   let request: Request
@@ -56,17 +57,17 @@ describe('ArrivalsController', () => {
     describe('new', () => {
       it('renders the form prepopulated with the current booking dates', async () => {
         const premises = premisesFactory.build()
-        const room = roomFactory.build()
+        const bedspace = cas3BedspaceFactory.build()
         const booking = bookingFactory.arrived().build()
 
         request.params = {
           premisesId: premises.id,
-          roomId: room.id,
+          bedspaceId: bedspace.id,
           bookingId: booking.id,
         }
 
         premisesService.getPremises.mockResolvedValue(premises)
-        bedspaceService.getRoom.mockResolvedValue(room)
+        bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
         bookingService.getBooking.mockResolvedValue(booking)
 
         const requestHandler = arrivalsController.new()
@@ -75,12 +76,12 @@ describe('ArrivalsController', () => {
         await requestHandler(request, response, next)
 
         expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-        expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+        expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
         expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/arrivals/new', {
           premises,
-          room,
+          bedspace,
           booking,
           errors: {},
           errorSummary: [],
@@ -98,7 +99,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -123,9 +124,7 @@ describe('ArrivalsController', () => {
           title: 'Booking marked as active',
           text: 'At the moment the CAS3 digital service does not automatically update NDelius. Please continue to record accommodation and address changes directly in NDelius.',
         })
-        expect(response.redirect).toHaveBeenCalledWith(
-          paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }),
-        )
+        expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       })
 
       it('renders with errors if the API returns an error', async () => {
@@ -138,7 +137,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -158,7 +157,7 @@ describe('ArrivalsController', () => {
           request,
           response,
           err,
-          paths.bookings.arrivals.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.new({ premisesId, bedspaceId, bookingId }),
         )
       })
 
@@ -172,7 +171,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -195,7 +194,7 @@ describe('ArrivalsController', () => {
 
         await requestHandler(request, response, next)
 
-        expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, roomId, 'plural')
+        expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, bedspaceId, 'plural')
         expect(insertBespokeError).toHaveBeenCalledWith(err, bespokeError)
         expect(insertGenericError).toHaveBeenCalledWith(err, 'arrivalDate', 'conflict')
         expect(insertGenericError).toHaveBeenCalledWith(err, 'expectedDepartureDate', 'conflict')
@@ -203,7 +202,7 @@ describe('ArrivalsController', () => {
           request,
           response,
           err,
-          paths.bookings.arrivals.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.new({ premisesId, bedspaceId, bookingId }),
         )
       })
 
@@ -220,7 +219,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -240,7 +239,7 @@ describe('ArrivalsController', () => {
           request,
           response,
           err,
-          paths.bookings.arrivals.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.new({ premisesId, bedspaceId, bookingId }),
         )
       })
     })
@@ -250,17 +249,17 @@ describe('ArrivalsController', () => {
     describe('edit', () => {
       it('renders the form', async () => {
         const premises = premisesFactory.build()
-        const room = roomFactory.build()
+        const bedspace = cas3BedspaceFactory.build()
         const booking = bookingFactory.arrived().build()
 
         request.params = {
           premisesId: premises.id,
-          roomId: room.id,
+          bedspaceId: bedspace.id,
           bookingId: booking.id,
         }
 
         premisesService.getPremises.mockResolvedValue(premises)
-        bedspaceService.getRoom.mockResolvedValue(room)
+        bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
         bookingService.getBooking.mockResolvedValue(booking)
 
         const requestHandler = arrivalsController.edit()
@@ -269,12 +268,12 @@ describe('ArrivalsController', () => {
         await requestHandler(request, response, next)
 
         expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-        expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+        expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
         expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
         expect(response.render).toHaveBeenCalledWith('temporary-accommodation/arrivals/edit', {
           premises,
-          room,
+          bedspace,
           booking,
           errors: {},
           errorSummary: [],
@@ -296,7 +295,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -316,9 +315,7 @@ describe('ArrivalsController', () => {
         )
 
         expect(request.flash).toHaveBeenCalledWith('success', 'Arrival updated')
-        expect(response.redirect).toHaveBeenCalledWith(
-          paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }),
-        )
+        expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       })
 
       it('renders with errors if the API returns an error', async () => {
@@ -331,7 +328,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -350,7 +347,7 @@ describe('ArrivalsController', () => {
           request,
           response,
           err,
-          paths.bookings.arrivals.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.edit({ premisesId, bedspaceId, bookingId }),
         )
       })
 
@@ -364,7 +361,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -386,14 +383,14 @@ describe('ArrivalsController', () => {
 
         await requestHandler(request, response, next)
 
-        expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, roomId, 'singular')
+        expect(generateConflictBespokeError).toHaveBeenCalledWith(err, premisesId, bedspaceId, 'singular')
         expect(insertBespokeError).toHaveBeenCalledWith(err, bespokeError)
         expect(insertGenericError).toHaveBeenCalledWith(err, 'arrivalDate', 'conflict')
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
           request,
           response,
           err,
-          paths.bookings.arrivals.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.edit({ premisesId, bedspaceId, bookingId }),
         )
       })
 
@@ -408,7 +405,7 @@ describe('ArrivalsController', () => {
 
         request.params = {
           premisesId,
-          roomId,
+          bedspaceId,
           bookingId,
         }
         request.body = {
@@ -428,7 +425,7 @@ describe('ArrivalsController', () => {
           request,
           response,
           err,
-          paths.bookings.arrivals.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.edit({ premisesId, bedspaceId, bookingId }),
         )
       })
     })
@@ -446,17 +443,17 @@ describe('ArrivalsController', () => {
 
     it('does not show the NDelius update message when creating', async () => {
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
       const booking = bookingFactory.arrived().build()
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
 
       const requestHandler = arrivalsController.new()
@@ -465,7 +462,7 @@ describe('ArrivalsController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
       expect(response.render).toHaveBeenCalledWith(
@@ -482,7 +479,7 @@ describe('ArrivalsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {

--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -2,7 +2,7 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import type { NewCas3Arrival as NewArrival } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { ArrivalService, BedspaceService, BookingService, PremisesService } from '../../../services'
+import { ArrivalService, BookingService, PremisesService } from '../../../services'
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
 import { DateFormats, dateIsInFuture } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
@@ -13,6 +13,7 @@ import {
   insertGenericError,
 } from '../../../utils/validation'
 import config from '../../../config'
+import BedspaceService from '../../../services/v2/bedspaceService'
 
 export default class ArrivalsController {
   constructor(
@@ -25,17 +26,17 @@ export default class ArrivalsController {
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, errorTitle, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/arrivals/new', {
         premises,
-        room,
+        bedspace,
         booking,
         errors,
         errorSummary,
@@ -50,7 +51,7 @@ export default class ArrivalsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
       try {
         const newArrival: NewArrival = {
@@ -85,10 +86,10 @@ export default class ArrivalsController {
             ? 'You no longer need to update NDelius with this change.'
             : 'At the moment the CAS3 digital service does not automatically update NDelius. Please continue to record accommodation and address changes directly in NDelius.',
         })
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         if (err.status === 409) {
-          insertBespokeError(err, generateConflictBespokeError(err, premisesId, roomId, 'plural'))
+          insertBespokeError(err, generateConflictBespokeError(err, premisesId, bedspaceId, 'plural'))
           insertGenericError(err, 'arrivalDate', 'conflict')
           insertGenericError(err, 'expectedDepartureDate', 'conflict')
         }
@@ -97,7 +98,7 @@ export default class ArrivalsController {
           req,
           res,
           err,
-          paths.bookings.arrivals.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.new({ premisesId, bedspaceId, bookingId }),
         )
       }
     }
@@ -106,19 +107,19 @@ export default class ArrivalsController {
   edit(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, errorTitle, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
-      const [premises, room, booking] = await Promise.all([
+      const [premises, bedspace, booking] = await Promise.all([
         this.premisesService.getPremises(callConfig, premisesId),
-        this.bedspacesService.getRoom(callConfig, premisesId, roomId),
+        this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId),
         this.bookingsService.getBooking(callConfig, premisesId, bookingId),
       ])
 
       return res.render('temporary-accommodation/arrivals/edit', {
         premises,
-        room,
+        bedspace,
         booking,
         errors,
         errorSummary,
@@ -131,7 +132,7 @@ export default class ArrivalsController {
 
   update(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
       try {
         const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
@@ -154,10 +155,10 @@ export default class ArrivalsController {
         // INFO: this may confuse, the API is overloading the POST with a writeback of existing and new data
         await this.arrivalService.createArrival(callConfig, premisesId, bookingId, updateArrival)
         req.flash('success', 'Arrival updated')
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         if (err.status === 409) {
-          insertBespokeError(err, generateConflictBespokeError(err, premisesId, roomId, 'singular'))
+          insertBespokeError(err, generateConflictBespokeError(err, premisesId, bedspaceId, 'singular'))
           insertGenericError(err, 'arrivalDate', 'conflict')
         }
 
@@ -165,7 +166,7 @@ export default class ArrivalsController {
           req,
           res,
           err,
-          paths.bookings.arrivals.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.arrivals.edit({ premisesId, bedspaceId, bookingId }),
         )
       }
     }

--- a/server/controllers/temporary-accommodation/manage/confirmationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/confirmationsController.ts
@@ -2,7 +2,8 @@ import type { Request, RequestHandler, Response } from 'express'
 
 import type { NewConfirmation } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BedspaceService, BookingService, PremisesService } from '../../../services'
+import { BookingService, PremisesService } from '../../../services'
+import BedspaceService from '../../../services/v2/bedspaceService'
 import ConfirmationService from '../../../services/confirmationService'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
@@ -18,17 +19,17 @@ export default class ConfirmationsController {
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       return res.render('temporary-accommodation/confirmations/new', {
         premises,
-        room,
+        bedspace,
         booking,
         errors,
         errorSummary: requestErrorSummary,
@@ -39,7 +40,7 @@ export default class ConfirmationsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       const newConfirmation: NewConfirmation = {
@@ -50,13 +51,13 @@ export default class ConfirmationsController {
         await this.confirmationService.createConfirmation(callConfig, premisesId, bookingId, newConfirmation)
 
         req.flash('success', 'Booking confirmed')
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,
           res,
           err,
-          paths.bookings.confirmations.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.confirmations.new({ premisesId, bedspaceId, bookingId }),
         )
       }
     }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -45,7 +45,7 @@ export const controllers = (services: Services) => {
   )
   const arrivalsController = new ArrivalsController(
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.bookingService,
     services.arrivalService,
   )

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -39,7 +39,7 @@ export const controllers = (services: Services) => {
 
   const confirmationsController = new ConfirmationsController(
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.bookingService,
     services.confirmationService,
   )

--- a/server/utils/bookingUtils.ts
+++ b/server/utils/bookingUtils.ts
@@ -181,7 +181,7 @@ export const shortenedOrExtended = (extension: Extension): 'shortened' | 'extend
 export const generateConflictBespokeError = (
   err: SanitisedError,
   premisesId: string,
-  roomId: string,
+  bedspaceId: string,
   datesGrammaticalNumber: 'plural' | 'singular',
 ): BespokeError => {
   const { detail } = err.data as { detail: string }
@@ -199,12 +199,12 @@ export const generateConflictBespokeError = (
       conflictingEntityType === 'lost-bed'
         ? `<a href="${paths.lostBeds.show({
             premisesId,
-            bedspaceId: roomId,
+            bedspaceId,
             lostBedId: conflictingEntityId,
           })}">existing void</a>`
         : `<a href="${paths.bookings.show({
             premisesId,
-            bedspaceId: roomId,
+            bedspaceId,
             bookingId: conflictingEntityId,
           })}">existing booking</a>`
 

--- a/server/views/temporary-accommodation/arrivals/edit.njk
+++ b/server/views/temporary-accommodation/arrivals/edit.njk
@@ -16,7 +16,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -28,13 +28,13 @@
   <h1 class="govuk-heading-l">Change arrival</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.arrivals.update({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}?_method=patch" method="post">
+      <form action="{{ paths.bookings.arrivals.update({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}?_method=patch" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ formPageDateInput(

--- a/server/views/temporary-accommodation/arrivals/new.njk
+++ b/server/views/temporary-accommodation/arrivals/new.njk
@@ -16,7 +16,7 @@
 {% block beforeContent %}
     {{ govukBackLink({
         text: "Back",
-        href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+        href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
     }) }}
 {% endblock %}
 
@@ -28,13 +28,13 @@
     <h1 class="govuk-heading-l">Mark booking as active</h1>
 
     {{ popDetailsHeader(booking.person) }}
-    {{ locationHeader({ premises: premises, room: room }) }}
+    {{ locationHeader({ premises: premises, room: bedspace }) }}
 
     {{ bookingInfo(booking) }}
 
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <form action="{{ paths.bookings.arrivals.create({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}"
+            <form action="{{ paths.bookings.arrivals.create({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}"
                   method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
 

--- a/server/views/temporary-accommodation/confirmations/new.njk
+++ b/server/views/temporary-accommodation/confirmations/new.njk
@@ -13,7 +13,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -23,13 +23,13 @@
   <h1 class="govuk-heading-l">Mark booking as confirmed</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.confirmations.create({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}" method="post">
+      <form action="{{ paths.bookings.confirmations.create({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ formPageTextarea(


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1928

The outcome of https://dsdmoj.atlassian.net/browse/CAS-1865 was to replace the current `Manage properties v1` routes with the new `Manage properties v2` routes. 

The above strategy helps us link into the other v1 areas of the application (e.g. `Bookings`, `Voids`, `Departures`, `Arrivals` etc) as the breadcrumbs still work (for the most part!) as they go back to v1 which is now the new v2 pages. 

However, these areas are currently driven by a `roomId` from the BE on the url path for the bedspace. With the way the new BE `cas3` endpoints have been delivered the primary key for bedspaces has become the `bedId` (not the `roomId`). This changes in the backend means that there is some refactoring to do in these `CAS3-UI` v1 areas to `retrieve the bedspace and not the room`. This has rippling effects on the v1 areas controllers, services and views and so we need to refactor these. 

# Changes in this PR
1. Get the `Booking confirmation` and `Arrivals` areas working
2. Add back in the related integration test / e2e test coverage that commented out in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1382

**Suggestion**: I have done separate commits for `Booking confirmation` area and `Arrivals` area so maybe easier to review 1 commit at a time
