### PR TITLE
Remove PSS release type on 30th April

### DIFF
--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.test.ts
@@ -286,15 +286,7 @@ describe('ReleaseType', () => {
         },
       ]
 
-      // only add pss before 30th April 2026
-      if (new Date() < DateFormats.isoToDateObj('2026-04-30')) {
-        expectedReleaseTypeOptions.push({
-          name: 'Post Sentence Supervision (PSS)',
-          value: 'pss',
-        })
-      }
-
-      expect(page.currentReleaseTypeOptions()).toEqual(expectedReleaseTypeOptions)
+      expect(page.currentReleaseTypeOptions()).toEqual(expect.objectContaining(expectedReleaseTypeOptions))
     })
 
     it('includes an excluded option if it is present in the current body', () => {
@@ -307,6 +299,38 @@ describe('ReleaseType', () => {
       )
 
       delete releaseTypes.ecsl
+    })
+
+    // TODO: remove tests after 30th April 2026
+    describe('PSS', () => {
+      let page: ReleaseType
+
+      const pss = {
+        name: 'Post Sentence Supervision (PSS)',
+        value: 'pss',
+      }
+
+      beforeEach(() => {
+        jest.useFakeTimers()
+        page = new ReleaseType(body, application)
+      })
+
+      afterEach(jest.useRealTimers)
+
+      it('should allow the user to select PSS before 30th April', () => {
+        jest.setSystemTime(DateFormats.isoToDateObj('2026-04-29'))
+        expect(page.currentReleaseTypeOptions()).toContainEqual(pss)
+      })
+
+      it('should not allow the user to select PSS on 30th April', () => {
+        jest.setSystemTime(DateFormats.isoToDateObj('2026-04-30'))
+        expect(page.currentReleaseTypeOptions()).not.toContainEqual(pss)
+      })
+
+      it('should not allow the user to select PSS after 30th April', () => {
+        jest.setSystemTime(DateFormats.isoToDateObj('2026-05-01'))
+        expect(page.currentReleaseTypeOptions()).not.toContainEqual(pss)
+      })
     })
   })
 

--- a/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
+++ b/server/form-pages/apply/accommodation-need/sentence-information/releaseType.ts
@@ -12,17 +12,14 @@ import { joinStrings } from '../../../../utils/utils'
 function getOptionsToExclude(): Array<string> {
   const options = ['ecsl']
 
-  const today = new Date()
-  const disablePss = DateFormats.isoToDateObj('2026-04-30')
-
-  if (today >= disablePss) {
+  // TODO: move pss to `options` after 30th April 2026
+  const today = DateFormats.dateObjToIsoDate(new Date())
+  if (today >= '2026-04-30') {
     options.push('pss')
   }
 
   return options
 }
-
-const optionsToExclude = getOptionsToExclude()
 
 export const releaseTypes: Record<string, { text: string; abbr: string }> = {
   crdLicence: {
@@ -176,6 +173,7 @@ export default class ReleaseType implements TasklistPage {
   }
 
   response() {
+    const optionsToExclude = getOptionsToExclude()
     const selectedTypes = this.body.releaseTypes?.filter(
       key => Boolean(releaseTypes[key]) || optionsToExclude.includes(key),
     )
@@ -255,6 +253,7 @@ export default class ReleaseType implements TasklistPage {
       [],
     )
 
+    const optionsToExclude = getOptionsToExclude()
     return releaseTypeOptions.filter(
       item =>
         !optionsToExclude.includes(item.value) ||
@@ -263,7 +262,7 @@ export default class ReleaseType implements TasklistPage {
   }
 
   checkForOldReleaseTypes() {
-    const validReleaseTypeKeys = [...Object.keys(releaseTypes), ...optionsToExclude]
+    const validReleaseTypeKeys = [...Object.keys(releaseTypes), ...getOptionsToExclude()]
     const invalidReleaseTypes = this.body.releaseTypes.filter(
       releaseType => releaseType !== undefined && !validReleaseTypeKeys.includes(releaseType),
     )


### PR DESCRIPTION
# Context

Ticket: https://dsdmoj.atlassian.net/browse/FM-375

Added some tests for PSS removal, and TODO messages to remove PSS date checking code after 30th April 2026

Turns out my previous release type-related PR covered hiding PSS from the UI, and removing PSS from valid selections/combinations already

# Changes in this PR

## Screenshots of UI changes

### Before

### After

# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
