### PR TITLE
Pin HMPPS Helm charts to major versions

### DIFF
--- a/helm_deploy/hmpps-temporary-accommodation-ui/Chart.yaml
+++ b/helm_deploy/hmpps-temporary-accommodation-ui/Chart.yaml
@@ -5,8 +5,8 @@ name: hmpps-temporary-accommodation-ui
 version: 0.2.0
 dependencies:
   - name: generic-service
-    version: 3.3
+    version: "3"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts
   - name: generic-prometheus-alerts
-    version: 1.7
+    version: "1"
     repository: https://ministryofjustice.github.io/hmpps-helm-charts


### PR DESCRIPTION
This updates the main HMPPS helm chart dependencies to use major versions. More info: https://mojdt.slack.com/archives/C06MWP0UKDE/p1766074257629119?thread_ts=1766070443.185369&cid=C06MWP0UKDE