### PR TITLE
Add costCentre field in void bedspaces

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
@@ -36,6 +36,9 @@ export default abstract class LostBedEditablePage extends Page {
     this.getLabel('What is the reason for this void?')
     this.getSelectInputByIdAndSelectAnEntry('reason', newOrUpdateLostBed.reason)
 
+    this.getLegend('Who pays for the cost?')
+    this.checkRadioByNameAndValue('costCentre', newOrUpdateLostBed.costCentre)
+
     this.getLabel('Please provide further details')
     this.getTextInputByIdAndEnterDetails('notes', newOrUpdateLostBed.notes)
 

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEditable.ts
@@ -36,7 +36,7 @@ export default abstract class LostBedEditablePage extends Page {
     this.getLabel('What is the reason for this void?')
     this.getSelectInputByIdAndSelectAnEntry('reason', newOrUpdateLostBed.reason)
 
-    this.getLegend('Who pays for the cost?')
+    this.getLegend('Who pays the cost?')
     this.checkRadioByNameAndValue('costCentre', newOrUpdateLostBed.costCentre)
 
     this.getLabel('Please provide further details')

--- a/e2e/tests/stepDefinitions/manage/lostBed.ts
+++ b/e2e/tests/stepDefinitions/manage/lostBed.ts
@@ -66,7 +66,7 @@ Given('I attempt to mark a bedspace as void with required details missing', () =
 Then('I should see a list of the problems encountered voiding the bedspace', () => {
   cy.then(function _() {
     const lostBedNewPage = Page.verifyOnPage(LostBedNewPage, this.premises, this.bedspace)
-    lostBedNewPage.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
+    lostBedNewPage.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'costCentre'])
   })
 })
 
@@ -117,7 +117,7 @@ Given('I attempt to edit the void booking with required details missing', () => 
 
     lostBedEditPage.clearForm()
     lostBedEditPage.clickSubmit()
-    lostBedEditPage.shouldShowErrorMessagesForFields(['startDate', 'endDate'])
+    lostBedEditPage.shouldShowErrorMessagesForFields(['startDate', 'endDate', 'costCentre'])
   })
 })
 

