### PR TITLE
CAS-2133: Add planned maintenance banner

### DIFF
--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -11,6 +11,8 @@
 
 {% block content %}
 
+{% include 'partials/plannedMaintenanceBanner.njk' %}
+
 {% include "../_messages.njk" %}
 
   <div class="govuk-grid-row">

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -19,6 +19,8 @@
 
 {% block content %}
 
+    {% include 'partials/plannedMaintenanceBanner.njk' %}
+
     {{ showErrorSummary(errorSummary) }}
     
     <h1 class="govuk-heading-xl">

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -18,6 +18,9 @@
 {% block content %}
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
+
+      {% include 'partials/plannedMaintenanceBanner.njk' %}
+
       <form action="{{ paths.applications.new() }}" method="get">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         <h1 class="govuk-heading-l">Make a referral for CAS3</h1>

--- a/server/views/partials/plannedMaintenanceBanner.njk
+++ b/server/views/partials/plannedMaintenanceBanner.njk
@@ -1,0 +1,10 @@
+{% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
+
+{% set html %}
+    <h3 class="govuk-notification-banner__heading">Planned maintenance</h3>
+    <p class="govuk-body">CAS3 will be unavailable on Monday 8 December 2025 from 7am to 8am.</p>
+{% endset %}
+
+{{ govukNotificationBanner({
+    html: html
+}) }}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -6,6 +6,8 @@
 
 {% block content %}
 
+  {% include 'partials/plannedMaintenanceBanner.njk' %}
+
   {% include "../../_messages.njk" %}
 
   <h1 class="govuk-heading-l">Manage estate</h1>


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-2133

# Changes in this PR

Adds a planned maintenance banner.

Given the infrequent need for this, we go with a hardcoded banner instead of using a more involved implementation based on environment variables or other types of config. Once the planned maintenance has happened, we can revert this change and redeploy to remove the banner once the site is ready to be taken off maintenance mode.

## Screenshots of UI changes

<details><summary>Assessor -- dashboard</summary>

<img width="1196" height="598" alt="Screenshot 2025-11-24 at 17 00 43" src="https://github.com/user-attachments/assets/335b3e9b-b717-4976-8261-591bfe2a745d" />

</details>

<details><summary>Referrer -- dashboard</summary>

<img width="1196" height="634" alt="Screenshot 2025-11-24 at 16 59 55" src="https://github.com/user-attachments/assets/8f876cc4-1e69-431c-9c18-a89e3ecf0c44" />

</details>

<details><summary>Referrer -- start referral</summary>

<img width="1196" height="634" alt="Screenshot 2025-11-24 at 17 00 15" src="https://github.com/user-attachments/assets/2d8b7bb3-fbd2-4286-bb49-ae8bcb247c99" />

</details>

<details><summary>Referrer -- task list</summary>

<img width="1196" height="674" alt="Screenshot 2025-11-24 at 17 00 29" src="https://github.com/user-attachments/assets/e1a461ba-7950-4167-b4eb-77f466072386" />

</details>