### PR TITLE
Fix issue with national user out of region

### DIFF
--- a/server/form-pages/apply/accommodation-need/placement-location/alternativePdu.test.ts
+++ b/server/form-pages/apply/accommodation-need/placement-location/alternativePdu.test.ts
@@ -67,7 +67,7 @@ describe('AlternativePdu', () => {
     })
   })
 
-  itShouldHavePreviousValue(new AlternativePdu({}, application, pdus), 'dashboard')
+  itShouldHavePreviousValue(new AlternativePdu({}, application, pdus), 'alternative-region')
 
   describe('next', () => {
     it('returns the different pdu reason page ID if the answer is yes', () => {

--- a/server/form-pages/apply/accommodation-need/placement-location/alternativePdu.ts
+++ b/server/form-pages/apply/accommodation-need/placement-location/alternativePdu.ts
@@ -50,6 +50,19 @@ export default class AlternativePdu implements TasklistPage {
       this._body.pduId = submittedPdu?.id || value.pduId
       this._body.pduName = submittedPdu?.name || value.pduName
     }
+
+    this.application.data['placement-location']['different-region'] = {}
+    this.application.data['placement-location']['placement-pdu'] = {}
+
+    if (this.application.data['placement-location']['alternative-region']?.alternativeRegion === 'no') {
+      const region =
+        this.regionName || this.application.data?.['placement-location']?.['alternative-region']?.regionName || ''
+
+      this.application.data['placement-location']['alternative-region'] = {
+        alternativeRegion: 'yes',
+        regionName: region,
+      }
+    }
   }
 
   get body() {
@@ -71,7 +84,7 @@ export default class AlternativePdu implements TasklistPage {
   }
 
   previous() {
-    return 'dashboard'
+    return 'alternative-region'
   }
 
   next() {

--- a/server/form-pages/apply/accommodation-need/placement-location/differentRegion.ts
+++ b/server/form-pages/apply/accommodation-need/placement-location/differentRegion.ts
@@ -56,15 +56,14 @@ export default class DifferentRegion implements TasklistPage {
       ...this.body,
       regionId:
         value.regionId ||
-        (this.body.currentRegionName === 'National'
+        (this.body.regionName === 'National'
           ? this.application.data?.['placement-location']?.['different-region']?.regionId
           : null),
       regionName: value.regionName || this.regions?.find(region => region.id === value.regionId)?.name || '',
     }
 
     const previousRegionId = this.application.data?.['placement-location']?.['different-region']?.regionId
-
-    if (previousRegionId && previousRegionId !== value.regionId && this.body.currentRegionName !== 'National') {
+    if (previousRegionId && previousRegionId !== value.regionId && this.body.regionName !== 'National') {
       this.application.data['placement-location']['placement-pdu'] = {}
     }
   }
@@ -82,13 +81,18 @@ export default class DifferentRegion implements TasklistPage {
   }
 
   previous() {
-    return 'alternative-region'
+    if (this.body.regionName !== 'National') {
+      return 'alternative-region'
+    }
+    return 'dashboard'
   }
 
   next() {
     if (this.body?.regionId === this.body.currentRegionId) {
       return 'alternative-pdu'
     }
+    this.application.data['placement-location']['alternative-pdu'] = {}
+    this.application.data['placement-location']['alternative-pdu-reason'] = {}
     return 'placement-pdu'
   }
 


### PR DESCRIPTION
# Context

This should sort an issue with out of region answers being remembered with national users.
Also sorts some back button links and flow when going from alternative region -> different region (picking same region) -> alternative pdu (back to same region flow)

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
