### PR TITLE
Add risk to self rosh risk fields

### DIFF
--- a/cypress_shared/fixtures/applicationData.json
+++ b/cypress_shared/fixtures/applicationData.json
@@ -223,7 +223,9 @@
       "riskToPublic": "Risk to public detail",
       "riskToKnownAdult": "Risk to known adult detail",
       "riskToStaff": "Risk to staff detail",
-      "riskToSelf": "Risk to self detail"
+      "riskToSelfConcerns": "yes",
+      "riskToSelf": "Risk to self detail",
+      "safetyPlanCompleted": "yesAndConsentToShareHasBeenGiven"
     },
     "risk-management-plan": {
       "version": "2",

--- a/cypress_shared/fixtures/applicationTranslatedDocument.json
+++ b/cypress_shared/fixtures/applicationTranslatedDocument.json
@@ -212,7 +212,9 @@
               "How will risk to public impact placement?": "Risk to public detail",
               "How will risk to known adult impact placement?": "Risk to known adult detail",
               "How will risk to staff impact placement?": "Risk to staff detail",
-              "How will risk to self impact placement?": "Risk to self detail"
+              "Are there any current or past concerns about self-harm or suicide?": "Yes",
+              "How will risk to self impact placement?": "Risk to self detail",
+              "Has a safety plan been completed?": "Yes, and consent to share has been given"
             },
             {
               "Victim safety planning": "Victim safety planning detail",

--- a/cypress_shared/pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
+++ b/cypress_shared/pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
@@ -22,6 +22,8 @@ export default class RoshLevelPage extends ApplyPage {
     this.completeTextInputFromPageBody('riskToPublic')
     this.completeTextInputFromPageBody('riskToKnownAdult')
     this.completeTextInputFromPageBody('riskToStaff')
+    this.checkRadioButtonFromPageBody('riskToSelfConcerns')
     this.completeTextInputFromPageBody('riskToSelf')
+    this.checkRadioButtonFromPageBody('safetyPlanCompleted')
   }
 }

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.test.ts
@@ -1,17 +1,19 @@
 import { PersonRisksUI } from '../../../../@types/ui'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
-import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { mapApiPersonRisksForUi, sentenceCase } from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import RoshLevel from './roshLevel'
 
 jest.mock('../../../../utils/utils')
 
-const body = {
+const body: ConstructorParameters<typeof RoshLevel>[0] = {
   riskToChildren: 'Risk to children detail',
   riskToPublic: 'Risk to public detail',
   riskToKnownAdult: 'Risk to known adult detail',
   riskToStaff: 'Risk to staff detail',
+  riskToSelfConcerns: 'yes',
   riskToSelf: 'Risk to self detail',
+  safetyPlanCompleted: 'yesAndConsentToShareHasBeenGiven',
 }
 const personRisksUi = { flags: { value: ['Some flag'] } } as PersonRisksUI
 
@@ -20,6 +22,12 @@ describe('RoshLevel', () => {
     person: personFactory.build({
       name: 'John Smith',
     }),
+  })
+
+  beforeEach(() => {
+    ;(sentenceCase as jest.MockedFunction<typeof sentenceCase>).mockImplementation(
+      value => value.charAt(0).toUpperCase() + value.slice(1),
+    )
   })
 
   describe('constructor', () => {
@@ -78,6 +86,25 @@ describe('RoshLevel', () => {
         riskToSelf: 'You must provide details on how risk to self will impact placement',
       })
     })
+
+    it('does not return an error if risk to self concerns is no and the risk to self field is not populated', () => {
+      const page = new RoshLevel({ ...body, riskToSelfConcerns: 'no', riskToSelf: undefined }, application)
+      expect(page.errors()).toEqual({})
+    })
+
+    it('returns an error if the risk to self concerns field is not populated', () => {
+      const page = new RoshLevel({ ...body, riskToSelfConcerns: undefined }, application)
+      expect(page.errors()).toEqual({
+        riskToSelfConcerns: 'Select yes if there are any current or past concerns about self harm or suicide',
+      })
+    })
+
+    it('returns an error if the safety plan field is not populated', () => {
+      const page = new RoshLevel({ ...body, safetyPlanCompleted: undefined }, application)
+      expect(page.errors()).toEqual({
+        safetyPlanCompleted: 'Select if a Safety plan has been completed',
+      })
+    })
   })
 
   describe('response', () => {
@@ -88,7 +115,9 @@ describe('RoshLevel', () => {
         'How will risk to public impact placement?': 'Risk to public detail',
         'How will risk to known adult impact placement?': 'Risk to known adult detail',
         'How will risk to staff impact placement?': 'Risk to staff detail',
+        'Are there any current or past concerns about self-harm or suicide?': 'Yes',
         'How will risk to self impact placement?': 'Risk to self detail',
+        'Has a safety plan been completed?': 'Yes, and consent to share has been given',
       })
     })
   })

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.test.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.test.ts
@@ -1,10 +1,8 @@
 import { PersonRisksUI } from '../../../../@types/ui'
 import { applicationFactory, personFactory } from '../../../../testutils/factories'
