### PR TITLE
Chore: Use Ubuntu latest for all jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -106,7 +106,7 @@ jobs:
 
   integration_test:
     name: "Integration testing 🧪"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v6.0.1
@@ -140,7 +140,7 @@ jobs:
   # TODO -- ENABLE_CAS3V2_API cleanup: remove the following test
   integration_test_cas3v2:
     name: "Integration testing 🧪 - CAS3v2 API"
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     steps:
       - name: Check out code
         uses: actions/checkout@v6.0.1


### PR DESCRIPTION
This aligns the integration test job to the other jobs in the workflow to use the latest version of Ubuntu for the runner.

This will prevent separate Renovate PRs for different versions.