### PR TITLE
Fixed redirect issue on Missing Staff Details error

### DIFF
--- a/server/controllers/landingController.ts
+++ b/server/controllers/landingController.ts
@@ -10,19 +10,10 @@ import {
   userHasReporterRole,
 } from '../utils/userUtils'
 
-// UNCOMMENT FOR DEBUG ONLY TO SIMULATE NO USER
-// const FORCE_DEBUG_USER_DETAILS_REQUIRED = true
-
 export default class LandingController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
       const user = res.locals.user as User
-
-      // UNCOMMENT FOR DEBUG ONLY TO SIMULATE NO USER
-      // if (FORCE_DEBUG_USER_DETAILS_REQUIRED) {
-      //   res.status(403)
-      //   return res.render('temporary-accommodation/static/userDetailsRequired')
-      // }
 
       if (userHasAssessorRole(user)) {
         return res.redirect(managePaths.dashboard.index({}))

--- a/server/controllers/landingController.ts
+++ b/server/controllers/landingController.ts
@@ -10,10 +10,19 @@ import {
   userHasReporterRole,
 } from '../utils/userUtils'
 
+// UNCOMMENT FOR DEBUG ONLY TO SIMULATE NO USER
+// const FORCE_DEBUG_USER_DETAILS_REQUIRED = true
+
 export default class LandingController {
   index(): RequestHandler {
     return (_req: Request, res: Response) => {
       const user = res.locals.user as User
+
+      // UNCOMMENT FOR DEBUG ONLY TO SIMULATE NO USER
+      // if (FORCE_DEBUG_USER_DETAILS_REQUIRED) {
+      //   res.status(403)
+      //   return res.render('temporary-accommodation/static/userDetailsRequired')
+      // }
 
       if (userHasAssessorRole(user)) {
         return res.redirect(managePaths.dashboard.index({}))

--- a/server/controllers/staticController.test.ts
+++ b/server/controllers/staticController.test.ts
@@ -49,4 +49,13 @@ describe('StaticController', () => {
       expect(response.render).toHaveBeenCalledWith('temporary-accommodation/static/notAuthorised')
     })
   })
+
+  describe('userDetailsRequired', () => {
+    it('should render the user details required page', () => {
+      const requestHandler = staticController.userDetailsRequired()
+      requestHandler(request, response, next)
+
+      expect(response.render).toHaveBeenCalledWith('temporary-accommodation/static/userDetailsRequired')
+    })
+  })
 })

--- a/server/controllers/staticController.ts
+++ b/server/controllers/staticController.ts
@@ -19,6 +19,12 @@ export default class StaticController {
     }
   }
 
