### PR TITLE
Fix premises edit link when there are no characteristics

### DIFF
--- a/server/services/v2/premisesService.test.ts
+++ b/server/services/v2/premisesService.test.ts
@@ -484,7 +484,7 @@ describe('PremisesService', () => {
 
       const propertyDetailsRow = summaryList.rows.find(row => (row.key as TextItem)?.text === 'Property details')
 
-      const expectedHtml = `<p>None</p><p><a href="#">Add property details</a></p>`
+      const expectedHtml = `<p>None</p><p><a href="/properties/${premises.id}/edit">Add property details</a></p>`
       expect(propertyDetailsRow.value).toEqual({ html: expectedHtml })
     })
 

--- a/server/services/v2/premisesService.ts
+++ b/server/services/v2/premisesService.ts
@@ -200,7 +200,7 @@ export default class PremisesService {
       },
       {
         key: { text: 'Property details' },
-        value: this.htmlValue(this.formatDetails(premises.characteristics)),
+        value: this.htmlValue(this.formatDetails(premises.id, premises.characteristics)),
       },
       {
         key: { text: 'Additional property details' },
@@ -336,9 +336,9 @@ export default class PremisesService {
     return `${numberOfDays} working days`
   }
 
-  private formatDetails(characteristics: Array<Characteristic>): string {
+  private formatDetails(premisesId: string, characteristics: Array<Characteristic>): string {
     if (characteristics === undefined || characteristics.length === 0) {
-      return '<p>None</p><p><a href="#">Add property details</a></p>'
+      return `<p>None</p><p><a href="${paths.premises.edit({ premisesId })}">Add property details</a></p>`
     }
 
     return characteristics


### PR DESCRIPTION
# Context

Quick fix for the "Add property details" link to take the user to the edit property page

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
