### PR TITLE
FM-711 Remove unused ‘applicable tier’ logic

### DIFF
--- a/server/utils/applicationUtils.test.ts
+++ b/server/utils/applicationUtils.test.ts
@@ -4,7 +4,7 @@ import Assess from '../form-pages/assess'
 import paths from '../paths/apply'
 import { applicationFactory, personFactory } from '../testutils/factories'
 import { DateFormats } from './dateUtils'
-import { isApplicableTier, personName, tierBadge } from './personUtils'
+import { personName, tierBadge } from './personUtils'
 
 import { FullPerson } from '../@types/shared'
 import {
@@ -383,7 +383,6 @@ describe('applicationUtils', () => {
 
   describe('firstPageOfApplicationJourney', () => {
     it('returns the sentence type page', () => {
-      ;(isApplicableTier as jest.Mock).mockReturnValue(true)
       const application = applicationFactory.build()
 
       expect(firstPageOfApplicationJourney(application)).toEqual(paths.applications.show({ id: application.id }))

--- a/server/utils/personUtils.test.ts
+++ b/server/utils/personUtils.test.ts
@@ -1,5 +1,5 @@
 import { personFactory, restrictedPersonFactory } from '../testutils/factories'
-import { isApplicableTier, isFullPerson, personName, statusTag, tierBadge } from './personUtils'
+import { isFullPerson, personName, statusTag, tierBadge } from './personUtils'
 
 describe('personUtils', () => {
   describe('statusTag', () => {
@@ -21,32 +21,6 @@ describe('personUtils', () => {
 
     it('returns the correct tier badge for B', () => {
       expect(tierBadge('B')).toEqual('<span class="moj-badge moj-badge--purple">B</span>')
-    })
-  })
-
-  describe('isApplicableTier', () => {
-    it(`returns true if the person's sex is male and has an applicable tier`, () => {
-      expect(isApplicableTier('Male', 'A3')).toBeTruthy()
-    })
-
-    it(`returns false if the person's sex is male and has a tier that is not applicable to males`, () => {
-      expect(isApplicableTier('Male', 'C3')).toBeFalsy()
-    })
-
-    it(`returns false if the person's sex is male and has an inapplicable tier`, () => {
-      expect(isApplicableTier('Male', 'D1')).toBeFalsy()
-    })
-
-    it(`returns true if the person's sex is female and has an applicable tier`, () => {
-      expect(isApplicableTier('Female', 'A3')).toBeTruthy()
-    })
-
-    it(`returns true if the person's sex is female and has a tier that is applicable to females`, () => {
-      expect(isApplicableTier('Female', 'C3')).toBeTruthy()
-    })
-
-    it(`returns false if the person's sex is female and has an inapplicable tier`, () => {
-      expect(isApplicableTier('Female', 'D1')).toBeFalsy()
     })
   })
 

--- a/server/utils/personUtils.ts
+++ b/server/utils/personUtils.ts
@@ -17,15 +17,6 @@ const tierBadge = (tier: string): string => {
   return `<span class="moj-badge ${colour}">${tier}</span>`
 }
 
-const isApplicableTier = (sex: string, tier: string): boolean => {
-  const applicableTiersAll = ['A3', 'A2', 'B1', 'B3', 'B2', 'B1']
-  const applicableTiersWomen = ['C3']
-
-  const applicableTiers = sex === 'Female' ? [applicableTiersAll, applicableTiersWomen].flat() : applicableTiersAll
-
-  return applicableTiers.includes(tier)
-}
-
 const personNameFallback = 'the person'
 
 const personName = (person: Person, fallback: string = personNameFallback) => {
@@ -39,4 +30,4 @@ const isFullPerson = (person: Person): person is FullPerson => {
   return person.type === 'FullPerson'
 }
 
-export { isApplicableTier, isFullPerson, personName, personNameFallback, statusTag, tierBadge }
+export { isFullPerson, personName, personNameFallback, statusTag, tierBadge }


### PR DESCRIPTION
This appears to have been copied from CAS1, but isn’t used (there is nothing calling the `isApplicableTier` function in `personUtils.ts`