-import { mapApiPersonRisksForUi, sentenceCase } from '../../../../utils/utils'
+import * as utils from '../../../../utils/utils'
 import { itShouldHaveNextValue, itShouldHavePreviousValue } from '../../../shared-examples'
 import RoshLevel from './roshLevel'
-
-jest.mock('../../../../utils/utils')
 
 const body: ConstructorParameters<typeof RoshLevel>[0] = {
   riskToChildren: 'Risk to children detail',
@@ -24,22 +22,20 @@ describe('RoshLevel', () => {
     }),
   })
 
-  beforeEach(() => {
-    ;(sentenceCase as jest.MockedFunction<typeof sentenceCase>).mockImplementation(
-      value => value.charAt(0).toUpperCase() + value.slice(1),
-    )
+  afterEach(() => {
+    jest.restoreAllMocks()
   })
 
   describe('constructor', () => {
     it('sets the body and risk information', () => {
-      ;(mapApiPersonRisksForUi as jest.MockedFunction<typeof mapApiPersonRisksForUi>).mockReturnValue(personRisksUi)
+      const mapApiPersonRisksForUiSpy = jest.spyOn(utils, 'mapApiPersonRisksForUi').mockReturnValue(personRisksUi)
 
       const page = new RoshLevel(body, application)
 
       expect(page.body).toEqual(body)
       expect(page.risks).toEqual(personRisksUi)
 
-      expect(mapApiPersonRisksForUi).toHaveBeenCalledWith(application.risks)
+      expect(mapApiPersonRisksForUiSpy).toHaveBeenCalledWith(application.risks)
     })
   })
 

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
@@ -47,7 +47,8 @@ export default class RoshLevel implements TasklistPage {
     safetyPlanCompleted: 'Has a safety plan been completed?',
   }
 
-  safetyPlanTemplateUrl = 'https://equip-portal.equip.service.justice.gov.uk/'
+  safetyPlanTemplateUrl =
+    'https://equip-portal.equip.service.justice.gov.uk/CtrlWebIsapi.dll/app/documents/A9B1745B307C4E1BAE10828FE0800CED/master'
 
   constructor(
     readonly body: Partial<RoshLevelBody>,

--- a/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
+++ b/server/form-pages/apply/assess-placement-risks-and-needs/placement-considerations/roshLevel.ts
@@ -1,21 +1,39 @@
 import { TemporaryAccommodationApplication as Application } from '@approved-premises/api'
-import type { PersonRisksUI, TaskListErrors } from '@approved-premises/ui'
+import type { PersonRisksUI, TaskListErrors, YesOrNo } from '@approved-premises/ui'
 import { Page } from '../../../utils/decorators'
 
 import TasklistPage from '../../../tasklistPage'
-import { mapApiPersonRisksForUi } from '../../../../utils/utils'
+import { mapApiPersonRisksForUi, sentenceCase } from '../../../../utils/utils'
+
+type SafetyPlanCompleted = 'yesAndConsentToShareHasBeenGiven' | 'yesButNoConsentToShare' | 'noSafetyPlan'
+
+const safetyPlanCompletedResponses: Record<SafetyPlanCompleted, string> = {
+  yesAndConsentToShareHasBeenGiven: 'Yes, and consent to share has been given',
+  yesButNoConsentToShare: 'Yes, but no consent to share',
+  noSafetyPlan: 'No safety plan',
+}
 
 type RoshLevelBody = {
   riskToChildren: string
   riskToPublic: string
   riskToKnownAdult: string
   riskToStaff: string
+  riskToSelfConcerns: YesOrNo
   riskToSelf: string
+  safetyPlanCompleted: SafetyPlanCompleted
 }
 
 @Page({
   name: 'rosh-level',
-  bodyProperties: ['riskToChildren', 'riskToPublic', 'riskToKnownAdult', 'riskToStaff', 'riskToSelf'],
+  bodyProperties: [
+    'riskToChildren',
+    'riskToPublic',
+    'riskToKnownAdult',
+    'riskToStaff',
+    'riskToSelfConcerns',
+    'riskToSelf',
+    'safetyPlanCompleted',
+  ],
 })
 export default class RoshLevel implements TasklistPage {
   title = 'RoSH level'
@@ -23,6 +41,13 @@ export default class RoshLevel implements TasklistPage {
   htmlDocumentTitle = this.title
 
   risks: PersonRisksUI
+
+  questions = {
+    riskToSelfConcerns: 'Are there any current or past concerns about self-harm or suicide?',
+    safetyPlanCompleted: 'Has a safety plan been completed?',
+  }
+
+  safetyPlanTemplateUrl = 'https://equip-portal.equip.service.justice.gov.uk/'
 
   constructor(
     readonly body: Partial<RoshLevelBody>,
@@ -37,7 +62,10 @@ export default class RoshLevel implements TasklistPage {
       'How will risk to public impact placement?': this.body.riskToPublic,
       'How will risk to known adult impact placement?': this.body.riskToKnownAdult,
       'How will risk to staff impact placement?': this.body.riskToStaff,
+      [this.questions.riskToSelfConcerns]: sentenceCase(this.body.riskToSelfConcerns as string),
       'How will risk to self impact placement?': this.body.riskToSelf,
+      [this.questions.safetyPlanCompleted]:
+        safetyPlanCompletedResponses[this.body.safetyPlanCompleted as SafetyPlanCompleted],
     }
   }
 
@@ -68,8 +96,16 @@ export default class RoshLevel implements TasklistPage {
       errors.riskToStaff = 'You must provide details on how risk to staff will impact placement'
     }
 
-    if (!this.body.riskToSelf) {
+    if (!this.body.riskToSelfConcerns) {
+      errors.riskToSelfConcerns = 'Select yes if there are any current or past concerns about self harm or suicide'
+    }
+
+    if (this.body.riskToSelfConcerns === 'yes' && !this.body.riskToSelf) {
       errors.riskToSelf = 'You must provide details on how risk to self will impact placement'
+    }
+
+    if (!this.body.safetyPlanCompleted) {
+      errors.safetyPlanCompleted = 'Select if a Safety plan has been completed'
     }
 
     return errors

--- a/server/form-pages/apply/schema.json
+++ b/server/form-pages/apply/schema.json
@@ -745,7 +745,22 @@
             "riskToStaff": {
               "type": "string"
             },
+            "riskToSelfConcerns": {
+              "enum": [
+                "no",
+                "yes"
+              ],
+              "type": "string"
+            },
             "riskToSelf": {
+              "type": "string"
+            },
+            "safetyPlanCompleted": {
+              "enum": [
+                "noSafetyPlan",
+                "yesAndConsentToShareHasBeenGiven",
+                "yesButNoConsentToShare"
+              ],
               "type": "string"
             }
           }

--- a/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/rosh-level.njk
+++ b/server/views/applications/pages/assess-placement-risks-and-needs/placement-considerations/rosh-level.njk
@@ -107,11 +107,33 @@
 
             <h2>Risk to self</h2>
             {% set riskToSelfHintHtml %}
-                <p class="govuk-hint">
-                    Explain what the risk is, the triggers and why it happens. Include details about whether it's severe
-                    and how often it happens. Consider how the risk could be managed in the placement.
-                </p>
+                <ul class="govuk-list govuk-list--bullet govuk-hint">
+                    <li>Explain what the risk is, the frequency, the triggers and why it happens.</li>
+                    <li>Use information from AP: SASP/CARE, ACCT, OASys.</li>
+                    <li>Include details about whether it’s severe and how often it happens.</li>
+                    <li>Consider how the risk could be managed in the placement.</li>
+                </ul>
             {% endset %}
+
+            {{ formPageRadios({
+                fieldName: "riskToSelfConcerns",
+                fieldset: {
+                    legend: {
+                        text: page.questions.riskToSelfConcerns,
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                items: [
+                    {
+                        value: "yes",
+                        text: "Yes"
+                    },
+                    {
+                        value: "no",
+                        text: "No"
+                    }
+                ]
+            }, fetchContext()) }}
 
             {{ formPageTextarea({
                 fieldName: 'riskToSelf',
@@ -122,6 +144,40 @@
                 hint: {
                     html: riskToSelfHintHtml
                 }
+            }, fetchContext()) }}
+
+            <h2>Safety plan</h2>
+            <p class="govuk-hint">
+                The probation safety plan template is a self management tool for individuals to manage a suicide crisis.
+                The <a class="govuk-link" href="{{ page.safetyPlanTemplateUrl }}">safety plan template</a> is in EQuiP
+                which can be accessed via the ‘risk to self’ process map.
+            </p>
+
+            {{ formPageRadios({
+                fieldName: "safetyPlanCompleted",
+                fieldset: {
+                    legend: {
+                        text: page.questions.safetyPlanCompleted,
+                        classes: "govuk-fieldset__legend--m"
+                    }
+                },
+                hint: {
+                    text: "The person on probation must consent to the plan being shared."
+                },
+                items: [
+                    {
+                        value: "yesAndConsentToShareHasBeenGiven",
+                        text: "Yes, and consent to share has been given"
+                    },
+                    {
+                        value: "yesButNoConsentToShare",
+                        text: "Yes, but no consent to share"
+                    },
+                    {
+                        value: "noSafetyPlan",
+                        text: "No safety plan"
+                    }
+                ]
             }, fetchContext()) }}
 
             {{ govukButton({


### PR DESCRIPTION
# Context

Jira: https://dsdmoj.atlassian.net/browse/FM-501

# Changes in this PR

Added 3 extra fields in the rosh level tab
/referrals/:id/tasks/placement-considerations/pages/rosh-level

## Screenshots of UI changes

<img width="571" height="708" alt="Screenshot 2026-04-22 at 16 54 39" src="https://github.com/user-attachments/assets/eeb78253-aa47-4a61-84f9-1b27ec068925" />


# Release checklist

[Release process documentation](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/edit-v2/4247847062?draftShareId=a1c360ab-bd31-4db1-aae3-7cc002761de9).

## Pre-merge checklist

- [ ] Are any changes required to dependent services for this change to work?
  (eg. CAS API)
- [ ] Have they been released to production already?

## Post-merge checklist

- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to test
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to preprod
- [ ] [Manually approve](https://dsdmoj.atlassian.net/wiki/spaces/AP/pages/4247847062/Release+process#Manual-releases)
  release to prod

<!-- Should a release fail at any step, you as the author should now lead the work to
fix it as soon as possible. You can monitor deployment failures in CircleCI
itself and application errors are found in
[Sentry](https://ministryofjustice.sentry.io/issues/?project=4504129156218880&referrer=sidebar&statsPeriod=24h).
Both events should be automatically sent to our [Slack
channel](https://mojdt.slack.com/archives/C048BJS7S2F). -->
