### PR TITLE
SAS-247: Remove planned maintenance banner

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -27,7 +27,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
-    PLANNED_MAINTENANCE_BANNER: true
+    PLANNED_MAINTENANCE_BANNER: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -24,7 +24,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
-    PLANNED_MAINTENANCE_BANNER: true
+    PLANNED_MAINTENANCE_BANNER: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-prod.yaml
+++ b/helm_deploy/values-prod.yaml
@@ -24,7 +24,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: false
-    PLANNED_MAINTENANCE_BANNER: true
+    PLANNED_MAINTENANCE_BANNER: false
 
   namespace_secrets:
     sqs-hmpps-audit-secret:

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -26,7 +26,7 @@ generic-service:
     SHOW_GAP_REPORT_BUTTON: true
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
-    PLANNED_MAINTENANCE_BANNER: true
+    PLANNED_MAINTENANCE_BANNER: false
 
   allowlist: null
 


### PR DESCRIPTION
# Context

https://dsdmoj.atlassian.net/browse/SAS-247

# Changes in this PR

This PR removes the Planned Maintenance banner by updating the environment.

_**Note: this PR should only be merged when the CAS2 migration has been started, to avoid removing the banner prematurely**_
