### PR TITLE
Lost beds (voids) area with Bedspace v2

### DIFF
--- a/cypress_shared/helpers/place.ts
+++ b/cypress_shared/helpers/place.ts
@@ -57,16 +57,33 @@ export default class PlaceHelper {
       this.bedspaceSearchResults = bedspaceSearchResultsFactory.build({
         results: [bedspaceSearchResultFactory.forBedspace(this.premises, this.room, null).build()],
       })
+      this.person = this.placeContext.assessment.application.person
+      this.booking = bookingFactory.build({
+        person: this.person,
+        bed: bedFactory.build({ id: room.beds[0].id }),
+      })
+      this.lostBeds = lostBedFactory
+        .active()
+        .params({
+          bedId: room.beds[0].id,
+        })
+        .buildList(5)
     } else {
       this.bedspaceSearchResults = bedspaceSearchResultsFactory.build({
         results: [bedspaceSearchResultFactory.forBedspace(this.premises, null, this.cas3Bedspace).build()],
       })
+      this.person = this.placeContext.assessment.application.person
+      this.booking = bookingFactory.build({
+        person: this.person,
+        bed: bedFactory.build({ id: cas3Bedspace.id }),
+      })
+      this.lostBeds = lostBedFactory
+        .active()
+        .params({
+          bedId: cas3Bedspace.id,
+        })
+        .buildList(5)
     }
