### PR TITLE
Chore: Update node version in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Stage: base image
-FROM node:22.14.0-bullseye-slim AS base
+FROM node:24.12-bullseye-slim AS base
 
 ARG BUILD_NUMBER=1_0_0
 ARG GIT_REF=not-available


### PR DESCRIPTION
CAS3 UI is now set to use Node 24, but the Dockerfile was still building with a Node 22 base -- this fixes it.

We only specify down to minor version to ensure patches are applied when available. This is in line with other CAS UIs.