### PR TITLE
Chore/update slack action

### DIFF
--- a/.github/actions/slack_failure_notification/action.yml
+++ b/.github/actions/slack_failure_notification/action.yml
@@ -18,11 +18,14 @@ inputs:
 runs:
   using: "composite"
   steps:
-    - uses: slackapi/slack-github-action@37ebaef184d7626c5f204ab8d3baff4262dd30f0 # v1.27.0
+    - uses: slackapi/slack-github-action@v2.1.1
       with:
-        channel-id: ${{ inputs.channel_id }}
+        method: chat.postMessage
+        token: ${{ inputs.slack_bot_token }}
+        payload-templated: true
         payload: |
           {
+            "channel": "${{ inputs.channel_id }}",
             "text": "Failed: ${{ inputs.title }} (${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }})",
             "blocks": [
               {
@@ -58,5 +61,3 @@ runs:
             "unfurl_links": false,
             "unfurl_media": false
           }
-      env:
-        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}


### PR DESCRIPTION
This updates the Slack Github Actions to v2. 

A test job has been run to verify the payload is being sent correctly (sent to me, can replicate on a shared channel if necessary): https://github.com/ministryofjustice/hmpps-temporary-accommodation-ui/actions/runs/20298720237/job/58298659565