### PR TITLE
CAS-2102 Fixing place context when adding bedspace

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bedspaceShow.ts
@@ -5,6 +5,7 @@ import BookingListingComponent from '../../../components/bookingListing'
 import LostBedListingComponent from '../../../components/lostBedListing'
 import Page from '../../page'
 import { DateFormats } from '../../../../server/utils/dateUtils'
+import { createQueryString } from '../../../../server/utils/utils'
 
 export default class BedspaceShowPage extends Page {
   constructor(
@@ -14,27 +15,49 @@ export default class BedspaceShowPage extends Page {
     super(`Bedspace reference: ${bedspace.reference}`)
   }
 
-  static visit(premises: Cas3Premises, bedspace: Cas3Bedspace): BedspaceShowPage {
-    cy.visit(paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id }))
+  static visit(premises: Cas3Premises, bedspace: Cas3Bedspace, queryParams?: Record<string, string>): BedspaceShowPage {
+    let path = paths.premises.bedspaces.show({ premisesId: premises.id, bedspaceId: bedspace.id })
+
+    if (queryParams) {
+      path = `${path}?${createQueryString(queryParams)}`
+    }
+
+    cy.visit(path)
     return new BedspaceShowPage(premises, bedspace)
   }
 
   shouldShowStatus(status: string): void {
-    cy.get('main dl').get('dd').eq(0).contains(status)
+    cy.get('main dl')
+      .first()
+      .within(() => {
+        cy.get('dd').eq(0).contains(status)
+      })
   }
 
   shouldShowStartDate(startDate: string): void {
-    cy.get('main dl').get('dd').eq(1).contains(startDate)
+    cy.get('main dl')
+      .first()
+      .within(() => {
+        cy.get('dd').eq(1).contains(startDate)
+      })
   }
 
   shouldShowDetails(): void {
     this.bedspace.bedspaceCharacteristics.forEach(characteristic => {
-      cy.get('main dl').get('dd').eq(2).contains(characteristic.description)
+      cy.get('main dl')
+        .first()
+        .within(() => {
+          cy.get('dd').eq(2).contains(characteristic.description)
+        })
     })
   }
 
   shouldShowAdditionalDetails(): void {
-    cy.get('main dl').get('dd').eq(3).contains(this.bedspace.notes)
+    cy.get('main dl')
+      .first()
+      .within(() => {
+        cy.get('dd').eq(3).contains(this.bedspace.notes)
+      })
   }
 
   shouldShowPropertyAddress(): void {

--- a/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/premisesShow.ts
@@ -9,15 +9,21 @@ import {
 import Page from '../../page'
 import { Cas3Bedspace, Cas3PremisesArchiveAction } from '../../../../server/@types/shared'
 import { DateFormats } from '../../../../server/utils/dateUtils'
-import { convertToTitleCase } from '../../../../server/utils/utils'
+import { convertToTitleCase, createQueryString } from '../../../../server/utils/utils'
 
 export default class PremisesShowPage extends Page {
   constructor(premises: Cas3Premises) {
     super(`${premises.addressLine1}, ${premises.postcode}`)
   }
 
-  static visit(premises: Cas3Premises): PremisesShowPage {
-    cy.visit(paths.premises.show({ premisesId: premises.id }))
+  static visit(premises: Cas3Premises, queryParams?: Record<string, string>): PremisesShowPage {
+    let path = paths.premises.show({ premisesId: premises.id })
+
+    if (queryParams) {
+      path = `${path}?${createQueryString(queryParams)}`
+    }
+
+    cy.visit(path)
     return new PremisesShowPage(premises)
   }
 

--- a/server/views/temporary-accommodation/premises/show.njk
+++ b/server/views/temporary-accommodation/premises/show.njk
@@ -114,7 +114,7 @@
                 {% else %}
                     <p>No bedspaces.</p>
                     <a class="govuk-link govuk-link--no-visited-state"
-                       href="{{ paths.premises.bedspaces.new({ premisesId: premises.id }) }}">
+                       href="{{ addPlaceContext(paths.premises.bedspaces.new({ premisesId: premises.id })) }}">
                         Add a bedspace
                     </a>
                 {% endif %}


### PR DESCRIPTION
# Context

Ticket: https://dsdmoj.atlassian.net/browse/CAS-2102

This bug occurred when creating a bedspace on a premises without any bedspaces using one of the the "Add a bedspace" links from the premises search page or from the show bedspaces page.

# Changes in this PR

## Screenshots of UI changes

### Before

### After
<img width="3456" height="1990" alt="image" src="https://github.com/user-attachments/assets/6304c18f-595c-46cc-9ac5-262359ed15c3" />
<img width="3456" height="1990" alt="image" src="https://github.com/user-attachments/assets/793d8ff8-994a-40eb-aff0-02f17efb5cb9" />

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
