### PR TITLE
CHORE: Remove excessive logs during integration tests

### DIFF
--- a/feature.env
+++ b/feature.env
@@ -3,6 +3,7 @@ HMPPS_AUTH_URL=http://localhost:9999/auth
 TOKEN_VERIFICATION_API_URL=http://localhost:9999/verification
 TOKEN_VERIFICATION_ENABLED=true
 NODE_ENV=development
+LOG_LEVEL=error
 API_CLIENT_ID=clientid
 API_CLIENT_SECRET=clientsecret
 REDIS_PORT=6380

--- a/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/values.yaml
@@ -41,6 +41,7 @@ generic-service:
     COMMUNITY_ACCOMMODATION_API_SERVICE_NAME: 'temporary-accommodation'
     AUDIT_SERVICE_NAME: 'hmpps-temporary-accommodation-ui'
     AUDIT_SQS_REGION: 'eu-west-2'
+    LOG_LEVEL: 'info'
 
   # Pre-existing kubernetes secrets to load as environment variables in the deployment.
   # namespace_secrets:

--- a/logger.ts
+++ b/logger.ts
@@ -1,11 +1,12 @@
-import bunyan from 'bunyan'
+import bunyan, { LogLevel } from 'bunyan'
 import bunyanFormat from 'bunyan-format'
 
 const formatOut = bunyanFormat({ outputMode: 'short', color: true })
 
-const logger =
-  process.env.NODE_ENV !== 'test'
-    ? bunyan.createLogger({ name: 'Temporary Accommodation UI', stream: formatOut, level: 'debug' })
-    : bunyan.createLogger({ name: 'Temporary Accommodation UI', stream: formatOut, level: 'fatal' })
+const logger = bunyan.createLogger({
+  name: 'Temporary Accommodation UI',
+  stream: formatOut,
+  level: (process.env.LOG_LEVEL || 'info') as LogLevel,
+})
 
 export default logger


### PR DESCRIPTION
This reduces the amount of logging produced during integration test runs, to make the output from the GitHub action and other loggers (own terminal, etc) more readable.

It also reduces the amount logged by default from the `debug` level to `info`. Should you wish to increase this default back to `debug`, the env var `LOG_LEVEL` can be set accordingly.