### PR TITLE
Chore/cas3v2 accommodation refactor migration

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -25,7 +25,7 @@ generic-service:
     DOMAIN_EVENTS_EMIT_ENABLED: 'personArrived,personDeparted'
     CANCEL_SCHEDULED_ARCHIVE_ENABLED: true
     SHOW_GAP_REPORT_BUTTON: true
-    ENABLE_CAS3V2_API: false
+    ENABLE_CAS3V2_API: true
     IN_MAINTENANCE_MODE: false
 
   namespace_secrets:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -23,7 +23,7 @@ generic-service:
     CANCEL_SCHEDULED_ARCHIVE_ENABLED: true
     SHOW_GAP_REPORT_BUTTON: true
     ENABLE_CAS3V2_API: true
-    IN_MAINTENANCE_MODE: false
+    IN_MAINTENANCE_MODE: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -22,7 +22,7 @@ generic-service:
     DOMAIN_EVENTS_EMIT_ENABLED: 'personArrived,personDeparted'
     CANCEL_SCHEDULED_ARCHIVE_ENABLED: true
     SHOW_GAP_REPORT_BUTTON: true
-    ENABLE_CAS3V2_API: false
+    ENABLE_CAS3V2_API: true
     IN_MAINTENANCE_MODE: false
 
   namespace_secrets:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -23,7 +23,7 @@ generic-service:
     CANCEL_SCHEDULED_ARCHIVE_ENABLED: true
     SHOW_GAP_REPORT_BUTTON: true
     ENABLE_CAS3V2_API: true
-    IN_MAINTENANCE_MODE: false
+    IN_MAINTENANCE_MODE: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -22,7 +22,7 @@ generic-service:
     DOMAIN_EVENTS_EMIT_ENABLED: 'personArrived,personDeparted'
     CANCEL_SCHEDULED_ARCHIVE_ENABLED: true
     SHOW_GAP_REPORT_BUTTON: true
-    ENABLE_CAS3V2_API: false
+    ENABLE_CAS3V2_API: true
     IN_MAINTENANCE_MODE: false
 
   namespace_secrets:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -24,7 +24,7 @@ generic-service:
     DOMAIN_EVENTS_EMIT_ENABLED: 'personArrived,personDeparted'
     CANCEL_SCHEDULED_ARCHIVE_ENABLED: true
     SHOW_GAP_REPORT_BUTTON: true
-    ENABLE_CAS3V2_API: false
+    ENABLE_CAS3V2_API: true
     IN_MAINTENANCE_MODE: false
 
   allowlist: null


### PR DESCRIPTION
In preparation for the CAS3 accommodation refactor migration, this PR:

- Enables the CAS3v2 feature flag for all environments
- Sets up maintenance mode for both preprod and prod

Once the migration has been run, a new PR will be pushed to reset the mainetance mode.