### PR TITLE
Use nonprod severity for nonprod environments

### DIFF
--- a/helm_deploy/values-development.yaml
+++ b/helm_deploy/values-development.yaml
@@ -37,4 +37,4 @@ generic-service:
   allowlist: null
 
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod

--- a/helm_deploy/values-preprod.yaml
+++ b/helm_deploy/values-preprod.yaml
@@ -32,4 +32,4 @@ generic-service:
       AUDIT_SQS_QUEUE_NAME: "sqs_queue_name"
 
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod

--- a/helm_deploy/values-test.yaml
+++ b/helm_deploy/values-test.yaml
@@ -34,4 +34,4 @@ generic-service:
   allowlist: null
 
 generic-prometheus-alerts:
-  alertSeverity: hmpps-approved-premises
+  alertSeverity: hmpps-approved-premises-nonprod


### PR DESCRIPTION
This will ensure that non prod prometheus alerts will be sent to the non prod slack channel