### PR TITLE
Ensure Cypress is installed for Cypress E2E tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -94,7 +94,7 @@ jobs:
           cache: 'npm'
 
       - name: Install dependencies
-        run: npm ci --no-audit
+        run: npm run setup
 
       - name: Determine tests splitting
         uses: chaosaffe/split-tests@v1


### PR DESCRIPTION
Now that postinstall npm scripts aren't run automatically, we need to use `npm run setup` to ensure Cypress is installed.

