### PR TITLE
Update assessment API paths to use CAS3 endpoints

### DIFF
--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -175,11 +175,11 @@ export default {
     ).body.requests,
   stubCreateAssessmentNoteErrors: (args: { assessmentId: string; params: Array<string> }): SuperAgentRequest =>
     stubFor(errorStub(args.params, api.cas3.assessments.notes({ id: args.assessmentId }), 'POST')),
-  stubUpdateAssessment: (assessment: Assessment): SuperAgentRequest =>
+  stubUpdateAssessment: (assessment: Cas3Assessment): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'PUT',
-        url: api.assessments.update({ id: assessment.id }),
+        url: api.cas3.assessments.update({ id: assessment.id }),
       },
       response: {
         status: 200,
@@ -188,13 +188,13 @@ export default {
       },
     }),
   stubUpdateAssessmentError: (args: {
-    assessment: Assessment
+    assessment: Cas3Assessment
     errorBody: Record<string, unknown>
   }): SuperAgentRequest =>
     stubFor({
       request: {
         method: 'PUT',
-        url: api.assessments.update({ id: args.assessment.id }),
+        url: api.cas3.assessments.update({ id: args.assessment.id }),
       },
       response: {
         status: 400,

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -3,6 +3,7 @@ import {
   Cas3Assessment as Assessment,
   AssessmentRejection,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
+  Cas3UpdateAssessment,
 } from '../@types/shared'
 import config from '../config'
 import paths from '../paths/api'
@@ -361,19 +362,17 @@ describeClient('AssessmentClient', provider => {
     it('puts updated data to the assessment', async () => {
       const updatedData = {
         accommodationRequiredFromDate: '2024-08-08',
-        data: assessment.data,
         releaseDate: '2024-08-08',
-      }
+      } as Cas3UpdateAssessment
 
       await provider.addInteraction({
         state: 'Assessment can be updated',
         uponReceiving: 'a request to update assessment',
         withRequest: {
           method: 'PUT',
-          path: paths.assessments.update({ id: assessment.id }),
+          path: paths.cas3.assessments.update({ id: assessment.id }),
           headers: {
             authorization: `Bearer ${callConfig.token}`,
-            'X-Service-Name': 'temporary-accommodation',
           },
           body: updatedData,
         },

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,10 +1,10 @@
 import type {
-  TemporaryAccommodationAssessment as Assessment,
   AssessmentAcceptance,
   AssessmentRejection,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   Cas3Assessment,
   Cas3AssessmentSummary,
+  Cas3UpdateAssessment,
   Cas3ReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
 } from '@approved-premises/api'
@@ -96,8 +96,8 @@ export default class AssessmentClient {
     return this.restClient.post<Note>({ path: paths.cas3.assessments.notes({ id }), data })
   }
 
-  async update(id: string, data: Partial<Assessment>) {
-    const updateData = { data: {}, ...data }
-    return this.restClient.put<void>({ path: paths.assessments.update({ id }), data: updateData })
+  async update(id: string, data: Cas3UpdateAssessment) {
+    const updateData = data
+    return this.restClient.put<void>({ path: paths.cas3.assessments.update({ id }), data: updateData })
   }
 }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -135,6 +135,7 @@ export default {
     assessments: {
       index: assessmentsCas3Path,
       show: assessmentsCas3Path.path(':id'),
+      update: assessmentsCas3Path.path(':id'),
       notes: assessmentsCas3Path.path(':id/referral-history-notes'),
     },
   },
@@ -164,7 +165,6 @@ export default {
   assessments: {
     index: assessPaths.assessments,
     show: assessPaths.singleAssessment,
-    update: assessPaths.singleAssessment,
     allocation: assessPaths.allocation,
     rejection: assessPaths.rejection,
     acceptance: assessPaths.acceptance,


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-2099) updates the assessments PUT endpoint to use the new cas3 one

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
