### PR TITLE
Booking overstay departures

### DIFF
--- a/cypress_shared/pages/temporary-accommodation/manage/bookingOverstayNew.ts
+++ b/cypress_shared/pages/temporary-accommodation/manage/bookingOverstayNew.ts
@@ -22,11 +22,14 @@ export default class BookingOverstayNewPage extends Page {
     bedspace: Cas3Bedspace,
     booking: Cas3Booking,
     overstay: Cas3Overstay | NewOverstay,
+    private departed: boolean,
   ) {
     const overstayDays = nightsBetween(booking.arrivalDate, overstay.newDepartureDate) - 84
-    super(
-      `The new departure date means the booking is ${overstayDays} ${overstayDays === 1 ? 'night' : 'nights'} over the limit`,
-    )
+    const nights = `${overstayDays} ${overstayDays === 1 ? 'night' : 'nights'}`
+    const title = departed
+      ? `The departure date means the booking was overstayed by ${nights}`
+      : `The new departure date means the booking is ${nights} over the limit`
+    super(title)
 
     this.bedspaceConflictErrorComponent = new BedspaceConflictErrorComponent(premises, bedspace, 'booking')
     this.popDetailsHeaderComponent = new PopDetailsHeaderComponent(booking.person)
@@ -39,9 +42,10 @@ export default class BookingOverstayNewPage extends Page {
     bedspace: Cas3Bedspace,
     booking: Cas3Booking,
     overstay: NewOverstay | Cas3Overstay,
+    departed: boolean,
   ): BookingOverstayNewPage {
     cy.visit(paths.bookings.overstays.new({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }))
-    return new BookingOverstayNewPage(premises, bedspace, booking, overstay)
+    return new BookingOverstayNewPage(premises, bedspace, booking, overstay, departed)
   }
 
   shouldShowBookingDetails(): void {
@@ -53,7 +57,7 @@ export default class BookingOverstayNewPage extends Page {
   completeForm(newOverstay: NewOverstay): void {
     this.clearForm()
 
-    this.getLegend('Is this an authorised overstay?')
+    this.getLegend(this.departed ? 'Was this an authorised overstay' : 'Is this an authorised overstay?')
     this.checkRadioByNameAndValue('isAuthorised', newOverstay.isAuthorised ? 'yes' : 'no')
 
     if ('reason' in newOverstay) {

--- a/integration_tests/tests/temporary-accommodation/manage/overstay.cy.ts
+++ b/integration_tests/tests/temporary-accommodation/manage/overstay.cy.ts
@@ -7,37 +7,20 @@ import { setupBookingStateStubs } from '../../../../cypress_shared/utils/booking
 import { setupTestUser } from '../../../../cypress_shared/utils/setupTestUser'
 import {
   cas3BookingFactory,
+  cas3DepartureFactory,
+  cas3NewDepartureFactory,
   cas3NewOverstayFactory,
   cas3OverstayFactory,
   newExtensionFactory,
 } from '../../../../server/testutils/factories'
 import { DateFormats } from '../../../../server/utils/dateUtils'
 import Cas3NewOverstay from '../../../../server/testutils/factories/cas3NewOverstay'
+import BookingDepartureNewPage from '../../../../cypress_shared/pages/temporary-accommodation/manage/bookingDepartureNew'
 
 context('Booking overstay', () => {
   beforeEach(() => {
     cy.task('reset')
     setupTestUser('assessor')
-  })
-
-  it('navigates to the overstay page via the booking extension page', () => {
-    cy.signIn()
-
-    const booking = cas3BookingFactory.arrived().build()
-    const { premises, bedspace } = setupBookingStateStubs(booking)
-
-    const bookingShow = BookingShowPage.visit(premises, bedspace, booking)
-    bookingShow.clickExtendBookingButton()
-
-    const extensionPage = Page.verifyOnPage(BookingExtensionNewPage, premises, bedspace, booking)
-
-    const tooLateDepartureDate = DateFormats.dateObjToIsoDate(addDays(booking.departureDate, 85))
-
-    const extension = newExtensionFactory.build({ newDepartureDate: tooLateDepartureDate })
-    extensionPage.completeForm(extension)
-
-    const newOverstay = Cas3NewOverstay.build({ newDepartureDate: tooLateDepartureDate })
-    Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay)
   })
 
   it('allows me to record an overstay', () => {
@@ -56,7 +39,7 @@ context('Booking overstay', () => {
     extensionPage.completeForm(extension)
 
     const overstay = cas3OverstayFactory.build({ newDepartureDate: tooLateDepartureDate })
-    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, overstay)
+    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, overstay, false)
 
     const newOverstay = cas3NewOverstayFactory.build({ ...overstay })
     cy.task('stubOverstayCreate', { premisesId: premises.id, bookingId: booking.id, overstay: newOverstay })
@@ -82,6 +65,62 @@ context('Booking overstay', () => {
     bookingShowPage.shouldShowOverstay(newOverstay)
   })
 
+  it('allows me to record an overstay for a departure', () => {
+    cy.signIn()
+
+    const eightySixDaysAgo = addDays(new Date(), -86)
+    const yesterday = addDays(new Date(), -1)
+
+    const booking = cas3BookingFactory.arrived().build({ arrivalDate: DateFormats.dateObjToIsoDate(eightySixDaysAgo) })
+    const { premises, bedspace } = setupBookingStateStubs(booking)
+
+    const bookingShow = BookingShowPage.visit(premises, bedspace, booking)
+    cy.task('stubDepartureReferenceData')
+    bookingShow.clickMarkDepartedBookingButton()
+
+    const departure = cas3DepartureFactory.build({ dateTime: DateFormats.dateObjToIsoDateTime(yesterday) })
+    const newDeparture = cas3NewDepartureFactory.build({
+      ...departure,
+      reasonId: departure.reason.id,
+      moveOnCategoryId: departure.moveOnCategory.id,
+    })
+
+    const departurePage = Page.verifyOnPage(BookingDepartureNewPage, premises, bedspace, booking)
+    departurePage.completeForm(newDeparture)
+
+    const overstay = cas3OverstayFactory.build({ newDepartureDate: DateFormats.dateObjToIsoDate(yesterday) })
+    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, overstay, true)
+
+    const newOverstay = Cas3NewOverstay.build({ ...overstay })
+    cy.task('stubOverstayCreate', { premisesId: premises.id, bookingId: booking.id, overstay: newOverstay })
+    cy.task('stubDepartureCreate', { premisesId: premises.id, bookingId: booking.id, departure })
+
+    overstayPage.completeForm(newOverstay)
+
+    cy.task('verifyOverstayCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+
+      const normaliseNewlines = (value?: string) => (value || '').replace(/\r\n/g, '\n')
+
+      expect(requestBody.newDepartureDate).equal(newOverstay.newDepartureDate)
+      expect(requestBody.isAuthorised).equal(newOverstay.isAuthorised)
+      expect(normaliseNewlines(requestBody.reason)).equal(normaliseNewlines(newOverstay.reason))
+    })
+
+    cy.task('verifyDepartureCreate', { premisesId: premises.id, bookingId: booking.id }).then(requests => {
+      expect(requests).to.have.length(1)
+      const requestBody = JSON.parse(requests[0].body)
+      expect(requestBody.dateTime).equal(newDeparture.dateTime)
+      expect(requestBody.reasonId).equal(newDeparture.reasonId)
+      expect(requestBody.moveOnCategoryId).equal(newDeparture.moveOnCategoryId)
+      expect(requestBody.notes).equal(newDeparture.notes)
+    })
+
+    const bookingShowPage = Page.verifyOnPage(BookingShowPage, premises, bedspace, booking)
+    bookingShowPage.shouldShowBanner('Booking marked as departed')
+  })
+
   it('redirects to the extension page when the server returns an error', () => {
     cy.signIn()
 
@@ -98,7 +137,7 @@ context('Booking overstay', () => {
     extensionPage.completeForm(extension)
 
     const newOverstay = cas3NewOverstayFactory.build({ newDepartureDate: tooLateDepartureDate })
-    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay)
+    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay, false)
 
     const conflictingBooking = cas3BookingFactory.confirmed().build()
     cy.task('stubBooking', { premisesId: premises.id, booking: conflictingBooking })
@@ -129,12 +168,12 @@ context('Booking overstay', () => {
     extensionPage.completeForm(extension)
 
     const newOverstay = cas3NewOverstayFactory.build({ newDepartureDate: tooLateDepartureDate })
-    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay)
+    const overstayPage = Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay, false)
 
     overstayPage.enterReason(newOverstay.reason)
     overstayPage.clickSubmit()
 
-    Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay)
+    Page.verifyOnPage(BookingOverstayNewPage, premises, bedspace, booking, newOverstay, false)
     overstayPage.shouldShowIsAuthorisedErrorMessage()
   })
 })

--- a/server/@types/express/index.d.ts
+++ b/server/@types/express/index.d.ts
@@ -1,4 +1,8 @@
-import type { TemporaryAccommodationApplication as Application, ProbationRegion } from '@approved-premises/api'
+import type {
+  TemporaryAccommodationApplication as Application,
+  Cas3NewDeparture,
+  ProbationRegion,
+} from '@approved-premises/api'
 import type { ErrorMessages, PlaceContext } from '@approved-premises/ui'
 import { UserDetails } from '../../services/userService'
 
@@ -14,6 +18,7 @@ declare module 'express-session' {
     probationRegion: ProbationRegion
     userDetails: UserDetails
     premisesSortBy: PremisesSortBy
+    departure: Cas3NewDeparture
   }
 }
 

--- a/server/controllers/temporary-accommodation/manage/extensionsController.ts
+++ b/server/controllers/temporary-accommodation/manage/extensionsController.ts
@@ -58,9 +58,9 @@ export default class ExtensionsController {
         ...DateFormats.dateAndTimeInputsToIsoString(req.body, 'newDepartureDate'),
       }
 
-      const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
-
       if (config.flags.bookingOverstayEnabled && newExtension.newDepartureDate) {
+        const booking = await this.bookingsService.getBooking(callConfig, premisesId, bookingId)
+
         const lengthOfStay = nightsBetween(booking.arrivalDate, newExtension.newDepartureDate)
 
         if (lengthOfStay >= 84) {
@@ -70,6 +70,7 @@ export default class ExtensionsController {
               newDepartureDate: newExtension.newDepartureDate,
             },
           })
+          req.session.departure = undefined
           res.redirect(address)
           return
         }

--- a/server/controllers/temporary-accommodation/manage/index.ts
+++ b/server/controllers/temporary-accommodation/manage/index.ts
@@ -68,6 +68,7 @@ export const controllers = (services: Services) => {
     services.bedspaceService,
     services.bookingService,
     services.overstaysService,
+    services.departureService,
   )
   const cancellationsController = new CancellationsController(
     services.premisesService,

--- a/server/views/temporary-accommodation/overstays/new.njk
+++ b/server/views/temporary-accommodation/overstays/new.njk
@@ -38,7 +38,7 @@
                 name: "isAuthorised",
                 fieldset: {
                     legend: {
-                        text: "Is this an authorised overstay?",
+                        text: question,
                         isPageHeading: false,
                         classes: "govuk-fieldset__legend--m"
                     }


### PR DESCRIPTION
# Context

This adds to the overstay functionality by allowing users to mark a booking as both overstayed and departed at the same time.

Based on https://dsdmoj.atlassian.net/jira/software/c/projects/CAS/boards/11445?selectedIssue=CAS-2140

This adds the `Mark booking as departed` route from the overstayers Miro board

# Changes in this PR

## Screenshots of UI changes

### Before
<img width="3426" height="2822" alt="image" src="https://github.com/user-attachments/assets/ab326651-9240-405d-bee7-1d14f5efd83f" />
