### PR TITLE
Auto-unarchive properties when a bedspace is online

### DIFF
--- a/e2e_playwright/steps/v2/manage.ts
+++ b/e2e_playwright/steps/v2/manage.ts
@@ -183,7 +183,10 @@ export const unarchiveBedspace = async (page: Page, property: Property, bedspace
   const unarchiveBedspacePage = await UnarchiveBedspacePage.initialise(page, bedspace.reference)
   await unarchiveBedspacePage.clickSubmit()
   const showUnarchivedBedspacePage = await ViewBedspacePage.initialise(page, bedspace.reference)
-  const isBannerMessageDisplayed = await showUnarchivedBedspacePage.isBannerMessageDisplayed('Bedspace online')
-  expect(isBannerMessageDisplayed).toBe(true)
+  const isArchiveBedspaceOnlyMessageDisplayed =
+    await showUnarchivedBedspacePage.isBannerMessageDisplayed('Bedspace online')
+  const isArchivedBedspaceAndPropertyMessageDisplayed =
+    await showUnarchivedBedspacePage.isBannerMessageDisplayed('Bedspace and property online')
+  expect(isArchiveBedspaceOnlyMessageDisplayed || isArchivedBedspaceAndPropertyMessageDisplayed).toBe(true)
   await showUnarchivedBedspacePage.shouldShowBedspaceStatus('Online')
 }


### PR DESCRIPTION
# Context

More info:
https://dsdmoj.atlassian.net/browse/CAS-1799

# Changes in this PR

Updated the success banner for bedspace unarchival to also mention the property when a bedspace is brought online. The remaining premises auto-unarchival logic is handled by the backend.

## Screenshots of UI changes

<img width="630" height="639" alt="Screenshot 2025-09-01 at 14 14 07" src="https://github.com/user-attachments/assets/13943173-eef8-4446-885a-6190703fea76" />
<img width="607" height="698" alt="Screenshot 2025-09-01 at 14 14 39" src="https://github.com/user-attachments/assets/8227e68e-1014-4088-813b-31944e85963d" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
