### PR TITLE
Cancellations, Departures and Extensions areas with Bedspace v2

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationEdit.ts
@@ -1,4 +1,4 @@
-import type { Booking, NewCancellation, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, NewCancellation, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -15,18 +15,27 @@ export default class BookingCancellationEditPage extends BookingCancellationEdit
   constructor(
     premises: Premises,
     room: Room,
+    bedspace: Cas3Bedspace,
     private readonly booking: Booking,
   ) {
     super('Update cancelled booking')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingCancellationEditPage {
-    cy.visit(paths.bookings.cancellations.edit({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingCancellationEditPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingCancellationEditPage {
+    if (room) {
+      cy.visit(
+        paths.bookings.cancellations.edit({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }),
+      )
+    } else {
+      cy.visit(
+        paths.bookings.cancellations.edit({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
+      )
+    }
+    return new BookingCancellationEditPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew.ts
@@ -1,4 +1,4 @@
-import type { Booking, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -12,17 +12,33 @@ export default class BookingCancellationNewPage extends BookingCancellationEdita
 
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(premises: Premises, room: Room, booking: Booking) {
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking) {
     super('Cancel booking')
 
     this.bookingInfoComponent = new BookingInfoComponent(booking)
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingCancellationNewPage {
-    cy.visit(paths.bookings.cancellations.new({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingCancellationNewPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingCancellationNewPage {
+    if (room) {
+      cy.visit(
+        paths.bookings.cancellations.new({
+          premisesId: premises.id,
+          bedspaceId: room.id,
+          bookingId: booking.id,
+        }),
+      )
+    } else {
+      cy.visit(
+        paths.bookings.cancellations.new({
+          premisesId: premises.id,
+          bedspaceId: bedspace.id,
+          bookingId: booking.id,
+        }),
+      )
+    }
+    return new BookingCancellationNewPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit.ts
@@ -1,4 +1,4 @@
-import type { Booking, NewDeparture, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, NewDeparture, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -15,18 +15,25 @@ export default class BookingDepartureEditPage extends BookingDepartureEditablePa
   constructor(
     premises: Premises,
     room: Room,
+    bedspace: Cas3Bedspace,
     private readonly booking: Booking,
   ) {
     super('Update departure details')
 
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingDepartureEditPage {
-    cy.visit(paths.bookings.departures.edit({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingDepartureEditPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingDepartureEditPage {
+    if (room) {
+      cy.visit(paths.bookings.departures.edit({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(
+        paths.bookings.departures.edit({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
+      )
+    }
+    return new BookingDepartureEditPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew.ts
@@ -1,4 +1,4 @@
-import type { Booking, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import BookingInfoComponent from '../../../components/bookingInfo'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -12,17 +12,23 @@ export default class BookingDepartureNewPage extends BookingDepartureEditablePag
 
   private readonly bookingInfoComponent: BookingInfoComponent
 
-  constructor(premises: Premises, room: Room, booking: Booking) {
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking) {
     super('Mark booking as departed')
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingDepartureNewPage {
-    cy.visit(paths.bookings.departures.new({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingDepartureNewPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingDepartureNewPage {
+    if (room) {
+      cy.visit(paths.bookings.departures.new({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(
+        paths.bookings.departures.new({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
+      )
+    }
+    return new BookingDepartureNewPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew.ts
@@ -1,4 +1,4 @@
-import type { Booking, LostBed, NewExtension, Premises, Room } from '@approved-premises/api'
+import type { Booking, Cas3Bedspace, LostBed, NewExtension, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import { getLatestExtension } from '../../../../server/utils/bookingUtils'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
@@ -19,19 +19,26 @@ export default class BookingExtensionNewPage extends Page {
   constructor(
     premises: Premises,
     room: Room,
+    bedspace: Cas3Bedspace,
     private readonly booking: Booking,
   ) {
     super('Extend or shorten booking')
 
     this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room, null, 'booking')
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
     this.bookingInfoComponent = new BookingInfoComponent(booking)
   }
 
-  static visit(premises: Premises, room: Room, booking: Booking): BookingExtensionNewPage {
-    cy.visit(paths.bookings.extensions.new({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }))
-    return new BookingExtensionNewPage(premises, room, booking)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, booking: Booking): BookingExtensionNewPage {
+    if (room) {
+      cy.visit(paths.bookings.extensions.new({ premisesId: premises.id, bedspaceId: room.id, bookingId: booking.id }))
+    } else {
+      cy.visit(
+        paths.bookings.extensions.new({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
+      )
+    }
+    return new BookingExtensionNewPage(premises, room, bedspace, booking)
   }
 
   shouldShowBookingDetails(): void {

--- a/e2e/tests/booking-errors.feature
+++ b/e2e/tests/booking-errors.feature
@@ -21,12 +21,12 @@ Feature: Manage Temporary Accommodation - Booking Errors
  Scenario: Showing booking cancellation errors
     Given I'm creating a booking
     And I create a booking with all necessary details
-#    And I attempt to cancel the booking with required details missing
-#    Then I should see a list of the problems encountered cancelling the booking
-#    And I cancel the booking
-#    And I attempt to edit the cancelled booking with required details missing
-#    Then I should see a list of the problems encountered editing the cancelling booking
-#
+    And I attempt to cancel the booking with required details missing
+    Then I should see a list of the problems encountered cancelling the booking
+    And I cancel the booking
+    And I attempt to edit the cancelled booking with required details missing
+    Then I should see a list of the problems encountered editing the cancelling booking
+
   Scenario: Showing booking arrival errors
     Given I'm creating a booking
     And I create a booking with all necessary details

--- a/e2e/tests/booking-errors.feature
+++ b/e2e/tests/booking-errors.feature
@@ -39,8 +39,8 @@ Feature: Manage Temporary Accommodation - Booking Errors
     And I create a booking with all necessary details
     And I confirm the booking
     And I mark the booking as arrived
- #   And I attempt to extend the booking with required details missing
- #   Then I should see a list of the problems encountered extending the booking
+    And I attempt to extend the booking with required details missing
+    Then I should see a list of the problems encountered extending the booking
 
   Scenario: Showing booking departure errors
     Given I'm creating a booking

--- a/e2e/tests/booking-errors.feature
+++ b/e2e/tests/booking-errors.feature
@@ -47,8 +47,8 @@ Feature: Manage Temporary Accommodation - Booking Errors
     And I create a booking with all necessary details
     And I confirm the booking
     And I mark the booking as arrived
-#    And I attempt to mark the booking as departed with required details missing
-#    Then I should see a list of the problems encountered marking the booking as departed
-#    And I mark the booking as departed
-#    And I attempt to edit the departed booking with required details missing
-#    Then I should see a list of the problems encountered editing the departed booking
+    And I attempt to mark the booking as departed with required details missing
+    Then I should see a list of the problems encountered marking the booking as departed
+    And I mark the booking as departed
+    And I attempt to edit the departed booking with required details missing
+    Then I should see a list of the problems encountered editing the departed booking

--- a/e2e/tests/bookingSearch.feature
+++ b/e2e/tests/bookingSearch.feature
@@ -15,18 +15,18 @@ Feature: Manage Temporary Accommodation - Booking search
     And I'm searching bookings
     Then I should see a summary of the booking on the confirmed bookings page
     And I mark the booking as arrived
-#    And I'm searching bookings
-#    Then I should see a summary of the booking on the active bookings page
-#    And I mark the booking as departed
-#    And I'm searching bookings
-#    Then I should see a summary of the booking on the departed bookings page
+    And I'm searching bookings
+    Then I should see a summary of the booking on the active bookings page
+    And I mark the booking as departed
+    And I'm searching bookings
+    Then I should see a summary of the booking on the departed bookings page
 #
   Scenario: Searching for a booking by CRN
     Given I'm searching bookings
     When I search for a CRN that does not exist in provisional bookings
     Then I should see a message that the provisional booking is not found
-#    When I click on the Departed bookings tab
-#    Then I should see a message that the departed booking is not found
-#    When I click on the Provisional bookings tab
-#    And I search for a valid CRN in provisional bookings
-#    Then I see the provisional booking I was searching for
+    When I click on the Departed bookings tab
+    Then I should see a message that the departed booking is not found
+    When I click on the Provisional bookings tab
+    And I search for a valid CRN in provisional bookings
+    Then I see the provisional booking I was searching for

--- a/e2e/tests/stepDefinitions/manage/cancellation.ts
+++ b/e2e/tests/stepDefinitions/manage/cancellation.ts
@@ -8,7 +8,7 @@ import { bookingFactory, cancellationFactory, newCancellationFactory } from '../
 
 Given('I cancel the booking', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickCancelBookingButton()
 
     const cancellation = cancellationFactory.build()
@@ -21,6 +21,7 @@ Given('I cancel the booking', () => {
       BookingCancellationNewPage,
       this.premises,
       this.room,
+      null,
       this.booking,
     )
     bookingCancellationPage.shouldShowBookingDetails()
@@ -39,13 +40,14 @@ Given('I cancel the booking', () => {
 
 Given('I attempt to cancel the booking with required details missing', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickCancelBookingButton()
 
     const bookingCancellationPage = Page.verifyOnPage(
       BookingCancellationNewPage,
       this.premises,
       this.room,
+      null,
       this.booking,
     )
     bookingCancellationPage.clickSubmit()
@@ -54,7 +56,7 @@ Given('I attempt to cancel the booking with required details missing', () => {
 
 Given('I edit the cancelled booking', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickEditCancelledBookingButton()
 
     const cancellation = cancellationFactory.build()
@@ -67,6 +69,7 @@ Given('I edit the cancelled booking', () => {
       BookingCancellationEditPage,
       this.premises,
       this.room,
+      null,
       this.booking,
     )
     bookingCancellationPage.shouldShowBookingDetails()
@@ -85,13 +88,14 @@ Given('I edit the cancelled booking', () => {
 
 Given('I attempt to edit the cancelled booking with required details missing', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickEditCancelledBookingButton()
 
     const bookingCancellationPage = Page.verifyOnPage(
       BookingCancellationEditPage,
       this.premises,
       this.room,
+      null,
       this.booking,
     )
     bookingCancellationPage.clearForm()
@@ -101,13 +105,13 @@ Given('I attempt to edit the cancelled booking with required details missing', (
 
 Then('I should see the booking with the cancelled status', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Booking cancelled')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -115,13 +119,13 @@ Then('I should see the booking with the cancelled status', () => {
 
 Then('I should see the booking with the edited cancellation details', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Cancelled booking updated')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -129,7 +133,7 @@ Then('I should see the booking with the edited cancellation details', () => {
 
 Then('I should see a list of the problems encountered cancelling the booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingCancellationNewPage, this.premises, this.room, this.booking)
+    const page = Page.verifyOnPage(BookingCancellationNewPage, this.premises, this.room, null, this.booking)
     page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
 
     page.clickBack()
@@ -138,7 +142,7 @@ Then('I should see a list of the problems encountered cancelling the booking', (
 
 Then('I should see a list of the problems encountered editing the cancelling booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingCancellationEditPage, this.premises, this.room, this.booking)
+    const page = Page.verifyOnPage(BookingCancellationEditPage, this.premises, this.room, null, this.booking)
     page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
 
     page.clickBack()

--- a/e2e/tests/stepDefinitions/manage/departure.ts
+++ b/e2e/tests/stepDefinitions/manage/departure.ts
@@ -1,5 +1,6 @@
 import { Given, Then } from '@badeball/cypress-cucumber-preprocessor'
 import { fakerEN_GB as faker } from '@faker-js/faker'
+import { BookingStatus } from '@approved-premises/ui'
 import Page from '../../../../cypress_shared/pages/page'
 import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
 import BookingDepartureEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit'
@@ -7,11 +8,10 @@ import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-
 import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
 import { bookingFactory, departureFactory, newDepartureFactory } from '../../../../server/testutils/factories'
 import { DateFormats } from '../../../../server/utils/dateUtils'
-import { BookingStatus } from '../../../../server/@types/ui/index'
 
 Given('I mark the booking as departed', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickMarkDepartedBookingButton()
 
     const departure = departureFactory.build({
@@ -28,7 +28,13 @@ Given('I mark the booking as departed', () => {
       moveOnCategoryId: departure.moveOnCategory.id,
     })
 
-    const bookingDeparturePage = Page.verifyOnPage(BookingDepartureNewPage, this.premises, this.room, this.booking)
+    const bookingDeparturePage = Page.verifyOnPage(
+      BookingDepartureNewPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingDeparturePage.shouldShowBookingDetails()
     bookingDeparturePage.completeForm(newDeparture)
 
@@ -46,17 +52,23 @@ Given('I mark the booking as departed', () => {
 
 Given('I attempt to mark the booking as departed with required details missing', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickMarkDepartedBookingButton()
 
-    const bookingDeparturePage = Page.verifyOnPage(BookingDepartureNewPage, this.premises, this.room, this.booking)
+    const bookingDeparturePage = Page.verifyOnPage(
+      BookingDepartureNewPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingDeparturePage.clickSubmit()
   })
 })
 
 Given('I edit the departed booking', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickEditDepartedBookingButton()
 
     const departure = departureFactory.build({
@@ -71,7 +83,13 @@ Given('I edit the departed booking', () => {
       dateTime: DateFormats.dateObjToIsoDate(faker.date.between({ from: this.booking.arrivalDate, to: Date.now() })),
     })
 
-    const bookingDeparturePage = Page.verifyOnPage(BookingDepartureEditPage, this.premises, this.room, this.booking)
+    const bookingDeparturePage = Page.verifyOnPage(
+      BookingDepartureEditPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingDeparturePage.shouldShowBookingDetails()
     bookingDeparturePage.completeForm(newDeparture)
 
@@ -89,10 +107,16 @@ Given('I edit the departed booking', () => {
 
 Given('I attempt to edit the departed booking with required details missing', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickEditDepartedBookingButton()
 
-    const bookingDeparturePage = Page.verifyOnPage(BookingDepartureEditPage, this.premises, this.room, this.booking)
+    const bookingDeparturePage = Page.verifyOnPage(
+      BookingDepartureEditPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingDeparturePage.clearForm()
     bookingDeparturePage.clickSubmit()
   })
@@ -100,13 +124,13 @@ Given('I attempt to edit the departed booking with required details missing', ()
 
 Then('I should see the booking with the departed status', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Booking marked as departed')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -114,13 +138,13 @@ Then('I should see the booking with the departed status', () => {
 
 Then('I should see the booking with the edited departure details', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Departure details changed')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -128,7 +152,7 @@ Then('I should see the booking with the edited departure details', () => {
 
 Then('I should see a list of the problems encountered marking the booking as departed', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingDepartureNewPage, this.premises, this.room, this.booking)
+    const page = Page.verifyOnPage(BookingDepartureNewPage, this.premises, this.room, null, this.booking)
     page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
 
     page.clickBack()
@@ -137,7 +161,7 @@ Then('I should see a list of the problems encountered marking the booking as dep
 
 Then('I should see a list of the problems encountered editing the departed booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingDepartureEditPage, this.premises, this.room, this.booking)
+    const page = Page.verifyOnPage(BookingDepartureEditPage, this.premises, this.room, null, this.booking)
     page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
 
     page.clickBack()

--- a/e2e/tests/stepDefinitions/manage/extension.ts
+++ b/e2e/tests/stepDefinitions/manage/extension.ts
@@ -9,7 +9,7 @@ import { DateFormats } from '../../../../server/utils/dateUtils'
 
 Given('I extend the booking', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickExtendBookingButton()
 
     const newExtension = newExtensionFactory.build({
@@ -22,7 +22,13 @@ Given('I extend the booking', () => {
       previousDepartureDate: this.booking.departureDate,
     })
 
-    const bookingExtensionPage = Page.verifyOnPage(BookingExtensionNewPage, this.premises, this.room, this.booking)
+    const bookingExtensionPage = Page.verifyOnPage(
+      BookingExtensionNewPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingExtensionPage.shouldShowBookingDetails()
     bookingExtensionPage.completeForm(newExtension)
 
@@ -39,10 +45,16 @@ Given('I extend the booking', () => {
 
 Given('I attempt to extend the booking with required details missing', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.clickExtendBookingButton()
 
-    const bookingExtensionPage = Page.verifyOnPage(BookingExtensionNewPage, this.premises, this.room, this.booking)
+    const bookingExtensionPage = Page.verifyOnPage(
+      BookingExtensionNewPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingExtensionPage.clearForm()
     bookingExtensionPage.clickSubmit()
   })
@@ -50,13 +62,13 @@ Given('I attempt to extend the booking with required details missing', () => {
 
 Then('I should see the booking with the extended departure date', () => {
   cy.then(function _() {
-    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, this.booking)
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, this.premises, this.room, null, this.booking)
     bookingShowPage.shouldShowBanner('Booking departure date changed')
     bookingShowPage.shouldShowBookingDetails()
 
     bookingShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowBookingDetails(this.booking)
     bedspaceShowPage.clickBookingLink(this.booking)
   })
@@ -64,7 +76,7 @@ Then('I should see the booking with the extended departure date', () => {
 
 Then('I should see a list of the problems encountered extending the booking', () => {
   cy.then(function _() {
-    const page = Page.verifyOnPage(BookingExtensionNewPage, this.premises, this.room, this.booking)
+    const page = Page.verifyOnPage(BookingExtensionNewPage, this.premises, this.room, null, this.booking)
     page.shouldShowErrorMessagesForFields(['newDepartureDate'])
 
     page.clickBack()

--- a/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/cancellation.cy.ts
@@ -1,10 +1,10 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BookingCancellationEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationEdit'
-// import BookingCancellationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-// import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingCancellationEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationEdit'
+import BookingCancellationNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingCancellationNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import { bookingFactory, cancellationFactory, newCancellationFactory } from '../../../../server/testutils/factories'
+import { bookingFactory, cancellationFactory, newCancellationFactory } from '../../../../server/testutils/factories'
 
 context('Booking cancellation', () => {
   beforeEach(() => {
@@ -15,201 +15,201 @@ context('Booking cancellation', () => {
   it('navigates to the booking cancellation page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there is a premises, a room, and a provisional booking in the database
-    //     const booking = bookingFactory.provisional().build()
-    //     const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //     // When I visit the show booking page
-    //     const bookingShow = BookingShowPage.visit(premises, room, booking)
-    //
-    //     // Add I click the cancel booking action
-    //     cy.task('stubCancellationReferenceData')
-    //     bookingShow.clickCancelBookingButton()
-    //
-    //     // Then I navigate to the booking cancellation page
-    //     Page.verifyOnPage(BookingCancellationNewPage, premises, room, booking)
-    //   })
-    //
-    //   it('navigates to the edit booking cancellation page', () => {
-    //     // Given I am signed in
-    //     cy.signIn()
-    //
-    //     // And there is a premises, a room, and a cancelled booking in the database
-    //     const booking = bookingFactory.cancelled().build()
-    //     const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //     // When I visit the show booking page
-    //     const bookingShow = BookingShowPage.visit(premises, room, booking)
-    //
-    //     // Add I click the cancel booking action
-    //     cy.task('stubCancellationReferenceData')
-    //     bookingShow.clickEditCancelledBookingButton()
-    //
-    //     // Then I navigate to the edit cancelled booking page
-    //     Page.verifyOnPage(BookingCancellationEditPage, premises, room, booking)
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the cancel booking action
+    cy.task('stubCancellationReferenceData')
+    bookingShow.clickCancelBookingButton()
+
+    // Then I navigate to the booking cancellation page
+    Page.verifyOnPage(BookingCancellationNewPage, premises, null, bedspace, booking)
   })
-  //
-  //   it('allows me to mark a booking as cancelled', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a provisional booking in the database
-  //     const booking = bookingFactory.provisional().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking cancellation page
-  //     cy.task('stubCancellationReferenceData')
-  //     const page = BookingCancellationNewPage.visit(premises, room, booking)
-  //     page.shouldShowBookingDetails()
-  //
-  //     // And I fill out the form
-  //     const cancellation = cancellationFactory.build()
-  //     const newCancellation = newCancellationFactory.build({
-  //       ...cancellation,
-  //       reason: cancellation.reason.id,
-  //     })
-  //
-  //     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
-  //
-  //     page.completeForm(newCancellation)
-  //
-  //     // Then the cancellation should have been created in the API
-  //     cy.task('verifyCancellationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //       expect(requestBody.date).equal(newCancellation.date)
-  //       expect(requestBody.reason).equal(newCancellation.reason)
-  //       expect(requestBody.notes).equal(newCancellation.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Booking cancelled')
-  //   })
-  //
-  //   it('shows errors when the API returns an error when cancelling a booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a provisional booking in the database
-  //     const booking = bookingFactory.provisional().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking cancellation page
-  //     cy.task('stubCancellationReferenceData')
-  //     const page = BookingCancellationNewPage.visit(premises, room, booking)
-  //
-  //     // And I miss required fields
-  //     cy.task('stubCancellationCreateErrors', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       params: ['date'],
-  //     })
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
-  //   })
-  //
-  //   it('navigates back from the booking cancellation page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a provisional booking in the database
-  //     const booking = bookingFactory.provisional().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking cancellation page
-  //     cy.task('stubCancellationReferenceData')
-  //     const page = BookingCancellationNewPage.visit(premises, room, booking)
-  //
-  //     // And I click the back link
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
-  //
-  //   it('allows me to edit a cancelled booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a cancelled booking in the database
-  //     const booking = bookingFactory.cancelled().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the edit cancelled booking page
-  //     cy.task('stubCancellationReferenceData')
-  //     const page = BookingCancellationEditPage.visit(premises, room, booking)
-  //     page.shouldShowBookingDetails()
-  //
-  //     // And I fill out the form
-  //     const cancellation = cancellationFactory.build()
-  //     const newCancellation = newCancellationFactory.build({
-  //       ...cancellation,
-  //       reason: cancellation.reason.id,
-  //     })
-  //
-  //     cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
-  //
-  //     page.completeForm(newCancellation)
-  //
-  //     // Then the cancellation should have been created in the API
-  //     cy.task('verifyCancellationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //       expect(requestBody.date).equal(newCancellation.date)
-  //       expect(requestBody.reason).equal(newCancellation.reason)
-  //       expect(requestBody.notes).equal(newCancellation.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Cancelled booking updated')
-  //   })
-  //
-  //   it('shows errors when the API returns an error when editing a cancelled booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a cancelled booking in the database
-  //     const booking = bookingFactory.cancelled().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the edit cancelled booking page
-  //     cy.task('stubCancellationReferenceData')
-  //     const page = BookingCancellationEditPage.visit(premises, room, booking)
-  //
-  //     // And I miss required fields
-  //     cy.task('stubCancellationCreateErrors', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       params: ['date'],
-  //     })
-  //     page.clearForm()
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
-  //   })
-  //
-  //   it('navigates back from the edit booking cancellation page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a cancelled booking in the database
-  //     const booking = bookingFactory.cancelled().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the edit cancelled booking page
-  //     cy.task('stubCancellationReferenceData')
-  //     const page = BookingCancellationEditPage.visit(premises, room, booking)
-  //
-  //     // And I click the back link
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
+
+  it('navigates to the edit booking cancellation page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a cancelled booking in the database
+    const booking = bookingFactory.cancelled().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the cancel booking action
+    cy.task('stubCancellationReferenceData')
+    bookingShow.clickEditCancelledBookingButton()
+
+    // Then I navigate to the edit cancelled booking page
+    Page.verifyOnPage(BookingCancellationEditPage, premises, null, bedspace, booking)
+  })
+
+  it('allows me to mark a booking as cancelled', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking cancellation page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationNewPage.visit(premises, null, bedspace, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const cancellation = cancellationFactory.build()
+    const newCancellation = newCancellationFactory.build({
+      ...cancellation,
+      reason: cancellation.reason.id,
+    })
+
+    cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
+
+    page.completeForm(newCancellation)
+
+    // Then the cancellation should have been created in the API
+    cy.task('verifyCancellationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.date).equal(newCancellation.date)
+      expect(requestBody.reason).equal(newCancellation.reason)
+      expect(requestBody.notes).equal(newCancellation.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking cancelled')
+  })
+
+  it('shows errors when the API returns an error when cancelling a booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking cancellation page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationNewPage.visit(premises, null, bedspace, booking)
+
+    // And I miss required fields
+    cy.task('stubCancellationCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['date'],
+    })
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
+  })
+
+  it('navigates back from the booking cancellation page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a provisional booking in the database
+    const booking = bookingFactory.provisional().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking cancellation page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationNewPage.visit(premises, null, bedspace, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
+
+  it('allows me to edit a cancelled booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a cancelled booking in the database
+    const booking = bookingFactory.cancelled().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the edit cancelled booking page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationEditPage.visit(premises, null, bedspace, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const cancellation = cancellationFactory.build()
+    const newCancellation = newCancellationFactory.build({
+      ...cancellation,
+      reason: cancellation.reason.id,
+    })
+
+    cy.task('stubCancellationCreate', { premisesId: premises.id, bookingId: booking.id, cancellation })
+
+    page.completeForm(newCancellation)
+
+    // Then the cancellation should have been created in the API
+    cy.task('verifyCancellationCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.date).equal(newCancellation.date)
+      expect(requestBody.reason).equal(newCancellation.reason)
+      expect(requestBody.notes).equal(newCancellation.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Cancelled booking updated')
+  })
+
+  it('shows errors when the API returns an error when editing a cancelled booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a cancelled booking in the database
+    const booking = bookingFactory.cancelled().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the edit cancelled booking page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationEditPage.visit(premises, null, bedspace, booking)
+
+    // And I miss required fields
+    cy.task('stubCancellationCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['date'],
+    })
+    page.clearForm()
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['date'], 'empty', 'bookingCancellation')
+  })
+
+  it('navigates back from the edit booking cancellation page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a cancelled booking in the database
+    const booking = bookingFactory.cancelled().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the edit cancelled booking page
+    cy.task('stubCancellationReferenceData')
+    const page = BookingCancellationEditPage.visit(premises, null, bedspace, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/departure.cy.ts
@@ -1,10 +1,10 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BookingDepartureEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit'
-// import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-// import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingDepartureEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureEdit'
+import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import { bookingFactory, departureFactory, newDepartureFactory } from '../../../../server/testutils/factories'
+import { bookingFactory, departureFactory, newDepartureFactory } from '../../../../server/testutils/factories'
 
 context('Booking departure', () => {
   beforeEach(() => {
@@ -15,205 +15,205 @@ context('Booking departure', () => {
   it('navigates to the booking departure page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there is a premises, a room, and an arrived booking in the database
-    //     const booking = bookingFactory.arrived().build()
-    //     const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //     // When I visit the show booking page
-    //     const bookingShow = BookingShowPage.visit(premises, room, booking)
-    //
-    //     // Add I click the marked departed booking action
-    //     cy.task('stubDepartureReferenceData')
-    //     bookingShow.clickMarkDepartedBookingButton()
-    //
-    //     // Then I navigate to the booking departure page
-    //     Page.verifyOnPage(BookingDepartureNewPage, premises, room, booking)
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the marked departed booking action
+    cy.task('stubDepartureReferenceData')
+    bookingShow.clickMarkDepartedBookingButton()
+
+    // Then I navigate to the booking departure page
+    Page.verifyOnPage(BookingDepartureNewPage, premises, null, bedspace, booking)
   })
-  //
-  //   it('navigates to the edit booking departure page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a departed booking in the database
-  //     const booking = bookingFactory.departed().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the show booking page
-  //     const bookingShow = BookingShowPage.visit(premises, room, booking)
-  //
-  //     // Add I click the marked departed booking action
-  //     cy.task('stubDepartureReferenceData')
-  //     bookingShow.clickEditDepartedBookingButton()
-  //
-  //     // Then I navigate to the booking departure page
-  //     Page.verifyOnPage(BookingDepartureEditPage, premises, room, booking)
-  //   })
-  //
-  //   it('allows me to mark a booking as departed', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and an arrived booking in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking departure page
-  //     cy.task('stubDepartureReferenceData')
-  //     const page = BookingDepartureNewPage.visit(premises, room, booking)
-  //     page.shouldShowBookingDetails()
-  //
-  //     // And I fill out the form
-  //     const departure = departureFactory.build()
-  //     const newDeparture = newDepartureFactory.build({
-  //       ...departure,
-  //       reasonId: departure.reason.id,
-  //       moveOnCategoryId: departure.moveOnCategory.id,
-  //     })
-  //
-  //     cy.task('stubDepartureCreate', { premisesId: premises.id, bookingId: booking.id, departure })
-  //
-  //     page.completeForm(newDeparture)
-  //
-  //     // Then the departure should have been created in the API
-  //     cy.task('verifyDepartureCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //       expect(requestBody.dateTime).equal(newDeparture.dateTime)
-  //       expect(requestBody.reasonId).equal(newDeparture.reasonId)
-  //       expect(requestBody.moveOnCategoryId).equal(newDeparture.moveOnCategoryId)
-  //       expect(requestBody.notes).equal(newDeparture.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Booking marked as departed')
-  //   })
-  //
-  //   it('shows errors when the API returns an error when marking a booking as departed', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is an arrived booking in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking departure page
-  //     cy.task('stubDepartureReferenceData')
-  //     const page = BookingDepartureNewPage.visit(premises, room, booking)
-  //
-  //     // And I miss required fields
-  //     cy.task('stubDepartureCreateErrors', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       params: ['dateTime', 'reasonId', 'moveOnCategoryId'],
-  //     })
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
-  //   })
-  //
-  //   it('navigates back from the booking departure page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and an arrived booking in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking departure page
-  //     cy.task('stubDepartureReferenceData')
-  //     const page = BookingDepartureNewPage.visit(premises, room, booking)
-  //
-  //     // And I click the back link
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
-  //
-  //   it('allows me to edit a departed booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a departed booking in the database
-  //     const booking = bookingFactory.departed().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the edit departed booking page
-  //     cy.task('stubDepartureReferenceData')
-  //     const page = BookingDepartureEditPage.visit(premises, room, booking)
-  //     page.shouldShowBookingDetails()
-  //
-  //     // And I fill out the form
-  //     const departure = departureFactory.build()
-  //     const newDeparture = newDepartureFactory.build({
-  //       ...departure,
-  //       reasonId: departure.reason.id,
-  //       moveOnCategoryId: departure.moveOnCategory.id,
-  //     })
-  //
-  //     cy.task('stubDepartureCreate', { premisesId: premises.id, bookingId: booking.id, departure })
-  //
-  //     page.completeForm(newDeparture)
-  //
-  //     // Then the departure should have been created in the API
-  //     cy.task('verifyDepartureCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //       expect(requestBody.dateTime).equal(newDeparture.dateTime)
-  //       expect(requestBody.reasonId).equal(newDeparture.reasonId)
-  //       expect(requestBody.moveOnCategoryId).equal(newDeparture.moveOnCategoryId)
-  //       expect(requestBody.notes).equal(newDeparture.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Departure details changed')
-  //   })
-  //
-  //   it('shows errors when the API returns an error when editing a departed booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a departed booking in the database
-  //     const booking = bookingFactory.departed().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the edit departed booking page
-  //     cy.task('stubDepartureReferenceData')
-  //     const page = BookingDepartureEditPage.visit(premises, room, booking)
-  //
-  //     // And I miss required fields
-  //     cy.task('stubDepartureCreateErrors', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       params: ['dateTime', 'reasonId', 'moveOnCategoryId'],
-  //     })
-  //     page.clearForm()
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
-  //   })
-  //
-  //   it('navigates back from the edit departured page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a departed booking in the database
-  //     const booking = bookingFactory.departed().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the edit departed booking page
-  //     cy.task('stubDepartureReferenceData')
-  //     const page = BookingDepartureEditPage.visit(premises, room, booking)
-  //
-  //     // And I click the back link
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
+
+  it('navigates to the edit booking departure page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a departed booking in the database
+    const booking = bookingFactory.departed().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the marked departed booking action
+    cy.task('stubDepartureReferenceData')
+    bookingShow.clickEditDepartedBookingButton()
+
+    // Then I navigate to the booking departure page
+    Page.verifyOnPage(BookingDepartureEditPage, premises, null, bedspace, booking)
+  })
+
+  it('allows me to mark a booking as departed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking departure page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureNewPage.visit(premises, null, bedspace, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const departure = departureFactory.build()
+    const newDeparture = newDepartureFactory.build({
+      ...departure,
+      reasonId: departure.reason.id,
+      moveOnCategoryId: departure.moveOnCategory.id,
+    })
+
+    cy.task('stubDepartureCreate', { premisesId: premises.id, bookingId: booking.id, departure })
+
+    page.completeForm(newDeparture)
+
+    // Then the departure should have been created in the API
+    cy.task('verifyDepartureCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.dateTime).equal(newDeparture.dateTime)
+      expect(requestBody.reasonId).equal(newDeparture.reasonId)
+      expect(requestBody.moveOnCategoryId).equal(newDeparture.moveOnCategoryId)
+      expect(requestBody.notes).equal(newDeparture.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking marked as departed')
+  })
+
+  it('shows errors when the API returns an error when marking a booking as departed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking departure page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureNewPage.visit(premises, null, bedspace, booking)
+
+    // And I miss required fields
+    cy.task('stubDepartureCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['dateTime', 'reasonId', 'moveOnCategoryId'],
+    })
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
+  })
+
+  it('navigates back from the booking departure page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking departure page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureNewPage.visit(premises, null, bedspace, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
+
+  it('allows me to edit a departed booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a departed booking in the database
+    const booking = bookingFactory.departed().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the edit departed booking page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureEditPage.visit(premises, null, bedspace, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const departure = departureFactory.build()
+    const newDeparture = newDepartureFactory.build({
+      ...departure,
+      reasonId: departure.reason.id,
+      moveOnCategoryId: departure.moveOnCategory.id,
+    })
+
+    cy.task('stubDepartureCreate', { premisesId: premises.id, bookingId: booking.id, departure })
+
+    page.completeForm(newDeparture)
+
+    // Then the departure should have been created in the API
+    cy.task('verifyDepartureCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.dateTime).equal(newDeparture.dateTime)
+      expect(requestBody.reasonId).equal(newDeparture.reasonId)
+      expect(requestBody.moveOnCategoryId).equal(newDeparture.moveOnCategoryId)
+      expect(requestBody.notes).equal(newDeparture.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Departure details changed')
+  })
+
+  it('shows errors when the API returns an error when editing a departed booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a departed booking in the database
+    const booking = bookingFactory.departed().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the edit departed booking page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureEditPage.visit(premises, null, bedspace, booking)
+
+    // And I miss required fields
+    cy.task('stubDepartureCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['dateTime', 'reasonId', 'moveOnCategoryId'],
+    })
+    page.clearForm()
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['dateTime', 'reasonId', 'moveOnCategoryId'])
+  })
+
+  it('navigates back from the edit departured page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and a departed booking in the database
+    const booking = bookingFactory.departed().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the edit departed booking page
+    cy.task('stubDepartureReferenceData')
+    const page = BookingDepartureEditPage.visit(premises, null, bedspace, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
@@ -1,14 +1,14 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BookingExtensionNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew'
-// import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
-// import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
+import Page from '../../../../cypress_shared/pages/page'
+import BookingExtensionNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingExtensionNew'
+import BookingShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingShow'
+import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import {
-//   bookingFactory,
-//   extensionFactory,
-//   lostBedFactory,
-//   newExtensionFactory,
-// } from '../../../../server/testutils/factories'
+import {
+  bookingFactory,
+  extensionFactory,
+  //   lostBedFactory,
+  newExtensionFactory,
+} from '../../../../server/testutils/factories'
 
 context('Booking extension', () => {
   beforeEach(() => {
@@ -19,80 +19,80 @@ context('Booking extension', () => {
   it('navigates to the booking extension page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there is a premises, a room, and an arrived booking in the database
-    //     const booking = bookingFactory.arrived().build()
-    //     const { premises, room } = setupBookingStateStubs(booking)
-    //
-    //     // When I visit the show booking page
-    //     const bookingShow = BookingShowPage.visit(premises, room, booking)
-    //
-    //     // Add I click the extend booking action
-    //     bookingShow.clickExtendBookingButton()
-    //
-    //     // Then I navigate to the booking extension page
-    //     Page.verifyOnPage(BookingExtensionNewPage, premises, room, booking)
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the show booking page
+    const bookingShow = BookingShowPage.visit(premises, null, bedspace, booking)
+
+    // Add I click the extend booking action
+    bookingShow.clickExtendBookingButton()
+
+    // Then I navigate to the booking extension page
+    Page.verifyOnPage(BookingExtensionNewPage, premises, null, bedspace, booking)
   })
-  //
-  //   it('allows me to extend a booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and an arrived booking in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking extension page
-  //     const page = BookingExtensionNewPage.visit(premises, room, booking)
-  //     page.shouldShowBookingDetails()
-  //
-  //     // And I fill out the form
-  //     const extension = extensionFactory.build()
-  //     const newExtension = newExtensionFactory.build({
-  //       ...extension,
-  //     })
-  //
-  //     cy.task('stubExtensionCreate', { premisesId: premises.id, bookingId: booking.id, extension })
-  //
-  //     page.completeForm(newExtension)
-  //
-  //     // Then the extension should have been created in the API
-  //     cy.task('verifyExtensionCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //       expect(requestBody.newDepartureDate).equal(newExtension.newDepartureDate)
-  //       expect(requestBody.notes).equal(newExtension.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //     bookingShowPage.shouldShowBanner('Booking departure date changed')
-  //   })
-  //
-  //   it('shows errors when the API returns an error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is an arrived booking in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking extension page
-  //     const page = BookingExtensionNewPage.visit(premises, room, booking)
-  //
-  //     // And I miss required fields
-  //     cy.task('stubExtensionCreateErrors', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       params: ['newDepartureDate'],
-  //     })
-  //     page.clearForm()
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['newDepartureDate'])
-  //   })
-  //
+
+  it('allows me to extend a booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking extension page
+    const page = BookingExtensionNewPage.visit(premises, null, bedspace, booking)
+    page.shouldShowBookingDetails()
+
+    // And I fill out the form
+    const extension = extensionFactory.build()
+    const newExtension = newExtensionFactory.build({
+      ...extension,
+    })
+
+    cy.task('stubExtensionCreate', { premisesId: premises.id, bookingId: booking.id, extension })
+
+    page.completeForm(newExtension)
+
+    // Then the extension should have been created in the API
+    cy.task('verifyExtensionCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.newDepartureDate).equal(newExtension.newDepartureDate)
+      expect(requestBody.notes).equal(newExtension.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking departure date changed')
+  })
+
+  it('shows errors when the API returns an error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking extension page
+    const page = BookingExtensionNewPage.visit(premises, null, bedspace, booking)
+
+    // And I miss required fields
+    cy.task('stubExtensionCreateErrors', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      params: ['newDepartureDate'],
+    })
+    page.clearForm()
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['newDepartureDate'])
+  })
+
   //   it('shows errors when the API returns a 409 conflict error', () => {
   //     // Given I am signed in
   //     cy.signIn()
@@ -124,22 +124,22 @@ context('Booking extension', () => {
   //     // Then I should see error messages for the conflict
   //     page.shouldShowDateConflictErrorMessages(conflictingLostBed, 'lost-bed')
   //   })
-  //
-  //   it('navigates back from the booking extension page to the show booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and an arrived booking in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //
-  //     // When I visit the booking extension page
-  //     const page = BookingExtensionNewPage.visit(premises, room, booking)
-  //
-  //     // And I click the back link
-  //     page.clickBack()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BookingShowPage, premises, room, booking)
-  //   })
+
+  it('navigates back from the booking extension page to the show booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and an arrived booking in the database
+    const booking = bookingFactory.arrived().build()
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    // When I visit the booking extension page
+    const page = BookingExtensionNewPage.visit(premises, null, bedspace, booking)
+
+    // And I click the back link
+    page.clickBack()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BookingShowPage, premises, null, bedspace, booking)
+  })
 })

--- a/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationController.test.ts
@@ -3,17 +3,18 @@ import type { NextFunction, Request, Response } from 'express'
 import { CancellationsController } from '.'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BedspaceService, BookingService, CancellationService, PremisesService } from '../../../services'
+import { BookingService, CancellationService, PremisesService } from '../../../services'
 import {
   bookingFactory,
   cancellationFactory,
+  cas3BedspaceFactory,
   newCancellationFactory,
   premisesFactory,
-  roomFactory,
 } from '../../../testutils/factories'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
+import BedspaceService from '../../../services/v2/bedspaceService'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
@@ -21,7 +22,7 @@ jest.mock('../../../utils/restUtils')
 describe('CancellationsController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
-  const roomId = 'roomId'
+  const bedspaceId = 'bedspaceId'
   const bookingId = 'bookingId'
 
   let request: Request
@@ -49,17 +50,17 @@ describe('CancellationsController', () => {
   describe('new', () => {
     it('renders the form', async () => {
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
       const booking = bookingFactory.arrived().build()
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
 
       cancellationService.getReferenceData.mockResolvedValue({ cancellationReasons: [] })
@@ -70,14 +71,14 @@ describe('CancellationsController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
       expect(cancellationService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/cancellations/new', {
         premises,
-        room,
+        bedspace,
         booking,
         allCancellationReasons: [],
         errors: {},
@@ -98,7 +99,7 @@ describe('CancellationsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -118,7 +119,7 @@ describe('CancellationsController', () => {
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Booking cancelled')
-      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
     })
 
     it('renders with errors if the API returns an error', async () => {
@@ -132,7 +133,7 @@ describe('CancellationsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -151,7 +152,7 @@ describe('CancellationsController', () => {
         request,
         response,
         err,
-        paths.bookings.cancellations.new({ premisesId, bedspaceId: roomId, bookingId }),
+        paths.bookings.cancellations.new({ premisesId, bedspaceId, bookingId }),
         'bookingCancellation',
       )
     })
@@ -160,17 +161,17 @@ describe('CancellationsController', () => {
   describe('edit', () => {
     it('renders the form', async () => {
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
       const booking = bookingFactory.cancelled().build()
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
 
       cancellationService.getReferenceData.mockResolvedValue({ cancellationReasons: [] })
@@ -181,14 +182,14 @@ describe('CancellationsController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
       expect(cancellationService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/cancellations/edit', {
         premises,
-        room,
+        bedspace,
         booking,
         allCancellationReasons: [],
         errors: {},
@@ -212,7 +213,7 @@ describe('CancellationsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -232,7 +233,7 @@ describe('CancellationsController', () => {
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Cancelled booking updated')
-      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
     })
 
     it('renders with errors if the API returns an error', async () => {
@@ -246,7 +247,7 @@ describe('CancellationsController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -265,7 +266,7 @@ describe('CancellationsController', () => {
         request,
         response,
         err,
-        paths.bookings.cancellations.edit({ premisesId, bedspaceId: roomId, bookingId }),
+        paths.bookings.cancellations.edit({ premisesId, bedspaceId, bookingId }),
         'bookingCancellation',
       )
     })

--- a/server/controllers/temporary-accommodation/manage/cancellationsController.ts
+++ b/server/controllers/temporary-accommodation/manage/cancellationsController.ts
@@ -1,12 +1,13 @@
 import type { Request, RequestHandler, Response } from 'express'
 import type { NewCancellation } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BedspaceService, BookingService, CancellationService, PremisesService } from '../../../services'
+import { BookingService, CancellationService, PremisesService } from '../../../services'
+import BedspaceService from '../../../services/v2/bedspaceService'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 
-export default class CanellationsController {
+export default class CancellationsController {
   constructor(
     private readonly premisesService: PremisesService,
     private readonly bedspacesService: BedspaceService,
@@ -17,12 +18,12 @@ export default class CanellationsController {
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       const { cancellationReasons: allCancellationReasons } =
@@ -30,7 +31,7 @@ export default class CanellationsController {
 
       return res.render('temporary-accommodation/cancellations/new', {
         premises,
-        room,
+        bedspace,
         booking,
         allCancellationReasons,
         errors,
@@ -42,7 +43,7 @@ export default class CanellationsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       const newCancellation: NewCancellation = {
@@ -54,13 +55,13 @@ export default class CanellationsController {
         await this.cancellationService.createCancellation(callConfig, premisesId, bookingId, newCancellation)
 
         req.flash('success', 'Booking cancelled')
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,
           res,
           err,
-          paths.bookings.cancellations.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.cancellations.new({ premisesId, bedspaceId, bookingId }),
           'bookingCancellation',
         )
       }
@@ -70,12 +71,12 @@ export default class CanellationsController {
   edit(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       const { cancellationReasons: allCancellationReasons } =
@@ -83,7 +84,7 @@ export default class CanellationsController {
 
       return res.render('temporary-accommodation/cancellations/edit', {
         premises,
-        room,
+        bedspace,
         booking,
         allCancellationReasons,
         errors,
@@ -98,7 +99,7 @@ export default class CanellationsController {
 
   update(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       const newCancellation: NewCancellation = {
@@ -110,13 +111,13 @@ export default class CanellationsController {
         await this.cancellationService.createCancellation(callConfig, premisesId, bookingId, newCancellation)
 
         req.flash('success', 'Cancelled booking updated')
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,
           res,
           err,
-          paths.bookings.cancellations.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.cancellations.edit({ premisesId, bedspaceId, bookingId }),
           'bookingCancellation',
         )
       }

--- a/server/controllers/temporary-accommodation/manage/departuresController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.test.ts
@@ -2,19 +2,20 @@ import { DeepMocked, createMock } from '@golevelup/ts-jest'
 import type { NextFunction, Request, Response } from 'express'
 import { CallConfig } from '../../../data/restClient'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BedspaceService, BookingService, DepartureService, PremisesService } from '../../../services'
+import { BookingService, DepartureService, PremisesService } from '../../../services'
 import {
   bookingFactory,
+  cas3BedspaceFactory,
   departureFactory,
   newDepartureFactory,
   premisesFactory,
-  roomFactory,
 } from '../../../testutils/factories'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput } from '../../../utils/validation'
 import DeparturesController from './departuresController'
 import config from '../../../config'
+import BedspaceService from '../../../services/v2/bedspaceService'
 
 jest.mock('../../../utils/validation')
 jest.mock('../../../utils/restUtils')
@@ -22,7 +23,7 @@ jest.mock('../../../utils/restUtils')
 describe('DeparturesController', () => {
   const callConfig = { token: 'some-call-config-token' } as CallConfig
   const premisesId = 'premisesId'
-  const roomId = 'roomId'
+  const bedspaceId = 'bedspaceId'
   const bookingId = 'bookingId'
 
   let request: Request
@@ -50,17 +51,17 @@ describe('DeparturesController', () => {
   describe('new', () => {
     it('renders the form', async () => {
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
       const booking = bookingFactory.build()
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
 
       departureService.getReferenceData.mockResolvedValue({ departureReasons: [], moveOnCategories: [] })
@@ -71,14 +72,14 @@ describe('DeparturesController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
       expect(departureService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/departures/new', {
         premises,
-        room,
+        bedspace,
         booking,
         allDepartureReasons: [],
         allMoveOnCategories: [],
@@ -100,7 +101,7 @@ describe('DeparturesController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -123,7 +124,7 @@ describe('DeparturesController', () => {
         title: 'Booking marked as departed',
         text: 'At the moment the CAS3 digital service does not automatically update NDelius. Please continue to record accommodation and address changes directly in NDelius.',
       })
-      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
     })
 
     it('renders with errors if the API returns an error', async () => {
@@ -136,7 +137,7 @@ describe('DeparturesController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -155,7 +156,7 @@ describe('DeparturesController', () => {
         request,
         response,
         err,
-        paths.bookings.departures.new({ premisesId, bedspaceId: roomId, bookingId }),
+        paths.bookings.departures.new({ premisesId, bedspaceId, bookingId }),
       )
     })
 
@@ -170,7 +171,7 @@ describe('DeparturesController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -184,7 +185,7 @@ describe('DeparturesController', () => {
         request,
         response,
         expect.any(Error),
-        paths.bookings.departures.new({ premisesId, bedspaceId: roomId, bookingId }),
+        paths.bookings.departures.new({ premisesId, bedspaceId, bookingId }),
       )
     })
   })
@@ -192,17 +193,17 @@ describe('DeparturesController', () => {
   describe('edit', () => {
     it('renders the form', async () => {
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
       const booking = bookingFactory.build()
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
 
       departureService.getReferenceData.mockResolvedValue({ departureReasons: [], moveOnCategories: [] })
@@ -213,14 +214,14 @@ describe('DeparturesController', () => {
       await requestHandler(request, response, next)
 
       expect(premisesService.getPremises).toHaveBeenCalledWith(callConfig, premises.id)
-      expect(bedspaceService.getRoom).toHaveBeenCalledWith(callConfig, premises.id, room.id)
+      expect(bedspaceService.getSingleBedspace).toHaveBeenCalledWith(callConfig, premises.id, bedspace.id)
       expect(bookingService.getBooking).toHaveBeenCalledWith(callConfig, premises.id, booking.id)
 
       expect(departureService.getReferenceData).toHaveBeenCalledWith(callConfig)
 
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/departures/edit', {
         premises,
-        room,
+        bedspace,
         booking,
         allDepartureReasons: [],
         allMoveOnCategories: [],
@@ -245,7 +246,7 @@ describe('DeparturesController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -265,7 +266,7 @@ describe('DeparturesController', () => {
       )
 
       expect(request.flash).toHaveBeenCalledWith('success', 'Departure details changed')
-      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+      expect(response.redirect).toHaveBeenCalledWith(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
     })
 
     it('renders with errors if the API returns an error', async () => {
@@ -278,7 +279,7 @@ describe('DeparturesController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {
@@ -297,7 +298,7 @@ describe('DeparturesController', () => {
         request,
         response,
         err,
-        paths.bookings.departures.edit({ premisesId, bedspaceId: roomId, bookingId }),
+        paths.bookings.departures.edit({ premisesId, bedspaceId, bookingId }),
       )
     })
   })
@@ -314,17 +315,17 @@ describe('DeparturesController', () => {
 
     it('does not show the NDelius update message when creating', async () => {
       const premises = premisesFactory.build()
-      const room = roomFactory.build()
+      const bedspace = cas3BedspaceFactory.build()
       const booking = bookingFactory.build()
 
       request.params = {
         premisesId: premises.id,
-        roomId: room.id,
+        bedspaceId: bedspace.id,
         bookingId: booking.id,
       }
 
       premisesService.getPremises.mockResolvedValue(premises)
-      bedspaceService.getRoom.mockResolvedValue(room)
+      bedspaceService.getSingleBedspace.mockResolvedValue(bedspace)
       bookingService.getBooking.mockResolvedValue(booking)
 
       departureService.getReferenceData.mockResolvedValue({ departureReasons: [], moveOnCategories: [] })
@@ -352,7 +353,7 @@ describe('DeparturesController', () => {
 
       request.params = {
         premisesId,
-        roomId,
+        bedspaceId,
         bookingId,
       }
       request.body = {

--- a/server/controllers/temporary-accommodation/manage/departuresController.ts
+++ b/server/controllers/temporary-accommodation/manage/departuresController.ts
@@ -1,7 +1,8 @@
 import type { Request, RequestHandler, Response } from 'express'
 import type { Cas3NewDeparture } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
-import { BedspaceService, BookingService, DepartureService, PremisesService } from '../../../services'
+import { BookingService, DepartureService, PremisesService } from '../../../services'
+import BedspaceService from '../../../services/v2/bedspaceService'
 import { DateFormats } from '../../../utils/dateUtils'
 import extractCallConfig from '../../../utils/restUtils'
 import { catchValidationErrorOrPropogate, fetchErrorsAndUserInput, insertGenericError } from '../../../utils/validation'
@@ -18,12 +19,12 @@ export default class DeparturesController {
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       const { departureReasons: allDepartureReasons, moveOnCategories: allMoveOnCategories } =
@@ -31,7 +32,7 @@ export default class DeparturesController {
 
       return res.render('temporary-accommodation/departures/new', {
         premises,
-        room,
+        bedspace,
         booking,
         allDepartureReasons,
         allMoveOnCategories,
@@ -45,7 +46,7 @@ export default class DeparturesController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       const newDeparture: Cas3NewDeparture = {
@@ -68,13 +69,13 @@ export default class DeparturesController {
             ? 'You no longer need to update NDelius with this change.'
             : 'At the moment the CAS3 digital service does not automatically update NDelius. Please continue to record accommodation and address changes directly in NDelius.',
         })
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,
           res,
           err,
-          paths.bookings.departures.new({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.departures.new({ premisesId, bedspaceId, bookingId }),
         )
       }
     }
@@ -83,12 +84,12 @@ export default class DeparturesController {
   edit(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary: requestErrorSummary, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
       const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
 
       const { departureReasons: allDepartureReasons, moveOnCategories: allMoveOnCategories } =
@@ -96,7 +97,7 @@ export default class DeparturesController {
 
       return res.render('temporary-accommodation/departures/edit', {
         premises,
-        room,
+        bedspace,
         booking,
         allDepartureReasons,
         allMoveOnCategories,
@@ -113,7 +114,7 @@ export default class DeparturesController {
 
   update(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, bookingId } = req.params
+      const { premisesId, bedspaceId, bookingId } = req.params
       const callConfig = extractCallConfig(req)
 
       const newDeparture: Cas3NewDeparture = {
@@ -125,13 +126,13 @@ export default class DeparturesController {
         await this.departureService.createDeparture(callConfig, premisesId, bookingId, newDeparture)
 
         req.flash('success', 'Departure details changed')
-        res.redirect(paths.bookings.show({ premisesId, bedspaceId: roomId, bookingId }))
+        res.redirect(paths.bookings.show({ premisesId, bedspaceId, bookingId }))
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,
           res,
           err,
-          paths.bookings.departures.edit({ premisesId, bedspaceId: roomId, bookingId }),
+          paths.bookings.departures.edit({ premisesId, bedspaceId, bookingId }),
         )
       }
     }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -51,7 +51,7 @@ export const controllers = (services: Services) => {
   )
   const departuresController = new DeparturesController(
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.bookingService,
     services.departureService,
   )

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -63,7 +63,7 @@ export const controllers = (services: Services) => {
   )
   const cancellationsController = new CancellationsController(
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.bookingService,
     services.cancellationService,
   )

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -57,7 +57,7 @@ export const controllers = (services: Services) => {
   )
   const extensionsController = new ExtensionsController(
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.bookingService,
     services.extensionService,
   )

--- a/server/views/temporary-accommodation/cancellations/edit.njk
+++ b/server/views/temporary-accommodation/cancellations/edit.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -24,13 +24,13 @@
   <h1 class="govuk-heading-l">Update cancelled booking</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
   
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.cancellations.update({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}?_method=PUT" method="post">
+      <form action="{{ paths.bookings.cancellations.update({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         {% include "./_editable.njk" %}  
       </form>

--- a/server/views/temporary-accommodation/cancellations/new.njk
+++ b/server/views/temporary-accommodation/cancellations/new.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -24,13 +24,13 @@
   <h1 class="govuk-heading-l">Cancel booking</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.cancellations.create({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}" method="post">
+      <form action="{{ paths.bookings.cancellations.create({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         {% include "./_editable.njk" %}  
       </form>

--- a/server/views/temporary-accommodation/departures/edit.njk
+++ b/server/views/temporary-accommodation/departures/edit.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -24,13 +24,13 @@
   <h1 class="govuk-heading-l">Update departure details</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
   
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.departures.update({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}?_method=PUT" method="post">
+      <form action="{{ paths.bookings.departures.update({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>      
         {% include "./_editable.njk" %}  
       </form>

--- a/server/views/temporary-accommodation/departures/new.njk
+++ b/server/views/temporary-accommodation/departures/new.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -24,13 +24,13 @@
   <h1 class="govuk-heading-l">Mark booking as departed</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.departures.create({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}" method="post">
+      <form action="{{ paths.bookings.departures.create({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>      
         {% include "./_editable.njk" %}  
       </form>

--- a/server/views/temporary-accommodation/extensions/new.njk
+++ b/server/views/temporary-accommodation/extensions/new.njk
@@ -15,7 +15,7 @@
 {% block beforeContent %}
   {{ govukBackLink({
     text: "Back",
-    href: paths.bookings.show({ premisesId: premises.id, roomId: room.id, bookingId: booking.id })
+    href: paths.bookings.show({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id })
   }) }}
 {% endblock %}
 
@@ -27,13 +27,13 @@
   <h1 class="govuk-heading-l">Extend or shorten booking</h1>
 
   {{ popDetailsHeader(booking.person) }}
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   {{ bookingInfo(booking) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.bookings.extensions.create({ premisesId: premises.id, roomId: room.id, bookingId: booking.id }) }}" method="post">
+      <form action="{{ paths.bookings.extensions.create({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }) }}" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
 
         {{ formPageDateInput(


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1928

The outcome of https://dsdmoj.atlassian.net/browse/CAS-1865 was to replace the current `Manage properties v1` routes with the new `Manage properties v2` routes. 

The above strategy helps us link into the other v1 areas of the application (e.g. `Bookings`, `Voids`, `Departures`, `Arrivals` etc) as the breadcrumbs still work (for the most part!) as they go back to v1 which is now the new v2 pages. 

However, these areas are currently driven by a `roomId` from the BE on the url path for the bedspace. With the way the new BE `cas3` endpoints have been delivered the primary key for bedspaces has become the `bedId` (not the `roomId`). This changes in the backend means that there is some refactoring to do in these `CAS3-UI` v1 areas to `retrieve the bedspace and not the room`. This has rippling effects on the v1 areas controllers, services and views and so we need to refactor these. 

# Changes in this PR
1. Get the `Cancellations`, `Departures`, and `Extensions` areas working
2. Add back in the related integration test / e2e test coverage that commented out in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1382

**Suggestion**: I have done separate commits for `Cancellations`, `Departures`, and `Extensions` areas so maybe easier to review 1 commit at a time
