### PR TITLE
BUGFIX/SAS-145: Use camelCase sort field types for bookings search

### DIFF
--- a/integration_tests/mockApis/bookingSearch.ts
+++ b/integration_tests/mockApis/bookingSearch.ts
@@ -5,7 +5,6 @@ import paths from '../../server/paths/api'
 import { stubFor } from '.'
 import { appendQueryString } from '../../server/utils/utils'
 import config from '../../server/config'
-import { searchSortFieldsMap } from '../../server/data/bookingClient'
 
 export type MockPagination = Pick<
   PaginatedResponse<BookingSearchResult>,
@@ -23,7 +22,7 @@ const cas3v2ApiEnabledStubs = {
       status: args.status,
       crnOrName: args.params?.crnOrName,
       page: args.params?.page || 1,
-      sortField: searchSortFieldsMap[args.params?.sortBy] || 'BOOKING_END_DATE',
+      sortField: args.params?.sortBy || 'endDate',
       sortDirection: args.params?.sortDirection || 'desc',
     })
 

--- a/server/@types/shared/models/Cas3BookingSearchSortField.ts
+++ b/server/@types/shared/models/Cas3BookingSearchSortField.ts
@@ -2,4 +2,4 @@
 /* istanbul ignore file */
 /* tslint:disable */
 /* eslint-disable */
-export type Cas3BookingSearchSortField = 'PERSON_NAME' | 'PERSON_CRN' | 'BOOKING_START_DATE' | 'BOOKING_END_DATE' | 'BOOKING_CREATED_AT';
+export type Cas3BookingSearchSortField = 'name' | 'crn' | 'startDate' | 'endDate' | 'createdAt';

--- a/server/data/bookingClient.cas3v2.test.ts
+++ b/server/data/bookingClient.cas3v2.test.ts
@@ -327,7 +327,7 @@ describeClient('BookingClient - CAS3v2', provider => {
           query: {
             status: 'provisional',
             page: '1',
-            sortField: 'BOOKING_END_DATE',
+            sortField: 'endDate',
             sortDirection: 'desc',
           },
           headers: {
@@ -363,7 +363,7 @@ describeClient('BookingClient - CAS3v2', provider => {
             status: 'confirmed',
             crnOrName: booking.person.crn,
             page: '1',
-            sortField: 'BOOKING_END_DATE',
+            sortField: 'endDate',
             sortDirection: 'asc',
           },
           headers: {

--- a/server/data/bookingClient.ts
+++ b/server/data/bookingClient.ts
@@ -1,12 +1,10 @@
 import type {
   Arrival,
   Booking,
-  BookingSearchSortField,
   Cancellation,
   Cas3Arrival,
   Cas3Booking,
   Cas3BookingSearchResult,
-  Cas3BookingSearchSortField,
   Cas3Cancellation,
   Cas3Confirmation,
   Cas3Departure,
@@ -34,14 +32,6 @@ import { BookingSearchResult } from '../@types/shared'
 
 type SearchResponse = {
   results: Array<BookingSearchResult> | Array<Cas3BookingSearchResult>
-}
-
-export const searchSortFieldsMap: Record<BookingSearchSortField, Cas3BookingSearchSortField> = {
-  name: 'PERSON_NAME',
-  crn: 'PERSON_CRN',
-  startDate: 'BOOKING_START_DATE',
-  endDate: 'BOOKING_END_DATE',
-  createdAt: 'BOOKING_CREATED_AT',
 }
 
 export default class BookingClient {
@@ -192,7 +182,7 @@ export default class BookingClient {
       status,
       crnOrName: params.crnOrName,
       page: !params.page ? 1 : params.page, // also handles NaN & <1
-      sortField: searchSortFieldsMap[params.sortBy] || 'BOOKING_END_DATE',
+      sortField: params.sortBy || 'endDate',
       sortDirection: params.sortDirection || 'desc',
     })
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/SAS-145

# Changes in this PR

This PR updates the types used for the sort field for the bookings search. These were for some reason returned by the CAS3v2 API spec as snake case enum keys, instead of their string values as was the case for the V1 endpoint. [This is being fixed in the API](https://github.com/ministryofjustice/hmpps-approved-premises-api/pull/4509): once the API PR is merged the tests in this PR should pass, and this fix can be deployed.