### PR TITLE
Security fix - stop logging username (log the user's ID instead)

### DIFF
--- a/server/errorHandler.ts
+++ b/server/errorHandler.ts
@@ -7,7 +7,7 @@ import paths from './paths/temporary-accommodation/static'
 
 export default function createErrorHandler(production: boolean) {
   return (error: HTTPError, req: Request, res: Response, next: NextFunction): void => {
-    logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.username}'`, error)
+    logger.error(`Error handling request for '${req.originalUrl}', user '${res.locals.user?.id}'`, error)
 
     if (error.status === 401 || error.status === 403) {
       logger.info('User not authorised')

--- a/server/middleware/populateCurrentUser.ts
+++ b/server/middleware/populateCurrentUser.ts
@@ -28,7 +28,7 @@ export default function populateCurrentUser(userService: UserService): RequestHa
         res.status(403)
         return res.redirect('/not-authorised')
       }
-      logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.username}`)
+      logger.error(error, `Failed to retrieve user for: ${res.locals.user && res.locals.user.id}`)
       return next(error)
     }
   }


### PR DESCRIPTION
# Context

* JIRA: https://dsdmoj.atlassian.net/browse/CAS-1653
* Discovered that we were logging usernames (which in most cases are personal emails)

# Changes in this PR
* Log `user.id` in the error logs where we were previously logging `user.username`