--- a/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/lostBedsController.test.ts
@@ -130,6 +130,12 @@ describe('LostBedsController', () => {
           bedspaceId,
         }
 
+        request.body = {
+          costCentre: 'HMPPS',
+          reason: 'some-reason',
+          notes: 'some notes',
+        }
+
         await requestHandler(request, response, next)
 
         expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
@@ -159,6 +165,12 @@ describe('LostBedsController', () => {
         request.params = {
           premisesId,
           bedspaceId,
+        }
+
+        request.body = {
+          costCentre: 'HMPPS',
+          reason: 'some-reason',
+          notes: 'some notes',
         }
 
         await requestHandler(request, response, next)
@@ -251,6 +263,12 @@ describe('LostBedsController', () => {
           lostBedId,
         }
 
+        request.body = {
+          costCentre: 'HMPPS',
+          reason: 'some-reason',
+          notes: 'some notes',
+        }
+
         const err = new Error()
 
         lostBedService.update.mockImplementation(() => {
@@ -274,6 +292,12 @@ describe('LostBedsController', () => {
           premisesId,
           bedspaceId,
           lostBedId,
+        }
+
+        request.body = {
+          costCentre: 'HMPPS',
+          reason: 'some-reason',
+          notes: 'some notes',
         }
 
         const err = { status: 409 }

--- a/server/controllers/temporary-accommodation/manage/lostBedsController.ts
+++ b/server/controllers/temporary-accommodation/manage/lostBedsController.ts
@@ -71,6 +71,12 @@ export default class LostBedsController {
           insertGenericError(err, 'endDate', 'conflict')
         }
 
+        // TODO: costCentre is optional in the API types right now, so we add a FE check to make sure it's present in the form.
+        //  Once the API makes costCentre mandatory, remove this check and let the backend handle validation.
+        if (!req.body.costCentre) {
+          insertGenericError(err, 'costCentre', 'empty')
+        }
+
         catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.new({ premisesId, bedspaceId }))
       }
     }
@@ -119,6 +125,12 @@ export default class LostBedsController {
           insertBespokeError(err, generateConflictBespokeError(err, premisesId, bedspaceId, 'plural'))
           insertGenericError(err, 'startDate', 'conflict')
           insertGenericError(err, 'endDate', 'conflict')
+        }
+
+        // TODO: costCentre is optional in the API types right now, so we add a FE check to make sure it's present in the form.
+        //  Once the API makes costCentre mandatory, remove this check and let the backend handle validation.
+        if (!req.body.costCentre) {
+          insertGenericError(err, 'costCentre', 'empty')
         }
 
         catchValidationErrorOrPropogate(req, res, err, paths.lostBeds.edit({ premisesId, bedspaceId, lostBedId }))

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -182,6 +182,9 @@
       "bedspaceNotScheduledToArchive": "This bedspace is not scheduled to be archived",
       "bedspaceAlreadyArchived": "This bedspace has already been archived",
       "bedspaceAlreadyOnline": "This bedspace is already online"
+    },
+    "costCentre": {
+      "empty": "You must select a cost centre"
     }
   },
   "bookingCancellation": {

--- a/server/testutils/factories/newLostBed.ts
+++ b/server/testutils/factories/newLostBed.ts
@@ -15,5 +15,6 @@ export default Factory.define<NewLostBed>(() => {
     referenceNumber: faker.string.uuid(),
     reason: referenceDataFactory.lostBedReasons().build().id,
     bedId: faker.string.uuid(),
+    costCentre: faker.helpers.arrayElement(['HMPPS', 'SUPPLIER']),
   }
 })

--- a/server/testutils/factories/updateLostBed.ts
+++ b/server/testutils/factories/updateLostBed.ts
@@ -11,4 +11,5 @@ export default Factory.define<UpdateLostBed>(() => ({
   notes: faker.lorem.sentence(),
   referenceNumber: faker.string.uuid(),
   id: faker.string.uuid(),
+  costCentre: faker.helpers.arrayElement(['HMPPS', 'SUPPLIER']),
 }))

--- a/server/views/temporary-accommodation/lost-beds/_editable.njk
+++ b/server/views/temporary-accommodation/lost-beds/_editable.njk
@@ -2,6 +2,7 @@
 {% from "../../components/formFields/form-page-date-input/macro.njk" import formPageDateInput %}
 {% from "../../components/formFields/form-page-select/macro.njk" import formPageSelect %}
 {% from "../../components/formFields/form-page-textarea/macro.njk" import formPageTextarea %}
+{% from "../../components/formFields/form-page-radios/macro.njk" import formPageRadios %}
 
 {{ formPageDateInput(
     {
@@ -40,6 +41,26 @@
           },
           fetchContext()
         ) }}
+
+{{ formPageRadios({
+    fieldName: "costCentre",
+    fieldset: {
+      legend: {
+        text: "Who pays for the cost?",
+        classes: "govuk-fieldset__legend--m"
+      }
+    },
+    items: [
+      {
+        value: "HMPPS",
+        text: "HMPPS"
+      },
+      {
+        value: "SUPPLIER",
+        text: "Supplier"
+      }
+    ]
+  }, fetchContext()) }}
 {{ formPageTextarea(
           {
             label: {

--- a/server/views/temporary-accommodation/lost-beds/_editable.njk
+++ b/server/views/temporary-accommodation/lost-beds/_editable.njk
@@ -30,6 +30,26 @@
     },
     fetchContext()
   ) }}
+{{ formPageRadios(
+  {
+      fieldName: "costCentre",
+      fieldset: {
+      legend: {
+      text: "Who pays the cost?",
+      classes: "govuk-fieldset__legend--m"
+    }
+    },
+      items: [
+    {
+      value: "HMPPS",
+      text: "HMPSS"
+      },
+    {
+      value: "SUPPLIER",
+      text: "Supplier"
+    }
+  ]
+}, fetchContext()) }}
 {{ formPageSelect(
     {
         label: {
@@ -41,26 +61,6 @@
           },
           fetchContext()
         ) }}
-
-{{ formPageRadios({
-    fieldName: "costCentre",
-    fieldset: {
-      legend: {
-        text: "Who pays for the cost?",
-        classes: "govuk-fieldset__legend--m"
-      }
-    },
-    items: [
-      {
-        value: "HMPPS",
-        text: "HMPPS"
-      },
-      {
-        value: "SUPPLIER",
-        text: "Supplier"
-      }
-    ]
-  }, fetchContext()) }}
 {{ formPageTextarea(
           {
             label: {


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CAS-1904

# Changes in this PR

Added Cost Centre as a new mandatory field in the void bedspace form ("Who pays the cost?")

## Screenshots of UI changes

<img width="584" height="825" alt="Screenshot 2025-09-29 at 13 05 06" src="https://github.com/user-attachments/assets/eb1bc837-e6ac-405c-bb5b-1edd98e4eb59" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
