### PR TITLE
Updated sha for hmpps-github-actions

### DIFF
--- a/.github/workflows/deploy_to_test.yml
+++ b/.github/workflows/deploy_to_test.yml
@@ -10,7 +10,7 @@ permissions:
 jobs:
   docker_build:
     name: Build docker image from hmpps-github-actions
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
@@ -22,7 +22,7 @@ jobs:
     name: Deploy to the test environment
     needs:
       - docker_build
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     secrets: inherit
     with:
       environment: 'test'

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -18,7 +18,7 @@ jobs:
 
   docker_build:
     name: Build docker image from hmpps-github-actions
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/docker_build.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       docker_registry: 'ghcr.io'
       registry_org: 'ministryofjustice'
@@ -30,7 +30,7 @@ jobs:
     needs:
       - test
       - docker_build
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     secrets: inherit
     with:
       environment: 'development'
@@ -48,7 +48,7 @@ jobs:
     needs:
       - docker_build
       - e2e_test
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     secrets: inherit
     with:
       environment: 'preprod'
@@ -59,7 +59,7 @@ jobs:
     needs:
       - docker_build
       - deploy_preprod
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/deploy_env.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     secrets: inherit
     with:
       environment: 'prod'

--- a/.github/workflows/security_codeql_actions_scan.yml
+++ b/.github/workflows/security_codeql_actions_scan.yml
@@ -12,7 +12,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security CodeQL actions scan
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql_actions.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql_actions.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_codeql_scan.yml
+++ b/.github/workflows/security_codeql_scan.yml
@@ -12,7 +12,7 @@ jobs:
       actions: read
       security-events: write
     name: Project security CodeQL scan
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_codeql.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       languages: 'javascript-typescript'

--- a/.github/workflows/security_npm_dependency.yml
+++ b/.github/workflows/security_npm_dependency.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_npm_dependency.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
       node_version_file: ".node-version"

--- a/.github/workflows/security_veracode_pipeline_scan.yml
+++ b/.github/workflows/security_veracode_pipeline_scan.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_pipeline_scan.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/security_veracode_policy_scan.yml
+++ b/.github/workflows/security_veracode_policy_scan.yml
@@ -12,7 +12,7 @@ jobs:
       contents: read
       actions: read
       security-events: write
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@v2 # WORKFLOW_VERSION
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/security_veracode_policy_scan.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     with:
       channel_id: ${{ vars.SECURITY_ALERTS_SLACK_CHANNEL_ID || 'NO_SLACK' }}
     secrets: inherit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ concurrency:
 jobs:
   helm_lint:
     name: "Helm config linting 🔎"
-    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@v2
+    uses: ministryofjustice/hmpps-github-actions/.github/workflows/test_helm_lint.yml@8de783c7b6dc61ad8ba384924dc1fe93098d9995 # 2.13.1
     strategy:
       matrix:
         environments: [ 'development', 'test', 'preprod', 'prod' ]


### PR DESCRIPTION
Update to pin `hmpps-github-actions` to a newer version after they removed a load of old unpinned actions from their repo

Same as the work done on CAS2 Bail: https://github.com/ministryofjustice/hmpps-community-accommodation-tier-2-bail-ui/pull/536