### PR TITLE
Chore: Ensure correct Local Authority is selected for E2E premises test

### DIFF
--- a/e2e_playwright/pages/manage/editablePropertyPage.ts
+++ b/e2e_playwright/pages/manage/editablePropertyPage.ts
@@ -13,7 +13,7 @@ export class EditablePropertyPage extends BasePage {
     const localAuthoritiesLocator = this.page.locator('#localAuthorityAreaId-select')
     const localAuthority = await this.getRandomOption(localAuthoritiesLocator)
     await this.page.getByLabel('What is the local authority?').fill(localAuthority)
-    await this.page.getByRole('listbox').locator('li').getByText(localAuthority).first().click()
+    await this.page.getByRole('listbox').locator('li').getByText(localAuthority, { exact: true }).first().click()
     property.localAuthority = localAuthority
 
     property.probationRegion = await this.selectOptionAtRandom('What is the region?', 'Select a probation region')


### PR DESCRIPTION
The Local Authority selected when creating or editing a premises is based on a random pick from the list of available options in the local authority dropdown select element.

If this pick happened to be 'York', the test would type 'York', then click on the first autocomplete option shown: in this case, this would be 'East Riding of Yorkshire'. This would cause a discrepancy between the value used to assert the correct details have been entered and the actual value entered.

To fix this, we ensure the autocomplete option clicked on is an exact match for the value randomly selected, rather than the first one shown.

### Autocomplete filled with 'York', showing first option is different:

<img width="810" height="342" alt="Screenshot 2025-11-10 at 11 44 28" src="https://github.com/user-attachments/assets/825a5be3-ca3b-42cf-8e7b-fd23694fe752" />