-    this.person = this.placeContext.assessment.application.person
-    this.booking = bookingFactory.build({
-      person: this.person,
-      bed: bedFactory.build({ id: cas3Bedspace.id }),
-    })
     this.assessmentSummaries = [
       assessmentSummaryFactory.build({
         ...this.placeContext.assessment,
@@ -76,12 +93,6 @@ export default class PlaceHelper {
     ]
     this.timeline = timelineEventsFactory.build()
     this.bookings = [this.booking]
-    this.lostBeds = lostBedFactory
-      .active()
-      .params({
-        bedId: cas3Bedspace.id,
-      })
-      .buildList(5)
   }
 
   setupStubs() {

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedCancel.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedCancel.ts
@@ -1,4 +1,4 @@
-import type { LostBed, NewLostBedCancellation, Premises, Room } from '@approved-premises/api'
+import type { Cas3Bedspace, LostBed, NewLostBedCancellation, Premises, Room } from '@approved-premises/api'
 
 import Page from '../../page'
 import LocationHeaderComponent from '../../../components/locationHeader'
@@ -10,6 +10,7 @@ export default class LostBedCancelPage extends Page {
   constructor(
     private readonly premises: Premises,
     private readonly room: Room,
+    private readonly bedspace: Cas3Bedspace,
     private readonly lostBed: LostBed,
   ) {
     super('Cancel void booking')
@@ -17,9 +18,17 @@ export default class LostBedCancelPage extends Page {
     this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
   }
 
-  static visit(premises: Premises, room: Room, lostBed: LostBed): LostBedCancelPage {
-    cy.visit(paths.lostBeds.cancellations.new({ premisesId: premises.id, roomId: room.id, lostBedId: lostBed.id }))
-    return new LostBedCancelPage(premises, room, lostBed)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, lostBed: LostBed): LostBedCancelPage {
+    if (room) {
+      cy.visit(
+        paths.lostBeds.cancellations.new({ premisesId: premises.id, bedspaceId: room.id, lostBedId: lostBed.id }),
+      )
+    } else {
+      cy.visit(
+        paths.lostBeds.cancellations.new({ premisesId: premises.id, bedspaceId: bedspace.id, lostBedId: lostBed.id }),
+      )
+    }
+    return new LostBedCancelPage(premises, room, bedspace, lostBed)
   }
 
   shouldShowBedspaceDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
@@ -1,4 +1,4 @@
-import type { LostBed, Premises, Room, UpdateLostBed } from '@approved-premises/api'
+import type { Cas3Bedspace, LostBed, Premises, Room, UpdateLostBed } from '@approved-premises/api'
 import LostBedEditablePage from './lostBedEditable'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
@@ -6,15 +6,19 @@ import paths from '../../../../server/paths/temporary-accommodation/manage'
 export default class LostBedEditPage extends LostBedEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-  constructor(premises: Premises, room: Room) {
-    super('Void a bedspace', premises, room)
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace) {
+    super('Void a bedspace', premises, room, bedspace)
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
   }
 
-  static visit(premises: Premises, room: Room, lostBed: LostBed): LostBedEditPage {
-    cy.visit(paths.lostBeds.edit({ premisesId: premises.id, roomId: room.id, lostBedId: lostBed.id }))
-    return new LostBedEditPage(premises, room)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace, lostBed: LostBed): LostBedEditPage {
+    if (room) {
+      cy.visit(paths.lostBeds.edit({ premisesId: premises.id, bedspaceId: room.id, lostBedId: lostBed.id }))
+    } else {
+      cy.visit(paths.lostBeds.edit({ premisesId: premises.id, bedspaceId: bedspace.id, lostBedId: lostBed.id }))
+    }
+    return new LostBedEditPage(premises, room, bedspace)
   }
 
   shouldShowBedspaceDetails(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
@@ -1,14 +1,14 @@
-import { Booking, LostBed, NewLostBed, Premises, Room, UpdateLostBed } from '@approved-premises/api'
+import { Booking, Cas3Bedspace, LostBed, NewLostBed, Premises, Room, UpdateLostBed } from '@approved-premises/api'
 import BedspaceConflictErrorComponent from '../../../components/bedspaceConflictError'
 import Page from '../../page'
 
 export default abstract class LostBedEditablePage extends Page {
   private readonly bedspaceConflictErrorComponent: BedspaceConflictErrorComponent
 
-  constructor(title: string, premises: Premises, room: Room) {
+  constructor(title: string, premises: Premises, room: Room, bedspace: Cas3Bedspace) {
     super(title)
 
-    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room, null, 'lost-bed')
+    this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, room, bedspace, 'lost-bed')
   }
 
   shouldShowDateConflictErrorMessages(

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedNew.ts
@@ -1,4 +1,4 @@
-import type { NewLostBed, Premises, Room } from '@approved-premises/api'
+import type { Cas3Bedspace, NewLostBed, Premises, Room } from '@approved-premises/api'
 import paths from '../../../../server/paths/temporary-accommodation/manage'
 import LocationHeaderComponent from '../../../components/locationHeader'
 import LostBedEditablePage from './lostBedEditable'
@@ -6,15 +6,19 @@ import LostBedEditablePage from './lostBedEditable'
 export default class LostBedNewPage extends LostBedEditablePage {
   private readonly locationHeaderComponent: LocationHeaderComponent
 
-  constructor(premises: Premises, room: Room) {
-    super('Void a bedspace', premises, room)
+  constructor(premises: Premises, room: Room, bedspace: Cas3Bedspace) {
+    super('Void a bedspace', premises, room, bedspace)
 
-    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room })
+    this.locationHeaderComponent = new LocationHeaderComponent({ premises, room, bedspace })
   }
 
-  static visit(premises: Premises, room: Room): LostBedNewPage {
-    cy.visit(paths.lostBeds.new({ premisesId: premises.id, roomId: room.id }))
-    return new LostBedNewPage(premises, room)
+  static visit(premises: Premises, room: Room, bedspace: Cas3Bedspace): LostBedNewPage {
+    if (room) {
+      cy.visit(paths.lostBeds.new({ premisesId: premises.id, bedspaceId: room.id }))
+    } else {
+      cy.visit(paths.lostBeds.new({ premisesId: premises.id, bedspaceId: bedspace.id }))
+    }
+    return new LostBedNewPage(premises, room, bedspace)
   }
 
   shouldShowBedspaceDetails(): void {

--- a/e2e/tests/lostBed.feature
+++ b/e2e/tests/lostBed.feature
@@ -3,40 +3,40 @@ Feature: Manage Temporary Accommodation - Lost beds
         Given I am logged in as an assessor
         And I view an existing active premises
         And I'm creating a bedspace
+        And I create a bedspace with all necessary details
 
     Scenario: Marking a bedspace as void
-        Given I create a bedspace with all necessary details
-#        Given I'm marking a bedspace as void
-#        And I create a void booking with all necessary details
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
 #        Then I should see a confirmation for my new void booking
-#
-#    Scenario: Showing void booking creation errors
-#        Given I'm marking a bedspace as void
-#        And I attempt to mark a bedspace as void with required details missing
-#        Then I should see a list of the problems encountered voiding the bedspace
-#
-#    Scenario: Showing void booking creation conflict errors
-#        Given I'm marking a bedspace as void
-#        And I create a void booking with all necessary details
-#        And I go up a breadcrumb level
-#        And I'm marking a bedspace as void
-#        And I attempt to create a conflicting void booking
-#        Then I should see errors for the conflicting void booking
-#
-#    Scenario: Editing a void booking
-#        Given I'm marking a bedspace as void
-#        And I create a void booking with all necessary details
-#        And I edit the void booking
+
+    Scenario: Showing void booking creation errors
+        Given I'm marking a bedspace as void
+        And I attempt to mark a bedspace as void with required details missing
+        Then I should see a list of the problems encountered voiding the bedspace
+
+    Scenario: Showing void booking creation conflict errors
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I go up a breadcrumb level
+        And I'm marking a bedspace as void
+        And I attempt to create a conflicting void booking
+        Then I should see errors for the conflicting void booking
+
+    Scenario: Editing a void booking
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I edit the void booking
 #        Then I should see confirmation for my updated void booking
-#
-#    Scenario: Showing void booking editing errors
-#        Given I'm marking a bedspace as void
-#        And I create a void booking with all necessary details
-#        And I attempt to edit the void booking with required details missing
-#        Then I should see a list of the problems encountered voiding the bedspace
-#
-#    Scenario: Cancelling a void booking
-#        Given I'm marking a bedspace as void
-#        And I create a void booking with all necessary details
-#        And I cancel the void booking
-#        Then I should see confirmation that the void is cancelled
+
+    Scenario: Showing void booking editing errors
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I attempt to edit the void booking with required details missing
+        Then I should see a list of the problems encountered voiding the bedspace
+
+    Scenario: Cancelling a void booking
+        Given I'm marking a bedspace as void
+        And I create a void booking with all necessary details
+        And I cancel the void booking
+        Then I should see confirmation that the void is cancelled

--- a/e2e/tests/lostBed.feature
+++ b/e2e/tests/lostBed.feature
@@ -8,7 +8,7 @@ Feature: Manage Temporary Accommodation - Lost beds
     Scenario: Marking a bedspace as void
         Given I'm marking a bedspace as void
         And I create a void booking with all necessary details
-#        Then I should see a confirmation for my new void booking
+        Then I should see a confirmation for my new void booking
 
     Scenario: Showing void booking creation errors
         Given I'm marking a bedspace as void
@@ -27,7 +27,7 @@ Feature: Manage Temporary Accommodation - Lost beds
         Given I'm marking a bedspace as void
         And I create a void booking with all necessary details
         And I edit the void booking
-#        Then I should see confirmation for my updated void booking
+        Then I should see confirmation for my updated void booking
 
     Scenario: Showing void booking editing errors
         Given I'm marking a bedspace as void

--- a/e2e/tests/stepDefinitions/manage/lostBed.ts
+++ b/e2e/tests/stepDefinitions/manage/lostBed.ts
@@ -104,7 +104,7 @@ Then('I should see confirmation for my updated void booking', () => {
 
     lostBedShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.name)
     bedspaceShowPage.shouldShowLostBedDetails(this.lostBed)
   })
 })

--- a/e2e/tests/stepDefinitions/manage/lostBed.ts
+++ b/e2e/tests/stepDefinitions/manage/lostBed.ts
@@ -14,17 +14,17 @@ import {
 
 Given(`I'm marking a bedspace as void`, () => {
   cy.then(function _() {
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.name)
     bedspaceShowPage.clickVoidBedspaceLink()
 
-    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room, null)
     lostBedNewPage.shouldShowBedspaceDetails()
   })
 })
 
 Given('I create a void booking with all necessary details', () => {
   cy.then(function _() {
-    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room, null)
     lostBedNewPage.assignReasons('reasons')
 
     cy.then(function __() {
@@ -45,37 +45,37 @@ Given('I create a void booking with all necessary details', () => {
 
 Then('I should see a confirmation for my new void booking', () => {
   cy.then(function _() {
-    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, null, this.lostBed)
     lostBedShowPage.shouldShowBanner('Void created')
     lostBedShowPage.shouldShowLostBedDetails()
 
     lostBedShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.name)
     bedspaceShowPage.shouldShowLostBedDetails(this.lostBed)
   })
 })
 
 Given('I attempt to mark a bedspace as void with required details missing', () => {
   cy.then(function _() {
-    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room, null)
     lostBedNewPage.clickSubmit()
   })
 })
 
 Then('I should see a list of the problems encountered voiding the bedspace', () => {
   cy.then(function _() {
-    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room, null)
     lostBedNewPage.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
   })
 })
 
 Given('I edit the void booking', () => {
   cy.then(function _() {
-    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, null, this.lostBed)
     lostBedShowPage.clickEditVoidLink()
 
-    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room)
+    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room, null)
     lostBedEditPage.assignReasons('reasons')
 
     cy.then(function __() {
@@ -97,23 +97,23 @@ Given('I edit the void booking', () => {
 
 Then('I should see confirmation for my updated void booking', () => {
   cy.then(function _() {
-    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, null, this.lostBed)
 
     lostBedShowPage.shouldShowBanner('Void booking updated')
     lostBedShowPage.shouldShowLostBedDetails()
 
     lostBedShowPage.clickBreadCrumbUp()
 
-    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room)
+    const bedspaceShowPage = Page.verifyOnPage(BedspaceShowPage, this.premises, this.room, null, this.room.reference)
     bedspaceShowPage.shouldShowLostBedDetails(this.lostBed)
   })
 })
 
 Given('I attempt to edit the void booking with required details missing', () => {
   cy.then(function _() {
-    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, null, this.lostBed)
     lostBedShowPage.clickEditVoidLink()
-    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room)
+    const lostBedEditPage = Page.verifyOnPage(LostBedEditPage, this.premises, this.room, null)
 
     lostBedEditPage.clearForm()
     lostBedEditPage.clickSubmit()
@@ -123,10 +123,10 @@ Given('I attempt to edit the void booking with required details missing', () => 
 
 Given('I cancel the void booking', () => {
   cy.then(function _() {
-    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, this.lostBed)
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, null, this.lostBed)
     lostBedShowPage.clickCancelVoidLink()
 
-    const lostBedCancelPage = Page.verifyOnPage(LostBedCancelPage, this.premises, this.room, this.lostBed)
+    const lostBedCancelPage = Page.verifyOnPage(LostBedCancelPage, this.premises, this.room, null, this.lostBed)
     const lostBedCancellation = lostBedCancellationFactory.build()
     cy.wrap(lostBedCancellation).as('lostBedCancellation')
 
@@ -138,7 +138,7 @@ Given('I cancel the void booking', () => {
 Then('I should see confirmation that the void is cancelled', () => {
   cy.then(function _() {
     const cancelledLostBed = { ...this.lostBed, status: 'cancelled', cancellation: this.lostBedCancellation }
-    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, cancelledLostBed)
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, this.premises, this.room, null, cancelledLostBed)
 
     lostBedShowPage.shouldShowBanner('Void booking cancelled')
     lostBedShowPage.shouldShowLostBedDetails()
@@ -147,7 +147,7 @@ Then('I should see confirmation that the void is cancelled', () => {
 
 Given('I attempt to create a conflicting void booking', () => {
   cy.then(function _() {
-    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room, null)
     const newLostBed = newLostBedFactory.build({ ...this.lostBed, reason: this.lostBed.reason.id })
     lostBedNewPage.completeForm(newLostBed)
   })
@@ -155,7 +155,7 @@ Given('I attempt to create a conflicting void booking', () => {
 
 Then('I should see errors for the conflicting void booking', () => {
   cy.then(function _() {
-    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room)
+    const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.room, null)
     lostBedNewPage.shouldShowDateConflictErrorMessages(this.lostBed, 'lost-bed')
   })
 })

--- a/e2e/tests/stepDefinitions/manage/turnaround.ts
+++ b/e2e/tests/stepDefinitions/manage/turnaround.ts
@@ -14,7 +14,13 @@ Given("I edit the booking's turnaround time", () => {
       ...newTurnaround,
     })
 
-    const bookingTurnaroundNewPage = Page.verifyOnPage(BookingTurnaroundNewPage, this.premises, this.room, this.booking)
+    const bookingTurnaroundNewPage = Page.verifyOnPage(
+      BookingTurnaroundNewPage,
+      this.premises,
+      this.room,
+      null,
+      this.booking,
+    )
     bookingTurnaroundNewPage.shouldShowBookingDetails()
     bookingTurnaroundNewPage.completeForm(newTurnaround)
 

--- a/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/extension.cy.ts
@@ -6,7 +6,7 @@ import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import {
   bookingFactory,
   extensionFactory,
-  //   lostBedFactory,
+  lostBedFactory,
   newExtensionFactory,
 } from '../../../../server/testutils/factories'
 
@@ -93,37 +93,37 @@ context('Booking extension', () => {
     page.shouldShowErrorMessagesForFields(['newDepartureDate'])
   })
 
-  //   it('shows errors when the API returns a 409 conflict error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is an arrived booking and a conflicting lost bed in the database
-  //     const booking = bookingFactory.arrived().build()
-  //     const conflictingLostBed = lostBedFactory.build()
-  //
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: conflictingLostBed })
-  //
-  //     // When I visit the booking extension page
-  //     const page = BookingExtensionNewPage.visit(premises, room, booking)
-  //
-  //     // And I fill out the form with dates that conflict with an existing booking
-  //     const extension = extensionFactory.build()
-  //     const newExtension = newExtensionFactory.build({
-  //       ...extension,
-  //     })
-  //     cy.task('stubExtensionCreateConflictError', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       conflictingEntityId: conflictingLostBed.id,
-  //       conflictingEntityType: 'lost-bed',
-  //     })
-  //
-  //     page.completeForm(newExtension)
-  //
-  //     // Then I should see error messages for the conflict
-  //     page.shouldShowDateConflictErrorMessages(conflictingLostBed, 'lost-bed')
-  //   })
+  it('shows errors when the API returns a 409 conflict error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is an arrived booking and a conflicting lost bed in the database
+    const booking = bookingFactory.arrived().build()
+    const conflictingLostBed = lostBedFactory.build()
+
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: conflictingLostBed })
+
+    // When I visit the booking extension page
+    const page = BookingExtensionNewPage.visit(premises, null, bedspace, booking)
+
+    // And I fill out the form with dates that conflict with an existing booking
+    const extension = extensionFactory.build()
+    const newExtension = newExtensionFactory.build({
+      ...extension,
+    })
+    cy.task('stubExtensionCreateConflictError', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      conflictingEntityId: conflictingLostBed.id,
+      conflictingEntityType: 'lost-bed',
+    })
+
+    page.completeForm(newExtension)
+
+    // Then I should see error messages for the conflict
+    page.shouldShowDateConflictErrorMessages(conflictingLostBed, 'lost-bed')
+  })
 
   it('navigates back from the booking extension page to the show booking page', () => {
     // Given I am signed in

--- a/integration_tests/tests/temporary-accommodation/manage/lostBed.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/lostBed.cy.ts
@@ -1,19 +1,20 @@
-// import Page from '../../../../cypress_shared/pages/page'
-// import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
-// import LostBedCancelPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedCancel'
-// import LostBedEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedEdit'
-// import LostBedNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedNew'
-// import LostBedShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedShow'
+import Page from '../../../../cypress_shared/pages/page'
+import BedspaceShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bedspaceShow'
+import LostBedCancelPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedCancel'
+import LostBedEditPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedEdit'
+import LostBedNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedNew'
+import LostBedShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedShow'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
-// import {
-//   bookingFactory,
-//   lostBedFactory,
-//   newLostBedCancellationFactory,
-//   newLostBedFactory,
-//   premisesFactory,
-//   roomFactory,
-//   updateLostBedFactory,
-// } from '../../../../server/testutils/factories'
+import {
+  bookingFactory,
+  cas3BedspaceFactory,
+  cas3PremisesFactory,
+  lostBedFactory,
+  newLostBedCancellationFactory,
+  newLostBedFactory,
+  premisesFactory,
+  updateLostBedFactory,
+} from '../../../../server/testutils/factories'
 
 context('Lost bed', () => {
   beforeEach(() => {
@@ -24,25 +25,27 @@ context('Lost bed', () => {
   it('navigates to the create void bedspace page', () => {
     // Given I am signed in
     cy.signIn()
-    //
-    //     // And there is an active premises and a room the database
-    //     const premises = premisesFactory.active().build()
-    //     const room = roomFactory.build()
-    //
-    //     cy.task('stubSinglePremises', premises)
-    //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-    //
-    //     // When I visit the show bedspace page
-    //     const bedspaceShow = BedspaceShowPage.visit(premises, room)
-    //
-    //     // Add I click the void bedspace link
-    //     cy.task('stubLostBedReferenceData')
-    //     bedspaceShow.clickVoidBedspaceLink()
-    //
-    //     // Then I navigate to the new lost bed page
-    //     Page.verifyOnPage(LostBedNewPage, premises, room)
+
+    // And there is an active premises and a bedspace the database
+    const premises = premisesFactory.active().build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build({ status: 'online', startDate: '2023-10-18' })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+
+    // When I visit the show bedspace page
+    const bedspaceShow = BedspaceShowPage.visit(premises, null, bedspace)
+
+    // Add I click the void bedspace link
+    cy.task('stubLostBedReferenceData')
+    bedspaceShow.clickVoidBedspaceLink()
+
+    // Then I navigate to the new lost bed page
+    Page.verifyOnPage(LostBedNewPage, premises, null, bedspace)
   })
-  //
+
   //   it('navigates to the show void bedspace page', () => {
   //     // Given I am signed in
   //     cy.signIn()
@@ -71,351 +74,375 @@ context('Lost bed', () => {
   //     // Then I navigate to the show lost bed page
   //     Page.verifyOnPage(LostBedShowPage, premises, room, lostBeds[0])
   //   })
-  //
-  //   it('allows me to create a void booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // When I visit the void a bedspace page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedNewPage.visit(premises, room)
-  //
-  //     // I should see the bedspace details
-  //     page.shouldShowBedspaceDetails()
-  //
-  //     // And when I fill out the form
-  //     const lostBed = lostBedFactory.build({
-  //       bedId: room.beds[0].id,
-  //     })
-  //
-  //     const newLostBed = newLostBedFactory.build({
-  //       ...lostBed,
-  //       reason: lostBed.reason.id,
-  //       bedId: lostBed.bedId,
-  //     })
-  //
-  //     cy.task('stubLostBedCreate', { premisesId: premises.id, lostBed })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     page.completeForm(newLostBed)
-  //
-  //     // Then a lost bed should have been created in the API
-  //     cy.task('verifyLostBedCreate', { premisesId: premises.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //
-  //       expect(requestBody.bedId).equal(newLostBed.bedId)
-  //       expect(requestBody.reason).equal(newLostBed.reason)
-  //       expect(requestBody.startDate).equal(newLostBed.startDate)
-  //       expect(requestBody.endDate).equal(newLostBed.endDate)
-  //       expect(requestBody.notes).equal(newLostBed.notes)
-  //     })
-  //
-  //     // And I should be redirected to the show booking page
-  //     const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, premises, room, lostBed)
-  //     lostBedShowPage.shouldShowBanner('Void created')
-  //   })
-  //
-  //   it('shows create errors when the API returns an error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // When I visit the new lost bed page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedNewPage.visit(premises, room)
-  //
-  //     // And I miss required fields
-  //     cy.task('stubLostBedErrors', {
-  //       premisesId: premises.id,
-  //       params: ['startDate', 'endDate'],
-  //     })
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
-  //   })
-  //
-  //   it('shows create errors when the API returns a 409 conflict error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a conflicting booking in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const conflictingBooking = bookingFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
-  //
-  //     // When I visit the new lost bed page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedNewPage.visit(premises, room)
-  //
-  //     // And I fill out the form with dates that conflict with an existing lost bed
-  //     const lostBed = lostBedFactory.build({
-  //       bedId: room.beds[0].id,
-  //     })
-  //     const newLostBed = newLostBedFactory.build({
-  //       ...lostBed,
-  //       reason: lostBed.reason.id,
-  //     })
-  //
-  //     cy.task('stubLostBedCreateConflictError', {
-  //       premisesId: premises.id,
-  //       conflictingEntityId: conflictingBooking.id,
-  //       conflictingEntityType: 'booking',
-  //     })
-  //
-  //     page.completeForm(newLostBed)
-  //
-  //     // Then I should see error messages for conflict
-  //     page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
-  //   })
-  //
-  //   it('navigates back from the new lost bed page to the show bedspace page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises and a room the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //
-  //     // When I visit the new lost bed page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedNewPage.visit(premises, room)
-  //
-  //     // And I click the previous bread crumb
-  //     page.clickBreadCrumbUp()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BedspaceShowPage, premises, room)
-  //   })
-  //
-  //   it('shows a single active lost bed', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and an active lost bed in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the show lost bed page
-  //     const page = LostBedShowPage.visit(premises, room, lostBed)
-  //
-  //     // Then I should see the booking details
-  //     page.shouldShowLostBedDetails()
-  //   })
-  //
-  //   it('shows a single cancelled lost bed', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and a cancelled lost bed in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.build({ status: 'cancelled' })
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the show lost bed page
-  //     const page = LostBedShowPage.visit(premises, room, lostBed)
-  //
-  //     // Then I should see the booking details
-  //     page.shouldShowLostBedDetails()
-  //   })
-  //
-  //   it('navigates back from the show lost bed page to the show bedspace page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and lost beds in the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBeds = lostBedFactory
-  //       .params({
-  //         bedId: room.beds[0].id,
-  //       })
-  //       .buildList(5)
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: lostBeds[0] })
-  //
-  //     // When I visit the show lost bed page
-  //     const page = LostBedShowPage.visit(premises, room, lostBeds[0])
-  //
-  //     // And I click the previous bread crumb
-  //     page.clickBreadCrumbUp()
-  //
-  //     // Then I navigate to the show bedspace page
-  //     Page.verifyOnPage(BedspaceShowPage, premises, room)
-  //   })
-  //
-  //   it('navigates to the update void bedspace page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and an active lost bed the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the show lost bed page
-  //     const page = LostBedShowPage.visit(premises, room, lostBed)
-  //
-  //     // Add I click the 'Edit this void' link
-  //     cy.task('stubLostBedReferenceData')
-  //     page.clickEditVoidLink()
-  //
-  //     // Then I navigate to the edit void booking page
-  //     Page.verifyOnPage(LostBedEditPage, premises, room)
-  //   })
-  //
-  //   it('navigates back from the update void booking page to the view void booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and an active lost bed the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the edit void booking page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedEditPage.visit(premises, room, lostBed)
-  //
-  //     // And I click the previous bread crumb
-  //     page.clickBreadCrumbUp()
-  //
-  //     // Then I navigate to the view bedspace page
-  //     Page.verifyOnPage(BedspaceShowPage, premises, room)
-  //   })
-  //
-  //   it('allows me to update a void booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and an active lost bed the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the edit void booking page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedEditPage.visit(premises, room, lostBed)
-  //
-  //     // I should see the bedspace details
-  //     page.shouldShowBedspaceDetails()
-  //
-  //     // And when I fill out the form
-  //     cy.task('stubLostBedUpdate', { premisesId: premises.id, lostBed })
-  //     const updateLostBed = updateLostBedFactory.build()
-  //     page.clearForm()
-  //     page.completeForm(updateLostBed)
-  //
-  //     // Then the lost bed should have been updated in the API
-  //     cy.task('verifyLostBedUpdate', { premisesId: premises.id, lostBedId: lostBed.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //
-  //       expect(requestBody.reason).equal(updateLostBed.reason)
-  //       expect(requestBody.startDate).equal(updateLostBed.startDate)
-  //       expect(requestBody.endDate).equal(updateLostBed.endDate)
-  //       expect(requestBody.notes).equal(updateLostBed.notes)
-  //     })
-  //   })
-  //
-  //   it('shows update errors when the API returns an error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and an active lost bed the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the edit void booking page
-  //     cy.task('stubLostBedReferenceData')
-  //     const page = LostBedEditPage.visit(premises, room, lostBed)
-  //
-  //     // And I miss required fields
-  //     page.clearForm()
-  //     cy.task('stubLostBedUpdateErrors', {
-  //       premisesId: premises.id,
-  //       lostBedId: lostBed.id,
-  //       params: ['startDate', 'endDate'],
-  //     })
-  //     page.clickSubmit()
-  //
-  //     // Then I should see error messages relating to those fields
-  //     page.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
-  //   })
-  //
-  //   it('navigates to the cancel void booking page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and an active lost bed the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the show lost bed page
-  //     const page = LostBedShowPage.visit(premises, room, lostBed)
-  //
-  //     // Add I click the 'Cancel this void' link
-  //     page.clickCancelVoidLink()
-  //
-  //     // Then I navigate to the edit void booking page
-  //     Page.verifyOnPage(LostBedCancelPage, premises, room, lostBed)
-  //   })
-  //
+
+  it('allows me to create a void booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a bedspace the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+
+    // When I visit the void a bedspace page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedNewPage.visit(premises, null, bedspace)
+
+    // I should see the bedspace details
+    page.shouldShowBedspaceDetails()
+
+    // And when I fill out the form
+    const lostBed = lostBedFactory.build({
+      bedId: bedspace.id,
+    })
+
+    const newLostBed = newLostBedFactory.build({
+      ...lostBed,
+      reason: lostBed.reason.id,
+      bedId: lostBed.bedId,
+    })
+
+    cy.task('stubLostBedCreate', { premisesId: premises.id, lostBed })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    page.completeForm(newLostBed)
+
+    // Then a lost bed should have been created in the API
+    cy.task('verifyLostBedCreate', { premisesId: premises.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.bedId).equal(newLostBed.bedId)
+      expect(requestBody.reason).equal(newLostBed.reason)
+      expect(requestBody.startDate).equal(newLostBed.startDate)
+      expect(requestBody.endDate).equal(newLostBed.endDate)
+      expect(requestBody.notes).equal(newLostBed.notes)
+    })
+
+    // And I should be redirected to the show booking page
+    const lostBedShowPage = Page.verifyOnPage(LostBedShowPage, premises, null, bedspace, lostBed)
+    lostBedShowPage.shouldShowBanner('Void created')
+  })
+
+  it('shows create errors when the API returns an error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a bedspace the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+
+    // When I visit the new lost bed page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedNewPage.visit(premises, null, bedspace)
+
+    // And I miss required fields
+    cy.task('stubLostBedErrors', {
+      premisesId: premises.id,
+      params: ['startDate', 'endDate'],
+    })
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
+  })
+
+  it('shows create errors when the API returns a 409 conflict error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace, and a conflicting booking in the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const conflictingBooking = bookingFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
+
+    // When I visit the new lost bed page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedNewPage.visit(premises, null, bedspace)
+
+    // And I fill out the form with dates that conflict with an existing lost bed
+    const lostBed = lostBedFactory.build({
+      bedId: bedspace.id,
+    })
+    const newLostBed = newLostBedFactory.build({
+      ...lostBed,
+      reason: lostBed.reason.id,
+    })
+
+    cy.task('stubLostBedCreateConflictError', {
+      premisesId: premises.id,
+      conflictingEntityId: conflictingBooking.id,
+      conflictingEntityType: 'booking',
+    })
+
+    page.completeForm(newLostBed)
+
+    // Then I should see error messages for conflict
+    page.shouldShowDateConflictErrorMessages(conflictingBooking, 'booking')
+  })
+
+  it('navigates back from the new lost bed page to the show bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises and a bedspace the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+
+    // When I visit the new lost bed page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedNewPage.visit(premises, null, bedspace)
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BedspaceShowPage, premises, null, bedspace, bedspace.reference)
+  })
+
+  it('shows a single active lost bed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace, and an active lost bed in the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the show lost bed page
+    const page = LostBedShowPage.visit(premises, null, bedspace, lostBed)
+
+    // Then I should see the booking details
+    page.shouldShowLostBedDetails()
+  })
+
+  it('shows a single cancelled lost bed', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace, and a cancelled lost bed in the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.build({ status: 'cancelled' })
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the show lost bed page
+    const page = LostBedShowPage.visit(premises, null, bedspace, lostBed)
+
+    // Then I should see the booking details
+    page.shouldShowLostBedDetails()
+  })
+
+  it('navigates back from the show lost bed page to the show bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace, and lost beds in the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBeds = lostBedFactory
+      .params({
+        bedId: bedspace.id,
+      })
+      .buildList(5)
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: lostBeds[0] })
+
+    // When I visit the show lost bed page
+    const page = LostBedShowPage.visit(premises, null, bedspace, lostBeds[0])
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the show bedspace page
+    Page.verifyOnPage(BedspaceShowPage, premises, null, bedspace, bedspace.reference)
+  })
+
+  it('navigates to the update void bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace and an active lost bed the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the show lost bed page
+    const page = LostBedShowPage.visit(premises, null, bedspace, lostBed)
+
+    // Add I click the 'Edit this void' link
+    cy.task('stubLostBedReferenceData')
+    page.clickEditVoidLink()
+
+    // Then I navigate to the edit void booking page
+    Page.verifyOnPage(LostBedEditPage, premises, null, bedspace)
+  })
+
+  it('navigates back from the update void booking page to the view void booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace and an active lost bed the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the edit void booking page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedEditPage.visit(premises, null, bedspace, lostBed)
+
+    // And I click the previous bread crumb
+    page.clickBreadCrumbUp()
+
+    // Then I navigate to the view bedspace page
+    Page.verifyOnPage(BedspaceShowPage, premises, null, bedspace, bedspace.reference)
+  })
+
+  it('allows me to update a void booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace and an active lost bed the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the edit void booking page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedEditPage.visit(premises, null, bedspace, lostBed)
+
+    // I should see the bedspace details
+    page.shouldShowBedspaceDetails()
+
+    // And when I fill out the form
+    cy.task('stubLostBedUpdate', { premisesId: premises.id, lostBed })
+    const updateLostBed = updateLostBedFactory.build()
+    page.clearForm()
+    page.completeForm(updateLostBed)
+
+    // Then the lost bed should have been updated in the API
+    cy.task('verifyLostBedUpdate', { premisesId: premises.id, lostBedId: lostBed.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.reason).equal(updateLostBed.reason)
+      expect(requestBody.startDate).equal(updateLostBed.startDate)
+      expect(requestBody.endDate).equal(updateLostBed.endDate)
+      expect(requestBody.notes).equal(updateLostBed.notes)
+    })
+  })
+
+  it('shows update errors when the API returns an error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace and an active lost bed the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the edit void booking page
+    cy.task('stubLostBedReferenceData')
+    const page = LostBedEditPage.visit(premises, null, bedspace, lostBed)
+
+    // And I miss required fields
+    page.clearForm()
+    cy.task('stubLostBedUpdateErrors', {
+      premisesId: premises.id,
+      lostBedId: lostBed.id,
+      params: ['startDate', 'endDate'],
+    })
+    page.clickSubmit()
+
+    // Then I should see error messages relating to those fields
+    page.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
+  })
+
+  it('navigates to the cancel void booking page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace and an active lost bed the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the show lost bed page
+    const page = LostBedShowPage.visit(premises, null, bedspace, lostBed)
+
+    // Add I click the 'Cancel this void' link
+    page.clickCancelVoidLink()
+
+    // Then I navigate to the edit void booking page
+    Page.verifyOnPage(LostBedCancelPage, premises, null, bedspace, lostBed)
+  })
+
   //   it('navigates back from the cancel void booking page to the view void booking page', () => {
   //     // Given I am signed in
   //     cy.signIn()
@@ -438,37 +465,39 @@ context('Lost bed', () => {
   //     // Then I navigate to the view bedspace page
   //     Page.verifyOnPage(BedspaceShowPage, premises, room)
   //   })
-  //
-  //   it('allows me to cancel a void booking', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room and an active lost bed the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBed = lostBedFactory.active().build()
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
-  //
-  //     // When I visit the cancel void booking page
-  //     const page = LostBedCancelPage.visit(premises, room, lostBed)
-  //
-  //     // I should see the bedspace details
-  //     page.shouldShowBedspaceDetails()
-  //
-  //     // And when I fill out the form
-  //     cy.task('stubLostBedCancel', { premisesId: premises.id, lostBed })
-  //     const cancelLostBed = newLostBedCancellationFactory.build()
-  //     page.completeForm(cancelLostBed)
-  //
-  //     // Then the lost bed should have been cancelled in the API
-  //     cy.task('verifyLostBedCancel', { premisesId: premises.id, lostBedId: lostBed.id }).then(requests => {
-  //       expect(requests).to.have.length(1)
-  //       const requestBody = JSON.parse(requests[0].body)
-  //
-  //       expect(requestBody.notes).equal(cancelLostBed.notes)
-  //     })
-  //   })
+
+  it('allows me to cancel a void booking', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a bedspace and an active lost bed the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build()
+    const lostBed = lostBedFactory.active().build()
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+
+    // When I visit the cancel void booking page
+    const page = LostBedCancelPage.visit(premises, null, bedspace, lostBed)
+
+    // I should see the bedspace details
+    page.shouldShowBedspaceDetails()
+
+    // And when I fill out the form
+    cy.task('stubLostBedCancel', { premisesId: premises.id, lostBed })
+    const cancelLostBed = newLostBedCancellationFactory.build()
+    page.completeForm(cancelLostBed)
+
+    // Then the lost bed should have been cancelled in the API
+    cy.task('verifyLostBedCancel', { premisesId: premises.id, lostBedId: lostBed.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      expect(requestBody.notes).equal(cancelLostBed.notes)
+    })
+  })
 })

--- a/integration_tests/tests/temporary-accommodation/manage/lostBed.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/lostBed.cy.ts
@@ -6,6 +6,7 @@ import LostBedNewPage from '../../../../cypress_shared/pages/temporary-accommoda
 import LostBedShowPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/lostBedShow'
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import {
+  bedFactory,
   bookingFactory,
   cas3BedspaceFactory,
   cas3PremisesFactory,
@@ -30,10 +31,23 @@ context('Lost bed', () => {
     const premises = premisesFactory.active().build()
     const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
     const bedspace = cas3BedspaceFactory.build({ status: 'online', startDate: '2023-10-18' })
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({ id: bedspace.id }),
+      })
+      .buildList(5)
+    const lostBeds = lostBedFactory
+      .active()
+      .params({
+        bedId: bedspace.id,
+      })
+      .buildList(5)
 
     cy.task('stubSinglePremises', premises)
     cy.task('stubSinglePremisesV2', cas3Premises)
     cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
 
     // When I visit the show bedspace page
     const bedspaceShow = BedspaceShowPage.visit(premises, null, bedspace)
@@ -46,34 +60,42 @@ context('Lost bed', () => {
     Page.verifyOnPage(LostBedNewPage, premises, null, bedspace)
   })
 
-  //   it('navigates to the show void bedspace page', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a premises, a room, and lost beds the database
-  //     const premises = premisesFactory.build()
-  //     const room = roomFactory.build()
-  //     const lostBeds = lostBedFactory
-  //       .active()
-  //       .params({
-  //         bedId: room.beds[0].id,
-  //       })
-  //       .buildList(5)
-  //
-  //     cy.task('stubSinglePremises', premises)
-  //     cy.task('stubSingleRoom', { premisesId: premises.id, room })
-  //     cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: lostBeds[0] })
-  //
-  //     // When I visit the show bedspace page
-  //     const bedspaceShowPage = BedspaceShowPage.visit(premises, room)
-  //
-  //     // Add I click the lost bed link
-  //     bedspaceShowPage.clickLostBedLink(lostBeds[0])
-  //
-  //     // Then I navigate to the show lost bed page
-  //     Page.verifyOnPage(LostBedShowPage, premises, room, lostBeds[0])
-  //   })
+  it('navigates to the show void bedspace page', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a premises, a room, and lost beds the database
+    const premises = premisesFactory.build()
+    const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
+    const bedspace = cas3BedspaceFactory.build({ status: 'online', startDate: '2023-10-18' })
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({ id: bedspace.id }),
+      })
+      .buildList(5)
+    const lostBeds = lostBedFactory
+      .active()
+      .params({
+        bedId: bedspace.id,
+      })
+      .buildList(5)
+
+    cy.task('stubSinglePremises', premises)
+    cy.task('stubSinglePremisesV2', cas3Premises)
+    cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: lostBeds[0] })
+
+    // When I visit the show bedspace page
+    const bedspaceShowPage = BedspaceShowPage.visit(premises, null, bedspace)
+
+    // Add I click the lost bed link
+    bedspaceShowPage.clickLostBedLink(lostBeds[0])
+
+    // Then I navigate to the show lost bed page
+    Page.verifyOnPage(LostBedShowPage, premises, null, bedspace, lostBeds[0])
+  })
 
   it('allows me to create a void booking', () => {
     // Given I am signed in
@@ -204,10 +226,23 @@ context('Lost bed', () => {
     const premises = premisesFactory.build()
     const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
     const bedspace = cas3BedspaceFactory.build()
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({ id: bedspace.id }),
+      })
+      .buildList(5)
+    const lostBeds = lostBedFactory
+      .active()
+      .params({
+        bedId: bedspace.id,
+      })
+      .buildList(5)
 
     cy.task('stubSinglePremises', premises)
     cy.task('stubSinglePremisesV2', cas3Premises)
     cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
 
     // When I visit the new lost bed page
     cy.task('stubLostBedReferenceData')
@@ -329,11 +364,24 @@ context('Lost bed', () => {
     const cas3Premises = cas3PremisesFactory.build({ id: premises.id, status: 'online' })
     const bedspace = cas3BedspaceFactory.build()
     const lostBed = lostBedFactory.active().build()
+    const bookings = bookingFactory
+      .params({
+        bed: bedFactory.build({ id: bedspace.id }),
+      })
+      .buildList(5)
+    const lostBeds = lostBedFactory
+      .active()
+      .params({
+        bedId: bedspace.id,
+      })
+      .buildList(5)
 
     cy.task('stubSinglePremises', premises)
     cy.task('stubSinglePremisesV2', cas3Premises)
     cy.task('stubBedspaceV2', { premisesId: cas3Premises.id, bedspace })
     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed })
+    cy.task('stubBookingsForPremisesId', { premisesId: premises.id, bookings })
+    cy.task('stubLostBedsForPremisesId', { premisesId: premises.id, lostBeds })
 
     // When I visit the edit void booking page
     cy.task('stubLostBedReferenceData')

--- a/integration_tests/tests/temporary-accommodation/manage/turnaround.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/turnaround.cy.ts
@@ -5,7 +5,7 @@ import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import {
   bookingFactory,
-  //  lostBedFactory,
+  lostBedFactory,
   newTurnaroundFactory,
   turnaroundFactory,
 } from '../../../../server/testutils/factories'
@@ -92,37 +92,37 @@ context('Booking turnarounds', () => {
     page.shouldShowErrorMessagesForFields(['workingDays'])
   })
 
-  //   it('shows errors when the API returns a 409 conflict error', () => {
-  //     // Given I am signed in
-  //     cy.signIn()
-  //
-  //     // And there is a booking and a conflicting lost bed in the database
-  //     const booking = bookingFactory.departed().build()
-  //     const conflictingLostBed = lostBedFactory.build()
-  //
-  //     const { premises, room } = setupBookingStateStubs(booking)
-  //     cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: conflictingLostBed })
-  //
-  //     // When I visit the change turnaround page
-  //     const page = BookingTurnaroundNewPage.visit(premises, room, booking)
-  //
-  //     // And I fill out the form with days that conflict with an existing booking
-  //     const turnaround = turnaroundFactory.build()
-  //     const newTurnaround = newTurnaroundFactory.build({
-  //       ...turnaround,
-  //     })
-  //     cy.task('stubTurnaroundCreateConflictError', {
-  //       premisesId: premises.id,
-  //       bookingId: booking.id,
-  //       conflictingEntityId: conflictingLostBed.id,
-  //       conflictingEntityType: 'lost-bed',
-  //     })
-  //
-  //     page.completeForm(newTurnaround)
-  //
-  //     // Then I should see error messages for the conflict
-  //     page.shouldShowDateConflictErrorMessages(conflictingLostBed, 'lost-bed')
-  //   })
+  it('shows errors when the API returns a 409 conflict error', () => {
+    // Given I am signed in
+    cy.signIn()
+
+    // And there is a booking and a conflicting lost bed in the database
+    const booking = bookingFactory.departed().build()
+    const conflictingLostBed = lostBedFactory.build()
+
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+    cy.task('stubSingleLostBed', { premisesId: premises.id, lostBed: conflictingLostBed })
+
+    // When I visit the change turnaround page
+    const page = BookingTurnaroundNewPage.visit(premises, null, bedspace, booking)
+
+    // And I fill out the form with days that conflict with an existing booking
+    const turnaround = turnaroundFactory.build()
+    const newTurnaround = newTurnaroundFactory.build({
+      ...turnaround,
+    })
+    cy.task('stubTurnaroundCreateConflictError', {
+      premisesId: premises.id,
+      bookingId: booking.id,
+      conflictingEntityId: conflictingLostBed.id,
+      conflictingEntityType: 'lost-bed',
+    })
+
+    page.completeForm(newTurnaround)
+
+    // Then I should see error messages for the conflict
+    page.shouldShowDateConflictErrorMessages(conflictingLostBed, 'lost-bed')
+  })
 
   it('navigates back from the change turnaround page to the show booking page', () => {
     // Given I am signed in

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -80,7 +80,7 @@ export const controllers = (services: Services) => {
   const lostBedsController = new LostBedsController(
     services.lostBedService,
     services.premisesService,
-    services.bedspaceService,
+    services.v2.bedspaceService,
     services.assessmentsService,
   )
 

--- a/server/controllers/temporary-accommodation/manage/lostBedsController.ts
+++ b/server/controllers/temporary-accommodation/manage/lostBedsController.ts
@@ -3,7 +3,7 @@ import type { Request, RequestHandler, Response } from 'express'
 import type { NewLostBed, NewLostBedCancellation, UpdateLostBed } from '@approved-premises/api'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { AssessmentsService, LostBedService, PremisesService } from '../../../services'
-import BedspaceService from '../../../services/bedspaceService'
+import BedspaceService from '../../../services/v2/bedspaceService'
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
 import { DateFormats } from '../../../utils/dateUtils'
 import { allStatuses, lostBedActions } from '../../../utils/lostBedUtils'
@@ -27,18 +27,18 @@ export default class LostBedsController {
   new(): RequestHandler {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, errorTitle, userInput } = fetchErrorsAndUserInput(req)
-      const { premisesId, roomId } = req.params
+      const { premisesId, bedspaceId } = req.params
 
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const lostBedReasons = await this.lostBedsService.getReferenceData(callConfig)
 
       return res.render('temporary-accommodation/lost-beds/new', {
         premises,
-        room,
+        bedspace,
         lostBedReasons,
         errors,
         errorTitle,
@@ -50,7 +50,7 @@ export default class LostBedsController {
 
   create(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId } = req.params
+      const { premisesId, bedspaceId } = req.params
       const callConfig = extractCallConfig(req)
 
       const newLostBed: NewLostBed = {
@@ -63,36 +63,36 @@ export default class LostBedsController {
         const lostBed = await this.lostBedsService.create(callConfig, premisesId, newLostBed)
 
         req.flash('success', 'Void created')
-        res.redirect(paths.lostBeds.show({ premisesId, bedspaceId: roomId, lostBedId: lostBed.id }))
+        res.redirect(paths.lostBeds.show({ premisesId, bedspaceId, lostBedId: lostBed.id }))
       } catch (err) {
         if (err.status === 409) {
-          insertBespokeError(err, generateConflictBespokeError(err, premisesId, roomId, 'plural'))
+          insertBespokeError(err, generateConflictBespokeError(err, premisesId, bedspaceId, 'plural'))
           insertGenericError(err, 'startDate', 'conflict')
           insertGenericError(err, 'endDate', 'conflict')
         }
 
-        catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.new({ premisesId, bedspaceId: roomId }))
+        catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.new({ premisesId, bedspaceId }))
       }
     }
   }
 
   show(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, lostBedId } = req.params
+      const { premisesId, bedspaceId, lostBedId } = req.params
       const callConfig = extractCallConfig(req)
 
       await preservePlaceContext(req, res, this.assessmentService)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const lostBed = await this.lostBedsService.find(callConfig, premisesId, lostBedId)
 
       return res.render('temporary-accommodation/lost-beds/show', {
         premises,
-        room,
+        bedspace,
         lostBed,
-        actions: lostBedActions(premisesId, roomId, lostBed),
+        actions: lostBedActions(premisesId, bedspaceId, lostBed),
         allStatuses,
       })
     }
@@ -100,7 +100,7 @@ export default class LostBedsController {
 
   update(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, lostBedId } = req.params
+      const { premisesId, bedspaceId, lostBedId } = req.params
       const callConfig = extractCallConfig(req)
 
       const lostBedUpdate: UpdateLostBed = {
@@ -113,20 +113,15 @@ export default class LostBedsController {
         const updatedLostBed = await this.lostBedsService.update(callConfig, premisesId, lostBedId, lostBedUpdate)
 
         req.flash('success', 'Void booking updated')
-        res.redirect(paths.lostBeds.show({ premisesId, bedspaceId: roomId, lostBedId: updatedLostBed.id }))
+        res.redirect(paths.lostBeds.show({ premisesId, bedspaceId, lostBedId: updatedLostBed.id }))
       } catch (err) {
         if (err.status === 409) {
-          insertBespokeError(err, generateConflictBespokeError(err, premisesId, roomId, 'plural'))
+          insertBespokeError(err, generateConflictBespokeError(err, premisesId, bedspaceId, 'plural'))
           insertGenericError(err, 'startDate', 'conflict')
           insertGenericError(err, 'endDate', 'conflict')
         }
 
-        catchValidationErrorOrPropogate(
-          req,
-          res,
-          err,
-          paths.lostBeds.edit({ premisesId, bedspaceId: roomId, lostBedId }),
-        )
+        catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.edit({ premisesId, bedspaceId, lostBedId }))
       }
     }
   }
@@ -135,11 +130,11 @@ export default class LostBedsController {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, errorTitle, userInput } = fetchErrorsAndUserInput(req)
 
-      const { premisesId, roomId, lostBedId } = req.params
+      const { premisesId, bedspaceId, lostBedId } = req.params
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const lostBedReasons = await this.lostBedsService.getReferenceData(callConfig)
 
@@ -151,7 +146,7 @@ export default class LostBedsController {
         errorSummary,
         errorTitle,
         premises,
-        room,
+        bedspace,
         lostBedId,
         ...updateLostBed,
         ...DateFormats.isoToDateAndTimeInputs(updateLostBed.startDate, 'startDate'),
@@ -165,11 +160,11 @@ export default class LostBedsController {
     return async (req: Request, res: Response) => {
       const { errors, errorSummary, userInput } = fetchErrorsAndUserInput(req)
 
-      const { premisesId, roomId, lostBedId } = req.params
+      const { premisesId, bedspaceId, lostBedId } = req.params
       const callConfig = extractCallConfig(req)
 
       const premises = await this.premisesService.getPremises(callConfig, premisesId)
-      const room = await this.bedspacesService.getRoom(callConfig, premisesId, roomId)
+      const bedspace = await this.bedspacesService.getSingleBedspace(callConfig, premisesId, bedspaceId)
 
       const lostBed = await this.lostBedsService.find(callConfig, premisesId, lostBedId)
 
@@ -177,7 +172,7 @@ export default class LostBedsController {
         errors,
         errorSummary,
         premises,
-        room,
+        bedspace,
         lostBed,
         allStatuses,
         notes: lostBed.notes,
@@ -188,7 +183,7 @@ export default class LostBedsController {
 
   createCancellation(): RequestHandler {
     return async (req: Request, res: Response) => {
-      const { premisesId, roomId, lostBedId } = req.params
+      const { premisesId, bedspaceId, lostBedId } = req.params
       const callConfig = extractCallConfig(req)
 
       const lostBedCancellation: NewLostBedCancellation = {
@@ -199,13 +194,13 @@ export default class LostBedsController {
         await this.lostBedsService.cancel(callConfig, premisesId, lostBedId, lostBedCancellation)
 
         req.flash('success', 'Void booking cancelled')
-        res.redirect(paths.lostBeds.show({ premisesId, bedspaceId: roomId, lostBedId }))
+        res.redirect(paths.lostBeds.show({ premisesId, bedspaceId, lostBedId }))
       } catch (err) {
         catchValidationErrorOrPropogate(
           req,
           res,
           err,
-          paths.lostBeds.cancellations.new({ premisesId, bedspaceId: roomId, lostBedId }),
+          paths.lostBeds.cancellations.new({ premisesId, bedspaceId, lostBedId }),
         )
       }
     }

--- a/server/utils/lostBedUtils.test.ts
+++ b/server/utils/lostBedUtils.test.ts
@@ -14,14 +14,14 @@ describe('lostBedUtils', () => {
     it('returns actions array when lost bed status is active', () => {
       const lostBed = lostBedFactory.active().build()
 
-      const result = lostBedActions('premisesId', 'roomId', lostBed)
+      const result = lostBedActions('premisesId', 'bedspaceId', lostBed)
       expect(result.length).toEqual(2)
     })
 
     it('returns null when lost bed status is cancelled', () => {
       const lostBed = lostBedFactory.build({ status: 'cancelled' })
 
-      const result = lostBedActions('premisesId', 'roomId', lostBed)
+      const result = lostBedActions('premisesId', 'bedspaceId', lostBed)
       expect(result).toEqual(null)
     })
   })

--- a/server/utils/lostBedUtils.ts
+++ b/server/utils/lostBedUtils.ts
@@ -23,18 +23,18 @@ export function statusTag(statusId: LostBed['status'], context: 'bookingsAndVoid
   return `<strong class="govuk-tag ${status.tagClass}">${status.name}</strong>`
 }
 
-export function lostBedActions(premisesId: string, roomId: string, lostBed: LostBed): Array<PageHeadingBarItem> {
+export function lostBedActions(premisesId: string, bedspaceId: string, lostBed: LostBed): Array<PageHeadingBarItem> {
   if (lostBed.status === 'active') {
     return [
       {
         text: 'Edit this void',
         classes: 'govuk-button--secondary',
-        href: paths.lostBeds.edit({ premisesId, bedspaceId: roomId, lostBedId: lostBed.id }),
+        href: paths.lostBeds.edit({ premisesId, bedspaceId, lostBedId: lostBed.id }),
       },
       {
         text: 'Cancel this void',
         classes: 'govuk-button--secondary',
-        href: paths.lostBeds.cancellations.new({ premisesId, bedspaceId: roomId, lostBedId: lostBed.id }),
+        href: paths.lostBeds.cancellations.new({ premisesId, bedspaceId, lostBedId: lostBed.id }),
       },
     ]
   }

--- a/server/views/temporary-accommodation/lost-beds/cancel.njk
+++ b/server/views/temporary-accommodation/lost-beds/cancel.njk
@@ -14,7 +14,7 @@
 {% block beforeContent %}
   {{ breadCrumb('Cancel a void booking', [
     {title: 'List of bedspaces', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+    {title: 'View bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id })}
   ]) }}
 {% endblock %}
 
@@ -28,10 +28,10 @@
     }
   }) }}
 
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
   {{ lostBedInfo(lostBed) }}
 
-  <form action="{{ paths.lostBeds.cancellations.create({ premisesId: premises.id, roomId: room.id, lostBedId: lostBed.id }) }}" method="post">
+  <form action="{{ paths.lostBeds.cancellations.create({ premisesId: premises.id, bedspaceId: bedspace.id, lostBedId: lostBed.id }) }}" method="post">
     <input type="hidden" name="_csrf" value="{{ csrfToken }}"/> 
     
     {{ formPageTextarea({

--- a/server/views/temporary-accommodation/lost-beds/edit.njk
+++ b/server/views/temporary-accommodation/lost-beds/edit.njk
@@ -10,7 +10,7 @@
   {{ breadCrumb('Record void bedspace', [
     {title: 'List of properties', href: paths.premises.online()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id })}
   ]) }}
 {% endblock %}
 
@@ -21,13 +21,13 @@
   
   <h1 class="govuk-heading-l">Void a bedspace</h1>
 
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
 
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
-      <form action="{{ paths.lostBeds.update({ premisesId: premises.id, roomId: room.id, lostBedId: lostBedId }) }}?_method=PUT" method="post">
+      <form action="{{ paths.lostBeds.update({ premisesId: premises.id, bedspaceId: bedspace.id, lostBedId: lostBedId }) }}?_method=PUT" method="post">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-        <input type="hidden" name="bedId" value="{{ room.beds[0].id }}"/> {% include "./_editable.njk" %}
+        <input type="hidden" name="bedId" value="{{ bedspace.id }}"/> {% include "./_editable.njk" %}
       </form>
     </div>
   </div>

--- a/server/views/temporary-accommodation/lost-beds/new.njk
+++ b/server/views/temporary-accommodation/lost-beds/new.njk
@@ -10,7 +10,7 @@
   {{ breadCrumb('Record void bedspace', [
     {title: 'List of properties', href: paths.premises.online()},
     {title: 'View a property', href: paths.premises.show({ premisesId: premises.id })},
-    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id })}
+    {title: 'View a bedspace', href: paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id })}
   ]) }}
 {% endblock %}
 
@@ -21,12 +21,12 @@
     
   <h1 class="govuk-heading-l">Void a bedspace</h1>
 
-  {{ locationHeader({ premises: premises, room: room }) }}
+  {{ locationHeader({ premises: premises, room: bedspace }) }}
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
-            <form action="{{ paths.lostBeds.create({ premisesId: premises.id, roomId: room.id }) }}" method="post">
+            <form action="{{ paths.lostBeds.create({ premisesId: premises.id, bedspaceId: bedspace.id }) }}" method="post">
                 <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
-                <input type="hidden" name="bedId" value="{{ room.beds[0].id }}"/> {% include "./_editable.njk" %}
+                <input type="hidden" name="bedId" value="{{ bedspace.id }}"/> {% include "./_editable.njk" %}
             </form>
         </div>
     </div>

--- a/server/views/temporary-accommodation/lost-beds/show.njk
+++ b/server/views/temporary-accommodation/lost-beds/show.njk
@@ -12,7 +12,7 @@
 {% block beforeContent %}
     {{ breadCrumb('View a void booking', [
         {title: 'List of bedspaces', href: addPlaceContext(paths.premises.show({ premisesId: premises.id }))},
-        {title: 'View bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, roomId: room.id }))}
+        {title: 'View bedspace', href: addPlaceContext(paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id }))}
     ]) }}
 {% endblock %}
 
@@ -26,7 +26,7 @@
         actions: actions
     }) }}
 
-    {{ locationHeader({ premises: premises, room: room }) }}
+    {{ locationHeader({ premises: premises, room: bedspace }) }}
 
     {{ lostBedInfo(lostBed) }}
 


### PR DESCRIPTION
# Context

JIRA: https://dsdmoj.atlassian.net/browse/CAS-1934

The outcome of https://dsdmoj.atlassian.net/browse/CAS-1865 was to replace the current `Manage properties v1` routes with the new `Manage properties v2` routes. 

The above strategy helps us link into the other v1 areas of the application (e.g. `Bookings`, `Voids`, `Departures`, `Arrivals` etc) as the breadcrumbs still work (for the most part!) as they go back to v1 which is now the new v2 pages. 

However, these areas are currently driven by a `roomId` from the BE on the url path for the bedspace. With the way the new BE `cas3` endpoints have been delivered the primary key for bedspaces has become the `bedId` (not the `roomId`). This changes in the backend means that there is some refactoring to do in these `CAS3-UI` v1 areas to `retrieve the bedspace and not the room`. This has rippling effects on the v1 areas controllers, services and views and so we need to refactor these. 

# Changes in this PR
1. Get the `Voids`, area working
2. Add back in the related integration test / e2e test coverage that commented out in https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1382

