### PR TITLE
Add scripts to split Cypress E2E and integration tests

### DIFF
--- a/.github/workflows/e2e_tests.yml
+++ b/.github/workflows/e2e_tests.yml
@@ -79,6 +79,10 @@ jobs:
   e2e_test_cypress:
     name: "CAS3 E2E Tests 🧪 (Cypress)"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [ 1, 2, 3, 4, 5, 6 ]
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -98,6 +102,10 @@ jobs:
       - name: Install dependencies
         run: npm run setup
 
+      - name: Split tests
+        id: split-tests
+        run: ./script/split-e2e-tests ${{ strategy.job-index }} ${{ strategy.job-total }}
+
       - name: Run E2E Tests
         env:
           CYPRESS_assessor_username: ${{ secrets.E2E_USER_CAS3_ASSESSOR_USERNAME }}
@@ -107,13 +115,14 @@ jobs:
           CYPRESS_environment: 'dev'
         run: |
           npm run test:e2e:ci -- \
-          --config baseUrl=https://transitional-accommodation-dev.hmpps.service.justice.gov.uk
+          --config baseUrl=https://transitional-accommodation-dev.hmpps.service.justice.gov.uk \
+          --spec $(echo ${{ steps.split-tests.outputs.test-suite }} | sed -E 's/ /,/g')
 
       - name: Upload Cypress report
         if: ${{ !cancelled() }}
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: CAS3-E2E-cypress-report
+          name: CAS3-E2E-cypress-report-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: test_results/cypress
           retention-days: 30
           if-no-files-found: ignore

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -121,6 +121,10 @@ jobs:
   integration_test:
     name: "Integration testing 🧪"
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [ 1, 2 ]
     steps:
       - name: Check out code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
@@ -140,14 +144,18 @@ jobs:
       - name: Building source
         run: npm run build
 
+      - name: Split tests
+        id: split-tests
+        run: ./script/split-integration-tests  ${{ strategy.job-index }} ${{ strategy.job-total }}
+
       - name: Running Integration tests
-        run: npm run test:integration
+        run: TEST_RUN_ARGS="--spec $(echo ${{ steps.split-tests.outputs.test-suite }})" npm run test:integration
 
       - name: Upload Integration test artefacts
         if: failure()
         uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6
         with:
-          name: integration-test-artefacts
+          name: integration-test-artefacts-${{ matrix.shard }}-of-${{ strategy.job-total }}
           path: |
             integration_tests/videos
             integration_tests/screenshots

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:ci": "jest --runInBand",
     "test:integration": "npm run start-test-wiremock && start-server-and-test start-feature http://localhost:3007/ping int-test",
     "test:integration:ui": "npm run start-test-wiremock && start-server-and-test start-feature:dev http://localhost:3007/ping int-test-ui",
-    "int-test": "cypress run --config video=false",
+    "int-test": "cypress run --config video=false $TEST_RUN_ARGS",
     "int-test-ui": "cypress open --e2e --browser electron",
     "test:e2e": "export $(cat e2e.env) && cypress run -C cypress.config.e2e.ts --config baseUrl=http://localhost:3000",
     "test:e2e:ui": "export $(cat e2e.env) && cypress open --e2e --browser chrome -C cypress.config.e2e.ts --config baseUrl=http://localhost:3000",

--- a/script/split-e2e-tests
+++ b/script/split-e2e-tests
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+SPLIT_INDEX=$1
+SPLIT_TOTAL=$2
+
+export TESTS="$(find e2e -type f -name "*.feature" | \
+    awk -v splitTotal=$SPLIT_TOTAL -v splitIndex=$SPLIT_INDEX 'NR % splitTotal == splitIndex % splitTotal' | \
+    tr '\n' ',' | sed 's/,$//')"
+
+echo "test-suite=$TESTS" >> "$GITHUB_OUTPUT"

--- a/script/split-integration-tests
+++ b/script/split-integration-tests
@@ -1,0 +1,10 @@
+#!/bin/sh
+
+SPLIT_INDEX=$1
+SPLIT_TOTAL=$2
+
+export TESTS="$(find integration_tests -type f -name "*.cy.ts" | \
+    awk -v splitTotal=$SPLIT_TOTAL -v splitIndex=$SPLIT_INDEX 'NR % splitTotal == splitIndex % splitTotal' | \
+    tr '\n' ',' | sed 's/,$//')"
+
+echo "test-suite=$TESTS" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
# Context

Re-add test splitting for E2E tests using a bash script rather than `chaosaffe/split-tests`

Also split the integration tests in 2 in order to speed up the build process by around 4 minutes

# Changes in this PR

## Screenshots of UI changes

### Before
<img width="796" height="781" alt="image" src="https://github.com/user-attachments/assets/67335434-7eb3-43fb-a0e8-dc86a7a0c1da" />

### After
<img width="832" height="742" alt="image" src="https://github.com/user-attachments/assets/8bc633d6-023c-4dd5-8a4b-78746e49efe1" />
