### PR TITLE
Fix wrong redirection issue in toggle LA/PDU options

### DIFF
--- a/server/controllers/temporary-accommodation/manage/v2/premisesController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/premisesController.test.ts
@@ -735,7 +735,7 @@ describe('PremisesController', () => {
   })
 
   describe('toggleSort', () => {
-    it('toggles from pdu to la and redirects with query params', async () => {
+    it('toggles from pdu to la and redirects to online tab with query params when status is online', async () => {
       const req = createMock<Request>({
         session: { premisesSortBy: 'pdu' },
         query: { postcodeOrAddress: 'SW1A' },
@@ -743,14 +743,14 @@ describe('PremisesController', () => {
       const res = createMock<Response>({})
       res.redirect = jest.fn()
 
-      const requestHandler = premisesController.toggleSort()
+      const requestHandler = premisesController.toggleSort('online')
       await requestHandler(req, res, next)
 
       expect(req.session.premisesSortBy).toBe('la')
       expect(res.redirect).toHaveBeenCalledWith('/properties/online?postcodeOrAddress=SW1A')
     })
 
-    it('toggles from la to pdu and redirects without query params', async () => {
+    it('toggles from la to pdu and redirects to online tab without query params when status is online', async () => {
       const req = createMock<Request>({
         session: { premisesSortBy: 'la' },
         query: {},
@@ -758,14 +758,14 @@ describe('PremisesController', () => {
       const res = createMock<Response>({})
       res.redirect = jest.fn()
 
-      const requestHandler = premisesController.toggleSort()
+      const requestHandler = premisesController.toggleSort('online')
       await requestHandler(req, res, next)
 
       expect(req.session.premisesSortBy).toBe('pdu')
       expect(res.redirect).toHaveBeenCalledWith('/properties/online')
     })
 
-    it('defaults to pdu if session value is missing, then toggles to la', async () => {
+    it('defaults to pdu if session value is missing, then toggles to la and redirects to online tab when no status provided', async () => {
       const req = createMock<Request>({
         session: {},
         query: {},
@@ -778,6 +778,21 @@ describe('PremisesController', () => {
 
       expect(req.session.premisesSortBy).toBe('la')
       expect(res.redirect).toHaveBeenCalledWith('/properties/online')
+    })
+
+    it('preserves query parameters when toggling sort', async () => {
+      const req = createMock<Request>({
+        session: { premisesSortBy: 'pdu' },
+        query: { postcodeOrAddress: 'SW1A', page: '2' },
+      })
+      const res = createMock<Response>({})
+      res.redirect = jest.fn()
+
+      const requestHandler = premisesController.toggleSort('archived')
+      await requestHandler(req, res, next)
+
+      expect(req.session.premisesSortBy).toBe('la')
+      expect(res.redirect).toHaveBeenCalledWith('/properties/archived?postcodeOrAddress=SW1A&page=2')
     })
   })
 

--- a/server/controllers/temporary-accommodation/manage/v2/premisesController.ts
+++ b/server/controllers/temporary-accommodation/manage/v2/premisesController.ts
@@ -106,15 +106,16 @@ export default class PremisesController {
     }
   }
 
-  toggleSort(): RequestHandler {
+  toggleSort(status: 'online' | 'archived' = 'online'): RequestHandler {
     return async (req: Request, res: Response) => {
       const currentSort = req.session.premisesSortBy || 'pdu'
-      const newSort = currentSort === 'pdu' ? 'la' : 'pdu'
-
-      req.session.premisesSortBy = newSort
+      req.session.premisesSortBy = currentSort === 'pdu' ? 'la' : 'pdu'
 
       const query = new URLSearchParams(req.query as Record<string, string>).toString()
-      const redirectUrl = paths.premises.online() + (query ? `?${query}` : '')
+      const redirectUrl =
+        status === 'archived'
+          ? paths.premises.archived() + (query ? `?${query}` : '')
+          : paths.premises.online() + (query ? `?${query}` : '')
 
       res.redirect(redirectUrl)
     }

--- a/server/paths/temporary-accommodation/manage.ts
+++ b/server/paths/temporary-accommodation/manage.ts
@@ -39,7 +39,10 @@ const paths: Record<string, any> = {
     index: premisesV2Path,
     online: premisesV2OnlinePath,
     archived: premisesV2ArchivedPath,
-    toggleSort: premisesV2Path.path('toggle-sort'),
+    toggleSort: {
+      online: premisesV2OnlinePath.path('toggle-sort'),
+      archived: premisesV2ArchivedPath.path('toggle-sort'),
+    },
     show: singlePremisesV2Path,
     new: premisesV2Path.path('new'),
     create: premisesV2Path,

--- a/server/routes/temporary-accommodation/manage.ts
+++ b/server/routes/temporary-accommodation/manage.ts
@@ -46,8 +46,11 @@ export default function routes(controllers: Controllers, services: Services, rou
   get(paths.premises.archived.pattern, premisesControllerV2.index('archived'), {
     auditEvent: 'VIEW_PREMISES_LIST_V2_ARCHIVED',
   })
-  get(paths.premises.toggleSort.pattern, premisesControllerV2.toggleSort(), {
-    auditEvent: 'TOGGLE_PREMISES_SORT_V2',
+  get(paths.premises.toggleSort.online.pattern, premisesControllerV2.toggleSort('online'), {
+    auditEvent: 'TOGGLE_PREMISES_SORT_V2_ONLINE',
+  })
+  get(paths.premises.toggleSort.archived.pattern, premisesControllerV2.toggleSort('archived'), {
+    auditEvent: 'TOGGLE_PREMISES_SORT_V2_ARCHIVED',
   })
   get(paths.premises.new.pattern, premisesControllerV2.new(), { auditEvent: 'CREATE_PREMISES_V2' })
   get(paths.premises.show.pattern, premisesControllerV2.showPremisesTab(), { auditEvent: 'SHOW_PREMISES_V2' })

--- a/server/views/temporary-accommodation/v2/premises/index.njk
+++ b/server/views/temporary-accommodation/v2/premises/index.njk
@@ -17,7 +17,7 @@
             Properties by probation delivery unit
         </div>
         <div class="govuk-!-margin-bottom-4">
-            <a href="{{ paths.premises.toggleSort() }}{% if params %}?{{ toQueryString(params) }}{% endif %}" data-cy="toggle-sort" class="govuk-link govuk-link--no-visited-state govuk-body govuk-!-font-weight-normal govuk-!-margin-bottom-4">
+            <a href="{{ paths.premises.toggleSort[status]() }}{% if params %}?{{ toQueryString(params) }}{% endif %}" data-cy="toggle-sort" class="govuk-link govuk-link--no-visited-state govuk-body govuk-!-font-weight-normal govuk-!-margin-bottom-4">
                 View by local authority
             </a>
         </div>
@@ -26,7 +26,7 @@
             Properties by local authority
         </div>
         <div class="govuk-!-margin-bottom-4">
-            <a href="{{ paths.premises.toggleSort() }}{% if params %}?{{ toQueryString(params) }}{% endif %}" data-cy="toggle-sort" class="govuk-link govuk-link--no-visited-state govuk-body govuk-!-font-weight-normal govuk-!-margin-bottom-4">
+            <a href="{{ paths.premises.toggleSort[status]() }}{% if params %}?{{ toQueryString(params) }}{% endif %}" data-cy="toggle-sort" class="govuk-link govuk-link--no-visited-state govuk-body govuk-!-font-weight-normal govuk-!-margin-bottom-4">
                 View by probation delivery unit
             </a>
         </div>


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CAS-2000

# Changes in this PR

Fixes a small bug where users where getting redirected to the online tab if they used to toggle by LA/PDU


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
