### PR TITLE
Update person's religion in e2e fixture

### DIFF
--- a/cypress_shared/fixtures/person-dev.json
+++ b/cypress_shared/fixtures/person-dev.json
@@ -5,7 +5,7 @@
   "nomsNumber": "A7779DY",
   "status": "InCustody",
   "prisonName": "Moorland (HMP & YOI)",
-  "religionOrBelief": "Apostolic",
+  "religionOrBelief": "Christian - Other",
   "nationality": "British",
   "ethnicity": "White: British/English/Welsh/Scottish/Northern Irish",
   "sex": "Male",


### PR DESCRIPTION
The person's nDelius record has been updated on dev. This PR updates the E2E fixture to reflect this change.

<img width="1179" height="141" alt="Screenshot 2026-02-18 at 10 17 39" src="https://github.com/user-attachments/assets/485eeb22-e41d-4510-b3bd-de478f0e060f" />
