### PR TITLE
Show no overstay if there is a more recent extension

### DIFF
--- a/server/utils/bookingUtils.test.ts
+++ b/server/utils/bookingUtils.test.ts
@@ -652,6 +652,41 @@ describe('bookingUtils', () => {
       expect(summary).toEqual('No')
     })
 
+    it('returns "No" when there is a more recent extension', () => {
+      const booking = cas3BookingFactory.build({
+        overstays: [cas3OverstayFactory.build({ createdAt: '2026-01-01' })],
+        extensions: [
+          cas3ExtensionFactory.build({ createdAt: '2025-12-10' }),
+          cas3ExtensionFactory.build({ createdAt: '2026-01-02' }),
+          cas3ExtensionFactory.build({ createdAt: '2025-12-20' }),
+        ],
+      })
+
+      const summary = getOverstaySummary(booking)
+
+      expect(summary).toEqual('No')
+    })
+
+    it('returns an overstay summary when there are not more recent extensions', () => {
+      const arrivalDate = DateFormats.dateObjtoUIDate(faker.date.recent({ days: 60 }))
+      const newDepartureDate = DateFormats.dateObjToIsoDate(addDays(arrivalDate, 90))
+
+      const booking = cas3BookingFactory.build({
+        arrivalDate,
+        overstays: [
+          cas3OverstayFactory.build({ newDepartureDate, createdAt: '2026-01-01', isAuthorised: true, reason: '' }),
+        ],
+        extensions: [
+          cas3ExtensionFactory.build({ createdAt: '2025-12-10' }),
+          cas3ExtensionFactory.build({ createdAt: '2025-12-20' }),
+        ],
+      })
+
+      const summary = getOverstaySummary(booking)
+
+      expect(summary).toEqual('6 days, Authorised')
+    })
+
     it('returns an authorised overstay summary without a reason', () => {
       const arrivalDate = DateFormats.dateObjtoUIDate(faker.date.recent({ days: 60 }))
       const newDepartureDate = DateFormats.dateObjToIsoDate(addDays(arrivalDate, 85))
@@ -659,6 +694,7 @@ describe('bookingUtils', () => {
       const booking = cas3BookingFactory.build({
         arrivalDate,
         overstays: [cas3OverstayFactory.build({ newDepartureDate, isAuthorised: true, reason: '' })],
+        extensions: [],
       })
 
       const summary = getOverstaySummary(booking)
@@ -673,6 +709,7 @@ describe('bookingUtils', () => {
       const booking = cas3BookingFactory.build({
         arrivalDate,
         overstays: [cas3OverstayFactory.build({ newDepartureDate, isAuthorised: false, reason: '' })],
+        extensions: [],
       })
 
       const summary = getOverstaySummary(booking)
@@ -686,6 +723,7 @@ describe('bookingUtils', () => {
       const booking = cas3BookingFactory.build({
         arrivalDate,
         overstays: [cas3OverstayFactory.build({ newDepartureDate, isAuthorised: true, reason: 'They asked nicely' })],
+        extensions: [],
       })
 
       const summary = getOverstaySummary(booking)
@@ -711,6 +749,7 @@ describe('bookingUtils', () => {
           }),
           cas3OverstayFactory.build({ createdAt: DateFormats.dateObjToIsoDateTime(addDays(new Date(), -20)) }),
         ],
+        extensions: [],
       })
 
       const summary = getOverstaySummary(booking)


### PR DESCRIPTION
# Context

Show no overstay if the booking departure date has been readjusted back to within 84 days

# Changes in this PR

## Screenshots of UI changes

### After
<img width="3426" height="2866" alt="image" src="https://github.com/user-attachments/assets/b94c6cba-7abb-4420-af5e-cad390c80f55" />
<img width="3426" height="3640" alt="image" src="https://github.com/user-attachments/assets/3feb3432-b9b9-4a2d-b33a-e9dc861bb0b7" />
<img width="3426" height="3160" alt="image" src="https://github.com/user-attachments/assets/98854aff-8536-4ff9-bf15-4d80e33b7f7a" />