+  userDetailsRequired(): RequestHandler {
+    return (_req: Request, res: Response) => {
+      res.render('temporary-accommodation/static/userDetailsRequired')
+    }
+  }
+
   notAuthorised(): RequestHandler {
     return (_req: Request, res: Response) => {
       res.render('temporary-accommodation/static/notAuthorised')

--- a/server/middleware/populateCurrentUser.test.ts
+++ b/server/middleware/populateCurrentUser.test.ts
@@ -59,7 +59,7 @@ describe('populateCurrentUser', () => {
     expect(next).toHaveBeenCalledWith()
   })
 
-  it('redirects to not authorised when staff record is missing', async () => {
+  it('redirects to used details required page when staff record is missing', async () => {
     const request = createMock<Request>()
     const response = createMock<Response>()
     const next = jest.fn()
@@ -71,7 +71,7 @@ describe('populateCurrentUser', () => {
     await populateCurrentUser(userService)(request, response, next)
 
     expect(response.status).toHaveBeenCalledWith(403)
-    expect(response.redirect).toHaveBeenCalledWith('/not-authorised')
+    expect(response.redirect).toHaveBeenCalledWith('/user-details-required')
     expect(next).not.toHaveBeenCalledWith(expect.any(Error))
   })
 

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -4,7 +4,7 @@ import UserService, { DeliusAccountMissingStaffDetailsError } from '../services/
 import extractCallConfig from '../utils/restUtils'
 import staticPaths from '../paths/temporary-accommodation/static'
 
-const USED_DETAILS_REQUIRED_PATH = staticPaths.static.userDetailsRequired.pattern
+const USER_DETAILS_REQUIRED_PATH = staticPaths.static.userDetailsRequired.pattern
 
 export default function populateCurrentUser(userService: UserService): RequestHandler {
   return async (req, res, next) => {
@@ -29,8 +29,8 @@ export default function populateCurrentUser(userService: UserService): RequestHa
     } catch (error) {
       if (error instanceof DeliusAccountMissingStaffDetailsError) {
         res.status(403)
-        if (req.path !== USED_DETAILS_REQUIRED_PATH) {
-          return res.redirect(USED_DETAILS_REQUIRED_PATH)
+        if (req.path !== USER_DETAILS_REQUIRED_PATH) {
+          return res.redirect(USER_DETAILS_REQUIRED_PATH)
         }
       }
       logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -4,16 +4,10 @@ import UserService, { DeliusAccountMissingStaffDetailsError } from '../services/
 import extractCallConfig from '../utils/restUtils'
 import staticPaths from '../paths/temporary-accommodation/static'
 
-// const FORCE_DEBUG_NOT_AUTHORISED = true
 const USED_DETAILS_REQUIRED_PATH = staticPaths.static.userDetailsRequired.pattern
 
 export default function populateCurrentUser(userService: UserService): RequestHandler {
   return async (req, res, next) => {
-    // if (FORCE_DEBUG_NOT_AUTHORISED && req.path !== USED_DETAILS_REQUIRED_PATH) {
-    //   res.status(403)
-    //   return res.redirect(USED_DETAILS_REQUIRED_PATH)
-    // }
-
     try {
       if (req.user) {
         const callConfig = extractCallConfig(req)

--- a/server/paths/temporary-accommodation/static.ts
+++ b/server/paths/temporary-accommodation/static.ts
@@ -5,6 +5,7 @@ const useNDeliusPath = temporaryAccommodationPath.path('use-ndelius')
 const notAuthorisedPath = temporaryAccommodationPath.path('not-authorised')
 const accessibilityStatementPath = temporaryAccommodationPath.path('accessibility-statement')
 const maintenancePath = temporaryAccommodationPath.path('maintenance')
+const userDetailsRequiredPath = temporaryAccommodationPath.path('user-details-required')
 
 const paths = {
   static: {
@@ -13,6 +14,7 @@ const paths = {
     useNDelius: useNDeliusPath,
     notAuthorised: notAuthorisedPath,
     maintenance: maintenancePath,
+    userDetailsRequired: userDetailsRequiredPath,
   },
 }
 

--- a/server/routes/temporary-accommodation/index.ts
+++ b/server/routes/temporary-accommodation/index.ts
@@ -24,6 +24,9 @@ export default function routes(controllers: Controllers, services: Services): Ro
   get(paths.static.useNDelius.pattern, staticController.useNDelius(), { auditEvent: 'VIEW_USE_NDELIUS' })
   get(paths.static.notAuthorised.pattern, staticController.notAuthorised(), { auditEvent: 'VIEW_NOT_AUTHORISED' })
   get(paths.static.maintenance.pattern, staticController.maintenance(), { auditEvent: 'VIEW_MAINTENANCE' })
+  get(paths.static.userDetailsRequired.pattern, staticController.userDetailsRequired(), {
+    auditEvent: 'VIEW_USER_DETAILS_REQUIRED',
+  })
 
   manageRoutes(controllers, services, router)
   applyRoutes(controllers, services, router)


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/CAS-2134

# Changes in this PR

There was an issue that was causing a redirect loop to users with an active nDelius account but without access to CAS3 service.
This should be working now.

# How to test:
Ideally login into CAS3 with a nDelius account without CAS3 access. You should now be able to see the recently added `/userDetailsRequired` route and NOT the `/not-authorised` one.

~~Left some commented out code to simulate the above. Will remove that once we are happy with this approach before merging.~~

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
