### PR TITLE
CAS-2179: planned maintenance banner

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -27,6 +27,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
+    PLANNED_MAINTENANCE_BANNER: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,6 +24,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
+    PLANNED_MAINTENANCE_BANNER: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,6 +24,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: false
+    PLANNED_MAINTENANCE_BANNER: true
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -26,6 +26,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
+    PLANNED_MAINTENANCE_BANNER: true
 
   allowlist: null
 

--- a/server/config.ts
+++ b/server/config.ts
@@ -54,6 +54,7 @@ export default {
     cancelScheduledArchiveEnabled: get('CANCEL_SCHEDULED_ARCHIVE_ENABLED', 'false') === 'true',
     showGapReportButton: get('SHOW_GAP_REPORT_BUTTON', 'false') === 'true',
     bookingOverstayEnabled: get('BOOKING_OVERSTAY_ENABLED', 'false') === 'true',
+    plannedMaintenance: get('PLANNED_MAINTENANCE_BANNER', 'false') === 'true',
   },
   environment,
   sentry: {

--- a/server/utils/nunjucksSetup.ts
+++ b/server/utils/nunjucksSetup.ts
@@ -170,6 +170,7 @@ export default function nunjucksSetup(app: express.Express, path: pathModule.Pla
   })
 
   njkEnv.addGlobal('oasysDisabled', config.flags.oasysDisabled)
+  njkEnv.addGlobal('plannedMaintenance', config.flags.plannedMaintenance)
 
   njkEnv.addFilter('mapApiPersonRisksForUi', mapApiPersonRisksForUi)
 

--- a/server/views/applications/index.njk
+++ b/server/views/applications/index.njk
@@ -11,6 +11,8 @@
 
 {% block content %}
 
+{% include 'partials/plannedMaintenanceBanner.njk' %}
+
 {% include "../_messages.njk" %}
 
   <div class="govuk-grid-row">

--- a/server/views/applications/show.njk
+++ b/server/views/applications/show.njk
@@ -19,6 +19,8 @@
 
 {% block content %}
 
+    {% include 'partials/plannedMaintenanceBanner.njk' %}
+
     {{ showErrorSummary(errorSummary) }}
     
     <h1 class="govuk-heading-xl">

--- a/server/views/applications/start.njk
+++ b/server/views/applications/start.njk
@@ -19,6 +19,8 @@
   <div class="govuk-grid-row">
     <div class="govuk-grid-column-two-thirds">
 
+      {% include 'partials/plannedMaintenanceBanner.njk' %}
+
       <form action="{{ paths.applications.new() }}" method="get">
         <input type="hidden" name="_csrf" value="{{ csrfToken }}"/>
         <h1 class="govuk-heading-l">Make a referral for CAS3</h1>

--- a/server/views/partials/plannedMaintenanceBanner.njk
+++ b/server/views/partials/plannedMaintenanceBanner.njk
@@ -1,10 +1,12 @@
 {% from "govuk/components/notification-banner/macro.njk" import govukNotificationBanner %}
 
-{% set html %}
-    <h3 class="govuk-notification-banner__heading">Planned maintenance</h3>
-    <p class="govuk-body">CAS3 will be unavailable on Monday 15 December 2025 from 7am to 8am.</p>
-{% endset %}
+{% if plannedMaintenance %}
+    {% set html %}
+        <h3 class="govuk-notification-banner__heading">Planned maintenance</h3>
+        <p class="govuk-body">CAS3 will be unavailable on Sunday 8 February 2026 from 10am to 2pm.</p>
+    {% endset %}
 
-{{ govukNotificationBanner({
-    html: html
-}) }}
+    {{ govukNotificationBanner({
+        html: html
+    }) }}
+{% endif %}

--- a/server/views/temporary-accommodation/dashboard/index.njk
+++ b/server/views/temporary-accommodation/dashboard/index.njk
@@ -6,6 +6,8 @@
 
 {% block content %}
 
+  {% include 'partials/plannedMaintenanceBanner.njk' %}
+
   {% include "../../_messages.njk" %}
 
   <h1 class="govuk-heading-l">Manage estate</h1>

--- a/server/views/temporary-accommodation/reports/index.njk
+++ b/server/views/temporary-accommodation/reports/index.njk
@@ -23,6 +23,8 @@
     <div class="govuk-grid-row">
         <div class="govuk-grid-column-two-thirds">
 
+            {% include 'partials/plannedMaintenanceBanner.njk' %}
+
             {% include "../../_messages.njk" %}
             {% set context = fetchContext() %}
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/CAS-2179

# Changes in this PR

This PR introduces a new environment variable, `PLANNED_MAINTENANCE_BANNER`. When set to `true`, this displays the Planned Maintenance Banner on selected pages of the service.

Note: due to the rarity of needing to show such a banner, we opt for hardcoded content to ensure consistency between environments.

## Screenshots of UI changes

<img width="1205" height="497" alt="Screenshot 2026-01-28 at 16 16 11" src="https://github.com/user-attachments/assets/25c3791b-8b8d-4cdc-9a9e-df70a3e74dc4" />

