### PR TITLE
Fix departure date validation logic

### DIFF
--- a/server/controllers/temporary-accommodation/manage/arrivalsController.ts
+++ b/server/controllers/temporary-accommodation/manage/arrivalsController.ts
@@ -1,6 +1,7 @@
 import type { Request, RequestHandler, Response } from 'express'
 
 import type { NewCas3Arrival as NewArrival } from '@approved-premises/api'
+import { addDays } from 'date-fns'
 import paths from '../../../paths/temporary-accommodation/manage'
 import { ArrivalService, BookingService, PremisesService } from '../../../services'
 import { generateConflictBespokeError } from '../../../utils/bookingUtils'
@@ -68,10 +69,9 @@ export default class ArrivalsController {
         }
 
         if (newArrival.arrivalDate) {
-          const parsedDepartureDate = DateFormats.isoToDateObj(newArrival.expectedDepartureDate)
-          const maxAllowedDate = new Date(newArrival.arrivalDate)
-          maxAllowedDate.setDate(maxAllowedDate.getDate() + 84)
-          if (parsedDepartureDate > maxAllowedDate) {
+          const maxAllowedDate = DateFormats.dateObjToIsoDate(addDays(newArrival.arrivalDate, 84))
+
+          if (newArrival.expectedDepartureDate > maxAllowedDate) {
             const error = new Error()
             insertGenericError(error, 'expectedDepartureDate', 'exceedsMaxNights')
             throw error


### PR DESCRIPTION
# Context

This fixes an issue with BST messing with the max allowed date. Slack message [here](https://mojdt.slack.com/archives/C05FA7RTG48/p1767626241912719).

You can revert the changes in the arrival controller and rerun arrival unit tests and the new test should fail.

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
