### PR TITLE
Auto-archive properties when last bedspace is archived

### DIFF
--- a/e2e_playwright/steps/v2/manage.ts
+++ b/e2e_playwright/steps/v2/manage.ts
@@ -168,8 +168,12 @@ export const archiveBedspace = async (page: Page, property: Property, bedspace: 
   await archiveBedspacePage.clickSubmit()
 
   const showArchivedBedspacePage = await ViewBedspacePage.initialise(page, bedspace.reference)
-  const isBannerMessageDisplayed = await showArchivedBedspacePage.isBannerMessageDisplayed('Bedspace archived')
-  expect(isBannerMessageDisplayed).toBe(true)
+  const isArchiveBedspaceOnlyMessageDisplayed =
+    await showArchivedBedspacePage.isBannerMessageDisplayed('Bedspace archived')
+  const isArchivedBedspaceAndPropertyMessageDisplayed = await showArchivedBedspacePage.isBannerMessageDisplayed(
+    'Bedspace and property archived',
+  )
+  expect(isArchiveBedspaceOnlyMessageDisplayed || isArchivedBedspaceAndPropertyMessageDisplayed).toBe(true)
   await showArchivedBedspacePage.shouldShowBedspaceStatus('Archived')
 }
 

--- a/integration_tests/tests/temporary-accommodation/manage/v2/bedspace.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/v2/bedspace.cy.ts
@@ -19,7 +19,6 @@ import PremisesShowPage from '../../../../../cypress_shared/pages/temporary-acco
 import BedspaceEditPage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceEdit'
 import BedspaceArchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceArchive'
 import BedspaceUnarchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceUnarchive'
-import BedspaceCannotArchivePage from '../../../../../cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceCannotArchive'
 
 context('Bedspace', () => {
   beforeEach(() => {

--- a/server/controllers/temporary-accommodation/manage/v2/bedspacesController.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/bedspacesController.ts
@@ -288,10 +288,20 @@ export default class BedspacesController {
       }
 
       try {
+        const allBedspaces = await this.bedspaceService.getBedspacesForPremises(callConfig, premisesId)
+        const onlineBedspaces = allBedspaces.bedspaces.filter(bedspace => bedspace.status === 'online')
+        const isLastOnlineBedspace = onlineBedspaces.length === 1 && onlineBedspaces[0].id === bedspaceId
+
         await this.bedspaceService.archiveBedspace(callConfig, premisesId, bedspaceId, endDate)
 
         const today = DateFormats.dateObjToIsoDate(new Date())
-        req.flash('success', `Bedspace ${endDate > today ? 'updated' : 'archived'}`)
+        const isArchived = endDate <= today
+        const action = isArchived ? 'archived' : 'updated'
+        const target = isLastOnlineBedspace ? 'Bedspace and property' : 'Bedspace'
+
+        const successMessage = `${target} ${action}`
+
+        req.flash('success', successMessage)
 
         return res.redirect(paths.premises.bedspaces.show({ premisesId, bedspaceId }))
       } catch (err) {


### PR DESCRIPTION
# Context

More info: 
https://dsdmoj.atlassian.net/browse/CAS-1798

# Changes in this PR

Updated the success banner for bedspace archival to also mention the property when the last bedspace is archived.
The remaining premises auto-archival logic is already handled by the backend.

## Screenshots of UI changes

<img width="597" height="715" alt="Screenshot 2025-09-01 at 12 19 12" src="https://github.com/user-attachments/assets/14e50472-555b-4587-92eb-8a3c5864c574" />

<img width="615" height="617" alt="Screenshot 2025-09-01 at 12 23 39" src="https://github.com/user-attachments/assets/21c560e5-3c12-40c7-abb0-704735a8c35d" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
