### PR TITLE
Add missing e2e test on costCentre void bedspace

### DIFF
--- a/cypress_shared/pages/page.ts
+++ b/cypress_shared/pages/page.ts
@@ -161,6 +161,10 @@ export default abstract class Page extends Component {
     cy.get(`#${id}`).clear()
   }
 
+  clearRadioByName(name: string): void {
+    cy.get(`input[type="radio"][name="${name}"]`).invoke('prop', 'checked', false)
+  }
+
   getSelectInputByIdAndSelectAnEntry(id: string, entry: string): void {
     cy.get(`#${id}`).select(entry)
   }

--- a/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/lostBedEdit.ts
@@ -25,6 +25,7 @@ export default class LostBedEditPage extends LostBedEditablePage {
     super.clearDateInputs('startDate')
     super.clearDateInputs('endDate')
     super.getTextInputByIdAndClear('notes')
+    super.clearRadioByName('costCentre')
   }
 
   completeForm(updateLostBed: UpdateLostBed): void {


### PR DESCRIPTION
# Context

Added a missing e2e test that fixes an issue with the current test workflow (void Bedspace)
more details: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/actions/runs/18101140193/job/51508717500


## Screenshots of UI changes

### Before
<img width="371" height="262" alt="Screenshot 2025-09-30 at 08 46 23" src="https://github.com/user-attachments/assets/93188f26-eea6-4ab9-aa97-b3b0a7c07a5d" />

### After
<img width="332" height="263" alt="Screenshot 2025-09-30 at 08 25 06" src="https://github.com/user-attachments/assets/86267c24-9af2-4cda-8e3f-3a90630c6fc3" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
