### PR TITLE
Add cancelling scheduled unarchive of bedspaces

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/v2/bedspaceShow.ts
@@ -92,6 +92,11 @@ export default class BedspaceShowPage extends Page {
     cy.get('main .govuk-notification-banner--success').contains('Bedspace edited')
   }
 
+  confirmCancelArchive() {
+    cy.get('main').contains('Yes').click()
+    cy.get('main').contains('Submit').click()
+  }
+
   shouldShowCancelArchive(bedspace: Cas3Bedspace): void {
     const endDate = DateFormats.isoDateToUIDate(bedspace.endDate)
 
@@ -101,9 +106,18 @@ export default class BedspaceShowPage extends Page {
     cy.get('main').contains('Submit')
   }
 
-  confirmCancelArchive() {
+  confirmCancelUnarchive() {
     cy.get('main').contains('Yes').click()
     cy.get('main').contains('Submit').click()
+  }
+
+  shouldShowCancelUnarchive(bedspace: Cas3Bedspace): void {
+    const scheduleUnarchiveDate = DateFormats.isoDateToUIDate(bedspace.scheduleUnarchiveDate)
+
+    cy.get('main').contains(`Are you sure you want to cancel the scheduled online date of ${scheduleUnarchiveDate}?`)
+    cy.get('main').contains('Yes, I want to cancel it')
+    cy.get('main').contains('No')
+    cy.get('main').contains('Submit')
   }
 
   clickArchiveLink(): void {

--- a/e2e_playwright/pages/manage/v2/cancelUnarchiveBedspacePage.ts
+++ b/e2e_playwright/pages/manage/v2/cancelUnarchiveBedspacePage.ts
@@ -1,0 +1,16 @@
+import { Page, expect } from '@playwright/test'
+import { BasePage } from '../../basePage'
+
+export class CancelUnarchiveBedspacePage extends BasePage {
+  static async initialise(page: Page, bedspaceUnarchiveDate: string) {
+    await expect(page.locator('h1')).toContainText(
+      `Are you sure you want to cancel the scheduled online date of ${bedspaceUnarchiveDate}?`,
+    )
+    return new CancelUnarchiveBedspacePage(page)
+  }
+
+  async clickYes(): Promise<void> {
+    await this.page.getByLabel('Yes, I want to cancel it').click()
+    await this.clickSubmit()
+  }
+}

--- a/e2e_playwright/pages/manage/v2/unarchiveBedspacePage.ts
+++ b/e2e_playwright/pages/manage/v2/unarchiveBedspacePage.ts
@@ -12,4 +12,20 @@ export class UnarchiveBedspacePage extends BasePage {
     await this.clickSubmit()
     return new Date()
   }
+
+  async unarchiveAnotherDate(date: Date): Promise<Date> {
+    await this.page.getByLabel('Another date').click()
+    await this.enterUnarchiveDate(date)
+    await this.clickSubmit()
+    return date
+  }
+
+  async enterUnarchiveDate(date: Date) {
+    await this.page.getByRole('textbox', { name: 'Day' }).clear()
+    await this.page.getByRole('textbox', { name: 'Day' }).fill(date.getDate().toString())
+    await this.page.getByRole('textbox', { name: 'Month' }).clear()
+    await this.page.getByRole('textbox', { name: 'Month' }).fill((date.getMonth() + 1).toString())
+    await this.page.getByRole('textbox', { name: 'Year' }).clear()
+    await this.page.getByRole('textbox', { name: 'Year' }).fill(date.getFullYear().toString())
+  }
 }

--- a/e2e_playwright/pages/manage/v2/viewBedspacePage.ts
+++ b/e2e_playwright/pages/manage/v2/viewBedspacePage.ts
@@ -69,6 +69,11 @@ export class ViewBedspacePage extends BasePage {
     await this.page.getByText('Cancel scheduled bedspace archive').click()
   }
 
+  async clickCancelUnarchiveButton() {
+    await this.page.getByRole('button').getByText('Actions').click()
+    await this.page.getByText('Cancel scheduled bedspace online date').click()
+  }
+
   async shouldShowBedspaceStatus(status: string) {
     await expect(this.getRowTextByLabel('Bedspace status')).toContainText(status)
   }

--- a/e2e_playwright/tests/manage/v2/manage-bedspaces.spec.ts
+++ b/e2e_playwright/tests/manage/v2/manage-bedspaces.spec.ts
@@ -4,6 +4,7 @@ import { signIn } from '../../../steps/signIn'
 import {
   archiveBedspace,
   cancelArchiveBedspace,
+  cancelUnarchiveBedspace,
   createBedspace,
   createProperty,
   editBedspace,
@@ -89,5 +90,20 @@ test('Unarchive a bedspace', async ({ page, assessor }) => {
   await createBedspace(page, property, bedspace)
   await showBedspace(page, property, bedspace)
   await archiveBedspace(page, bedspace)
-  await unarchiveBedspace(page, property, bedspace)
+  await unarchiveBedspace(page, bedspace)
+})
+
+test('Cancel unarchive a bedspace', async ({ page, assessor }) => {
+  const property = getProperty()
+  const bedspace = getBedspace()
+  await signIn(page, assessor)
+  await visitListPropertiesPage(page)
+  await createProperty(page, property)
+  await createBedspace(page, property, bedspace)
+  await showBedspace(page, property, bedspace)
+  await archiveBedspace(page, bedspace)
+
+  const unarchiveDate = new Date(Date.now() + 5 * 24 * 60 * 60 * 1000)
+  await unarchiveBedspace(page, bedspace, { date: unarchiveDate })
+  await cancelUnarchiveBedspace(page, bedspace, { date: unarchiveDate })
 })

--- a/integration_tests/mockApis/v2/bedspace.ts
+++ b/integration_tests/mockApis/v2/bedspace.ts
@@ -248,6 +248,37 @@ const stubBedspaceUnarchiveV2WithError = (args: { premisesId: string; bedspaceId
     },
   })
 
+const stubBedspaceCancelUnarchive = (args: BedspaceArguments) =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      url: paths.cas3.premises.bedspaces.cancelUnarchive({ premisesId: args.premisesId, bedspaceId: args.bedspace.id }),
+    },
+    response: {
+      status: 200,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: args.bedspace,
+    },
+  })
+
+const stubBedspaceCancelUnarchiveError = (args: BedspaceArguments) =>
+  stubFor({
+    request: {
+      method: 'PUT',
+      url: paths.cas3.premises.bedspaces.cancelUnarchive({ premisesId: args.premisesId, bedspaceId: args.bedspace.id }),
+    },
+    response: {
+      status: 400,
+      headers: { 'Content-Type': 'application/json;charset=UTF-8' },
+      jsonBody: {
+        title: 'Bad Request',
+        status: 400,
+        detail: 'This bedspace is not scheduled to be made online',
+        'invalid-params': [{ propertyName: '$.bedspaceId', errorType: 'bedspaceAlreadyOnline' }],
+      },
+    },
+  })
+
 const stubBedspaceCanArchiveV2 = (args: { premisesId: string; bedspaceId: string }) =>
   stubFor({
     request: {
@@ -303,6 +334,8 @@ export default {
   stubBedspaceUpdate,
   stubBedspaceCancelArchive,
   stubBedspaceCancelArchiveError,
+  stubBedspaceCancelUnarchive,
+  stubBedspaceCancelUnarchiveError,
   verifyBedspaceUpdate,
   stubBedspaceUpdateErrors,
   stubBedspaceArchiveV2,

--- a/server/data/v2/bedspaceClient.ts
+++ b/server/data/v2/bedspaceClient.ts
@@ -33,18 +33,6 @@ export default class BedspaceClient {
     })
   }
 
-  async cancelArchive(premisesId: string, bedspaceId: string) {
-    return this.restClient.put<Cas3Bedspace>({
-      path: paths.cas3.premises.bedspaces.cancelArchive({ premisesId, bedspaceId }),
-    })
-  }
-
-  async canArchive(premisesId: string, bedspaceId: string) {
-    return this.restClient.get<{ date?: string; entityId?: string; entityReference?: string }>({
-      path: paths.cas3.premises.bedspaces.canArchive({ premisesId, bedspaceId }),
-    })
-  }
-
   async archive(premisesId: string, bedspaceId: string, data: { endDate: string }) {
     return this.restClient.post<void>({
       path: paths.cas3.premises.bedspaces.archive({ premisesId, bedspaceId }),
@@ -56,6 +44,24 @@ export default class BedspaceClient {
     return this.restClient.post<void>({
       path: paths.cas3.premises.bedspaces.unarchive({ premisesId, bedspaceId }),
       data,
+    })
+  }
+
+  async cancelArchive(premisesId: string, bedspaceId: string) {
+    return this.restClient.put<Cas3Bedspace>({
+      path: paths.cas3.premises.bedspaces.cancelArchive({ premisesId, bedspaceId }),
+    })
+  }
+
+  async cancelUnarchive(premisesId: string, bedspaceId: string) {
+    return this.restClient.put<Cas3Bedspace>({
+      path: paths.cas3.premises.bedspaces.cancelUnarchive({ premisesId, bedspaceId }),
+    })
+  }
+
+  async canArchive(premisesId: string, bedspaceId: string) {
+    return this.restClient.get<{ date?: string; entityId?: string; entityReference?: string }>({
+      path: paths.cas3.premises.bedspaces.canArchive({ premisesId, bedspaceId }),
     })
   }
 }

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -180,7 +180,8 @@
     },
     "bedspaceId": {
       "bedspaceNotScheduledToArchive": "This bedspace is not scheduled to be archived",
-      "bedspaceAlreadyArchived": "This bedspace has already been archived"
+      "bedspaceAlreadyArchived": "This bedspace has already been archived",
+      "bedspaceAlreadyOnline": "This bedspace is already online"
     }
   },
   "bookingCancellation": {
@@ -234,7 +235,7 @@
       "invalid": "You must enter a real date",
       "invalidRestartDateInThePast": "The date cannot be more than 7 days in the past",
       "invalidRestartDateInTheFuture": "The date cannot be more than 7 days in the future",
-      "beforeLastBedspaceArchivedDate": "The restart date must be after the last archive end date"
+      "beforeLastBedspaceArchivedDate": "The restart date must be after the last archive date"
     }
   },
   "application": {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -82,6 +82,7 @@ const managePathsCas3 = {
       archive: singleBedspacePath.path('archive'),
       unarchive: singleBedspacePath.path('unarchive'),
       cancelArchive: singleBedspacePath.path('cancel-archive'),
+      cancelUnarchive: singleBedspacePath.path('cancel-unarchive'),
     },
     bookings: {
       arrival: singleBookingCas3Path.path('arrivals'),
@@ -133,6 +134,7 @@ export default {
         archive: managePathsCas3.premises.bedspaces.archive,
         unarchive: managePathsCas3.premises.bedspaces.unarchive,
         cancelArchive: managePathsCas3.premises.bedspaces.cancelArchive,
+        cancelUnarchive: managePathsCas3.premises.bedspaces.cancelUnarchive,
       },
       bookings: {
         arrival: managePathsCas3.premises.bookings.arrival,

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -54,10 +54,11 @@ const paths: Record<string, any> = {
       create: bedspacesV2Path,
       list: bedspacesV2Path,
       edit: singleBedspaceV2Path.path('edit'),
-      cancelArchive: singleBedspaceV2Path.path('cancel-archive'),
-      update: singleBedspaceV2Path,
       archive: singleBedspaceV2Path.path('archive'),
       unarchive: singleBedspaceV2Path.path('unarchive'),
+      cancelArchive: singleBedspaceV2Path.path('cancel-archive'),
+      cancelUnarchive: singleBedspaceV2Path.path('cancel-unarchive'),
+      update: singleBedspaceV2Path,
     },
   },
   bookings: {

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -153,6 +153,21 @@ export default function routes(controllers: Controllers, services: Services, rou
       },
     ],
   })
+  get(paths.premises.bedspaces.cancelUnarchive.pattern, bedspacesControllerV2.cancelUnarchive(), {
+    auditEvent: 'VIEW_BEDSPACE_CANCEL_UNARCHIVE_V2',
+  })
+  post(paths.premises.bedspaces.cancelUnarchive.pattern, bedspacesControllerV2.submitCancelUnarchive(), {
+    redirectAuditEventSpecs: [
+      {
+        path: paths.premises.bedspaces.cancelUnarchive.pattern,
+        auditEvent: 'CANCEL_BEDSPACE_UNARCHIVE_V2_FAILURE',
+      },
+      {
+        path: paths.premises.bedspaces.show.pattern,
+        auditEvent: 'CANCEL_BEDSPACE_UNARCHIVE_V2_SUCCESS',
+      },
+    ],
+  })
   post(paths.premises.bedspaces.update.pattern, bedspacesControllerV2.update(), {
     redirectAuditEventSpecs: [
       {

--- a/server/services/v2/bedspaceService.ts
+++ b/server/services/v2/bedspaceService.ts
@@ -153,9 +153,34 @@ export default class BedspaceService {
     return bedspaceClient.update(premisesId, bedspaceId, updatedBedspace)
   }
 
+  async archiveBedspace(
+    callConfig: CallConfig,
+    premisesId: string,
+    bedspaceId: string,
+    endDate: string,
+  ): Promise<void> {
+    const bedspaceClient = this.bedspaceClientFactory(callConfig)
+    return bedspaceClient.archive(premisesId, bedspaceId, { endDate })
+  }
+
+  async unarchiveBedspace(
+    callConfig: CallConfig,
+    premisesId: string,
+    bedspaceId: string,
+    restartDate: string,
+  ): Promise<void> {
+    const bedspaceClient = this.bedspaceClientFactory(callConfig)
+    return bedspaceClient.unarchive(premisesId, bedspaceId, { restartDate })
+  }
+
   async cancelArchiveBedspace(callConfig: CallConfig, premisesId: string, bedspaceId: string): Promise<Cas3Bedspace> {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
     return bedspaceClient.cancelArchive(premisesId, bedspaceId)
+  }
+
+  async cancelUnarchiveBedspace(callConfig: CallConfig, premisesId: string, bedspaceId: string): Promise<Cas3Bedspace> {
+    const bedspaceClient = this.bedspaceClientFactory(callConfig)
+    return bedspaceClient.cancelUnarchive(premisesId, bedspaceId)
   }
 
   async canArchiveBedspace(
@@ -165,16 +190,6 @@ export default class BedspaceService {
   ): Promise<{ date?: string; entityId?: string; entityReference?: string }> {
     const bedspaceClient = this.bedspaceClientFactory(callConfig)
     return bedspaceClient.canArchive(premisesId, bedspaceId)
-  }
-
-  async archiveBedspace(
-    callConfig: CallConfig,
-    premisesId: string,
-    bedspaceId: string,
-    endDate: string,
-  ): Promise<void> {
-    const bedspaceClient = this.bedspaceClientFactory(callConfig)
-    return bedspaceClient.archive(premisesId, bedspaceId, { endDate })
   }
 
   summaryListForBedspaceStatus(bedspace: Cas3Bedspace): SummaryList {
@@ -212,15 +227,5 @@ export default class BedspaceService {
 
   private htmlValue(value: string) {
     return { html: value }
-  }
-
-  async unarchiveBedspace(
-    callConfig: CallConfig,
-    premisesId: string,
-    bedspaceId: string,
-    restartDate: string,
-  ): Promise<void> {
-    const bedspaceClient = this.bedspaceClientFactory(callConfig)
-    return bedspaceClient.unarchive(premisesId, bedspaceId, { restartDate })
   }
 }

--- a/server/utils/v2/bedspaceUtils.test.ts
+++ b/server/utils/v2/bedspaceUtils.test.ts
@@ -122,12 +122,12 @@ describe('bedspaceV2Utils', () => {
 
       const actions = bedspaceActions(premises, bedspace, placeContext)
 
-      expect(actions).toHaveLength(1)
-      // expect(actions).toContainEqual({
-      //   text: 'Cancel scheduled bedspace online date',
-      //   href: paths.premises.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
-      //   classes: 'govuk-button--secondary',
-      // })
+      expect(actions).toHaveLength(2)
+      expect(actions).toContainEqual({
+        text: 'Cancel scheduled bedspace online date',
+        href: paths.premises.bedspaces.cancelUnarchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
+        classes: 'govuk-button--secondary',
+      })
       expect(actions).toContainEqual({
         text: 'Edit bedspace details',
         href: paths.premises.bedspaces.edit({ premisesId: premises.id, bedspaceId: bedspace.id }),

--- a/server/utils/v2/bedspaceUtils.ts
+++ b/server/utils/v2/bedspaceUtils.ts
@@ -39,11 +39,11 @@ const upcomingBedspaceActions = (premises: Cas3Premises, bedspace: Cas3Bedspace)
   const actions: Array<PageHeadingBarItem> = []
 
   if (bedspace.archiveHistory.length >= 1) {
-    // actions.push({
-    //   text: 'Cancel scheduled bedspace online date',
-    //   href: paths.premises.bedspaces.cancelArchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
-    //   classes: 'govuk-button--secondary',
-    // })
+    actions.push({
+      text: 'Cancel scheduled bedspace online date',
+      href: paths.premises.bedspaces.cancelUnarchive({ premisesId: premises.id, bedspaceId: bedspace.id }),
+      classes: 'govuk-button--secondary',
+    })
   }
   actions.push({
     text: 'Edit bedspace details',

--- a/server/views/temporary-accommodation/v2/bedspaces/cancel-unarchive.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/cancel-unarchive.njk
@@ -1,0 +1,61 @@
+{% from "../../../partials/showErrorSummary.njk" import showErrorSummary %}
+{% from "govuk/components/summary-list/macro.njk" import govukSummaryList %}
+{% from "govuk/components/back-link/macro.njk" import govukBackLink %}
+{% from "../../../components/formFields/form-page-input/macro.njk" import formPageInput %}
+{% from "govuk/components/checkboxes/macro.njk" import govukCheckboxes %}
+{% from "govuk/components/textarea/macro.njk" import govukTextarea %}
+{% from "govuk/components/button/macro.njk" import govukButton %}
+{% from "../../../components/ta-radios/macro.njk" import taRadios %}
+
+{% extends "../../../partials/layout.njk" %}
+
+{% set mainClasses = "govuk-body" %}
+
+{% block beforeContent %}
+    {{ govukBackLink({
+        text: 'Back',
+        href: paths.premises.bedspaces.show({ premisesId: premisesId, bedspaceId: bedspaceId }),
+        classes: 'govuk-!-display-none-print'
+    }) }}
+{% endblock %}
+
+{% block content %}
+    {% include "../../../_messages.njk" %}
+
+    {{ showErrorSummary(errorSummary) }}
+
+
+    <div class="govuk-grid-row">
+        <div class="govuk-grid-column-two-thirds">
+            <form action="{{ paths.premises.bedspaces.cancelUnarchive({ premisesId: premisesId, bedspaceId: bedspaceId })}}" method="post">
+                <input type="hidden" name="_csrf" value="{{ csrfToken }}" />
+                <div class="govuk-form-group">
+                    <fieldset class="govuk-fieldset">
+                    <legend class="govuk-fieldset__legend govuk-fieldset__legend--l">
+                        <h1 class="govuk-fieldset__heading">Are you sure you want to cancel the scheduled online date of {{ scheduleUnarchiveDate }}?</h1>
+                    </legend>
+                    {{ taRadios(
+                        {
+                            items: [
+                            {
+                                value: "yes",
+                                text: "Yes, I want to cancel it"
+                            },
+                            {
+                                value: "no",
+                                text: "No"
+                            }
+                        ],
+                        fieldName: "bedspaceId"
+                        }, fetchContext()
+                    ) }}
+                    </fieldset>
+                </div>
+                {{ govukButton({
+                    text: "Submit",
+                    preventDoubleClick: true
+                }) }}
+            </form>
+        </div>
+    </div>
+{% endblock %}

--- a/server/views/temporary-accommodation/v2/bedspaces/unarchive.njk
+++ b/server/views/temporary-accommodation/v2/bedspaces/unarchive.njk
@@ -31,7 +31,7 @@
             namePrefix: "restartDate",
             fieldset: {
                 legend: {
-                    text: "Enter a date within the last 7 days or the next 3 months",
+                    text: "Enter a date within the last 7 days or the next 7 days",
                     classes: "govuk-fieldset__legend--s"
                 }
             },


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-1836) adds the ability to cancel scheduled unarchive.

# Changes in this PR

## Screenshots of UI changes

<img width="840" height="394" alt="image" src="https://github.com/user-attachments/assets/ab54b4e9-ed52-4d31-99a2-8c8fff2f797e" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
