### PR TITLE
Adding SQS variables to test helm chart to fix test deployment

### DIFF
--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -27,6 +27,9 @@ generic-service:
     IN_MAINTENANCE_MODE: false
     BOOKING_OVERSTAY_ENABLED: true
     PLANNED_MAINTENANCE_BANNER: false
+    # required so hmpps-audit-client doesn't raise an error
+    AUDIT_SQS_QUEUE_URL: ""
+    AUDIT_SQS_QUEUE_NAME: ""
 
   allowlist: null
 


### PR DESCRIPTION
# Context

Part of ticket https://dsdmoj.atlassian.net/browse/FM-426

I've already deployed this branch to the `test` environment, so it has fixed the issue we were seeing previously

The issue was a consequence of the audit logging we updated recently, as the environment variable `get` function in the `hmpps-audit-client` had different logic that was throwing an exception if `NODE_ENV` was set to `production` and the environment variables for the SQS variables weren't set
