### PR TITLE
Migrate POST assessments/assessmentId to CAS3

### DIFF
--- a/integration_tests/mockApis/assessments.ts
+++ b/integration_tests/mockApis/assessments.ts
@@ -139,7 +139,7 @@ export default {
     stubFor({
       request: {
         method: 'POST',
-        url: api.assessments.closure({ id: assessment.id }),
+        url: api.cas3.assessments.closure({ id: assessment.id }),
       },
       response: {
         status: 200,
@@ -151,7 +151,7 @@ export default {
     (
       await getMatchingRequests({
         method: 'POST',
-        url: api.assessments.closure({ id: assessmentId }),
+        url: api.cas3.assessments.closure({ id: assessmentId }),
       })
     ).body.requests,
   stubCreateAssessmentNote: (assessment: Assessment): SuperAgentRequest =>

--- a/server/data/assessmentClient.test.ts
+++ b/server/data/assessmentClient.test.ts
@@ -322,7 +322,7 @@ describeClient('AssessmentClient', provider => {
         uponReceiving: 'a request to close assessment',
         withRequest: {
           method: 'POST',
-          path: paths.assessments.closure({ id: assessment.id }),
+          path: paths.cas3.assessments.closure({ id: assessment.id }),
           headers: {
             authorization: `Bearer ${callConfig.token}`,
           },

--- a/server/data/assessmentClient.ts
+++ b/server/data/assessmentClient.ts
@@ -88,7 +88,7 @@ export default class AssessmentClient {
 
   async closeAssessment(id: string) {
     return this.restClient.post<void>({
-      path: paths.assessments.closure({ id }),
+      path: paths.cas3.assessments.closure({ id }),
     })
   }
 

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -128,6 +128,7 @@ const cas3Api = {
     update: assessmentsCas3Path.path(':id'),
     notes: singleAssessmentCas3Path.path('referral-history-notes'),
     rejection: assessmentsCas3Path.path(':id/rejection'),
+    closure: assessmentsCas3Path.path(':id/closure'),
   },
   referenceData: cas3Path.path('reference-data'),
 }


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CAS-2114

# Changes in this PR

Migrated `POST /cas3/assessments/{assessmentId}/closure` to use the new CAS3 endpoint

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
****