### PR TITLE
CAS-2004: Set gap report extension to xlsx

### DIFF
--- a/server/utils/reportUtils.test.ts
+++ b/server/utils/reportUtils.test.ts
@@ -96,7 +96,7 @@ describe('reportUtils', () => {
 
       const result = reportForProbationRegionFilename(probationRegion.name, startDate, endDate, type)
 
-      expect(result).toEqual('booking-gap-kent-surrey-sussex-11-08-2023-to-23-11-2023.csv')
+      expect(result).toEqual('booking-gap-kent-surrey-sussex-11-08-2023-to-23-11-2023.xlsx')
     })
   })
 

--- a/server/utils/reportUtils.ts
+++ b/server/utils/reportUtils.ts
@@ -24,7 +24,7 @@ const reportNames: Record<Cas3ReportType, string> = {
 }
 
 const reportFileType = (reportType: Cas3ReportType): string => {
-  if (reportType === 'futureBookingsCsv' || reportType === 'bookingGap') {
+  if (reportType === 'futureBookingsCsv') {
     return 'csv'
   }
   return 'xlsx'


### PR DESCRIPTION
This Pull Request updates the report generation functionality in the server utilities, specifically related to file type handling and tests verifying report file names.

Main Changes:
- Test Update: The test case for reportForProbationRegionFilename in reportUtils.test.ts was updated to check for .xlsx file output instead of .csv.