### PR TITLE
Add error message on users without CAS3 access

### DIFF
--- a/cypress_shared/pages/userDetailsRequired.ts
+++ b/cypress_shared/pages/userDetailsRequired.ts
@@ -1,0 +1,7 @@
+import Page from './page'
+
+export default class UserDetailsRequiredPage extends Page {
+  constructor() {
+    super('Update your account details to use this service')
+  }
+}

--- a/integration_tests/tests/landing.cy.ts
+++ b/integration_tests/tests/landing.cy.ts
@@ -1,5 +1,5 @@
 import { ListPage } from '../../cypress_shared/pages/apply'
-import NotAuthorisedPage from '../../cypress_shared/pages/notAuthorised'
+import UserDetailsRequiredPage from '../../cypress_shared/pages/userDetailsRequired'
 import Page from '../../cypress_shared/pages/page'
 import DashboardPage from '../../cypress_shared/pages/temporary-accommodation/dashboardPage'
 import { setupTestUser, setupTestUserWithoutRole } from '../../cypress_shared/utils/setupTestUser'
@@ -30,12 +30,12 @@ context('Landing', () => {
     Page.verifyOnPage(ListPage, [], [], [])
   })
 
-  it('redirects a user who is not an assessor or a referrer', () => {
+  it('redirects to the `User Details Required` page a user who is not an assessor or a referrer', () => {
     // Given I am signed in as a user without a role
     setupTestUserWithoutRole()
-    cy.signIn()
+    cy.signIn({ failOnStatusCode: false })
 
     // I am redirected to the not authorised page
-    Page.verifyOnPage(NotAuthorisedPage)
+    Page.verifyOnPage(UserDetailsRequiredPage)
   })
 })

--- a/server/controllers/landingController.test.ts
+++ b/server/controllers/landingController.test.ts
@@ -5,7 +5,6 @@ import paths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
 import { userFactory } from '../testutils/factories'
-import { UnauthorizedError } from '../utils/errors'
 import { isApplyEnabledForUser } from '../utils/userUtils'
 import LandingController from './landingController'
 

--- a/server/controllers/landingController.test.ts
+++ b/server/controllers/landingController.test.ts
@@ -78,7 +78,7 @@ describe('LandingController', () => {
       expect(response.redirect).toHaveBeenCalledWith(staticPaths.static.useNDelius.pattern)
     })
 
-    it('throws an error if the user is neither a assessor or a referrer', () => {
+    it('redirects to the `User Details Required` page if the user is neither a assessor or a referrer', () => {
       const response: DeepMocked<Response> = createMock<Response>({
         locals: {
           user: userFactory.build({
@@ -89,7 +89,9 @@ describe('LandingController', () => {
 
       const requestHandler = landingController.index()
 
-      expect(() => requestHandler(request, response, next)).toThrowError(UnauthorizedError)
+      requestHandler(request, response, next)
+      expect(response.status).toHaveBeenCalledWith(403)
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/static/userDetailsRequired')
     })
 
     it('redirects to the reports page when the user is a reporter', () => {

--- a/server/controllers/landingController.ts
+++ b/server/controllers/landingController.ts
@@ -3,7 +3,6 @@ import { TemporaryAccommodationUser as User } from '../@types/shared'
 import applyPaths from '../paths/apply'
 import managePaths from '../paths/temporary-accommodation/manage'
 import staticPaths from '../paths/temporary-accommodation/static'
-import { UnauthorizedError } from '../utils/errors'
 import {
   isApplyEnabledForUser,
   userHasAssessorRole,

--- a/server/controllers/landingController.ts
+++ b/server/controllers/landingController.ts
@@ -31,7 +31,8 @@ export default class LandingController {
         return res.redirect(managePaths.reports.index({}))
       }
 
-      throw new UnauthorizedError()
+      res.status(403)
+      return res.render('temporary-accommodation/static/userDetailsRequired')
     }
   }
 }

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -59,7 +59,7 @@ describe('populateCurrentUser', () => {
     expect(next).toHaveBeenCalledWith()
   })
 
-  it('renders the dedicated 403 page when staff record is missing', async () => {
+  it('redirects to not authorised when staff record is missing', async () => {
     const request = createMock<Request>()
     const response = createMock<Response>()
     const next = jest.fn()
@@ -71,7 +71,7 @@ describe('populateCurrentUser', () => {
     await populateCurrentUser(userService)(request, response, next)
 
     expect(response.status).toHaveBeenCalledWith(403)
-    expect(response.render).toHaveBeenCalledWith('temporary-accommodation/static/userDetailsRequired')
+    expect(response.redirect).toHaveBeenCalledWith('/not-authorised')
     expect(next).not.toHaveBeenCalledWith(expect.any(Error))
   })
 

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -26,7 +26,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
     } catch (error) {
       if (error instanceof DeliusAccountMissingStaffDetailsError) {
         res.status(403)
-        return res.render('temporary-accommodation/static/userDetailsRequired')
+        return res.redirect('/not-authorised')
       }
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
       return next(error)

--- a/server/views/temporary-accommodation/static/userDetailsRequired.njk
+++ b/server/views/temporary-accommodation/static/userDetailsRequired.njk
@@ -6,7 +6,7 @@
 <div class="govuk-grid-row">
   <div class="govuk-grid-column-full">
     <h1 class="govuk-heading-l">Update your account details to use this service</h1>
-    <p class="govuk-body">Ask your line manager or HPT lead to add an 'assessor' role to your account. You can use the service once that's done.</p>
+    <p class="govuk-body">Ask your line manager or HPT lead to add the relevant role to your account. You can use the service once that's done.</p>
     <p class="govuk-body">If you still have problems, please raise a <a class="govuk-link" href="https://mojprod.service-now.com/moj_sp?id=sc_cat_item&sys_id=4f0128741b6fd61025dc6351f54bcb31" rel="noopener noreferrer" target="_blank">support ticket</a> to get help or raise a bug.</p>
   </div>
 </div>


### PR DESCRIPTION
# Context

Jira comment: 
https://dsdmoj.atlassian.net/browse/CAS-1311?focusedCommentId=673308

# Changes in this PR

Swapped the access logic for nDelius and CAS3.
nDelius users without a CAS3 role now see the new "Update your account" page that was first introduced here (merged: https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/pull/1458 ).
Every other user see the "non authorised" page

Before it was the opposite.

## How to test:

Case 1: Login as a user with nDelius access but without CAS3 access: should see the new "Update your account" page.

Case 2: Login as a user without nDelius or CAS3 access: should see the existing "not authorised" page

## Screenshots of UI changes

<img width="836" height="278" alt="updateyouraccount" src="https://github.com/user-attachments/assets/ca9b3bc8-60c3-4c0e-9276-eb963196e654" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
