### PR TITLE
Chore: Fix issue with samesite cookies inside Cypress UI

### DIFF
--- a/e2e/tests/stepDefinitions/manage.ts
+++ b/e2e/tests/stepDefinitions/manage.ts
@@ -24,15 +24,22 @@ const signIn = (usernameVariable: string, passwordVariable: string) => {
   const username = Cypress.env(usernameVariable) || throwMissingCypressEnvError(usernameVariable)
   const password = Cypress.env(passwordVariable) || throwMissingCypressEnvError(passwordVariable)
 
+  // If the test is run in Cypress UI mode, rewrite auth cookies with strict or lax samesite policy
+  // to ensure they work from the Cypress iframe.
+  // https://www.tomoliver.net/posts/cypress-samesite-problem
+  if (!Cypress.env('CYPRESS_RUN_HEADLESS')) {
+    cy.intercept(/^(\/sign-in.*|\/)$/, req =>
+      req.on('response', res => {
+        const setCookies = res.headers['set-cookie']
+        res.headers['set-cookie'] = (Array.isArray(setCookies) ? setCookies : [setCookies])
+          .filter(x => x && x.match(/samesite=(lax|strict)/gi))
+          .map(headerContent => headerContent.replace(/samesite=(lax|strict)/gi, 'secure; samesite=none'))
+      }),
+    )
+  }
+
   cy.visit('/')
   cy.get('input[name="username"]').type(username)
   cy.get('input[name="password"]').type(password, { log: false })
   cy.get('.govuk-button').contains('Sign in').click()
-
-  // temp hack to get local e2es working against dev upstream services - this will only be executed when e2es run locally (i.e. not in the pipeline)
-  if (environment === 'local') {
-    // eslint-disable-next-line cypress/no-unnecessary-waiting
-    cy.wait(200)
-    cy.visit('/dashboard')
-  }
 }


### PR DESCRIPTION
A [recent change to the Auth service](https://github.com/ministryofjustice/hmpps-auth/commit/6829de75efc17fc453282e1cb4e6c6751d63a3df) specifies `samesite=Strict` for auth cookies. This breaks flows in Cypress UI, as those are run inside a frame for the given URL, which means they never pass the samesite validation. This change intercepts requests containing those auth cookies to remove the restriction.

This commit also removes a wait and navigateto the dashboard, which is seemingly no longer needed. This may save milliseconds to our test runs 🙂 
