### PR TITLE
Add hpt email to pdu evidence

### DIFF
--- a/cypress_shared/helpers/apply.ts
+++ b/cypress_shared/helpers/apply.ts
@@ -685,6 +685,18 @@ export default class ApplyHelper {
   }
 
   completePlacementLocationAlternativeRegionWithEvidence() {
+    const stubbedProbationRegions = [
+      referenceDataFactory.probationRegion().build({
+        id: '1',
+        name: 'South West',
+        hptEmail: 'southwest.test@justice.gov.uk',
+      }),
+      referenceDataFactory.probationRegion().build({
+        id: '2',
+        name: 'North West',
+        hptEmail: 'northwest.test@justice.gov.uk',
+      }),
+    ]
     if (this.environment === 'integration') {
       const pdu = referenceDataFactory.pdu().build({
         id: this.application.data['placement-location']['alternative-pdu'].pduId,
@@ -694,16 +706,7 @@ export default class ApplyHelper {
         pdus: [pdu, ...referenceDataFactory.pdu().buildList(5)],
         probationRegionId: '2',
       })
-      cy.task('stubProbationRegions', [
-        referenceDataFactory.probationRegion().build({
-          id: '1',
-          name: 'South West',
-        }),
-        referenceDataFactory.probationRegion().build({
-          id: '2',
-          name: 'North West',
-        }),
-      ])
+      cy.task('stubProbationRegions', stubbedProbationRegions)
     }
 
     // Given I click on the safeguarding and support task
@@ -724,9 +727,10 @@ export default class ApplyHelper {
 
     const pduEvidencePage = new PduEvidencePage(this.application)
     pduEvidencePage.completeForm()
+    pduEvidencePage.shouldHaveCorrectRegionalInformation(stubbedProbationRegions)
     pduEvidencePage.clickSubmit()
 
-    this.pages.placementLocation = [alternativeRegionPage, placementPduPage, differentRegionPage]
+    this.pages.placementLocation = [alternativeRegionPage, placementPduPage, differentRegionPage, pduEvidencePage]
 
     // Then I should be redirected to the task list
     const tasklistPage = Page.verifyOnPage(TaskListPage, this.application)

--- a/cypress_shared/pages/apply/accommodation-need/placement-location/pduEvidence.ts
+++ b/cypress_shared/pages/apply/accommodation-need/placement-location/pduEvidence.ts
@@ -1,11 +1,12 @@
-import type { Application, FullPerson, TemporaryAccommodationApplication } from '@approved-premises/api'
+import type { TemporaryAccommodationApplication as Application, FullPerson } from '@approved-premises/api'
+import { ReferenceData } from '@approved-premises/ui'
 import paths from '../../../../../server/paths/apply'
 import ApplyPage from '../../applyPage'
 
 export default class PduEvidencePage extends ApplyPage {
   application: Application
 
-  constructor(application: TemporaryAccommodationApplication) {
+  constructor(application: Application) {
     const pduName = application.data?.['placement-location']?.['placement-pdu'].pduName
     super(
       `Evidence from ${pduName} PDU that they’ll consider a CAS3 bedspace for ${(application.person as FullPerson).name}`,
@@ -16,6 +17,23 @@ export default class PduEvidencePage extends ApplyPage {
         id: application.id,
       }),
     )
+
+    this.application = application
+  }
+
+  shouldHaveCorrectRegionalInformation(stubbedProbationRegions: Array<ReferenceData>) {
+    const { pduName } = this.application.data['placement-location']['alternative-pdu']
+    const { regionName } = this.application.data['placement-location']['different-region']
+    const hptEmail = stubbedProbationRegions.find(region => region.name === regionName)?.hptEmail
+
+    cy.get('ol.govuk-list--number li')
+      .eq(0)
+      .invoke('text')
+      .then(text => {
+        expect(text).to.contain(regionName)
+        expect(text).to.contain(pduName)
+        if (hptEmail) expect(text).to.contain(hptEmail)
+      })
   }
 
   completeForm() {

--- a/server/@types/ui/index.d.ts
+++ b/server/@types/ui/index.d.ts
@@ -226,6 +226,7 @@ export interface ReferenceData {
   name: string
   isActive: boolean
   serviceScope: 'approved-premises' | 'temporary-accommodation' | '*'
+  hptEmail?: string
 }
 
 export type PersonRisksUI = PersonRisks
@@ -248,7 +249,7 @@ export type DataServices = Partial<{
   referenceDataService: {
     getLocalAuthorities: (CallConfig: CallConfig) => Promise<Array<LocalAuthorityArea>>
     getPdus: (CallConfig: CallConfig, options: GetPdusOptions = {}) => Promise<Array<ProbationDeliveryUnit>>
-    getProbationRegions: (CallConfig: CallConfig) => Promise<Array<{ id: string; name: string }>>
+    getProbationRegions: (CallConfig: CallConfig) => Promise<Array<ProbationRegion>>
   }
 }>
 

--- a/server/form-pages/apply/accommodation-need/placement-location/pduEvidence.ts
+++ b/server/form-pages/apply/accommodation-need/placement-location/pduEvidence.ts
@@ -1,5 +1,6 @@
 import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
-import type { PageResponse, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import type { DataServices, PageResponse, TaskListErrors, YesOrNo } from '@approved-premises/ui'
+import { CallConfig } from '../../../../data/restClient'
 import { Page } from '../../../utils/decorators'
 import { personName } from '../../../../utils/personUtils'
 import TasklistPage from '../../../tasklistPage'
@@ -29,9 +30,22 @@ export default class PduEvidence implements TasklistPage {
     const regionName = application.data?.['placement-location']?.['different-region'].regionName
     this.pduName = pduName || ''
     this.regionName = regionName || ''
-    this.email = ''
     this.title = `Evidence from ${this.pduName} PDU that they’ll consider a CAS3 bedspace for ${name}`
     this.htmlDocumentTitle = this.title
+  }
+
+  static async initialize(
+    body: ConsentRefusedBody,
+    application: Application,
+    callConfig: CallConfig,
+    dataServices: DataServices,
+  ) {
+    const regions = await dataServices.referenceDataService.getProbationRegions(callConfig)
+    const instance = new PduEvidence(body, application)
+    instance.regionName = application.data?.['placement-location']?.['different-region'].regionName
+    instance.email = regions.find((region: { name: string }) => region.name === instance.regionName)?.hptEmail || ''
+
+    return instance
   }
 
   set body(value) {

--- a/server/services/referenceDataService.ts
+++ b/server/services/referenceDataService.ts
@@ -28,8 +28,8 @@ export default class ReferenceDataService {
   async getProbationRegions(callConfig: CallConfig) {
     const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
-    return (await referenceDataClient.getReferenceData<{ id: string; name: string }>('probation-regions')).sort(
-      (a, b) => a.name.localeCompare(b.name),
-    )
+    return (
+      await referenceDataClient.getReferenceData<{ id: string; name: string; hptEmail: string }>('probation-regions')
+    ).sort((a, b) => a.name.localeCompare(b.name))
   }
 }

--- a/server/testutils/factories/probationRegion.ts
+++ b/server/testutils/factories/probationRegion.ts
@@ -8,5 +8,6 @@ export default Factory.define<ReferenceData>(() => {
     name: faker.location.county(),
     isActive: true,
     serviceScope: 'temporary-accommodation',
+    hptEmail: faker.internet.email(),
   }
 })

--- a/server/testutils/stubs/probation-regions.json
+++ b/server/testutils/stubs/probation-regions.json
@@ -3,72 +3,84 @@
     "id": "d73ae6b5-041e-4d44-b859-b8c77567d893",
     "name": "London",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "london.test@justice.gov.uk"
   },
   {
     "id": "c5acff6c-d0d2-4b89-9f4d-89a15cfa3891",
     "name": "North East",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "northeast.test@justice.gov.uk"
   },
   {
     "id": "5e44b880-df20-4751-938f-a14be5fe609d",
     "name": "Yorkshire & The Humber",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "yorkshire.test@justice.gov.uk"
   },
   {
     "id": "a02b7727-63aa-46f2-80f1-e0b05b31903c",
     "name": "North West",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "northwest.test@justice.gov.uk"
   },
   {
     "id": "f6db2e41-040e-47c7-8bba-a345b6d35ca1",
     "name": "Greater Manchester",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "greatermanchester.test@justice.gov.uk"
   },
   {
     "id": "0544d95a-f6bb-43f8-9be7-aae66e3bf244",
     "name": "East Midlands",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "eastmidlands.test@justice.gov.uk"
   },
   {
     "id": "734261a0-d053-4aed-968d-ffc518cc17f8",
     "name": "West Midlands",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "westmidlands.test@justice.gov.uk"
   },
   {
     "id": "ca979718-b15d-4318-9944-69aaff281cad",
     "name": "East of England",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "eastofengland.test@justice.gov.uk"
   },
   {
     "id": "db82d408-d440-4eb5-960b-119cb33427cd",
     "name": "Kent, Surrey & Sussex",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "kent.test@justice.gov.uk"
   },
   {
     "id": "43606be0-9836-441d-9bc1-5586de9ac931",
     "name": "South West",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "southwest.test@justice.gov.uk"
   },
   {
     "id": "6b4a1308-17af-4c1a-a330-6005bec9e27b",
     "name": "South Central",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "southcentral.test@justice.gov.uk"
   },
   {
     "id": "afee0696-8df3-4d9f-9d0c-268f17772e2c",
     "name": "Wales",
     "isActive": true,
-    "serviceScope": "temporary-accommodation"
+    "serviceScope": "temporary-accommodation",
+    "hptEmail": "wales.test@justice.gov.uk"
   }
 ]

--- a/server/views/applications/pages/accommodation-need/placement-location/pdu-evidence.njk
+++ b/server/views/applications/pages/accommodation-need/placement-location/pdu-evidence.njk
@@ -33,7 +33,8 @@
     </h2>
     <ol class="govuk-list govuk-list--number  govuk-list--spaced">
         <li>
-            Email {{ page.regionName }} Homelessness Prevention Team (HPT) if you need to get the email address for {{ page.pduName }} PDU.
+            Email {{ page.regionName }} Homelessness Prevention Team (HPT){% if page.email %} at <a class="govuk-link" href="mailto:{{ page.email }}">{{ page.email }}</a>
+            {% endif %} if you need to get the email address for {{ page.pduName }} PDU.
         </li>
         <li>Email the PDU to ask them to consider this CAS3 request.</li>
         <li>The PDU must reply by email to confirm they’ll consider it.</li>


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-2064) adds a dynamic hpt email address to the pdu evidence screen.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

<img width="656" height="633" alt="image" src="https://github.com/user-attachments/assets/5bc86357-c993-43b4-9c23-b29e91f377c9" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
