### PR TITLE
Fix delete referral error handling

### DIFF
--- a/cypress_shared/pages/assess/list.ts
+++ b/cypress_shared/pages/assess/list.ts
@@ -31,7 +31,11 @@ export default class ListPage extends Page {
 
   clickAssessment(assessment: Assessment) {
     if (isFullPerson(assessment.application.person)) {
-      cy.get('a').contains(assessment.application.person.name).click()
+      cy.get('td')
+        .contains(DateFormats.isoDateToUIDate(assessment.accommodationRequiredFromDate))
+        .parent('tr')
+        .contains(assessment.application.person.name)
+        .click()
     } else {
       cy.get(`a[href*="${paths.assessments.summary({ id: assessment.id })}"]`).click()
     }

--- a/e2e/tests/stepDefinitions/place.ts
+++ b/e2e/tests/stepDefinitions/place.ts
@@ -1,7 +1,7 @@
 import { Given, Then, When } from '@badeball/cypress-cucumber-preprocessor'
 
 import type {
-  TemporaryAccommodationAssessment as Assessment,
+  Cas3Assessment as Assessment,
   TemporaryAccommodationAssessmentStatus as AssessmentStatus,
 } from '@approved-premises/api'
 import PlaceHelper from '../../../cypress_shared/helpers/place'

--- a/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/assess/assess.cy.ts
@@ -242,6 +242,7 @@ context('Apply', () => {
             status: 'unallocated',
             person: assessment.application.person,
             id: assessment.id,
+            arrivalDate: assessment.accommodationRequiredFromDate,
           })
 
           const timeline = timelineEventsFactory.build()
@@ -430,6 +431,7 @@ context('Apply', () => {
             status: 'unallocated',
             person: assessment.application.person,
             id: assessment.id,
+            arrivalDate: assessment.accommodationRequiredFromDate,
           })
 
           cy.task('stubAssessments', { data: assessmentSummary })

--- a/server/controllers/apply/applications/deleteController.test.ts
+++ b/server/controllers/apply/applications/deleteController.test.ts
@@ -84,7 +84,7 @@ describe('DeleteController', () => {
         request,
         response,
         expect.any(Error),
-        paths.applications.index({ id: 'some-id' }),
+        paths.applications.show({ id: 'some-id' }),
         'application',
       )
     })

--- a/server/controllers/apply/applications/deleteController.ts
+++ b/server/controllers/apply/applications/deleteController.ts
@@ -37,11 +37,11 @@ export default class DeleteController {
       if (confirmDelete === 'yes') {
         try {
           await this.applicationService.deleteApplication(callConfig, id)
-          req.flash('success', `You have deleted the referral`)
+          req.flash('success', 'You have deleted the referral')
           return res.redirect(paths.applications.index({}))
         } catch (err) {
           insertGenericError(err, 'delete', 'invalid')
-          catchValidationErrorOrPropogate(req, res, err, paths.applications.index({ id }), 'application')
+          return catchValidationErrorOrPropogate(req, res, err, paths.applications.show({ id }), 'application')
         }
       }
 

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -329,6 +329,9 @@
     },
     "confirmation": {
       "invalid": "You must confirm the information provided is complete, accurate and up to date"
+    },
+    "delete": {
+      "invalid": "Unable to delete referral"
     }
   },
   "assessmentUpdate": {


### PR DESCRIPTION
# Context

Ticket: https://dsdmoj.atlassian.net/browse/CAS-2137

Added error localisation for referral deletion, and changed to redirect back to the referral on error rather than the list of referrals.

Also (hopefully) fixed a flaky E2E test where sometimes the wrong referral would be clicked if there were multiple referrals for one person with different dates.

# Changes in this PR

## Screenshots of UI changes

### After
<img width="3426" height="2000" alt="image" src="https://github.com/user-attachments/assets/aa027ed6-d5e8-466c-866d-c3438b079d57" />
