### PR TITLE
SAS-220: replace lost bed ref data endpoint

### DIFF
--- a/integration_tests/mockApis/referenceData.ts
+++ b/integration_tests/mockApis/referenceData.ts
@@ -1,11 +1,12 @@
 import { LocalAuthorityArea, ProbationDeliveryUnit, ProbationRegion } from '@approved-premises/api'
 import { stubFor } from '.'
+import paths from '../../server/paths/api'
 
 const stubLocalAuthorities = (localAuthorities: Array<LocalAuthorityArea>) =>
   stubFor({
     request: {
       method: 'GET',
-      url: '/reference-data/local-authority-areas',
+      url: paths.referenceData({ objectType: 'local-authority-areas' }),
     },
     response: {
       status: 200,
@@ -20,7 +21,12 @@ const stubPdus = (args: { pdus: Array<ProbationDeliveryUnit>; probationRegionId?
   stubFor({
     request: {
       method: 'GET',
-      url: `/reference-data/probation-delivery-units${args.probationRegionId ? `?probationRegionId=${args.probationRegionId}` : ''}`,
+      urlPath: paths.referenceData({
+        objectType: 'probation-delivery-units',
+      }),
+      queryParameters: {
+        probationRegionId: args.probationRegionId ? { equalTo: args.probationRegionId } : undefined,
+      },
     },
     response: {
       status: 200,
@@ -35,7 +41,7 @@ const stubProbationRegions = (regions: Array<ProbationRegion>) =>
   stubFor({
     request: {
       method: 'GET',
-      url: '/reference-data/probation-regions',
+      url: paths.referenceData({ objectType: 'probation-regions' }),
     },
     response: {
       status: 200,

--- a/server/@types/shared/models/Cas3VoidBedspaceReason.ts
+++ b/server/@types/shared/models/Cas3VoidBedspaceReason.ts
@@ -3,6 +3,7 @@
 /* tslint:disable */
 /* eslint-disable */
 export type Cas3VoidBedspaceReason = {
+    description?: string;
     id: string;
     isActive: boolean;
     name: string;

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -50,7 +50,7 @@ describeClient('ReferenceDataClient', provider => {
           uponReceiving: 'a request for reference data',
           withRequest: {
             method: 'GET',
-            path: `/reference-data/${key}`,
+            path: paths.referenceData({ objectType: key }),
             headers: {
               authorization: `Bearer ${callConfig.token}`,
             },

--- a/server/data/referenceDataClient.test.ts
+++ b/server/data/referenceDataClient.test.ts
@@ -5,7 +5,6 @@ import {
   DepartureReason,
   DestinationProvider,
   LocalAuthorityArea,
-  LostBedReason,
   MoveOnCategory,
   NonArrivalReason,
   ProbationDeliveryUnit,
@@ -14,6 +13,7 @@ import {
 import {
   cas3BedspaceCharacteristicsFactory,
   cas3PremisesCharacteristicsFactory,
+  cas3VoidBedspaceReasonFactory,
   referenceDataFactory,
 } from '../testutils/factories'
 import ReferenceDataClient from './referenceDataClient'
@@ -35,7 +35,6 @@ describeClient('ReferenceDataClient', provider => {
       'move-on-categories': referenceDataFactory.moveOnCategories().buildList(5) as Array<MoveOnCategory>,
       'destination-providers': referenceDataFactory.destinationProviders().buildList(5) as Array<DestinationProvider>,
       'cancellation-reasons': referenceDataFactory.cancellationReasons().buildList(5) as Array<CancellationReason>,
-      'lost-bed-reasons': referenceDataFactory.lostBedReasons().buildList(5) as Array<LostBedReason>,
       'non-arrival-reasons': referenceDataFactory.nonArrivalReason().buildList(5) as Array<NonArrivalReason>,
       'probation-regions': referenceDataFactory.probationRegion().buildList(5) as Array<ProbationRegion>,
       pdus: referenceDataFactory.pdu().buildList(5) as Array<ProbationDeliveryUnit>,
@@ -72,6 +71,7 @@ describeClient('ReferenceDataClient', provider => {
     it.each([
       ['PREMISES_CHARACTERISTICS', cas3PremisesCharacteristicsFactory.buildList(3)],
       ['BEDSPACE_CHARACTERISTICS', cas3BedspaceCharacteristicsFactory.buildList(3)],
+      ['VOID_BEDSPACE_REASONS', cas3VoidBedspaceReasonFactory.buildList(3)],
     ])('returns reference data of type %s', async (type: Cas3RefDataType, records) => {
       await provider.addInteraction({
         state: 'Reference data exists',

--- a/server/data/referenceDataClient.ts
+++ b/server/data/referenceDataClient.ts
@@ -12,7 +12,7 @@ export default class ReferenceDataClient {
   }
 
   async getReferenceData<T = ReferenceData>(objectType: string, query?: Record<string, string>) {
-    return this.restClient.get<Array<T>>({ path: `/reference-data/${objectType}`, query })
+    return this.restClient.get<Array<T>>({ path: paths.referenceData({ objectType }), query })
   }
 
   async getCas3ReferenceData(objectType: Cas3RefDataType) {

--- a/server/paths/api.ts
+++ b/server/paths/api.ts
@@ -140,4 +140,5 @@ export default {
       profile: path('/profile/v2'),
     },
   },
+  referenceData: path('/reference-data/:objectType'),
 }

--- a/server/services/lostBedService.test.ts
+++ b/server/services/lostBedService.test.ts
@@ -45,22 +45,24 @@ describe('LostBedService', () => {
   })
 
   describe('getReferenceData', () => {
-    it('should return the lost bed reasons data needed', async () => {
-      const lostBedReasons = cas3VoidBedspaceReasonFactory.buildList(2)
+    it('should return the lost bed reasons data needed ordered by name', async () => {
+      const lostBedReasons = [
+        cas3VoidBedspaceReasonFactory.build({ name: 'Reason B' }),
+        cas3VoidBedspaceReasonFactory.build({ name: 'Reason A' }),
+        cas3VoidBedspaceReasonFactory.build({ name: 'Reason C' }),
+      ]
 
-      referenceDataClient.getReferenceData.mockImplementation(category => {
-        return Promise.resolve(
-          {
-            'lost-bed-reasons': lostBedReasons,
-          }[category],
-        )
-      })
+      referenceDataClient.getCas3ReferenceData.mockResolvedValue(lostBedReasons)
 
       const result = await service.getReferenceData(callConfig)
 
-      expect(result).toEqual(lostBedReasons)
+      expect(result).toEqual([
+        { name: 'Reason A', id: expect.any(String) },
+        { name: 'Reason B', id: expect.any(String) },
+        { name: 'Reason C', id: expect.any(String) },
+      ])
       expect(ReferenceDataClientFactory).toHaveBeenCalledWith(callConfig)
-      expect(referenceDataClient.getReferenceData).toHaveBeenCalledWith('lost-bed-reasons')
+      expect(referenceDataClient.getCas3ReferenceData).toHaveBeenCalledWith('VOID_BEDSPACE_REASONS')
     })
   })
 

--- a/server/services/lostBedService.ts
+++ b/server/services/lostBedService.ts
@@ -1,7 +1,7 @@
 import type {
+  Cas3ReferenceData,
   Cas3VoidBedspace,
   Cas3VoidBedspaceCancellation,
-  Cas3VoidBedspaceReason,
   Cas3VoidBedspaceRequest,
 } from '@approved-premises/api'
 import type { LostBedClient, ReferenceDataClient, RestClientBuilder } from '../data'
@@ -80,9 +80,11 @@ export default class LostBedService {
     )) as Cas3VoidBedspaceCancellation
   }
 
-  async getReferenceData(callConfig: CallConfig): Promise<Array<Cas3VoidBedspaceReason>> {
+  async getReferenceData(callConfig: CallConfig): Promise<Array<Cas3ReferenceData>> {
     const referenceDataClient = this.referenceDataClientFactory(callConfig)
 
-    return (await referenceDataClient.getReferenceData('lost-bed-reasons')).sort((a, b) => a.name.localeCompare(b.name))
+    return (await referenceDataClient.getCas3ReferenceData('VOID_BEDSPACE_REASONS')).sort((a, b) =>
+      a.name.localeCompare(b.name),
+    )
   }
 }

--- a/server/testutils/factories/cas3VoidBedspace.ts
+++ b/server/testutils/factories/cas3VoidBedspace.ts
@@ -1,8 +1,7 @@
 import { fakerEN_GB as faker } from '@faker-js/faker'
 import { Factory } from 'fishery'
 
-import type { Cas3VoidBedspace } from '@approved-premises/api'
-import { ReferenceData } from '@approved-premises/ui'
+import type { Cas3ReferenceData, Cas3VoidBedspace, Cas3VoidBedspaceReason } from '@approved-premises/api'
 import { DateFormats } from '../../utils/dateUtils'
 import cas3VoidBedspaceReasonFactory from './cas3VoidBedspaceReason'
 
@@ -27,7 +26,7 @@ class Cas3VoidBedspaceFactory extends Factory<Cas3VoidBedspace> {
   }
 
   /* istanbul ignore next */
-  forEnvironment(reasons: ReferenceData[]) {
+  forEnvironment(reasons: Cas3ReferenceData[]) {
     return this.params({
       reason: faker.helpers.arrayElement(reasons),
     })
@@ -43,7 +42,7 @@ export default Cas3VoidBedspaceFactory.define(() => ({
   endDate: DateFormats.dateObjToIsoDate(faker.date.future()),
   id: faker.string.uuid(),
   notes: faker.lorem.sentence(),
-  reason: cas3VoidBedspaceReasonFactory.build(),
+  reason: cas3VoidBedspaceReasonFactory.build() as Cas3VoidBedspaceReason,
   referenceNumber: faker.string.uuid(),
   startDate: DateFormats.dateObjToIsoDate(faker.date.soon()),
   status: faker.helpers.arrayElement(['active', 'cancelled'] as const),

--- a/server/testutils/factories/cas3VoidBedspaceReason.ts
+++ b/server/testutils/factories/cas3VoidBedspaceReason.ts
@@ -1,6 +1,13 @@
 import { Factory } from 'fishery'
-import { Cas3VoidBedspaceReason } from '@approved-premises/api'
+import { Cas3ReferenceData } from '@approved-premises/api'
 import { faker } from '@faker-js/faker'
 import lostBedReasonsJson from '../stubs/lost-bed-reasons.json'
 
-export default Factory.define<Cas3VoidBedspaceReason>(() => faker.helpers.arrayElement(lostBedReasonsJson))
+export default Factory.define<Cas3ReferenceData>(({ params }) => {
+  if (!Object.keys(params).length) return faker.helpers.arrayElement(lostBedReasonsJson)
+
+  return {
+    id: faker.string.uuid(),
+    name: faker.word.words(3),
+  }
+})

--- a/server/testutils/factories/referenceData.ts
+++ b/server/testutils/factories/referenceData.ts
@@ -8,7 +8,6 @@ import characteristicsJson from '../stubs/characteristics.json'
 import departureReasonsJson from '../stubs/departure-reasons.json'
 import destinationProvidersJson from '../stubs/destination-providers.json'
 import localAuthoritiesJson from '../stubs/local-authorities.json'
-import lostBedReasonsJson from '../stubs/lost-bed-reasons.json'
 import moveOnCategoriesJson from '../stubs/move-on-categories.json'
 import nonArrivalReasonsJson from '../stubs/non-arrival-reasons.json'
 import pdusJson from '../stubs/pdus.json'
@@ -34,11 +33,6 @@ class ReferenceDataFactory extends Factory<ReferenceData> {
   cancellationReasons() {
     const data = faker.helpers.arrayElement(cancellationReasonsJson)
     return this.params(data)
-  }
-
-  lostBedReasons() {
-    const data = faker.helpers.arrayElement(lostBedReasonsJson)
-    return this.params(data as ReferenceData)
   }
 
   nonArrivalReason() {

--- a/server/testutils/stubs/lost-bed-reasons.json
+++ b/server/testutils/stubs/lost-bed-reasons.json
@@ -1,47 +1,38 @@
 [
   {
     "id": "607c5526-e101-4b8b-b26d-dfefb4173e1d",
-    "name": "Cooling off after incident (e.g. crime scene)",
-    "isActive": true
+    "name": "Cooling off after incident (e.g. crime scene)"
   },
   {
     "id": "6697bb59-5b2b-48c7-82b1-d73013018602",
-    "name": "Damage repairs (e.g. by person, from flooding)",
-    "isActive": true
+    "name": "Damage repairs (e.g. by person, from flooding)"
   },
   {
     "id": "ee5b1638-d578-4fc6-b83f-1c9b94b5bffd",
-    "name": "Death – personal property collection",
-    "isActive": true
+    "name": "Death – personal property collection"
   },
   {
     "id": "040dce03-24f8-4fc4-8536-c1a311a307b3",
-    "name": "Deep clean",
-    "isActive": true
+    "name": "Deep clean"
   },
   {
     "id": "ae8cfadf-b556-4119-a471-baa87d316ef9",
-    "name": "Maintenance repairs (e.g. damp, infestation)",
-    "isActive": true
+    "name": "Maintenance repairs (e.g. damp, infestation)"
   },
   {
     "id": "1cfd451c-afde-4dba-a157-c1cf3289299f",
-    "name": "Needle sweep",
-    "isActive": true
+    "name": "Needle sweep"
   },
   {
     "id": "f47ac10b-58cc-4372-a567-0e02b2c3d480",
-    "name": "Occupancy reduced (e.g. from 2 bed to single)",
-    "isActive": true
+    "name": "Occupancy reduced (e.g. from 2 bed to single)"
   },
   {
     "id": "6ba7b818-9dad-11d1-80b4-00c04fd430c8",
-    "name": "Pending handback of property",
-    "isActive": true
+    "name": "Pending handback of property"
   },
   {
     "id": "479e8765-a978-4343-9eba-34f5e055bd30",
-    "name": "Replacing furniture or stolen goods",
-    "isActive": true
+    "name": "Replacing furniture or stolen goods"
   }
 ]

--- a/server/testutils/stubs/referenceDataStubs.ts
+++ b/server/testutils/stubs/referenceDataStubs.ts
@@ -71,7 +71,10 @@ const cancellationReasons = {
 const lostBedReasons = {
   request: {
     method: 'GET',
-    url: paths.referenceData({ objectType: 'lost-bed-reasons' }),
+    urlPath: paths.cas3.referenceData({}),
+    queryParameters: {
+      type: { equalTo: 'VOID_BEDSPACE_REASONS' },
+    },
   },
   response: {
     status: 200,

--- a/server/testutils/stubs/referenceDataStubs.ts
+++ b/server/testutils/stubs/referenceDataStubs.ts
@@ -15,7 +15,7 @@ import paths from '../../paths/api'
 const departureReasons = {
   request: {
     method: 'GET',
-    url: '/reference-data/departure-reasons',
+    url: paths.referenceData({ objectType: 'departure-reasons' }),
   },
   response: {
     status: 200,
@@ -29,7 +29,7 @@ const departureReasons = {
 const moveOnCategories = {
   request: {
     method: 'GET',
-    url: '/reference-data/move-on-categories',
+    url: paths.referenceData({ objectType: 'move-on-categories' }),
   },
   response: {
     status: 200,
@@ -43,7 +43,7 @@ const moveOnCategories = {
 const destinationProviders = {
   request: {
     method: 'GET',
-    url: '/reference-data/destination-providers',
+    url: paths.referenceData({ objectType: 'destination-providers' }),
   },
   response: {
     status: 200,
@@ -57,7 +57,7 @@ const destinationProviders = {
 const cancellationReasons = {
   request: {
     method: 'GET',
-    url: '/reference-data/cancellation-reasons',
+    url: paths.referenceData({ objectType: 'cancellation-reasons' }),
   },
   response: {
     status: 200,
@@ -71,7 +71,7 @@ const cancellationReasons = {
 const lostBedReasons = {
   request: {
     method: 'GET',
-    url: '/reference-data/lost-bed-reasons',
+    url: paths.referenceData({ objectType: 'lost-bed-reasons' }),
   },
   response: {
     status: 200,
@@ -85,7 +85,7 @@ const lostBedReasons = {
 const keyWorkers = {
   request: {
     method: 'GET',
-    url: '/reference-data/key-workers',
+    url: paths.referenceData({ objectType: 'key-workers' }),
   },
   response: {
     status: 200,
@@ -133,7 +133,7 @@ const bedspaceCharacteristics = {
 const localAuthorities = {
   request: {
     method: 'GET',
-    url: '/reference-data/local-authority-areas',
+    url: paths.referenceData({ objectType: 'local-authority-areas' }),
   },
   response: {
     status: 200,
@@ -147,7 +147,7 @@ const localAuthorities = {
 const probationRegions = {
   request: {
     method: 'GET',
-    url: '/reference-data/probation-regions',
+    url: paths.referenceData({ objectType: 'probation-regions' }),
   },
   response: {
     status: 200,
@@ -161,7 +161,7 @@ const probationRegions = {
 const pdus = {
   request: {
     method: 'GET',
-    urlPath: '/reference-data/probation-delivery-units',
+    urlPath: paths.referenceData({ objectType: 'probation-delivery-units' }),
   },
   response: {
     status: 200,
@@ -175,7 +175,7 @@ const pdus = {
 const referralRejectionReasons = {
   request: {
     method: 'GET',
-    urlPath: '/reference-data/referral-rejection-reasons',
+    urlPath: paths.referenceData({ objectType: 'referral-rejection-reasons' }),
   },
   response: {
     status: 200,


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/SAS-220

# Changes in this PR

This PR changes the endpoint used to fetch the Void Bedspace reasons reference data from `/reference-data/lost-bed-reasons` to `/cas3/reference-data?type=VOID_BEDSPACE_REASONS`.

In addition, this creates a new definition for the existing `/reference-data` endpoint, and updates hardcoded references, to make usages more discoverable.

A test has been updated to assert that the reasons are returned in the correct order.

## Screenshots of UI changes

No UI changes.
