### PR TITLE
Update referral history notes API paths to use CAS3 endpoints

### DIFF
--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -153,7 +153,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: api.assessments.notes({ id: assessment.id }),
+        url: api.cas3.assessments.notes({ id: assessment.id }),
       },
       response: {
         status: 200,
@@ -165,11 +165,11 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: api.assessments.notes({ id: assessmentId }),
+        url: api.cas3.assessments.notes({ id: assessmentId }),
       })
     ).body.requests,
   stubCreateAssessmentNoteErrors: (args: { assessmentId: string; params: Array<string> }): SuperAgentRequest =>
-    stubFor(errorStub(args.params, api.assessments.notes({ id: args.assessmentId }), 'POST')),
+    stubFor(errorStub(args.params, api.cas3.assessments.notes({ id: args.assessmentId }), 'POST')),
   stubUpdateAssessment: (assessment: Assessment): SuperAgentRequest =>
     stubFor({
       request: {

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -12,7 +12,7 @@ import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import {
   assessmentFactory,
   assessmentSummaryFactory,
-  newReferralHistoryUserNoteFactory,
+  cas3ReferralHistoryUserNoteFactory,
   timelineEventsFactory,
 } from '../../../../server/testutils/factories'
 import { MockPagination } from '../../../mockApis/bookingSearch'
@@ -480,7 +480,7 @@ context('Apply', () => {
         const assessmentSummaryPage = AssessmentSummaryPage.visit(assessment, timeline)
 
         // When I create a new notes
-        const newNote = newReferralHistoryUserNoteFactory.build()
+        const newNote = cas3ReferralHistoryUserNoteFactory.build()
 
         cy.task('stubCreateAssessmentNote', assessment)
         assessmentSummaryPage.createNote(newNote.message)

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.test.ts
@@ -16,7 +16,7 @@ import {
   assessmentFactory,
   assessmentSearchParametersFactory,
   assessmentSummaryFactory,
-  newReferralHistoryUserNoteFactory,
+  cas3ReferralHistoryUserNoteFactory,
   probationRegionFactory,
   referenceDataFactory,
   referralHistorySystemNoteFactory,
@@ -531,7 +531,7 @@ describe('AssessmentsController', () => {
     it('creates a new note and redirects to assessment summary page', async () => {
       const requestHandler = assessmentsController.createNote()
       const assessmentId = 'some-id'
-      const newNote = newReferralHistoryUserNoteFactory.build()
+      const newNote = cas3ReferralHistoryUserNoteFactory.build()
 
       request.params = { id: assessmentId }
       request.body = { message: newNote.message }
@@ -550,7 +550,7 @@ describe('AssessmentsController', () => {
     it('redirects to the assessment summary page with errors if the API returns an error', async () => {
       const requestHandler = assessmentsController.createNote()
       const assessmentId = 'some-id'
-      const newNote = newReferralHistoryUserNoteFactory.build()
+      const newNote = cas3ReferralHistoryUserNoteFactory.build()
 
       const err = new Error()
 

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -7,7 +7,7 @@ import {
 } from '@approved-premises/ui'
 import {
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
-  NewReferralHistoryUserNote as NewNote,
+  Cas3ReferralHistoryUserNote as NewNote,
 } from '../../../@types/shared'
 import paths from '../../../paths/temporary-accommodation/manage'
 import AssessmentsService from '../../../services/assessmentsService'

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -10,7 +10,7 @@ import {
   assessmentFactory,
   cas3AssessmentSummariesFactory,
   cas3AssessmentSummaryFactory,
-  newReferralHistoryUserNoteFactory,
+  cas3ReferralHistoryUserNoteFactory,
 } from '../testutils/factories'
 import AssessmentClient from './assessmentClient'
 import { CallConfig } from './restClient'
@@ -21,7 +21,7 @@ describeClient('AssessmentClient', provider => {
   let assessment: Assessment
   let assessments: ReturnType<typeof cas3AssessmentSummariesFactory.build>
   let assessmentSummaryList: Array<ReturnType<typeof cas3AssessmentSummaryFactory.build>>
-  let newNote: ReturnType<typeof newReferralHistoryUserNoteFactory.build>
+  let newNote: ReturnType<typeof cas3ReferralHistoryUserNoteFactory.build>
   const callConfig = { token: 'some-token' } as CallConfig
 
   beforeEach(() => {
@@ -29,7 +29,7 @@ describeClient('AssessmentClient', provider => {
     assessment = assessmentFactory.build()
     assessments = cas3AssessmentSummariesFactory.build()
     assessmentSummaryList = cas3AssessmentSummaryFactory.buildList(5)
-    newNote = newReferralHistoryUserNoteFactory.build()
+    newNote = cas3ReferralHistoryUserNoteFactory.build()
   })
 
   describe('all', () => {
@@ -342,7 +342,7 @@ describeClient('AssessmentClient', provider => {
         uponReceiving: 'a request to create assessment note',
         withRequest: {
           method: 'POST',
-          path: paths.assessments.notes({ id: assessment.id }),
+          path: paths.cas3.assessments.notes({ id: assessment.id }),
           headers: {
             authorization: `Bearer ${callConfig.token}`,
           },

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -4,7 +4,7 @@ import type {
   AssessmentRejection,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   Cas3AssessmentSummary,
-  NewReferralHistoryUserNote as NewNote,
+  Cas3ReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
 } from '@approved-premises/api'
 
@@ -92,7 +92,7 @@ export default class AssessmentClient {
   }
 
   async createNote(id: string, data: NewNote) {
-    return this.restClient.post<Note>({ path: paths.assessments.notes({ id }), data })
+    return this.restClient.post<Note>({ path: paths.cas3.assessments.notes({ id }), data })
   }
 
   async update(id: string, data: Partial<Assessment>) {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -1,7 +1,7 @@
 import { path } from 'static-path'
 
 const cas3Path = path('/cas3')
-const assessmentsCas3Path = cas3Path.path('/assessments')
+const assessmentsCas3Path = cas3Path.path('assessments')
 const premisesPath = path('/premises')
 const cas3PremisesPath = cas3Path.path('premises')
 const singlePremisesPath = premisesPath.path(':premisesId')
@@ -34,7 +34,6 @@ const assessPaths = {
   rejection: path('/assessments/:id/rejection'),
   acceptance: path('/assessments/:id/acceptance'),
   closure: path('/assessments/:id/closure'),
-  notes: path('/assessments/:id/referral-history-notes'),
 }
 
 const clarificationNotePaths = {
@@ -135,6 +134,7 @@ export default {
     },
     assessments: {
       index: assessmentsCas3Path,
+      notes: assessmentsCas3Path.path(':id/referral-history-notes'),
     },
   },
   premises: {
@@ -168,7 +168,6 @@ export default {
     rejection: assessPaths.rejection,
     acceptance: assessPaths.acceptance,
     closure: assessPaths.closure,
-    notes: assessPaths.notes,
     clarificationNotes: {
       create: clarificationNotePaths.notes,
       update: clarificationNotePaths.notes.path(':clarificationNoteId'),

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -9,7 +9,7 @@ import { CallConfig } from '../data/restClient'
 import {
   assessmentFactory,
   assessmentSummaryFactory,
-  newReferralHistoryUserNoteFactory,
+  cas3ReferralHistoryUserNoteFactory,
   referenceDataFactory,
   referralHistoryUserNoteFactory,
 } from '../testutils/factories'
@@ -186,7 +186,7 @@ describe('AssessmentsService', () => {
 
   describe('createNote', () => {
     it('returns a newly created user note', async () => {
-      const newNote = newReferralHistoryUserNoteFactory.build()
+      const newNote = cas3ReferralHistoryUserNoteFactory.build()
       const note = referralHistoryUserNoteFactory.build()
       assessmentClient.createNote.mockResolvedValue(note)
 

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -9,7 +9,7 @@ import type {
 import type {
   TemporaryAccommodationAssessment as Assessment,
   AssessmentRejection,
-  NewReferralHistoryUserNote as NewNote,
+  Cas3ReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
   TemporaryAccommodationAssessmentStatus,
 } from '../@types/shared'

--- a/server/testutils/factories/cas3ReferralHistoryUserNote.ts
+++ b/server/testutils/factories/cas3ReferralHistoryUserNote.ts
@@ -1,0 +1,8 @@
+import { fakerEN_GB as faker } from '@faker-js/faker'
+import { Factory } from 'fishery'
+
+import type { Cas3ReferralHistoryUserNote } from '@approved-premises/api'
+
+export default Factory.define<Cas3ReferralHistoryUserNote>(() => ({
+  message: faker.lorem.lines(),
+}))

--- a/server/testutils/factories/index.ts
+++ b/server/testutils/factories/index.ts
@@ -39,7 +39,6 @@ import newDepartureFactory from './newDeparture'
 import newExtensionFactory from './newExtension'
 import newLostBedFactory from './newLostBed'
 import newLostBedCancellationFactory from './newLostBedCancellation'
-import newReferralHistoryUserNoteFactory from './newReferralHistoryUserNote'
 import newTurnaroundFactory from './newTurnaround'
 import oasysSectionsFactory, { roshSummaryFactory } from './oasysSections'
 import overlapFactory from './overlap'
@@ -66,6 +65,7 @@ import cas3UpdateBedspaceFactory from './cas3UpdateBedspace'
 import cas3BedspaceSummaryFactory from './cas3BedspaceSummary'
 import cas3BedspaceReferenceFactory from './cas3BedspaceReference'
 import cas3BedspacesReferenceFactory from './cas3BedspacesReference'
+import cas3ReferralHistoryUserNoteFactory from './cas3ReferralHistoryUserNote'
 import prisonCaseNotesFactory from './prisonCaseNotes'
 import probationRegionFactory from './probationRegion'
 import referenceDataFactory from './referenceData'
@@ -122,7 +122,7 @@ export {
   newExtensionFactory,
   newLostBedCancellationFactory,
   newLostBedFactory,
-  newReferralHistoryUserNoteFactory,
+  cas3ReferralHistoryUserNoteFactory,
   newTurnaroundFactory,
   oasysSectionsFactory,
   overlapFactory,

--- a/server/testutils/factories/newReferralHistoryUserNote.ts
+++ b/server/testutils/factories/newReferralHistoryUserNote.ts
@@ -1,8 +1,0 @@
-import { fakerEN_GB as faker } from '@faker-js/faker'
-import { Factory } from 'fishery'
-
-import type { NewReferralHistoryUserNote } from '@approved-premises/api'
-
-export default Factory.define<NewReferralHistoryUserNote>(() => ({
-  message: faker.lorem.lines(),
-}))


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-2118) is to update the assessment referral history notes endpoint to use the new cas3 one.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
