### PR TITLE
Update assessment rejection to use CAS3 endpoint

### DIFF
--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -101,7 +101,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: api.assessments.rejection({ id: assessment.id }),
+        url: api.cas3.assessments.rejection({ id: assessment.id }),
       },
       response: {
         status: 200,
@@ -113,7 +113,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: api.assessments.rejection({ id: assessmentId }),
+        url: api.cas3.assessments.rejection({ id: assessmentId }),
       })
     ).body.requests,
   stubAcceptAssessment: (assessment: Assessment): SuperAgentRequest =>

--- a/server/controllers/temporary-accommodation/manage/assessmentsController.ts
+++ b/server/controllers/temporary-accommodation/manage/assessmentsController.ts
@@ -7,6 +7,7 @@ import {
 } from '@approved-premises/ui'
 import {
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
+  Cas3AssessmentRejection,
   Cas3ReferralHistoryUserNote as NewNote,
 } from '../../../@types/shared'
 import paths from '../../../paths/temporary-accommodation/manage'
@@ -213,7 +214,7 @@ export default class AssessmentsController {
           referralRejectionReasonId,
           referralRejectionReasonDetail: isOtherReason ? referralRejectionReasonDetail : undefined,
           isWithdrawn: ppRequestedWithdrawal === 'yes',
-        })
+        } as Cas3AssessmentRejection)
 
         req.flash('success', statusChangeMessage(id, 'rejected'))
         res.redirect(paths.assessments.summary({ id }))

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -1,8 +1,8 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import {
   Cas3Assessment as Assessment,
-  AssessmentRejection,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
+  Cas3AssessmentRejection,
   Cas3UpdateAssessment,
 } from '../@types/shared'
 import config from '../config'
@@ -266,7 +266,7 @@ describeClient('AssessmentClient', provider => {
 
   describe('rejectAssessment', () => {
     it('posts a new rejection for the assessment', async () => {
-      const assessmentRejection: AssessmentRejection = {
+      const assessmentRejection: Cas3AssessmentRejection = {
         document: {},
         rejectionRationale: 'default',
         referralRejectionReasonId: faker.string.uuid(),
@@ -278,7 +278,7 @@ describeClient('AssessmentClient', provider => {
         uponReceiving: 'a request to reject assessment',
         withRequest: {
           method: 'POST',
-          path: paths.assessments.rejection({ id: assessment.id }),
+          path: paths.cas3.assessments.rejection({ id: assessment.id }),
           headers: {
             authorization: `Bearer ${callConfig.token}`,
           },

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -1,8 +1,8 @@
 import type {
   AssessmentAcceptance,
-  AssessmentRejection,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
   Cas3Assessment,
+  Cas3AssessmentRejection,
   Cas3AssessmentSummary,
   Cas3UpdateAssessment,
   Cas3ReferralHistoryUserNote as NewNote,
@@ -72,9 +72,9 @@ export default class AssessmentClient {
     })
   }
 
-  async rejectAssessment(id: string, assessmentRejection: AssessmentRejection) {
+  async rejectAssessment(id: string, assessmentRejection: Cas3AssessmentRejection) {
     return this.restClient.post<void>({
-      path: paths.assessments.rejection({ id }),
+      path: paths.cas3.assessments.rejection({ id }),
       data: assessmentRejection,
     })
   }

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -127,6 +127,7 @@ const cas3Api = {
     show: assessmentsCas3Path.path(':id'),
     update: assessmentsCas3Path.path(':id'),
     notes: singleAssessmentCas3Path.path('referral-history-notes'),
+    rejection: assessmentsCas3Path.path(':id/rejection'),
   },
   referenceData: cas3Path.path('reference-data'),
 }

--- a/server/services/assessmentsService.test.ts
+++ b/server/services/assessmentsService.test.ts
@@ -1,7 +1,7 @@
 import { AssessmentSearchApiStatus } from '@approved-premises/ui'
 import {
   TemporaryAccommodationAssessment as Assessment,
-  AssessmentRejection,
+  Cas3AssessmentRejection,
   TemporaryAccommodationAssessmentStatus,
 } from '@approved-premises/api'
 import AssessmentClient from '../data/assessmentClient'
@@ -126,7 +126,7 @@ describe('AssessmentsService', () => {
 
   describe('rejectAssessment', () => {
     it('calls the rejectAssessment method on the client with rejection details', async () => {
-      const assessmentRejection: AssessmentRejection = {
+      const assessmentRejection: Cas3AssessmentRejection = {
         document: {},
         rejectionRationale: 'default',
         referralRejectionReasonId: 'rejection-reason-id',

--- a/server/services/assessmentsService.ts
+++ b/server/services/assessmentsService.ts
@@ -8,8 +8,8 @@ import type {
 } from '@approved-premises/ui'
 import type {
   TemporaryAccommodationAssessment as Assessment,
-  AssessmentRejection,
   Cas3Assessment,
+  Cas3AssessmentRejection,
   Cas3ReferralHistoryUserNote as NewNote,
   ReferralHistoryNote as Note,
   TemporaryAccommodationAssessmentStatus,
@@ -62,7 +62,7 @@ export default class AssessmentsService {
   async rejectAssessment(
     callConfig: CallConfig,
     assessmentId: string,
-    assessmentRejection: AssessmentRejection,
+    assessmentRejection: Cas3AssessmentRejection,
   ): Promise<void> {
     const assessmentClient = this.assessmentClientFactory(callConfig)
 


### PR DESCRIPTION
# Context

[This](https://dsdmoj.atlassian.net/browse/CAS-2109) updates the assessment rejection endpoint to use the new cas3 one

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
