### PR TITLE
Show error message when users account is missing staff details

### DIFF
--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -59,6 +59,22 @@ describe('populateCurrentUser', () => {
     expect(next).toHaveBeenCalledWith()
   })
 
+  it('renders the dedicated 403 page when staff record is missing', async () => {
+    const request = createMock<Request>()
+    const response = createMock<Response>()
+    const next = jest.fn()
+    ;(extractCallConfig as jest.MockedFunction<typeof extractCallConfig>).mockReturnValue(callConfig)
+
+    const { DeliusAccountMissingStaffDetailsError } = jest.requireActual('../services/userService')
+    userService.getActingUser.mockRejectedValue(new DeliusAccountMissingStaffDetailsError('missing'))
+
+    await populateCurrentUser(userService)(request, response, next)
+
+    expect(response.status).toHaveBeenCalledWith(403)
+    expect(response.render).toHaveBeenCalledWith('temporary-accommodation/static/userDetailsRequired')
+    expect(next).not.toHaveBeenCalledWith(expect.any(Error))
+  })
+
   it('propogates any error from the user service', async () => {
     const request = createMock<Request>()
     const response = createMock<Response>()

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -21,14 +21,15 @@ export default function populateCurrentUser(userService: UserService): RequestHa
           logger.info('No user available')
         }
       }
-      next()
+
+      return next()
     } catch (error) {
       if (error instanceof DeliusAccountMissingStaffDetailsError) {
         res.status(403)
         return res.render('temporary-accommodation/static/userDetailsRequired')
       }
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
-      next(error)
+      return next(error)
     }
   }
 }

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -1,6 +1,6 @@
 import { RequestHandler } from 'express'
 import logger from '../../logger'
-import UserService from '../services/userService'
+import UserService, { DeliusAccountMissingStaffDetailsError } from '../services/userService'
 import extractCallConfig from '../utils/restUtils'
 
 export default function populateCurrentUser(userService: UserService): RequestHandler {
@@ -23,6 +23,10 @@ export default function populateCurrentUser(userService: UserService): RequestHa
       }
       next()
     } catch (error) {
+      if (error instanceof DeliusAccountMissingStaffDetailsError) {
+        res.status(403)
+        return res.render('temporary-accommodation/static/userDetailsRequired')
+      }
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
       next(error)
     }

--- a/server/views/temporary-accommodation/static/userDetailsRequired.njk
+++ b/server/views/temporary-accommodation/static/userDetailsRequired.njk
@@ -1,0 +1,13 @@
+{% extends "partials/layout.njk" %}
+
+{% set pageTitle = "Update your account details - " + applicationName %}
+
+{% block content %}
+<div class="govuk-grid-row">
+  <div class="govuk-grid-column-full">
+    <h1 class="govuk-heading-l">Update your account details to use this service</h1>
+    <p class="govuk-body">Ask your line manager or HPT lead to add an 'assessor' role to your account. You can use the service once that's done.</p>
+    <p class="govuk-body">If you still have problems, please raise a <a class="govuk-link" href="https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=4f0128741b6fd61025dc6351f54bcb31" rel="noopener noreferrer" target="_blank">support ticket</a> to get help or raise a bug.</p>
+  </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CAS-1311

# Changes in this PR

Added a new screen that notify users if there is an issue with their account

## Screenshots of UI changes
<img width="836" height="278" alt="Screenshot 2025-10-17 at 14 00 18" src="https://github.com/user-attachments/assets/8107269c-d5fe-4a63-aad1-6408ccd6844a" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
