### PR TITLE
Update failing e2e tests

### DIFF
--- a/e2e/tests/stepDefinitions/place.ts
+++ b/e2e/tests/stepDefinitions/place.ts
@@ -59,9 +59,34 @@ Given('I view the assessment', () => {
   const assessmentListPage = Page.verifyOnPage(AssessmentListPage, 'Unallocated referrals')
   const assessment = getAssessment('unallocated')
 
-  assessmentListPage.searchByCrnOrName(assessment.application.person.crn, 'unallocated')
+  cy.wrap(null).then(() => {
+    try {
+      assessmentListPage.searchByCrnOrName(assessment.application.person.crn, 'unallocated')
+      assessmentListPage.clickAssessment(assessment)
+    } catch {
+      AssessmentListPage.visit('ready_to_place')
+      assessmentListPage.searchByCrnOrName(assessment.application.person.crn, 'ready to place')
+      assessmentListPage.clickAssessment(assessment)
 
-  assessmentListPage.clickAssessment(assessment)
+      const unallocatedAssesmentSummaryPage = Page.verifyOnPage(AssessmentSummaryPage, {
+        ...assessment,
+        status: 'ready_to_place',
+      })
+      unallocatedAssesmentSummaryPage.clickAction('In review')
+
+      const inReviewConfirmationPage = Page.verifyOnPage(AssessmentConfirmPage, 'Mark this referral as in review')
+      inReviewConfirmationPage.clickSubmit()
+
+      const inReviewAssessmentSummaryPage = Page.verifyOnPage(AssessmentSummaryPage, {
+        ...assessment,
+        status: 'in_review',
+      })
+      inReviewAssessmentSummaryPage.clickAction('Unallocated')
+
+      const readyToPlaceConfirmationPage = Page.verifyOnPage(AssessmentConfirmPage, 'Unallocate this referral')
+      readyToPlaceConfirmationPage.clickSubmit()
+    }
+  })
 })
 
 Given('I mark the assessment as ready to place', () => {

--- a/server/testutils/factories/newArrival.ts
+++ b/server/testutils/factories/newArrival.ts
@@ -20,7 +20,12 @@ export default Factory.define<NewArrival>(({ params }) => {
     const now = new Date()
     const latestArrivalDate = dayBeforeDeparture < now ? dayBeforeDeparture : now
 
-    arrivalDate = faker.date.between({ from: sevenDays, to: latestArrivalDate })
+    const earliestArrivalDate = new Date(expectedDepartureDate)
+    earliestArrivalDate.setDate(earliestArrivalDate.getDate() - 84)
+
+    const lowerBoundDate = earliestArrivalDate > sevenDays ? earliestArrivalDate : sevenDays
+
+    arrivalDate = faker.date.between({ from: lowerBoundDate, to: latestArrivalDate })
   } else {
     arrivalDate = faker.date.soon({ days: 7, refDate: sevenDays })
 

--- a/server/testutils/factories/newBooking.ts
+++ b/server/testutils/factories/newBooking.ts
@@ -12,10 +12,13 @@ export default Factory.define<NewBooking>(() => {
   const dayAfterArrival = new Date(arrivalDate)
   dayAfterArrival.setDate(dayAfterArrival.getDate() + 1)
 
-  const eightyFourDaysAfterArrival = new Date(arrivalDate)
-  eightyFourDaysAfterArrival.setDate(eightyFourDaysAfterArrival.getDate() + 84)
+  // departure can be at most 84 days after arrival,
+  // but newArrival validation subtracts 7 days, so use 77 days here.
+  const maxDepartureGapDays = 84 - 7
+  const latestAllowedDepartureDate = new Date(arrivalDate)
+  latestAllowedDepartureDate.setDate(latestAllowedDepartureDate.getDate() + maxDepartureGapDays)
 
-  const expectedDepartureDate = faker.date.between({ from: dayAfterArrival, to: eightyFourDaysAfterArrival })
+  const expectedDepartureDate = faker.date.between({ from: dayAfterArrival, to: latestAllowedDepartureDate })
 
   return {
     crn: personFactory.build().crn,


### PR DESCRIPTION
# Context

This fixes two failing e2e tests.

[First](https://github.com/ministryofjustice/hmpps-approved-premises-api/actions/runs/18192052586/job/51790131001) is new arrival/departure dates being out of validation range.

[Second](https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/actions/runs/18169400049/job/51721034941) I was able to reproduce locally, so not sure if it's a complete fix but might help.
The test fails twice in two different ways, the first is messing up the bedspace booking.
<img width="720" height="429" alt="image" src="https://github.com/user-attachments/assets/ae86f917-bc21-45b7-a6ba-ccae95265296" />
Then the second is it goes to retry from unallocated referrals, but because the referral has been moved to ready to place it fails again
<img width="720" height="405" alt="image" src="https://github.com/user-attachments/assets/b90b3232-5165-4783-9767-5b6e8fdbe98c" />

The potential fix is to move the referral back to unallocated, so it can hopefully do it on the second try, not sure if that'll help though.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
