### PR TITLE
Update bedspace and premises to format notes

### DIFF
--- a/server/services/bedspaceService.test.ts
+++ b/server/services/bedspaceService.test.ts
@@ -116,7 +116,7 @@ describe('BedspaceService', () => {
         },
         {
           key: { text: 'Additional bedspace details' },
-          value: { text: bedspace.notes },
+          value: { html: bedspace.notes.replace(/\n/g, '<br />') },
         },
       )
       const expectedSummary = {
@@ -258,7 +258,7 @@ describe('BedspaceService', () => {
           },
           {
             key: { text: 'Additional bedspace details' },
-            value: { text: bedspace.notes },
+            value: { html: bedspace.notes.replace(/\n/g, '<br />') },
           },
         ],
       }
@@ -291,7 +291,7 @@ describe('BedspaceService', () => {
           },
           {
             key: { text: 'Additional bedspace details' },
-            value: { text: bedspace.notes },
+            value: { html: bedspace.notes.replace(/\n/g, '<br />') },
           },
         ],
       }
@@ -324,7 +324,7 @@ describe('BedspaceService', () => {
           },
           {
             key: { text: 'Additional bedspace details' },
-            value: { text: bedspace.notes },
+            value: { html: bedspace.notes.replace(/\n/g, '<br />') },
           },
         ],
       }

--- a/server/services/bedspaceService.ts
+++ b/server/services/bedspaceService.ts
@@ -66,7 +66,7 @@ export default class BedspaceService {
       },
       {
         key: { text: 'Additional bedspace details' },
-        value: { text: bedspace.notes ?? 'None' },
+        value: { html: this.formatNotes(bedspace.notes ?? 'None') },
       },
     )
     return {
@@ -227,5 +227,9 @@ export default class BedspaceService {
 
   private htmlValue(value: string) {
     return { html: value }
+  }
+
+  private formatNotes(notes: string): string {
+    return notes.replace(/\n/g, '<br />')
   }
 }

--- a/server/services/premisesService.test.ts
+++ b/server/services/premisesService.test.ts
@@ -433,7 +433,7 @@ describe('PremisesService', () => {
           },
           {
             key: { text: 'Additional property details' },
-            value: { text: onlinePremises.notes },
+            value: { html: onlinePremises.notes.replace(/\n/g, '<br />') },
           },
         ],
       }
@@ -486,7 +486,7 @@ describe('PremisesService', () => {
           },
           {
             key: { text: 'Additional property details' },
-            value: { text: archivedPremises.notes },
+            value: { html: archivedPremises.notes.replace(/\n/g, '<br />') },
           },
         ],
       }
@@ -502,7 +502,7 @@ describe('PremisesService', () => {
         row => (row.key as TextItem)?.text === 'Additional property details',
       )
 
-      expect(additionalPropertyDetailsRow.value).toEqual({ text: 'None' })
+      expect(additionalPropertyDetailsRow.value).toEqual({ html: 'None' })
     })
 
     it('should show "None" and "Add property details" link for property details when there are none', () => {

--- a/server/services/premisesService.ts
+++ b/server/services/premisesService.ts
@@ -208,7 +208,7 @@ export default class PremisesService {
       },
       {
         key: { text: 'Additional property details' },
-        value: this.textValue(premises.notes || 'None'),
+        value: this.htmlValue(this.formatNotes(premises.notes || 'None')),
       },
     )
     return {
@@ -405,5 +405,9 @@ export default class PremisesService {
     }
 
     return html
+  }
+
+  private formatNotes(notes: string): string {
+    return notes.replace(/\n/g, '<br />')
   }
 }


### PR DESCRIPTION
# Context

[This](https://mojdt.slack.com/archives/C06CN4PJZKM/p1763039190679279) was a request to have additional details keep formatting for new lines.

# Changes in this PR

## Screenshots of UI changes

### Before

<img width="639" height="232" alt="image" src="https://github.com/user-attachments/assets/71194c6a-a872-4782-b03d-9394b4aa249a" />

<img width="785" height="105" alt="image" src="https://github.com/user-attachments/assets/3b6b76c4-cd77-48a1-bf2d-088b99bbfa96" />


### After

<img width="640" height="330" alt="image" src="https://github.com/user-attachments/assets/1bfa5194-abb3-4799-bec8-0fd2bd11997a" />

<img width="803" height="89" alt="image" src="https://github.com/user-attachments/assets/e9275c44-e4b3-443e-ab77-5a18842045f4" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
