### PR TITLE
CAS-2004: Change gap report button text

### DIFF
--- a/e2e_playwright/tests/reports/download-reports.spec.ts
+++ b/e2e_playwright/tests/reports/download-reports.spec.ts
@@ -27,7 +27,7 @@ test('Download referrals report for a probation region', async ({ page, assessor
   await visitReportsPageAndDownloadReport(page, 'referrals', assessor.probationRegion)
 })
 
-test('Download Gap report for a probation region', async ({ page, assessor }) => {
+test('Download gap report for a probation region', async ({ page, assessor }) => {
   await signIn(page, assessor)
   await visitReportsPageAndDownloadReport(page, 'bookingGap', assessor.probationRegion)
 })

--- a/server/views/temporary-accommodation/reports/index.njk
+++ b/server/views/temporary-accommodation/reports/index.njk
@@ -142,7 +142,7 @@
 
                 {% if showGapReportButton %}
                     {{ govukButton({
-                        text: "Download GAP report",
+                        text: "Download gap report",
                         name: "reportType",
                         value: 'bookingGap',
                         classes: 'govuk-!-width-one-half',


### PR DESCRIPTION
Change gap report wording to 'Download gap report', all lowercase.