### PR TITLE
Show cost centre and void reason in the void details box

### DIFF
--- a/server/components/lostBedInfo.test.ts
+++ b/server/components/lostBedInfo.test.ts
@@ -15,6 +15,8 @@ describe('LostBedInfo', () => {
       const lostBed = lostBedFactory.active().build({
         startDate: '2023-03-21',
         endDate: '2023-03-24',
+        reason: { name: 'some active void Reason' },
+        costCentre: 'HMPPS',
       })
 
       const result = await summaryListRows(lostBed)
@@ -46,6 +48,22 @@ describe('LostBedInfo', () => {
         },
         {
           key: {
+            text: 'Cost Centre',
+          },
+          value: {
+            text: 'HMPPS',
+          },
+        },
+        {
+          key: {
+            text: 'Reason',
+          },
+          value: {
+            text: 'some active void Reason',
+          },
+        },
+        {
+          key: {
             text: 'Notes',
           },
           value: {
@@ -58,6 +76,8 @@ describe('LostBedInfo', () => {
       const lostBed = lostBedFactory.cancelled().build({
         startDate: '2023-04-21',
         endDate: '2023-04-24',
+        reason: { name: 'some cancelled void Reason' },
+        costCentre: 'HMPPS',
       })
 
       const result = await summaryListRows(lostBed)
@@ -85,6 +105,22 @@ describe('LostBedInfo', () => {
           },
           value: {
             text: '24 April 2023',
+          },
+        },
+        {
+          key: {
+            text: 'Cost Centre',
+          },
+          value: {
+            text: 'HMPPS',
+          },
+        },
+        {
+          key: {
+            text: 'Reason',
+          },
+          value: {
+            text: 'some cancelled void Reason',
           },
         },
         {

--- a/server/components/lostBedInfo.ts
+++ b/server/components/lostBedInfo.ts
@@ -26,7 +26,7 @@ export default (lostBed: LostBed): SummaryList['rows'] => {
 
   rows.push({
     key: textValue('Cost Centre'),
-    value: textValue(costCentre),
+    value: textValue({ HMPPS: 'HMPPS', SUPPLIER: 'Supplier' }[costCentre] || costCentre),
   })
 
   rows.push({

--- a/server/components/lostBedInfo.ts
+++ b/server/components/lostBedInfo.ts
@@ -5,7 +5,7 @@ import { formatLines } from '../utils/viewUtils'
 import { statusTag } from '../utils/lostBedUtils'
 
 export default (lostBed: LostBed): SummaryList['rows'] => {
-  const { status, startDate, endDate } = lostBed
+  const { status, startDate, endDate, reason, costCentre } = lostBed
 
   const rows: SummaryList['rows'] = []
 
@@ -22,6 +22,16 @@ export default (lostBed: LostBed): SummaryList['rows'] => {
   rows.push({
     key: textValue('End date'),
     value: textValue(DateFormats.isoDateToUIDate(endDate)),
+  })
+
+  rows.push({
+    key: textValue('Cost Centre'),
+    value: textValue(costCentre),
+  })
+
+  rows.push({
+    key: textValue('Reason'),
+    value: textValue(reason.name),
   })
 
   rows.push({


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CAS-2017

## Changes in this PR

Added the Cost Centre and Reason fields in the void booking screen details

## Screenshots of UI changes

### Before

<img width="840" height="441" alt="Screenshot 2025-10-01 at 15 31 43" src="https://github.com/user-attachments/assets/1a52f3c6-b7ab-4449-946d-6b3e5b7035c7" />

### After

<img width="852" height="488" alt="Screenshot 2025-10-01 at 15 04 14" src="https://github.com/user-attachments/assets/b0e1b40f-796e-4a7a-b3eb-3c00c26a2d1a" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
