### PR TITLE
Use major version for checkout action

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,7 +109,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out code
-        uses: actions/checkout@v6.0.1
+        uses: actions/checkout@v6
 
       - name: Setup Node.js environment
         uses: actions/setup-node@v6


### PR DESCRIPTION
This aligns this workflow to the other ones and will remove any Renovate PRs for patch/minor versions (like this one: #1561)
