### PR TITLE
Added support for overstay when editing departures

### DIFF
--- a/server/controllers/temporary-accommodation/manage/overstaysController.test.ts
+++ b/server/controllers/temporary-accommodation/manage/overstaysController.test.ts
@@ -280,7 +280,14 @@ describe('OverstaysController', () => {
       })
       const overstay = cas3OverstayFactory.build({ ...newOverstay })
 
+      const newDeparturesPage = paths.bookings.departures.new({
+        premisesId: premises.id,
+        bedspaceId: bedspace.id,
+        bookingId: booking.id,
+      })
+
       request.session.departure = newDeparture
+      request.session.previousPage = newDeparturesPage
 
       request.body = {
         newDepartureDate: newOverstay.newDepartureDate,
@@ -298,12 +305,7 @@ describe('OverstaysController', () => {
 
       await requestHandler(request, response, next)
 
-      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(
-        request,
-        response,
-        err,
-        paths.bookings.departures.new({ premisesId: premises.id, bedspaceId: bedspace.id, bookingId: booking.id }),
-      )
+      expect(catchValidationErrorOrPropogate).toHaveBeenCalledWith(request, response, err, newDeparturesPage)
     })
 
     it('shows an error when the user tries to submit without selecting whether the overstay is authorised', async () => {

--- a/server/controllers/temporary-accommodation/manage/overstaysController.ts
+++ b/server/controllers/temporary-accommodation/manage/overstaysController.ts
@@ -110,10 +110,11 @@ export default class OverstaysController {
 
         if (departure !== undefined) {
           // redirectUrl is used in the catch block, ignore any IDE warnings about it being unused
-          redirectUrl = paths.bookings.departures.new({ premisesId, bedspaceId, bookingId })
+          redirectUrl = req.session.previousPage
           successMessage = 'Booking marked as departed'
           await this.departureService.createDeparture(callConfig, premisesId, bookingId, departure)
           req.session.departure = undefined
+          req.session.previousPage = undefined
         }
 
         req.flash('success', successMessage)

--- a/server/i18n/en/errors.json
+++ b/server/i18n/en/errors.json
@@ -60,6 +60,7 @@
     "dateTime": {
       "empty": "You must enter a departure date and time",
       "invalid": "The departure date and time is an invalid date and time",
+      "invalidDate": "The departure date is an invalid date",
       "beforeBookingArrivalDate": "The departure date and time must be after the booking's arrival date",
       "departureDateInFuture": "Departure date cannot be in the future"
     },

--- a/server/views/temporary-accommodation/departures/_editable.njk
+++ b/server/views/temporary-accommodation/departures/_editable.njk
@@ -13,6 +13,9 @@
         }
     },
         fieldName: "dateTime",
+        hint: {
+            text: 'For example, 27 3 2025'
+        },
         items: dateFieldValues('dateTime', errors)
     },
     fetchContext()


### PR DESCRIPTION
# Context

Still related to [CAS-2140](https://dsdmoj.atlassian.net/browse/CAS-2140), adding the overstay flow when editing/updating a departure over 84 nights.

Thankfully updating a departure just POSTs a new departure over the top of the old one, so I was able to re-use a lot of the work from adding overstays to new departures with a minor refactor.

I've also refactored some of the error handling in the `overstaysController` based on some of Fred's feedback from my last PR
